### PR TITLE
fix: fix renovate regex pattern

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,9 +4,16 @@
   ],
   regexManagers: [
     {
-      fileMatch: ["README.md", "aqua.yaml"],
+      fileMatch: ["README.md"],
       matchStrings: [
-        " (?<currentValue>.*?) # renovate: depName=(?<depName>.*)",
+        "ref: (?<currentValue>.*?) # renovate: depName=(?<depName>.*)",
+      ],
+      datasourceTemplate: "github-releases",
+    },
+    {
+      fileMatch: ["aqua.yaml"],
+      matchStrings: [
+        'version: "?(?<currentValue>.*?)"? # renovate: depName=(?<depName>.*)',
       ],
       datasourceTemplate: "github-releases",
     },


### PR DESCRIPTION
```
               {
                 "depName": "vmware-tanzu/carvel-ytt",
                 "currentValue": " version: v0.36.0",
                 "datasource": "github-releases",
                 "replaceString": "  version: v0.36.0 # renovate: depName=vmware-tanzu/carvel-ytt",
                 "depIndex": 35,
                 "updates": [],
                 "warnings": [],
                 "versioning": "semver",
                 "skipReason": "invalid-value"
               }
```