### PR TITLE
feat: rename and sort packages

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1,355 +1,14 @@
 packages:
-- name: jonaslu/ain
+# init: a
+- name: accurics/terrascan
   type: github_release
-  repo_owner: jonaslu
-  repo_name: ain
-  asset: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
-  link: https://github.com/jonaslu/ain
-  description: An HTTP API client for the terminal
+  repo_owner: accurics
+  repo_name: terrascan
+  asset: 'terrascan_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://docs.accurics.com/projects/accurics-terrascan/en/latest/
+  description: Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure
   files:
-  - name: ain
-    src: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}/ain'
-- name: suzuki-shunsuke/akoi
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: akoi
-  asset: 'akoi_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/akoi
-  description: binary installer
-  files:
-  - name: akoi
-- name: suzuki-shunsuke/aqua-installer
-  type: http
-  url: "https://raw.githubusercontent.com/suzuki-shunsuke/aqua-installer/{{.Package.Version}}/aqua-installer"
-  link: https://github.com/suzuki-shunsuke/aqua-installer
-  description: Install aqua quickly
-  files:
-  - name: aqua-installer
-- name: argoproj/argo-cd
-  type: github_release
-  repo_owner: argoproj
-  repo_name: argo-cd
-  asset: 'argocd-{{.OS}}-{{.Arch}}'
-  link: https://argo-cd.readthedocs.io/
-  description: Declarative continuous deployment for Kubernetes
-  files:
-  - name: argocd
-    src: 'argocd-{{.OS}}-{{.Arch}}'
-- name: argoproj/argo-rollouts
-  type: github_release
-  repo_owner: argoproj
-  repo_name: argo-rollouts
-  asset: 'kubectl-argo-rollouts-{{.OS}}-{{.Arch}}'
-  link: https://argoproj.github.io/argo-rollouts/
-  description: Progressive Delivery for Kubernetes
-  files:
-  - name: kubectl-argo-rollouts
-
-- name: suzuki-shunsuke/ci-info
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: ci-info
-  asset: 'ci-info_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/ci-info
-  description: CLI tool to get CI related information
-  files:
-  - name: ci-info
-- name: circleci-cli
-  type: github_release
-  repo_owner: CircleCI-Public
-  repo_name: circleci-cli
-  asset: 'circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/CircleCI-Public/circleci-cli
-  description: Use CircleCI from the command line
-  files:
-  - name: circleci
-    src: circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/circleci
-- name: suzuki-shunsuke/circleci-config-merge
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: circleci-config-merge
-  asset: 'circleci-config-merge_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/circleci-config-merge
-  description: Generate .circleci/config.yml by merging multiple files
-  files:
-  - name: circleci-config-merge
-- name: suzuki-shunsuke/cmdx
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: cmdx
-  asset: 'cmdx_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/cmdx
-  description: Task runner. It provides useful help messages and supports interactive prompts and validation of arguments
-  files:
-  - name: cmdx
-- name: codeclimate/test-reporter
-  type: http
-  archive_type: raw
-  url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Package.Version}}-{{.OS}}-{{.Arch}}
-  link: https://github.com/codeclimate/test-reporter
-  description: Code Climate Test Reporter
-  files:
-  - name: test-reporter
-- name: conftest
-  type: github_release
-  repo_owner: open-policy-agent
-  repo_name: conftest
-  # https://github.com/open-policy-agent/conftest/blob/f68c92599fa8fd1c2e81527aee351064f5419df5/.goreleaser.yml#L21-L31
-  asset: 'conftest_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_x86_64.tar.gz'
-  link: https://www.conftest.dev/
-  description: Write tests against structured configuration data using the Open Policy Agent Rego query language
-  files:
-  - name: conftest
-- name: consul
-  type: http
-  url: https://releases.hashicorp.com/consul/{{trimPrefix "v" .Package.Version}}/consul_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.consul.io/
-  description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
-  files:
-  - name: consul
-
-- name: direnv
-  type: github_release
-  repo_owner: direnv
-  repo_name: direnv
-  asset: 'direnv.{{.OS}}-{{.Arch}}'
-  archive_type: raw
-  link: https://github.com/direnv/direnv
-  description: unclutter your .profile
-  files:
-  - name: direnv
-- name: homeport/dyff
-  type: github_release
-  repo_owner: homeport
-  repo_name: dyff
-  asset: 'dyff_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/homeport/dyff
-  description: A diff tool for YAML files, and sometimes JSON
-  files:
-  - name: dyff
-
-- name: eksctl
-  type: github_release
-  repo_owner: weaveworks
-  repo_name: eksctl
-  asset: 'eksctl_{{title .OS}}_{{.Arch}}.tar.gz'
-  link: https://eksctl.io/
-  description: The official CLI for Amazon EKS
-  files:
-  - name: eksctl
-
-- name: fzf
-  type: github_release
-  repo_owner: junegunn
-  repo_name: fzf
-  asset: 'fzf-{{.Package.Version}}-{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
-  link: https://github.com/junegunn/fzf
-  description: A command-line fuzzy finder
-  files:
-  - name: fzf
-- name: fatedier/frp
-  type: github_release
-  repo_owner: fatedier
-  repo_name: frp
-  asset: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/fatedier/frp
-  description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet
-  files:
-  - name: frpc
-    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frpc'
-  - name: frps
-    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frps'
-
-- name: gh
-  type: github_release
-  repo_owner: cli
-  repo_name: cli
-  asset: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}.tar.gz'
-  link: https://cli.github.com/
-  description: GitHub’s official command line tool
-  files:
-  - name: gh
-    src: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}/bin/gh'
-- name: int128/ghcp
-  type: github_release
-  repo_owner: int128
-  repo_name: ghcp
-  asset: "ghcp_{{.OS}}_{{.Arch}}.zip"
-  link: https://github.com/int128/ghcp
-  description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
-  files:
-  - name: ghcp
-- name: ghq
-  type: github_release
-  repo_owner: x-motemen
-  repo_name: ghq
-  asset: 'ghq_{{.OS}}_{{.Arch}}.zip'
-  link: https://github.com/x-motemen/ghq
-  description: Remote repository management made easy
-  files:
-  - name: ghq
-    src: ghq_{{.OS}}_{{.Arch}}/ghq
-- name: suzuki-shunsuke/git-rm-branch
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: git-rm-branch
-  asset: 'git-rm-branch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/git-rm-branch
-  description: cli tool to remove merged branches
-  files:
-  - name: git-rm-branch
-- name: suzuki-shunsuke/github-comment
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: github-comment
-  asset: 'github-comment_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/github-comment
-  description: CLI to create a GitHub comment
-  files:
-  - name: github-comment
-- name: zricethezav/gitleaks
-  type: github_release
-  repo_owner: zricethezav
-  repo_name: gitleaks
-  asset: 'gitleaks-{{.OS}}-{{.Arch}}'
-  link: https://github.com/zricethezav/gitleaks
-  description: Scan git repos (or files) for secrets using regex and entropy
-  files:
-  - name: gitleaks
-- name: go
-  type: http
-  url: https://golang.org/dl/go{{.Package.Version}}.{{.OS}}-{{.Arch}}.tar.gz
-  link: https://golang.org/
-  description: The Go programming language
-  files:
-  - name: go
-    src: go/bin/go
-  - name: gofmt
-    src: go/bin/gofmt
-- name: gofumpt
-  type: github_release
-  repo_owner: mvdan
-  repo_name: gofumpt
-  asset: 'gofumpt_{{.Package.Version}}_{{.OS}}_{{.Arch}}'
-  archive_type: raw
-  link: https://github.com/mvdan/gofumpt
-  description: A stricter gofmt
-  files:
-  - name: gofumpt
-- name: golangci-lint
-  type: github_release
-  repo_owner: golangci
-  repo_name: golangci-lint
-  asset: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://golangci-lint.run/
-  description: Fast linters Runner for Go
-  files:
-  - name: golangci-lint
-    src: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}/golangci-lint'
-- name: golang-migrate/migrate
-  type: github_release
-  repo_owner: golang-migrate
-  repo_name: migrate
-  asset: 'migrate.{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://github.com/golang-migrate/migrate
-  description: Database migrations. CLI and Golang library
-  files:
-  - name: migrate
-    src: 'migrate.{{.OS}}-{{.Arch}}'
-- name: gomplate
-  type: github_release
-  repo_owner: hairyhenderson
-  repo_name: gomplate
-  asset: "gomplate_{{.OS}}-{{.Arch}}"
-  link: https://docs.gomplate.ca/
-  description: A flexible commandline tool for template rendering. Supports lots of local and remote datasources
-  files:
-  - name: gomplate
-- name: goreleaser
-  type: github_release
-  repo_owner: goreleaser
-  repo_name: goreleaser
-  # https://github.com/goreleaser/goreleaser/blob/5a01a10f9bbc60ab75aff0b2971af75d32436bdf/.goreleaser.yml#L98-L104
-  asset: 'goreleaser_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
-  link: https://goreleaser.com/
-  description: Deliver Go binaries as fast and easily as possible
-  files:
-  - name: goreleaser
-
-- name: minamijoyo/hcledit
-  type: github_release
-  repo_owner: minamijoyo
-  repo_name: hcledit
-  asset: 'hcledit_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/minamijoyo/hcledit
-  description: A command line editor for HCL
-  files:
-  - name: hcledit
-- name: helm
-  type: http
-  url: https://get.helm.sh/helm-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-  link: https://helm.sh/
-  description: The Kubernetes Package Manager
-  files:
-  - name: helm
-    src: "{{.OS}}-{{.Arch}}/helm"
-- name: helmfile
-  type: github_release
-  repo_owner: roboll
-  repo_name: helmfile
-  asset: 'helmfile_{{.OS}}_{{.Arch}}'
-  archive_type: raw
-  link: https://github.com/roboll/helmfile
-  description: Deploy Kubernetes Helm Charts
-  files:
-  - name: helmfile
-
-- name: jq
-  type: github_release
-  repo_owner: stedolan
-  repo_name: jq
-  asset: 'jq-{{if eq .OS "darwin"}}osx-amd64{{else}}{{if eq .OS "linux"}}linux64{{else}}win64.exe{{end}}{{end}}'
-  archive_type: raw
-  link: http://stedolan.github.io/jq/
-  description: Command-line JSON processor
-  files:
-  - name: jq
-
-- name: kind
-  type: http
-  url: 'https://kind.sigs.k8s.io/dl/{{.Package.Version}}/kind-{{.OS}}-{{.Arch}}'
-  archive_type: raw
-  link: https://kind.sigs.k8s.io/
-  description: Kubernetes IN Docker - local clusters for testing Kubernetes
-  files:
-  - name: kind
-- name: kubernetes-sigs/krew
-  type: github_release
-  repo_owner: kubernetes-sigs
-  repo_name: krew
-  asset: krew.tar.gz
-  link: https://krew.sigs.k8s.io/
-  description: Find and install kubectl plugins
-  files:
-  - name: krew
-    src: 'krew-{{.OS}}_{{.Arch}}'
-- name: dty1er/kubecolor
-  type: github_release
-  repo_owner: dty1er
-  repo_name: kubecolor
-  asset: 'kubecolor_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
-  link: https://github.com/dty1er/kubecolor
-  description: colorizes kubectl output
-  files:
-  - name: kubecolor
-- name: kubectl
-  type: http
-  url: https://storage.googleapis.com/kubernetes-release/release/{{.Package.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl
-  archive_type: raw
-  link: https://kubernetes.io/docs/reference/kubectl/overview/
-  description: The kubectl command line tool lets you control Kubernetes clusters
-  files:
-  - name: kubectl
+  - name: terrascan
 - name: ahmetb/kubectl-tree
   type: github_release
   repo_owner: ahmetb
@@ -377,35 +36,112 @@ packages:
   description: Faster way to switch between clusters and namespaces in kubectl
   files:
   - name: kubens
-- name: kubeval
+- name: aquasecurity/tfsec
   type: github_release
-  repo_owner: instrumenta
-  repo_name: kubeval
-  asset: 'kubeval-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://www.kubeval.com/
-  description: Validate your Kubernetes configuration files, supports multiple Kubernetes versions
+  repo_owner: aquasecurity
+  repo_name: tfsec
+  asset: "tfsec-{{.OS}}-{{.Arch}}"
+  link: https://tfsec.dev/
+  description: A static analysis security scanner for your Terraform code
   files:
-  - name: kubeval
-- name: kube-linter
+  - name: tfsec
+- name: argoproj/argo-cd
   type: github_release
-  repo_owner: stackrox
-  repo_name: kube-linter
-  asset: 'kube-linter-{{.OS}}.tar.gz'
-  link: https://docs.kubelinter.io/#/
-  description: KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices.
+  repo_owner: argoproj
+  repo_name: argo-cd
+  asset: 'argocd-{{.OS}}-{{.Arch}}'
+  link: https://argo-cd.readthedocs.io/
+  description: Declarative continuous deployment for Kubernetes
   files:
-  - name: kube-linter
-- name: kustomize
+  - name: argocd
+    src: 'argocd-{{.OS}}-{{.Arch}}'
+- name: argoproj/argo-rollouts
   type: github_release
