### PR TITLE
feat: add `GoogleContainerTools/kpt`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -150,6 +150,15 @@ packages:
   description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
   files:
   - name: mkcert
+- name: fluxcd/flux2
+  type: github_release
+  repo_owner: fluxcd
+  repo_name: flux2
+  asset: 'flux_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/fluxcd/flux2
+  description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit
+  files:
+  - name: flux
 - name: fujiwara/lambroll
   type: github_release
   repo_owner: fujiwara
@@ -396,6 +405,15 @@ packages:
   description: ecspresso is a deployment tool for Amazon ECS
   files:
   - name: ecspresso
+- name: knqyf263/pet
+  type: github_release
+  repo_owner: knqyf263
+  repo_name: pet
+  asset: 'pet_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz' # TODO support ARM
+  link: https://github.com/knqyf263/pet
+  description: Simple command-line snippet manager, written in Go
+  files:
+  - name: pet
 - name: koalaman/shellcheck
   type: github_release
   repo_owner: koalaman

--- a/registry.yaml
+++ b/registry.yaml
@@ -115,6 +115,15 @@ packages:
   description: colorizes kubectl output
   files:
   - name: kubecolor
+- name: drone/drone-cli
+  type: github_release
+  repo_owner: drone
+  repo_name: drone-cli
+  asset: 'drone_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/drone/drone-cli
+  description: Command Line Tools for Drone CI
+  files:
+  - name: drone
 
 # init: e
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -414,6 +414,15 @@ packages:
   description: Simple command-line snippet manager, written in Go
   files:
   - name: pet
+- name: knqyf263/utern
+  type: github_release
+  repo_owner: knqyf263
+  repo_name: utern
+  asset: 'utern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip' # TODO support ARM
+  link: https://github.com/knqyf263/utern
+  description: Multi group and stream log tailing for AWS CloudWatch Logs
+  files:
+  - name: utern
 - name: koalaman/shellcheck
   type: github_release
   repo_owner: koalaman

--- a/registry.yaml
+++ b/registry.yaml
@@ -192,6 +192,26 @@ packages:
   files:
   - name: migrate
     src: 'migrate.{{.OS}}-{{.Arch}}'
+- name: GoogleCloudPlatform/terraformer
+  link: https://github.com/GoogleCloudPlatform/terraformer
+  description: CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
+  type: github_release
+  repo_owner: GoogleCloudPlatform
+  repo_name: terraformer
+  asset: 'terraformer-all-{{.OS}}-{{.Arch}}'
+  files:
+  - name: terraformer
+    src: 'terraformer-all-{{.OS}}-{{.Arch}}'
+- name: GoogleCloudPlatform/terraformer/aws
+  link: https://github.com/GoogleCloudPlatform/terraformer
+  description: CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
+  type: github_release
+  repo_owner: GoogleCloudPlatform
+  repo_name: terraformer
+  asset: 'terraformer-aws-{{.OS}}-{{.Arch}}'
+  files:
+  - name: terraformer
+    src: 'terraformer-aws-{{.OS}}-{{.Arch}}'
 - name: GoogleContainerTools/container-diff
   type: http
   url: 'https://storage.googleapis.com/container-diff/{{.Package.Version}}/container-diff-{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -192,6 +192,32 @@ packages:
   files:
   - name: migrate
     src: 'migrate.{{.OS}}-{{.Arch}}'
+- name: GoogleContainerTools/container-diff
+  type: http
+  url: 'https://storage.googleapis.com/container-diff/{{.Package.Version}}/container-diff-{{.OS}}-{{.Arch}}'
+  link: https://github.com/GoogleContainerTools/container-diff
+  description: 'container-diff: Diff your Docker containers'
+  files:
+  - name: container-diff
+    src: 'container-diff-{{.OS}}-{{.Arch}}'
+- name: GoogleContainerTools/container-structure-test
+  type: http
+  url: 'https://storage.googleapis.com/container-structure-test/{{.Package.Version}}/container-structure-test-{{.OS}}-{{.Arch}}'
+  link: https://github.com/GoogleContainerTools/container-structure-test
+  description: validate the structure of your container images
+  files:
+  - name: container-structure-test
+    src: 'container-structure-test-{{.OS}}-{{.Arch}}'
+- name: GoogleContainerTools/kpt
+  link: https://kpt.dev/
+  description: A Git-native, schema-aware, extensible client-side tool for packaging, customizing, validating, and applying Kubernetes resources
+  type: github_release
+  repo_owner: GoogleContainerTools
+  repo_name: kpt
+  asset: 'kpt_{{.OS}}_{{.Arch}}'
+  files:
+  - name: kpt
+    src: 'kpt_{{.OS}}_{{.Arch}}'
 - name: GoogleContainerTools/skaffold
   type: http
   url: 'https://storage.googleapis.com/skaffold/releases/{{.Package.Version}}/skaffold-{{.OS}}-{{.Arch}}'


### PR DESCRIPTION
## New Packages

* #107 `GoogleContainerTools/container-diff`
  * https://github.com/GoogleContainerTools/container-diff
  * container-diff: Diff your Docker containers
* #108 `GoogleContainerTools/container-structure-test`
  * https://github.com/GoogleContainerTools/container-structure-test
  * validate the structure of your container images
* #109 `GoogleContainerTools/kpt`
  * https://kpt.dev/
  * A Git-native, schema-aware, extensible client-side tool for packaging, customizing, validating, and applying Kubernetes resources
* #110 `GoogleCloudPlatform/terraformer`
  * https://github.com/GoogleCloudPlatform/terraformer
  * CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
* #110 `GoogleCloudPlatform/terraformer/aws`
  * https://github.com/GoogleCloudPlatform/terraformer
  * CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
* #112 `drone/drone-cli`
  * https://github.com/drone/drone-cli
  * Command Line Tools for Drone CI
* #111 `fluxcd/flux2`
  * https://github.com/fluxcd/flux2
  * Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit
* #114 `knqyf263/pet`
  * https://github.com/knqyf263/pet
  * Simple command-line snippet manager, written in Go
* #115 `knqyf263/utern`
  * https://github.com/knqyf263/utern
  * Multi group and stream log tailing for AWS CloudWatch Logs