### PR TITLE
feat: add `lima-vm/lima`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -407,6 +407,18 @@ packages:
   files:
   - name: lambroll
     src: lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}/lambroll
+- name: lima-vm/lima
+  type: github_release
+  repo_owner: lima-vm
+  repo_name: lima
+  asset: 'lima-{{trimPrefix "v" .Package.Version}}-{{title .OS}}-{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/lima-vm/lima
+  description: Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially)
+  files:
+  - name: lima
+    src: bin/lima
+  - name: limactl
+    src: bin/limactl
 
 - name: suzuki-shunsuke/matchfile
   type: github_release


### PR DESCRIPTION
Close #81

* https://github.com/lima-vm/lima
* > Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially)
* https://github.com/lima-vm/lima#installation