### PR TITLE
feat: add `go-task/task` and `fatedier/frp`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -120,6 +120,18 @@ packages:
   description: A command-line fuzzy finder
   files:
   - name: fzf
+- name: fatedier/frp
+  type: github_release
+  repo_owner: fatedier
+  repo_name: frp
+  asset: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/fatedier/frp
+  description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet
+  files:
+  - name: frpc
+    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frpc'
+  - name: frps
+    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frps'
 
 - name: gh
   type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -433,6 +433,15 @@ packages:
   - name: stern
     src: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/stern'
 
+- name: go-task/task
+  type: github_release
+  repo_owner: go-task
+  repo_name: task
+  asset: 'task_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://taskfile.dev/
+  description: A task runner / simpler Make alternative written in Go
+  files:
+  - name: task
 - name: terraform
   type: http
   url: https://releases.hashicorp.com/terraform/{{trimPrefix "v" .Package.Version}}/terraform_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip


### PR DESCRIPTION
* `go-task/task` https://taskfile.dev/ - A task runner / simpler Make alternative written in Go
* `fatedier/frp` https://github.com/fatedier/frp - A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet