### PR TITLE
docs: add the versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Please see [Releases](https://github.com/suzuki-shunsuke/aqua-registry/releases).
 
+## Versioning Policy
+
+We are Conforming [suzuki-shunsuke/versioning-policy v0.1.0](https://github.com/suzuki-shunsuke/versioning-policy/blob/v0.1.0/POLICY.md), which is compatible with [Semantic Versioning 2.0.0](https://semver.org/).
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Versioning Policy

We are Conforming [suzuki-shunsuke/versioning-policy v0.1.0](https://github.com/suzuki-shunsuke/versioning-policy/blob/v0.1.0/POLICY.md), which is compatible with [Semantic Versioning 2.0.0](https://semver.org/).