-  repo_owner: kubernetes-sigs
-  repo_name: kustomize
-  asset: 'kustomize_{{trimPrefix "kustomize/" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/kubernetes-sigs/kustomize
-  description: Customization of kubernetes YAML configurations
+  repo_owner: argoproj
+  repo_name: argo-rollouts
+  asset: 'kubectl-argo-rollouts-{{.OS}}-{{.Arch}}'
+  link: https://argoproj.github.io/argo-rollouts/
+  description: Progressive Delivery for Kubernetes
   files:
-  - name: kustomize
+  - name: kubectl-argo-rollouts
 
-- name: lambroll
+# init: c
+- name: CircleCI-Public/circleci-cli
+  type: github_release
+  repo_owner: CircleCI-Public
+  repo_name: circleci-cli
+  asset: 'circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/CircleCI-Public/circleci-cli
+  description: Use CircleCI from the command line
+  files:
+  - name: circleci
+    src: circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/circleci
+- name: cli/cli
+  type: github_release
+  repo_owner: cli
+  repo_name: cli
+  asset: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}.tar.gz'
+  link: https://cli.github.com/
+  description: GitHub’s official command line tool
+  files:
+  - name: gh
+    src: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}/bin/gh'
+- name: codeclimate/test-reporter
+  type: http
+  archive_type: raw
+  url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Package.Version}}-{{.OS}}-{{.Arch}}
+  link: https://github.com/codeclimate/test-reporter
+  description: Code Climate Test Reporter
+  files:
+  - name: test-reporter
+
+# init: d
+- name: direnv/direnv
+  type: github_release
+  repo_owner: direnv
+  repo_name: direnv
+  asset: 'direnv.{{.OS}}-{{.Arch}}'
+  archive_type: raw
+  link: https://github.com/direnv/direnv
+  description: unclutter your .profile
+  files:
+  - name: direnv
+- name: dty1er/kubecolor
+  type: github_release
+  repo_owner: dty1er
+  repo_name: kubecolor
+  asset: 'kubecolor_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/dty1er/kubecolor
+  description: colorizes kubectl output
+  files:
+  - name: kubecolor
+
+# init: e
+
+# init: f
+- name: fatedier/frp
+  type: github_release
+  repo_owner: fatedier
+  repo_name: frp
+  asset: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/fatedier/frp
+  description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet
+  files:
+  - name: frpc
+    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frpc'
+  - name: frps
+    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frps'
+- name: FiloSottile/mkcert
+  type: github_release
+  repo_owner: FiloSottile
+  repo_name: mkcert
+  archive_type: raw
+  asset: "mkcert-{{.Package.Version}}-{{.OS}}-{{.Arch}}"
+  link: https://github.com/FiloSottile/mkcert
+  description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
+  files:
+  - name: mkcert
+- name: fujiwara/lambroll
   type: github_release
   repo_owner: fujiwara
   repo_name: lambroll
@@ -415,6 +151,241 @@ packages:
   files:
   - name: lambroll
     src: lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}/lambroll
