### PR TITLE
feat: add `kubernetes-sigs/krew`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -287,7 +287,6 @@ packages:
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
   files:
   - name: kind
-
 - name: kubernetes-sigs/krew
   type: github_release
   repo_owner: kubernetes-sigs
@@ -306,6 +305,15 @@ packages:
   description: The kubectl command line tool lets you control Kubernetes clusters
   files:
   - name: kubectl
+- name: ahmetb/kubectl-tree
+  type: github_release
+  repo_owner: ahmetb
+  repo_name: kubectl-tree
+  asset: 'kubectl-tree_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/ahmetb/kubectl-tree
+  description: kubectl plugin to browse Kubernetes object hierarchies as a tree
+  files:
+  - name: kubectl-tree
 - name: kubeval
   type: github_release
   repo_owner: instrumenta

--- a/registry.yaml
+++ b/registry.yaml
@@ -25,6 +25,15 @@ packages:
   description: Install aqua quickly
   files:
   - name: aqua-installer
+- name: argoproj/argo-rollouts
+  type: github_release
+  repo_owner: argoproj
+  repo_name: argo-rollouts
+  asset: 'kubectl-argo-rollouts-{{.OS}}-{{.Arch}}'
+  link: https://argoproj.github.io/argo-rollouts/
+  description: Progressive Delivery for Kubernetes
+  files:
+  - name: kubectl-argo-rollouts
 
 - name: suzuki-shunsuke/ci-info
   type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -25,6 +25,16 @@ packages:
   description: Install aqua quickly
   files:
   - name: aqua-installer
+- name: argoproj/argo-cd
+  type: github_release
+  repo_owner: argoproj
+  repo_name: argo-cd
+  asset: 'argocd-{{.OS}}-{{.Arch}}'
+  link: https://argo-cd.readthedocs.io/
+  description: Declarative continuous deployment for Kubernetes
+  files:
+  - name: argocd
+    src: 'argocd-{{.OS}}-{{.Arch}}'
 - name: argoproj/argo-rollouts
   type: github_release
   repo_owner: argoproj

--- a/registry.yaml
+++ b/registry.yaml
@@ -323,6 +323,24 @@ packages:
   description: kubectl plugin to browse Kubernetes object hierarchies as a tree
   files:
   - name: kubectl-tree
+- name: ahmetb/kubectx
+  type: github_release
+  repo_owner: ahmetb
+  repo_name: kubectx
+  asset: 'kubectx_{{.Package.Version}}_{{.OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/ahmetb/kubectx
+  description: Faster way to switch between clusters and namespaces in kubectl
+  files:
+  - name: kubectx
+- name: ahmetb/kubens
+  type: github_release
+  repo_owner: ahmetb
+  repo_name: kubectx
+  asset: 'kubens_{{.Package.Version}}_{{.OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/ahmetb/kubectx
+  description: Faster way to switch between clusters and namespaces in kubectl
+  files:
+  - name: kubens
 - name: kubeval
   type: github_release
   repo_owner: instrumenta

--- a/registry.yaml
+++ b/registry.yaml
@@ -316,6 +316,15 @@ packages:
   files:
   - name: krew
     src: 'krew-{{.OS}}_{{.Arch}}'
+- name: dty1er/kubecolor
+  type: github_release
+  repo_owner: dty1er
+  repo_name: kubecolor
+  asset: 'kubecolor_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/dty1er/kubecolor
+  description: colorizes kubectl output
+  files:
+  - name: kubecolor
 - name: kubectl
   type: http
   url: https://storage.googleapis.com/kubernetes-release/release/{{.Package.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl

--- a/registry.yaml
+++ b/registry.yaml
@@ -287,6 +287,17 @@ packages:
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
   files:
   - name: kind
+
+- name: kubernetes-sigs/krew
+  type: github_release
+  repo_owner: kubernetes-sigs
+  repo_name: krew
+  asset: krew.tar.gz
+  link: https://krew.sigs.k8s.io/
+  description: Find and install kubectl plugins
+  files:
+  - name: krew
+    src: 'krew-{{.OS}}_{{.Arch}}'
 - name: kubectl
   type: http
   url: https://storage.googleapis.com/kubernetes-release/release/{{.Package.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl


### PR DESCRIPTION
Close #69
Close #70
Close #71
Close #72
Close #73
Close #74

## New Packages

* `argoproj/argo-cd`
  * Declarative continuous deployment for Kubernetes
  * https://argo-cd.readthedocs.io/
* `ahmetb/kubectx`, `ahmetb/kubens`
  * Faster way to switch between clusters and namespaces in kubectl
  * https://github.com/ahmetb/kubectx
* `argoproj/argo-rollouts`
  * Progressive Delivery for Kubernetes
  * https://argoproj.github.io/argo-rollouts/
* `kubernetes-sigs/krew`
  * Find and install kubectl plugins
  * https://krew.sigs.k8s.io/
* `ahmetb/kubectl-tree`
  * kubectl plugin to browse Kubernetes object hierarchies as a tree
  * https://github.com/ahmetb/kubectl-tree
* `dty1er/kubecolor`
  * colorizes kubectl output
  * https://github.com/dty1er/kubecolor