### PR TITLE
feat: add mattn/memo, etc

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -332,6 +332,15 @@ packages:
   - name: fzf
 
 # init: k
+- name: kayac/ecspresso
+  type: github_release
+  repo_owner: kayac
+  repo_name: ecspresso
+  asset: 'ecspresso_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/kayac/ecspresso
+  description: ecspresso is a deployment tool for Amazon ECS
+  files:
+  - name: ecspresso
 - name: koalaman/shellcheck
   type: github_release
   repo_owner: koalaman

--- a/registry.yaml
+++ b/registry.yaml
@@ -583,6 +583,16 @@ packages:
   files:
   - name: yamldiff
     src: 'yamldiff-v{{.Package.Version}}-{{.OS}}-{{.Arch}}'
+- name: Songmu/ecschedule
+  type: github_release
+  repo_owner: Songmu
+  repo_name: ecschedule
+  asset: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/ecschedule
+  description: ecschedule is a tool to manage ECS Scheduled Tasks
+  files:
+  - name: ecschedule
+    src: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ecschedule'
 - name: Songmu/gocredits
   type: github_release
   repo_owner: Songmu

--- a/registry.yaml
+++ b/registry.yaml
@@ -583,6 +583,16 @@ packages:
   files:
   - name: yamldiff
     src: 'yamldiff-v{{.Package.Version}}-{{.OS}}-{{.Arch}}'
+- name: Songmu/gocredits
+  type: github_release
+  repo_owner: Songmu
+  repo_name: gocredits
+  asset: 'gocredits_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/gocredits
+  description: creates CREDITS file from LICENSE files of dependencies
+  files:
+  - name: gocredits
+    src: 'gocredits_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gocredits'
 - name: stackrox/kube-linter
   type: github_release
   repo_owner: stackrox

--- a/registry.yaml
+++ b/registry.yaml
@@ -593,6 +593,16 @@ packages:
   files:
   - name: ecschedule
     src: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ecschedule'
+- name: Songmu/ghch
+  type: github_release
+  repo_owner: Songmu
+  repo_name: ghch
+  asset: 'ghch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/ghch
+  description: Generate changelog from git history, tags and merged pull requests
+  files:
+  - name: ghch
+    src: 'ghch_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ghch'
 - name: Songmu/ghg
   type: github_release
   repo_owner: Songmu

--- a/registry.yaml
+++ b/registry.yaml
@@ -613,6 +613,16 @@ packages:
   files:
   - name: gotesplit
     src: 'gotesplit_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gotesplit'
+- name: Songmu/goxz
+  type: github_release
+  repo_owner: Songmu
+  repo_name: goxz
+  asset: 'goxz_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/goxz
+  description: Just do cross building and archiving go tools conventionally
+  files:
+  - name: goxz
+    src: 'goxz_{{.Package.Version}}_{{.OS}}_{{.Arch}}/goxz'
 - name: stackrox/kube-linter
   type: github_release
   repo_owner: stackrox

--- a/registry.yaml
+++ b/registry.yaml
@@ -400,6 +400,16 @@ packages:
     src: bin/limactl
 
 # init: m
+- name: mattn/memo
+  type: github_release
+  repo_owner: mattn
+  repo_name: memo
+  asset: 'memo_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/mattn/memo
+  description: Memo Life For You
+  files:
+  - name: memo
+    src: 'memo_{{.Package.Version}}_{{.OS}}_{{.Arch}}/memo'
 - name: mikefarah/yq
   type: github_release
   repo_owner: mikefarah

--- a/registry.yaml
+++ b/registry.yaml
@@ -593,6 +593,16 @@ packages:
   files:
   - name: gocredits
     src: 'gocredits_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gocredits'
+- name: Songmu/gotesplit
+  type: github_release
+  repo_owner: Songmu
+  repo_name: gotesplit
+  asset: 'gotesplit_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/gotesplit
+  description: Splits the testing in Go into a subset and run it. It is useful for the CI environment
+  files:
+  - name: gotesplit
+    src: 'gotesplit_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gotesplit'
 - name: stackrox/kube-linter
   type: github_release
   repo_owner: stackrox

--- a/registry.yaml
+++ b/registry.yaml
@@ -633,6 +633,16 @@ packages:
   files:
   - name: goxz
     src: 'goxz_{{.Package.Version}}_{{.OS}}_{{.Arch}}/goxz'
+- name: Songmu/horenso
+  type: github_release
+  repo_owner: Songmu
+  repo_name: horenso
+  asset: 'horenso_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/horenso
+  description: Command wrapper for reporting the result. It is useful for cron jobs
+  files:
+  - name: horenso
+    src: 'horenso_{{.Package.Version}}_{{.OS}}_{{.Arch}}/horenso'
 - name: stackrox/kube-linter
   type: github_release
   repo_owner: stackrox

--- a/registry.yaml
+++ b/registry.yaml
@@ -593,6 +593,16 @@ packages:
   files:
   - name: ecschedule
     src: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ecschedule'
+- name: Songmu/ghg
+  type: github_release
+  repo_owner: Songmu
+  repo_name: ghg
+  asset: 'ghg_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/Songmu/ghg
+  description: Get the executable from github releases easily
+  files:
+  - name: ghg
+    src: 'ghg_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ghg'
 - name: Songmu/gocredits
   type: github_release
   repo_owner: Songmu

--- a/registry.yaml
+++ b/registry.yaml
@@ -400,6 +400,16 @@ packages:
     src: bin/limactl
 
 # init: m
+- name: mattn/goreman
+  type: github_release
+  repo_owner: mattn
+  repo_name: goreman
+  asset: 'goreman_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  link: https://github.com/mattn/goreman
+  description: foreman clone written in go language
+  files:
+  - name: goreman
+    src: 'goreman_{{.Package.Version}}_{{.OS}}_{{.Arch}}/goreman'
 - name: mattn/memo
   type: github_release
   repo_owner: mattn


### PR DESCRIPTION
## New Packages

* #98 `mattn/memo`
  * https://github.com/mattn/memo
  * Memo Life For You
* #97 `mattn/goreman`
  * https://github.com/mattn/goreman
  * foreman clone written in go language
* #96 `kayac/ecspresso`
  * https://github.com/kayac/ecspresso
  * ecspresso is a deployment tool for Amazon ECS
* #95 `Songmu/gocredits`
  * https://github.com/Songmu/gocredits
  * creates CREDITS file from LICENSE files of dependencies
* #94 `Songmu/gotesplit`
  * https://github.com/Songmu/gotesplit
  * Splits the testing in Go into a subset and run it. It is useful for the CI environment
* #93 `Songmu/ecschedule`
  * https://github.com/Songmu/ecschedule
  * ecschedule is a tool to manage ECS Scheduled Tasks
* #92 `Songmu/goxz`
  * https://github.com/Songmu/goxz
  * Just do cross building and archiving go tools conventionally
* #91 `Songmu/ghg`
  * https://github.com/Songmu/ghg
  * Get the executable from github releases easily
* #90 `Songmu/horenso`
  * https://github.com/Songmu/horenso
  * Command wrapper for reporting the result. It is useful for cron jobs
* #87 `Songmu/ghch`
  * https://github.com/Songmu/ghch
  * Generate changelog from git history, tags and merged pull requests