+
+# init: g
+- name: go-task/task
+  type: github_release
+  repo_owner: go-task
+  repo_name: task
+  asset: 'task_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://taskfile.dev/
+  description: A task runner / simpler Make alternative written in Go
+  files:
+  - name: task
+- name: golang/go
+  type: http
+  url: https://golang.org/dl/go{{.Package.Version}}.{{.OS}}-{{.Arch}}.tar.gz
+  link: https://golang.org/
+  description: The Go programming language
+  files:
+  - name: go
+    src: go/bin/go
+  - name: gofmt
+    src: go/bin/gofmt
+- name: golangci/golangci-lint
+  type: github_release
+  repo_owner: golangci
+  repo_name: golangci-lint
+  asset: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  link: https://golangci-lint.run/
+  description: Fast linters Runner for Go
+  files:
+  - name: golangci-lint
+    src: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}/golangci-lint'
+- name: golang-migrate/migrate
+  type: github_release
+  repo_owner: golang-migrate
+  repo_name: migrate
+  asset: 'migrate.{{.OS}}-{{.Arch}}.tar.gz'
+  link: https://github.com/golang-migrate/migrate
+  description: Database migrations. CLI and Golang library
+  files:
+  - name: migrate
+    src: 'migrate.{{.OS}}-{{.Arch}}'
+- name: GoogleContainerTools/skaffold
+  type: http
+  url: 'https://storage.googleapis.com/skaffold/releases/{{.Package.Version}}/skaffold-{{.OS}}-{{.Arch}}'
+  link: https://skaffold.dev/
+  description: Easy and Repeatable Kubernetes Development
+  files:
+  - name: skaffold
+    src: 'skaffold-{{.OS}}-{{.Arch}}'
+- name: goreleaser/goreleaser
+  type: github_release
+  repo_owner: goreleaser
+  repo_name: goreleaser
+  # https://github.com/goreleaser/goreleaser/blob/5a01a10f9bbc60ab75aff0b2971af75d32436bdf/.goreleaser.yml#L98-L104
+  asset: 'goreleaser_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://goreleaser.com/
+  description: Deliver Go binaries as fast and easily as possible
+  files:
+  - name: goreleaser
+
+# init: h
+- name: hairyhenderson/gomplate
+  type: github_release
+  repo_owner: hairyhenderson
+  repo_name: gomplate
+  asset: "gomplate_{{.OS}}-{{.Arch}}"
+  link: https://docs.gomplate.ca/
+  description: A flexible commandline tool for template rendering. Supports lots of local and remote datasources
+  files:
+  - name: gomplate
+- name: hashicorp/consul
+  type: http
+  url: https://releases.hashicorp.com/consul/{{trimPrefix "v" .Package.Version}}/consul_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.consul.io/
+  description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
+  files:
+  - name: consul
+- name: hashicorp/nomad
+  type: http
+  url: https://releases.hashicorp.com/nomad/{{trimPrefix "v" .Package.Version}}/nomad_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.nomadproject.io/
+  description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations
+  files:
+  - name: nomad
+- name: hashicorp/packer
+  type: http
+  url: https://releases.hashicorp.com/packer/{{trimPrefix "v" .Package.Version}}/packer_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.packer.io/
+  description: Packer is a tool for creating identical machine images for multiple platforms from a single source configuration
+  files:
+  - name: packer
+- name: hashicorp/terraform
+  type: http
+  url: https://releases.hashicorp.com/terraform/{{trimPrefix "v" .Package.Version}}/terraform_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.terraform.io/
+  description: Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned
+  files:
+  - name: terraform
+- name: hashicorp/vault
+  type: http
+  url: https://releases.hashicorp.com/vault/{{trimPrefix "v" .Package.Version}}/vault_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.vaultproject.io/
+  description: A tool for secrets management, encryption as a service, and privileged access management
+  files:
+  - name: vault
+- name: hashicorp/waypoint
+  type: http
+  url: https://releases.hashicorp.com/waypoint/{{trimPrefix "v" .Package.Version}}/waypoint_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  link: https://www.waypointproject.io/
+  description: A tool to build, deploy, and release any application on any platform
+  files:
+  - name: waypoint
+- name: helm/helm
+  type: http
+  url: https://get.helm.sh/helm-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+  link: https://helm.sh/
+  description: The Kubernetes Package Manager
+  files:
+  - name: helm
+    src: "{{.OS}}-{{.Arch}}/helm"
+- name: homeport/dyff
+  type: github_release
+  repo_owner: homeport
+  repo_name: dyff
+  asset: 'dyff_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/homeport/dyff
+  description: A diff tool for YAML files, and sometimes JSON
+  files:
+  - name: dyff
+
+# init: i
+- name: instrumenta/kubeval
+  type: github_release
+  repo_owner: instrumenta
+  repo_name: kubeval
+  asset: 'kubeval-{{.OS}}-{{.Arch}}.tar.gz'
+  link: https://www.kubeval.com/
+  description: Validate your Kubernetes configuration files, supports multiple Kubernetes versions
+  files:
+  - name: kubeval
+- name: int128/ghcp
+  type: github_release
+  repo_owner: int128
+  repo_name: ghcp
+  asset: "ghcp_{{.OS}}_{{.Arch}}.zip"
+  link: https://github.com/int128/ghcp
+  description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
+  files:
+  - name: ghcp
+- name: int128/yamlpatch
+  type: github_release
+  repo_owner: int128
+  repo_name: yamlpatch
+  asset: 'yamlpatch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/int128/yamlpatch
+  description: Apply JSON Patch to YAML Document preserving positions and comments
+  files:
+  - name: yamlpatch
+
+# init: j
+- name: jonaslu/ain
+  type: github_release
+  repo_owner: jonaslu
+  repo_name: ain
+  asset: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  link: https://github.com/jonaslu/ain
+  description: An HTTP API client for the terminal
+  files:
+  - name: ain
+    src: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}/ain'
+- name: junegunn/fzf
+  type: github_release
+  repo_owner: junegunn
+  repo_name: fzf
+  asset: 'fzf-{{.Package.Version}}-{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/junegunn/fzf
+  description: A command-line fuzzy finder
+  files:
+  - name: fzf
+
+# init: k
+- name: koalaman/shellcheck
+  type: github_release
+  repo_owner: koalaman
+  repo_name: shellcheck
+  asset: "shellcheck-{{.Package.Version}}.{{.OS}}.x86_64.tar.xz" # TODO fix arch
+  link: https://github.com/koalaman/shellcheck
+  description: ShellCheck, a static analysis tool for shell scripts
+  files:
+  - name: shellcheck
+    src: shellcheck-{{.Package.Version}}/shellcheck
+- name: kubectl
+  type: http
+  url: https://storage.googleapis.com/kubernetes-release/release/{{.Package.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl
+  archive_type: raw
+  link: https://kubernetes.io/docs/reference/kubectl/overview/
+  description: The kubectl command line tool lets you control Kubernetes clusters
+  files:
+  - name: kubectl
+- name: kubernetes-sigs/kind
+  type: http
+  url: 'https://kind.sigs.k8s.io/dl/{{.Package.Version}}/kind-{{.OS}}-{{.Arch}}'
+  archive_type: raw
+  link: https://kind.sigs.k8s.io/
+  description: Kubernetes IN Docker - local clusters for testing Kubernetes
+  files:
+  - name: kind
+- name: kubernetes-sigs/krew
+  type: github_release
+  repo_owner: kubernetes-sigs
+  repo_name: krew
+  asset: krew.tar.gz
+  link: https://krew.sigs.k8s.io/
+  description: Find and install kubectl plugins
+  files:
+  - name: krew
+    src: 'krew-{{.OS}}_{{.Arch}}'
+- name: kubernetes-sigs/kustomize
+  type: github_release
+  repo_owner: kubernetes-sigs
+  repo_name: kustomize
+  asset: 'kustomize_{{trimPrefix "kustomize/" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/kubernetes-sigs/kustomize
+  description: Customization of kubernetes YAML configurations
+  files:
+  - name: kustomize
+- name: kubernetes/minikube
+  type: http
+  url: 'https://storage.googleapis.com/minikube/releases/{{.Package.Version}}/minikube-{{.OS}}-{{.Arch}}'
+  link: https://minikube.sigs.k8s.io/docs/
+  description: Run Kubernetes locally
+  files:
+  - name: minikube
+
+# init: l
 - name: lima-vm/lima
   type: github_release
   repo_owner: lima-vm
