### PR TITLE
feat: add packages: `eksctl` and `golang-migrate/migrate`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -151,6 +151,14 @@ packages:
   files:
   - name: golangci-lint
     src: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}/golangci-lint'
+- name: golang-migrate/migrate
+  type: github_release
+  repo_owner: golang-migrate
+  repo_name: migrate
+  asset: 'migrate.{{.OS}}-{{.Arch}}.tar.gz'
+  files:
+  - name: migrate
+    src: 'migrate.{{.OS}}-{{.Arch}}'
 - name: gomplate
   type: github_release
   repo_owner: hairyhenderson

--- a/registry.yaml
+++ b/registry.yaml
@@ -74,6 +74,14 @@ packages:
   files:
   - name: dyff
 
+- name: eksctl
+  type: github_release
+  repo_owner: weaveworks
+  repo_name: eksctl
+  asset: 'eksctl_{{title .OS}}_{{.Arch}}.tar.gz'
+  files:
+  - name: eksctl
+
 - name: fzf
   type: github_release
   repo_owner: junegunn


### PR DESCRIPTION
* `eksctl`: The official CLI for Amazon EKS
  * https://github.com/weaveworks/eksctl
  * https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html
* `golang-migrate/migrate`: Database migrations. CLI and Golang library.
  * https://github.com/golang-migrate/migrate