@@ -428,179 +399,25 @@ packages:
   - name: limactl
     src: bin/limactl
 
-- name: suzuki-shunsuke/matchfile
+# init: m
+- name: mikefarah/yq
   type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: matchfile
-  asset: 'matchfile_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/matchfile
-  description: CLI tool to check file paths are matched to the condition
+  repo_owner: mikefarah
+  repo_name: yq
+  asset: "yq_{{.OS}}_{{.Arch}}"
+  link: https://mikefarah.gitbook.io/yq/
+  description: yq is a portable command-line YAML processor
   files:
-  - name: matchfile
-- name: minikube
-  type: http
-  url: 'https://storage.googleapis.com/minikube/releases/{{.Package.Version}}/minikube-{{.OS}}-{{.Arch}}'
-  link: https://minikube.sigs.k8s.io/docs/
-  description: Run Kubernetes locally
-  files:
-  - name: minikube
-- name: FiloSottile/mkcert
+  - name: yq
+- name: minamijoyo/hcledit
   type: github_release
-  repo_owner: FiloSottile
-  repo_name: mkcert
-  archive_type: raw
-  asset: "mkcert-{{.Package.Version}}-{{.OS}}-{{.Arch}}"
-  link: https://github.com/FiloSottile/mkcert
-  description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
+  repo_owner: minamijoyo
+  repo_name: hcledit
+  asset: 'hcledit_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/minamijoyo/hcledit
+  description: A command line editor for HCL
   files:
-  - name: mkcert
-
-- name: nomad
-  type: http
-  url: https://releases.hashicorp.com/nomad/{{trimPrefix "v" .Package.Version}}/nomad_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.nomadproject.io/
-  description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations
-  files:
-  - name: nomad
-- name: projectdiscovery/nuclei
-  type: github_release
-  repo_owner: projectdiscovery
-  repo_name: nuclei
-  asset: 'nuclei_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}{{.OS}}{{end}}_{{.Arch}}.zip'
-  link: https://nuclei.projectdiscovery.io/
-  description: Fast and customizable vulnerability scanner based on simple YAML based DSL
-  files:
-  - name: nuclei
-
-- name: opa
-  type: github_release
-  repo_owner: open-policy-agent
-  repo_name: opa
-  asset: "opa_{{.OS}}_{{.Arch}}"
-  link: https://www.openpolicyagent.org/
-  description: An open source, general-purpose policy engine
-  files:
-  - name: opa
-
-- name: packer
-  type: http
-  url: https://releases.hashicorp.com/packer/{{trimPrefix "v" .Package.Version}}/packer_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.packer.io/
-  description: Packer is a tool for creating identical machine images for multiple platforms from a single source configuration
-  files:
-  - name: packer
-- name: peco
-  type: github_release
-  repo_owner: peco
-  repo_name: peco
-  asset: 'peco_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
-  link: https://github.com/peco/peco
-  description: Simplistic interactive filtering tool
-  files:
-  - name: peco
-    src: 'peco_{{.OS}}_{{.Arch}}/peco'
-- name: thought-machine/please
-  type: github_release
-  repo_owner: thought-machine
-  repo_name: please
-  asset: 'please_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://please.build/
-  description: High-performance extensible build system for reproducible multi-language builds
-  files:
-  - name: please
-    src: please/please
-
-- name: shellcheck
-  type: github_release
-  repo_owner: koalaman
-  repo_name: shellcheck
-  asset: "shellcheck-{{.Package.Version}}.{{.OS}}.x86_64.tar.xz" # TODO fix arch
-  link: https://github.com/koalaman/shellcheck
-  description: ShellCheck, a static analysis tool for shell scripts
-  files:
-  - name: shellcheck
-    src: shellcheck-{{.Package.Version}}/shellcheck
-- name: shfmt
-  type: github_release
-  repo_owner: mvdan
-  repo_name: sh
-  archive_type: raw
-  asset: "shfmt_{{.Package.Version}}_{{.OS}}_{{.Arch}}"
-  link: https://github.com/mvdan/sh
-  description: A shell parser, formatter, and interpreter with bash support; includes shfmt
-  files:
-  - name: shfmt
-- name: skaffold
-  type: http
-  url: 'https://storage.googleapis.com/skaffold/releases/{{.Package.Version}}/skaffold-{{.OS}}-{{.Arch}}'
-  link: https://skaffold.dev/
-  description: Easy and Repeatable Kubernetes Development
-  files:
-  - name: skaffold
-    src: 'skaffold-{{.OS}}-{{.Arch}}'
-- name: stern/stern
-  type: github_release
-  repo_owner: stern
-  repo_name: stern
-  asset: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/stern/stern
-  description: Multi pod and container log tailing for Kubernetes -- Friendly fork of https://github.com/wercker/stern
-  files:
-  - name: stern
-    src: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/stern'
-
-- name: go-task/task
-  type: github_release
-  repo_owner: go-task
-  repo_name: task
-  asset: 'task_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://taskfile.dev/
-  description: A task runner / simpler Make alternative written in Go
-  files:
-  - name: task
-- name: terraform
-  type: http
-  url: https://releases.hashicorp.com/terraform/{{trimPrefix "v" .Package.Version}}/terraform_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.terraform.io/
-  description: Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned
-  files:
-  - name: terraform
-- name: terraform-docs
-  type: github_release
-  repo_owner: terraform-docs
-  repo_name: terraform-docs
-  asset: 'terraform-docs-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://terraform-docs.io/
-  description: Generate documentation from Terraform modules in various output formats
-  files:
-  - name: terraform-docs
-- name: accurics/terrascan
-  type: github_release
-  repo_owner: accurics
-  repo_name: terrascan
-  asset: 'terrascan_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
-  link: https://docs.accurics.com/projects/accurics-terrascan/en/latest/
-  description: Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure
-  files:
-  - name: terrascan
-- name: suzuki-shunsuke/tfcmt
-  type: github_release
-  repo_owner: suzuki-shunsuke
-  repo_name: tfcmt
-  asset: 'tfcmt_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/suzuki-shunsuke/tfcmt
-  description: Fork of mercari/tfnotify
-  files:
-  - name: tfcmt
-- name: tflint
-  type: github_release
-  repo_owner: terraform-linters
-  repo_name: tflint
-  asset: "tflint_{{.OS}}_{{.Arch}}.zip"
-  link: https://github.com/terraform-linters/tflint
-  description: A Pluggable Terraform Linter
-  files:
-  - name: tflint
+  - name: hcledit
 - name: minamijoyo/tfmigrate
   type: github_release
   repo_owner: minamijoyo
@@ -610,15 +427,6 @@ packages:
   description: A Terraform state migration tool for GitOps
   files:
   - name: tfmigrate
-- name: tfmigrator/cli
-  type: github_release
-  repo_owner: tfmigrator
-  repo_name: cli
-  asset: tfmigrator_{{.OS}}_{{.Arch}}.tar.gz
-  link: https://github.com/tfmigrator/cli
-  description: CLI to migrate Terraform Configuration and State
-  files:
-  - name: tfmigrator
 - name: minamijoyo/tfschema
   type: github_release
   repo_owner: minamijoyo
@@ -628,15 +436,6 @@ packages:
   description: A schema inspector for Terraform providers
   files:
   - name: tfschema
-- name: tfsec
-  type: github_release
-  repo_owner: aquasecurity
-  repo_name: tfsec
-  asset: "tfsec-{{.OS}}-{{.Arch}}"
-  link: https://tfsec.dev/
-  description: A static analysis security scanner for your Terraform code
-  files:
-  - name: tfsec
 - name: minamijoyo/tfupdate
   type: github_release
   repo_owner: minamijoyo
@@ -646,7 +445,6 @@ packages:
   description: Update version constraints in your Terraform configurations
   files:
   - name: tfupdate
-
 - name: mumoshu/variant
   type: github_release
   repo_owner: mumoshu
@@ -665,31 +463,86 @@ packages:
   description: Turn your bash scripts into a modern, single-executable CLI app today
   files:
   - name: variant
-- name: vault
-  type: http
-  url: https://releases.hashicorp.com/vault/{{trimPrefix "v" .Package.Version}}/vault_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.vaultproject.io/
-  description: A tool for secrets management, encryption as a service, and privileged access management
-  files:
-  - name: vault
-- name: tsenart/vegeta
+- name: mvdan/gofumpt
   type: github_release
-  repo_owner: tsenart
-  repo_name: vegeta
-  asset: 'vegeta_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/tsenart/vegeta
-  description: HTTP load testing tool and library. It's over 9000!
+  repo_owner: mvdan
+  repo_name: gofumpt
+  asset: 'gofumpt_{{.Package.Version}}_{{.OS}}_{{.Arch}}'
+  archive_type: raw
+  link: https://github.com/mvdan/gofumpt
+  description: A stricter gofmt
   files:
-  - name: vegeta
-
-- name: waypoint
-  type: http
-  url: https://releases.hashicorp.com/waypoint/{{trimPrefix "v" .Package.Version}}/waypoint_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
-  link: https://www.waypointproject.io/
-  description: A tool to build, deploy, and release any application on any platform
+  - name: gofumpt
+- name: mvdan/sh
+  type: github_release
+  repo_owner: mvdan
+  repo_name: sh
+  archive_type: raw
+  asset: "shfmt_{{.Package.Version}}_{{.OS}}_{{.Arch}}"
+  link: https://github.com/mvdan/sh
+  description: A shell parser, formatter, and interpreter with bash support; includes shfmt
   files:
-  - name: waypoint
+  - name: shfmt
 
+# init: n
+
+# init: o
+- name: open-policy-agent/conftest
+  type: github_release
+  repo_owner: open-policy-agent
+  repo_name: conftest
+  # https://github.com/open-policy-agent/conftest/blob/f68c92599fa8fd1c2e81527aee351064f5419df5/.goreleaser.yml#L21-L31
+  asset: 'conftest_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_x86_64.tar.gz'
+  link: https://www.conftest.dev/
+  description: Write tests against structured configuration data using the Open Policy Agent Rego query language
+  files:
+  - name: conftest
+- name: open-policy-agent/opa
+  type: github_release
+  repo_owner: open-policy-agent
+  repo_name: opa
+  asset: "opa_{{.OS}}_{{.Arch}}"
+  link: https://www.openpolicyagent.org/
+  description: An open source, general-purpose policy engine
+  files:
+  - name: opa
+
+# init: p
+- name: peco/peco
+  type: github_release
+  repo_owner: peco
+  repo_name: peco
+  asset: 'peco_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/peco/peco
+  description: Simplistic interactive filtering tool
+  files:
+  - name: peco
+    src: 'peco_{{.OS}}_{{.Arch}}/peco'
+- name: projectdiscovery/nuclei
+  type: github_release
+  repo_owner: projectdiscovery
+  repo_name: nuclei
+  asset: 'nuclei_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}{{.OS}}{{end}}_{{.Arch}}.zip'
+  link: https://nuclei.projectdiscovery.io/
+  description: Fast and customizable vulnerability scanner based on simple YAML based DSL
+  files:
+  - name: nuclei
+
+# init: q
+
+# init: r
+- name: roboll/helmfile
+  type: github_release
+  repo_owner: roboll
+  repo_name: helmfile
+  asset: 'helmfile_{{.OS}}_{{.Arch}}'
+  archive_type: raw
+  link: https://github.com/roboll/helmfile
+  description: Deploy Kubernetes Helm Charts
+  files:
+  - name: helmfile
+
+# init: s
 - name: sahilm/yamldiff
   type: github_release
   repo_owner: sahilm
@@ -701,24 +554,166 @@ packages:
   files:
   - name: yamldiff
     src: 'yamldiff-v{{.Package.Version}}-{{.OS}}-{{.Arch}}'
-- name: int128/yamlpatch
+- name: stackrox/kube-linter
   type: github_release
-  repo_owner: int128
-  repo_name: yamlpatch
-  asset: 'yamlpatch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://github.com/int128/yamlpatch
-  description: Apply JSON Patch to YAML Document preserving positions and comments
+  repo_owner: stackrox
+  repo_name: kube-linter
+  asset: 'kube-linter-{{.OS}}.tar.gz'
+  link: https://docs.kubelinter.io/#/
+  description: KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices.
   files:
-  - name: yamlpatch
-- name: mikefarah/yq
+  - name: kube-linter
+- name: stedolan/jq
   type: github_release
-  repo_owner: mikefarah
-  repo_name: yq
-  asset: "yq_{{.OS}}_{{.Arch}}"
-  link: https://mikefarah.gitbook.io/yq/
-  description: yq is a portable command-line YAML processor
+  repo_owner: stedolan
+  repo_name: jq
+  asset: 'jq-{{if eq .OS "darwin"}}osx-amd64{{else}}{{if eq .OS "linux"}}linux64{{else}}win64.exe{{end}}{{end}}'
+  archive_type: raw
+  link: http://stedolan.github.io/jq/
+  description: Command-line JSON processor
   files:
-  - name: yq
+  - name: jq
+- name: stern/stern
+  type: github_release
+  repo_owner: stern
+  repo_name: stern
+  asset: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/stern/stern
+  description: Multi pod and container log tailing for Kubernetes -- Friendly fork of https://github.com/wercker/stern
+  files:
+  - name: stern
+    src: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/stern'
+- name: suzuki-shunsuke/akoi
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: akoi
+  asset: 'akoi_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/akoi
+  description: binary installer
+  files:
+  - name: akoi
+- name: suzuki-shunsuke/aqua-installer
+  type: http
+  url: "https://raw.githubusercontent.com/suzuki-shunsuke/aqua-installer/{{.Package.Version}}/aqua-installer"
+  link: https://github.com/suzuki-shunsuke/aqua-installer
+  description: Install aqua quickly
+  files:
+  - name: aqua-installer
+- name: suzuki-shunsuke/ci-info
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: ci-info
+  asset: 'ci-info_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/ci-info
+  description: CLI tool to get CI related information
+  files:
+  - name: ci-info
+- name: suzuki-shunsuke/circleci-config-merge
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: circleci-config-merge
+  asset: 'circleci-config-merge_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/circleci-config-merge
+  description: Generate .circleci/config.yml by merging multiple files
+  files:
+  - name: circleci-config-merge
+- name: suzuki-shunsuke/cmdx
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: cmdx
+  asset: 'cmdx_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/cmdx
+  description: Task runner. It provides useful help messages and supports interactive prompts and validation of arguments
+  files:
+  - name: cmdx
+- name: suzuki-shunsuke/git-rm-branch
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: git-rm-branch
+  asset: 'git-rm-branch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/git-rm-branch
+  description: cli tool to remove merged branches
+  files:
+  - name: git-rm-branch
+- name: suzuki-shunsuke/github-comment
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: github-comment
+  asset: 'github-comment_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/github-comment
+  description: CLI to create a GitHub comment
+  files:
+  - name: github-comment
+- name: suzuki-shunsuke/matchfile
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: matchfile
+  asset: 'matchfile_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/matchfile
+  description: CLI tool to check file paths are matched to the condition
+  files:
+  - name: matchfile
+- name: suzuki-shunsuke/tfcmt
+  type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: tfcmt
+  asset: 'tfcmt_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/suzuki-shunsuke/tfcmt
+  description: Fork of mercari/tfnotify
+  files:
+  - name: tfcmt
+
+# init: t
+- name: terraform-docs/terraform-docs
+  type: github_release
+  repo_owner: terraform-docs
+  repo_name: terraform-docs
+  asset: 'terraform-docs-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  link: https://terraform-docs.io/
+  description: Generate documentation from Terraform modules in various output formats
+  files:
+  - name: terraform-docs
+- name: terraform-linters/tflint
+  type: github_release
+  repo_owner: terraform-linters
+  repo_name: tflint
+  asset: "tflint_{{.OS}}_{{.Arch}}.zip"
+  link: https://github.com/terraform-linters/tflint
+  description: A Pluggable Terraform Linter
+  files:
+  - name: tflint
+- name: tfmigrator/cli
+  type: github_release
+  repo_owner: tfmigrator
+  repo_name: cli
+  asset: tfmigrator_{{.OS}}_{{.Arch}}.tar.gz
+  link: https://github.com/tfmigrator/cli
+  description: CLI to migrate Terraform Configuration and State
+  files:
+  - name: tfmigrator
+- name: thought-machine/please
+  type: github_release
+  repo_owner: thought-machine
+  repo_name: please
+  asset: 'please_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://please.build/
+  description: High-performance extensible build system for reproducible multi-language builds
+  files:
+  - name: please
+    src: please/please
+- name: tsenart/vegeta
+  type: github_release
+  repo_owner: tsenart
+  repo_name: vegeta
+  asset: 'vegeta_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/tsenart/vegeta
+  description: HTTP load testing tool and library. It's over 9000!
+  files:
+  - name: vegeta
+
+# init: u
+
+# init: v
 - name: vmware-tanzu/ytt
   type: github_release
   repo_owner: vmware-tanzu
@@ -728,3 +723,39 @@ packages:
   description: YAML templating tool that works on YAML structure instead of text
   files:
   - name: ytt
+
+# init: w
+- name: weaveworks/eksctl
+  type: github_release
+  repo_owner: weaveworks
+  repo_name: eksctl
+  asset: 'eksctl_{{title .OS}}_{{.Arch}}.tar.gz'
+  link: https://eksctl.io/
+  description: The official CLI for Amazon EKS
+  files:
+  - name: eksctl
+
+# init: x
+- name: x-motemen/ghq
+  type: github_release
+  repo_owner: x-motemen
+  repo_name: ghq
+  asset: 'ghq_{{.OS}}_{{.Arch}}.zip'
+  link: https://github.com/x-motemen/ghq
+  description: Remote repository management made easy
+  files:
+  - name: ghq
+    src: ghq_{{.OS}}_{{.Arch}}/ghq
+
+# init: y
+
+# init: z
+- name: zricethezav/gitleaks
+  type: github_release
+  repo_owner: zricethezav
+  repo_name: gitleaks
+  asset: 'gitleaks-{{.OS}}-{{.Arch}}'
+  link: https://github.com/zricethezav/gitleaks
+  description: Scan git repos (or files) for secrets using regex and entropy
+  files:
+  - name: gitleaks


### PR DESCRIPTION
Rename packages to make package names consistent.

## :warning: BREAKING CHANGE: some packages are renamed

Renamed Packages

* circleci-cli => CircleCI-Public/circleci-cli
* conftest => open-policy-agent/conftest
* consul => hashicorp/consul
* direnv => direnv/direnv
* eksctl => weaveworks/eksctl
* fzf => junegunn/fzf
* gh => cli/cli
* ghq => x-motemen/ghq
* go => golang/go
* gofumpt => mvdan/gofumpt
* golangci-lint => golangci/golangci-lint
* gomplate => hairyhenderson/gomplate
* goreleaser => goreleaser/goreleaser
* helm => helm/helm
* helmfile => roboll/helmfile
* jq => stedolan/jq
* kind => kubernetes-sigs/kind
* kubeval => instrumenta/kubeval
* kube-linter => stackrox/kube-linter
* kustomize => kubernetes-sigs/kustomize
* lambroll => fujiwara/lambroll
* minikube => kubernetes/minikube
* nomad => hashicorp/nomad
* opa => open-policy-agent/opa
* packer => hashicorp/packer
* peco => peco/peco
* shellcheck => koalaman/shellcheck
* shfmt => mvdan/sh
* skaffold => GoogleContainerTools/skaffold
* terraform => hashicorp/terraform
* terraform-docs => terraform-docs/terraform-docs
* tflint => terraform-linters/tflint
* tfsec => aquasecurity/tfsec
* vault => hashicorp/vault
* waypoint => hashicorp/waypoint