### PR TITLE
refactor: simplify packages configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,9 +11,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: cache ~/.aqua
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.aqua/pkgs
+            ~/.aqua/registries
+          key: ${{ runner.os }}-${{ hashFiles('registry.yaml') }}-${{ hashFiles('aqua.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('registry.yaml') }}-
+            ${{ runner.os }}-
+
       - uses: suzuki-shunsuke/aqua-installer@main
         with:
-          version: v0.5.5 # renovate: depName=suzuki-shunsuke/aqua
+          version: v0.6.0-0 # renovate: depName=suzuki-shunsuke/aqua
       - run: aqua i --test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:
-          version: v0.6.0-0 # renovate: depName=suzuki-shunsuke/aqua
+          version: v0.6.0 # renovate: depName=suzuki-shunsuke/aqua
       - run: aqua i --test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -4,6 +4,300 @@ registries:
   path: registry.yaml
 
 packages:
+- name: accurics/terrascan
+  registry: standard
+  version: v1.10.0 # renovate: depName=accurics/terrascan
+- name: ahmetb/kubectl-tree
+  registry: standard
+  version: v0.4.1 # renovate: depName=ahmetb/kubectl-tree
+- name: ahmetb/kubectx
+  registry: standard
+  version: v0.9.4 # renovate: depName=ahmetb/kubectx
+- name: ahmetb/kubens
+  registry: standard
+  version: v0.9.4 # renovate: depName=ahmetb/kubens
+- name: aquasecurity/tfsec
+  registry: standard
+  version: v0.58.6 # renovate: depName=aquasecurity/tfsec
+- name: argoproj/argo-cd
+  registry: standard
+  version: v2.1.2 # renovate: depName=argoproj/argo-cd
+- name: argoproj/argo-rollouts
+  registry: standard
+  version: v1.0.6 # renovate: depName=argoproj/argo-rollouts
+- name: CircleCI-Public/circleci-cli
+  registry: standard
+  version: v0.1.15932 # renovate: depName=CircleCI-Public/circleci-cli
+- name: cli/cli
+  registry: standard
+  version: v2.0.0 # renovate: depName=cli/cli
+- name: codeclimate/test-reporter
+  registry: standard
+  version: 0.10.1 # renovate: depName=codeclimate/test-reporter
+- name: direnv/direnv
+  registry: standard
+  version: v2.28.0 # renovate: depName=direnv/direnv
+- name: dty1er/kubecolor
+  registry: standard
+  version: v0.0.20 # renovate: depName=dty1er/kubecolor
+- name: drone/drone-cli
+  registry: standard
+  version: v1.4.0 # renovate: depName=drone/drone-cli
+- name: fatedier/frp
+  registry: standard
+  version: v0.37.1 # renovate: depName=fatedier/frp
+- name: FiloSottile/mkcert
+  registry: standard
+  version: v1.4.3 # renovate: depName=FiloSottile/mkcert
+- name: fluxcd/flux2
+  registry: standard
+  version: v0.17.0 # renovate: depName=fluxcd/flux2
+- name: fujiwara/lambroll
+  registry: standard
+  version: v0.11.8 # renovate: depName=fujiwara/lambroll
+- name: go-task/task
+  registry: standard
+  version: v3.7.3 # renovate: depName=go-task/task
+- name: golang/go
+  registry: standard
+  version: "1.17" # TODO renovate
+- name: golangci/golangci-lint
+  registry: standard
+  version: v1.42.1 # renovate: depName=golangci/golangci-lint
+- name: golang-migrate/migrate
+  registry: standard
+  version: v4.14.1 # renovate: depName=golang-migrate/migrate
+- name: GoogleCloudPlatform/terraformer
+  registry: standard
+  version: 0.8.16 # renovate: depName=GoogleCloudPlatform/terraformer
+- name: GoogleCloudPlatform/terraformer/aws
+  registry: standard
+  version: 0.8.16 # renovate: depName=GoogleCloudPlatform/terraformer/aws
+- name: GoogleContainerTools/container-diff
+  registry: standard
+  version: v0.17.0 # renovate: depName=GoogleContainerTools/container-diff
+- name: GoogleContainerTools/container-structure-test
+  registry: standard
+  version: v1.10.0 # renovate: depName=GoogleContainerTools/container-structure-test
+- name: GoogleContainerTools/kpt
+  registry: standard
+  version: v1.0.0-beta.5 # renovate: depName=GoogleContainerTools/kpt
+- name: GoogleContainerTools/skaffold
+  registry: standard
+  version: v1.31.0 # renovate: depName=GoogleContainerTools/skaffold
+- name: goreleaser/goreleaser
+  registry: standard
+  version: v0.179.0 # renovate: depName=goreleaser/goreleaser
+- name: hairyhenderson/gomplate
+  registry: standard
+  version: v3.9.0 # renovate: depName=hairyhenderson/gomplate
+- name: hashicorp/consul
+  registry: standard
+  version: v1.10.2 # renovate: depName=hashicorp/consul
+- name: hashicorp/nomad
+  registry: standard
+  version: v1.1.4 # renovate: depName=hashicorp/nomad
+- name: hashicorp/packer
+  registry: standard
+  version: v1.7.4 # renovate: depName=hashicorp/packer
+- name: hashicorp/terraform
+  registry: standard
+  version: v1.0.6 # renovate: depName=hashicorp/terraform
+- name: hashicorp/vault
+  registry: standard
+  version: v1.8.2 # renovate: depName=hashicorp/vault
+- name: hashicorp/waypoint
+  registry: standard
+  version: v0.5.2 # renovate: depName=hashicorp/waypoint
+- name: helm/helm
+  registry: standard
+  version: v3.6.3 # renovate: depName=helm/helm
+- name: homeport/dyff
+  registry: standard
+  version: v1.4.4 # renovate: depName=homeport/dyff
+- name: instrumenta/kubeval
+  registry: standard
+  version: v0.16.1 # renovate: depName=instrumenta/kubeval
+- name: int128/ghcp
+  registry: standard
+  version: v1.13.0 # renovate: depName=int128/ghcp
+- name: int128/yamlpatch
+  registry: standard
+  version: v0.1.1 # renovate: depName=int128/yamlpatch
+- name: jonaslu/ain
+  registry: standard
+  version: v1.1.0 # renovate: depName=jonaslu/ain
+- name: junegunn/fzf
+  registry: standard
+  version: 0.27.2 # renovate: depName=junegunn/fzf
+- name: kayac/ecspresso
+  registry: standard
+  version: v1.6.2 # renovate: depName=kayac/ecspresso
+- name: knqyf263/pet
+  registry: standard
+  version: v0.3.6 # renovate: depName=knqyf263/pet
+- name: knqyf263/utern
+  registry: standard
+  version: v0.1.2 # renovate: depName=knqyf263/utern
+- name: koalaman/shellcheck
+  registry: standard
+  version: v0.7.2 # renovate: depName=koalaman/shellcheck
+- name: kubectl
+  registry: standard
+  version: v1.22.0 # TODO renovate
+- name: kubernetes-sigs/kind
+  registry: standard
+  version: v0.11.1 # renovate: depName=kubernetes-sigs/kind
+- name: kubernetes-sigs/krew
+  registry: standard
+  version: v0.4.1 # renovate: depName=kubernetes-sigs/krew
+- name: kubernetes-sigs/kustomize
+  registry: standard
+  version: kustomize/v4.3.0 # renovate: depName=kubernetes-sigs/kustomize
+- name: kubernetes/minikube
+  registry: standard
+  version: v1.23.0 # renovate: depName=kubernetes/minikube
+- name: lima-vm/lima
+  registry: standard
+  version: v0.6.3 # renovate: depName=lima-vm/lima
+- name: mattn/goreman
+  registry: standard
+  version: v0.3.7 # renovate: depName=mattn/goreman
+- name: mattn/memo
+  registry: standard
+  version: v0.0.15 # renovate: depName=mattn/memo
+- name: mikefarah/yq
+  registry: standard
+  version: v4.12.2 # renovate: depName=mikefarah/yq
+- name: minamijoyo/hcledit
+  registry: standard
+  version: v0.2.0 # renovate: depName=minamijoyo/hcledit
+- name: minamijoyo/tfmigrate
+  registry: standard
+  version: v0.2.9 # renovate: depName=minamijoyo/tfmigrate
+- name: minamijoyo/tfschema
+  registry: standard
+  version: v0.7.0 # renovate: depName=minamijoyo/tfschema
+- name: minamijoyo/tfupdate
+  registry: standard
+  version: v0.6.1 # renovate: depName=minamijoyo/tfupdate
+- name: mumoshu/variant
+  registry: standard
+  version: v0.37.0 # renovate: depName=mumoshu/variant
+- name: mumoshu/variant2
+  registry: standard
+  version: v0.38.0 # renovate: depName=mumoshu/variant2
+- name: mvdan/gofumpt
+  registry: standard
+  version: v0.1.1 # renovate: depName=mvdan/gofumpt
+- name: mvdan/sh
+  registry: standard
+  version: v3.3.1 # renovate: depName=mvdan/sh
+- name: nektos/act
+  registry: standard
+  version: v0.2.24 # renovate: depName=nektos/act
+- name: open-policy-agent/conftest
+  registry: standard
+  version: v0.27.0 # renovate: depName=open-policy-agent/conftest
+- name: open-policy-agent/opa
+  registry: standard
+  version: v0.32.0 # renovate: depName=open-policy-agent/opa
+- name: peco/peco
+  registry: standard
+  version: v0.5.10 # renovate: depName=peco/peco
+- name: projectdiscovery/nuclei
+  registry: standard
+  version: v2.5.1 # renovate: depName=projectdiscovery/nuclei
+- name: roboll/helmfile
+  registry: standard
+  version: v0.140.0 # renovate: depName=roboll/helmfile
+- name: sahilm/yamldiff
+  registry: standard
+  version: 0.1.0 # renovate: depName=sahilm/yamldiff
+- name: Songmu/ecschedule
+  registry: standard
+  version: v0.3.1 # renovate: depName=Songmu/ecschedule
+- name: Songmu/ghch
+  registry: standard
+  version: v0.10.2 # renovate: depName=Songmu/ghch
+- name: Songmu/ghg
+  registry: standard
+  version: v0.2.0 # renovate: depName=Songmu/ghg
+- name: Songmu/gocredits
+  registry: standard
+  version: v0.2.0 # renovate: depName=Songmu/gocredits
+- name: Songmu/gotesplit
+  registry: standard
+  version: v0.1.2 # renovate: depName=Songmu/gotesplit
+- name: Songmu/goxz
+  registry: standard
+  version: v0.7.0 # renovate: depName=Songmu/goxz
+- name: Songmu/horenso
+  registry: standard
+  version: v0.9.1 # renovate: depName=Songmu/horenso
+- name: stackrox/kube-linter
+  registry: standard
+  version: 0.2.3 # renovate: depName=stackrox/kube-linter
+- name: stedolan/jq
+  registry: standard
+  version: jq-1.6 # renovate: depName=stedolan/jq
+- name: stern/stern
+  registry: standard
+  version: v1.20.1 # renovate: depName=stern/stern
 - name: suzuki-shunsuke/akoi
   registry: standard
   version: v2.2.1 # renovate: depName=suzuki-shunsuke/akoi
+- name: suzuki-shunsuke/aqua-installer
+  registry: standard
+  version: v0.1.3 # renovate: depName=suzuki-shunsuke/aqua-installer
+- name: suzuki-shunsuke/ci-info
+  registry: standard
+  version: v2.0.1 # renovate: depName=suzuki-shunsuke/ci-info
+- name: suzuki-shunsuke/circleci-config-merge
+  registry: standard
+  version: v1.0.0 # renovate: depName=suzuki-shunsuke/circleci-config-merge
+- name: suzuki-shunsuke/cmdx
+  registry: standard
+  version: v1.6.0 # renovate: depName=suzuki-shunsuke/cmdx
+- name: suzuki-shunsuke/git-rm-branch
+  registry: standard
+  version: 1.0.5 # renovate: depName=suzuki-shunsuke/git-rm-branch
+- name: suzuki-shunsuke/github-comment
+  registry: standard
+  version: v3.1.0 # renovate: depName=suzuki-shunsuke/github-comment
+- name: suzuki-shunsuke/matchfile
+  registry: standard
+  version: v1.0.0 # renovate: depName=suzuki-shunsuke/matchfile
+- name: suzuki-shunsuke/tfcmt
+  registry: standard
+  version: v1.1.0 # renovate: depName=suzuki-shunsuke/tfcmt
+- name: tcnksm/ghr
+  registry: standard
+  version: v0.14.0 # renovate: depName=tcnksm/ghr
+- name: terraform-docs/terraform-docs
+  registry: standard
+  version: v0.15.0 # renovate: depName=terraform-docs/terraform-docs
+- name: terraform-linters/tflint
+  registry: standard
+  version: v0.32.1 # renovate: depName=terraform-linters/tflint
+- name: tfmigrator/cli
+  registry: standard
+  version: v0.2.0 # renovate: depName=tfmigrator/cli
+- name: thought-machine/please
+  registry: standard
+  version: v16.7.0 # renovate: depName=thought-machine/please
+- name: tsenart/vegeta
+  registry: standard
+  version: v12.8.4 # renovate: depName=tsenart/vegeta
+- name: vmware-tanzu/ytt
+  registry: standard
+  version: v0.36.0 # renovate: depName=vmware-tanzu/ytt
+- name: weaveworks/eksctl
+  registry: standard
+  version: v0.66.0 # renovate: depName=weaveworks/eksctl
+- name: x-motemen/ghq
+  registry: standard
+  version: v1.2.1 # renovate: depName=x-motemen/ghq
+- name: zricethezav/gitleaks
+  registry: standard
+  version: v7.6.1 # renovate: depName=zricethezav/gitleaks

--- a/registry.yaml
+++ b/registry.yaml
@@ -4,16 +4,18 @@ packages:
   type: github_release
   repo_owner: accurics
   repo_name: terrascan
-  asset: 'terrascan_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'terrascan_{{trimV .Version}}_{{title .OS}}_{{.Arch}}.tar.gz'
   link: https://docs.accurics.com/projects/accurics-terrascan/en/latest/
   description: Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure
   files:
   - name: terrascan
+  replacements:
+    amd64: x86_64
 - name: ahmetb/kubectl-tree
   type: github_release
   repo_owner: ahmetb
   repo_name: kubectl-tree
-  asset: 'kubectl-tree_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'kubectl-tree_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/ahmetb/kubectl-tree
   description: kubectl plugin to browse Kubernetes object hierarchies as a tree
   files:
@@ -22,20 +24,24 @@ packages:
   type: github_release
   repo_owner: ahmetb
   repo_name: kubectx
-  asset: 'kubectx_{{.Package.Version}}_{{.OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'kubectx_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/ahmetb/kubectx
   description: Faster way to switch between clusters and namespaces in kubectl
   files:
   - name: kubectx
+  replacements:
+    amd64: x86_64
 - name: ahmetb/kubens
   type: github_release
   repo_owner: ahmetb
   repo_name: kubectx
-  asset: 'kubens_{{.Package.Version}}_{{.OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'kubens_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/ahmetb/kubectx
   description: Faster way to switch between clusters and namespaces in kubectl
   files:
   - name: kubens
+  replacements:
+    amd64: x86_64
 - name: aquasecurity/tfsec
   type: github_release
   repo_owner: aquasecurity
@@ -45,6 +51,27 @@ packages:
   description: A static analysis security scanner for your Terraform code
   files:
   - name: tfsec
+- name: aquasecurity/trivy
+  type: github_release
+  repo_owner: aquasecurity
+  repo_name: trivy
+  link: https://github.com/aquasecurity/trivy
+  description: Scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues
+  asset: 'trivy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.tar.gz'
+  files:
+  - name: trivy
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    ppc64le: PPC64LE
+    darwin: macOS
+    linux: Linux
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
 - name: argoproj/argo-cd
   type: github_release
   repo_owner: argoproj
@@ -70,26 +97,28 @@ packages:
   type: github_release
   repo_owner: CircleCI-Public
   repo_name: circleci-cli
-  asset: 'circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/CircleCI-Public/circleci-cli
   description: Use CircleCI from the command line
   files:
   - name: circleci
-    src: circleci-cli_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/circleci
+    src: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/circleci
 - name: cli/cli
   type: github_release
   repo_owner: cli
   repo_name: cli
-  asset: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}.tar.gz'
+  asset: 'gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://cli.github.com/
   description: GitHub’s official command line tool
   files:
   - name: gh
-    src: 'gh_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}linux{{end}}_{{.Arch}}/bin/gh'
+    src: 'gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}/bin/gh'
+  replacements:
+    darwin: macOS
 - name: codeclimate/test-reporter
   type: http
   archive_type: raw
-  url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Package.Version}}-{{.OS}}-{{.Arch}}
+  url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Version}}-{{.OS}}-{{.Arch}}
   link: https://github.com/codeclimate/test-reporter
   description: Code Climate Test Reporter
   files:
@@ -110,11 +139,13 @@ packages:
   type: github_release
   repo_owner: dty1er
   repo_name: kubecolor
-  asset: 'kubecolor_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'kubecolor_{{trimV .Version}}_{{title .OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/dty1er/kubecolor
   description: colorizes kubectl output
   files:
   - name: kubecolor
+  replacements:
+    amd64: x86_64
 - name: drone/drone-cli
   type: github_release
   repo_owner: drone
@@ -132,20 +163,20 @@ packages:
   type: github_release
   repo_owner: fatedier
   repo_name: frp
-  asset: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'frp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/fatedier/frp
   description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet
   files:
   - name: frpc
-    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frpc'
+    src: 'frp_{{trimV .Version}}_{{.OS}}_{{.Arch}}/frpc'
   - name: frps
-    src: 'frp_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/frps'
+    src: 'frp_{{trimV .Version}}_{{.OS}}_{{.Arch}}/frps'
 - name: FiloSottile/mkcert
   type: github_release
   repo_owner: FiloSottile
   repo_name: mkcert
   archive_type: raw
-  asset: "mkcert-{{.Package.Version}}-{{.OS}}-{{.Arch}}"
+  asset: "mkcert-{{.Version}}-{{.OS}}-{{.Arch}}"
   link: https://github.com/FiloSottile/mkcert
   description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
   files:
@@ -154,7 +185,7 @@ packages:
   type: github_release
   repo_owner: fluxcd
   repo_name: flux2
-  asset: 'flux_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'flux_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/fluxcd/flux2
   description: Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit
   files:
@@ -163,12 +194,16 @@ packages:
   type: github_release
   repo_owner: fujiwara
   repo_name: lambroll
-  asset: 'lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'lambroll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/fujiwara/lambroll
   description: lambroll is a minimal deployment tool for AWS Lambda
   files:
   - name: lambroll
-    src: lambroll_{{.Package.Version}}_{{.OS}}_{{.Arch}}/lambroll
+    src: lambroll_{{.Version}}_{{.OS}}_{{.Arch}}/lambroll
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 
 # init: g
 - name: go-task/task
@@ -182,7 +217,7 @@ packages:
   - name: task
 - name: golang/go
   type: http
-  url: https://golang.org/dl/go{{.Package.Version}}.{{.OS}}-{{.Arch}}.tar.gz
+  url: https://golang.org/dl/go{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz
   link: https://golang.org/
   description: The Go programming language
   files:
@@ -194,12 +229,12 @@ packages:
   type: github_release
   repo_owner: golangci
   repo_name: golangci-lint
-  asset: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  asset: 'golangci-lint-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   link: https://golangci-lint.run/
   description: Fast linters Runner for Go
   files:
   - name: golangci-lint
-    src: 'golangci-lint-{{trimPrefix "v" .Package.Version}}-{{.OS}}-{{.Arch}}/golangci-lint'
+    src: 'golangci-lint-{{trimV .Version}}-{{.OS}}-{{.Arch}}/golangci-lint'
 - name: golang-migrate/migrate
   type: github_release
   repo_owner: golang-migrate
@@ -232,7 +267,7 @@ packages:
     src: 'terraformer-aws-{{.OS}}-{{.Arch}}'
 - name: GoogleContainerTools/container-diff
   type: http
-  url: 'https://storage.googleapis.com/container-diff/{{.Package.Version}}/container-diff-{{.OS}}-{{.Arch}}'
+  url: 'https://storage.googleapis.com/container-diff/{{.Version}}/container-diff-{{.OS}}-{{.Arch}}'
   link: https://github.com/GoogleContainerTools/container-diff
   description: 'container-diff: Diff your Docker containers'
   files:
@@ -240,7 +275,7 @@ packages:
     src: 'container-diff-{{.OS}}-{{.Arch}}'
 - name: GoogleContainerTools/container-structure-test
   type: http
-  url: 'https://storage.googleapis.com/container-structure-test/{{.Package.Version}}/container-structure-test-{{.OS}}-{{.Arch}}'
+  url: 'https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}'
   link: https://github.com/GoogleContainerTools/container-structure-test
   description: validate the structure of your container images
   files:
@@ -258,7 +293,7 @@ packages:
     src: 'kpt_{{.OS}}_{{.Arch}}'
 - name: GoogleContainerTools/skaffold
   type: http
-  url: 'https://storage.googleapis.com/skaffold/releases/{{.Package.Version}}/skaffold-{{.OS}}-{{.Arch}}'
+  url: 'https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}'
   link: https://skaffold.dev/
   description: Easy and Repeatable Kubernetes Development
   files:
@@ -269,11 +304,13 @@ packages:
   repo_owner: goreleaser
   repo_name: goreleaser
   # https://github.com/goreleaser/goreleaser/blob/5a01a10f9bbc60ab75aff0b2971af75d32436bdf/.goreleaser.yml#L98-L104
-  asset: 'goreleaser_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'goreleaser_{{title .OS}}_{{.Arch}}.tar.gz'
   link: https://goreleaser.com/
   description: Deliver Go binaries as fast and easily as possible
   files:
   - name: goreleaser
+  replacements:
+    amd64: x86_64
 
 # init: h
 - name: hairyhenderson/gomplate
@@ -287,49 +324,49 @@ packages:
   - name: gomplate
 - name: hashicorp/consul
   type: http
-  url: https://releases.hashicorp.com/consul/{{trimPrefix "v" .Package.Version}}/consul_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/consul/{{trimV .Version}}/consul_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.consul.io/
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
   files:
   - name: consul
 - name: hashicorp/nomad
   type: http
-  url: https://releases.hashicorp.com/nomad/{{trimPrefix "v" .Package.Version}}/nomad_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/nomad/{{trimV .Version}}/nomad_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.nomadproject.io/
   description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations
   files:
   - name: nomad
 - name: hashicorp/packer
   type: http
-  url: https://releases.hashicorp.com/packer/{{trimPrefix "v" .Package.Version}}/packer_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/packer/{{trimV .Version}}/packer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.packer.io/
   description: Packer is a tool for creating identical machine images for multiple platforms from a single source configuration
   files:
   - name: packer
 - name: hashicorp/terraform
   type: http
-  url: https://releases.hashicorp.com/terraform/{{trimPrefix "v" .Package.Version}}/terraform_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/terraform/{{trimV .Version}}/terraform_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.terraform.io/
   description: Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned
   files:
   - name: terraform
 - name: hashicorp/vault
   type: http
-  url: https://releases.hashicorp.com/vault/{{trimPrefix "v" .Package.Version}}/vault_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/vault/{{trimV .Version}}/vault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.vaultproject.io/
   description: A tool for secrets management, encryption as a service, and privileged access management
   files:
   - name: vault
 - name: hashicorp/waypoint
   type: http
-  url: https://releases.hashicorp.com/waypoint/{{trimPrefix "v" .Package.Version}}/waypoint_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip
+  url: 'https://releases.hashicorp.com/waypoint/{{trimV .Version}}/waypoint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://www.waypointproject.io/
   description: A tool to build, deploy, and release any application on any platform
   files:
   - name: waypoint
 - name: helm/helm
   type: http
-  url: https://get.helm.sh/helm-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+  url: 'https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   link: https://helm.sh/
   description: The Kubernetes Package Manager
   files:
@@ -339,7 +376,7 @@ packages:
   type: github_release
   repo_owner: homeport
   repo_name: dyff
-  asset: 'dyff_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/homeport/dyff
   description: A diff tool for YAML files, and sometimes JSON
   files:
@@ -368,7 +405,7 @@ packages:
   type: github_release
   repo_owner: int128
   repo_name: yamlpatch
-  asset: 'yamlpatch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'yamlpatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/int128/yamlpatch
   description: Apply JSON Patch to YAML Document preserving positions and comments
   files:
@@ -379,28 +416,35 @@ packages:
   type: github_release
   repo_owner: jonaslu
   repo_name: ain
-  asset: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'ain_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/jonaslu/ain
   description: An HTTP API client for the terminal
   files:
   - name: ain
-    src: 'ain_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}mac_os{{else}}{{.OS}}{{end}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}/ain'
+    src: 'ain_{{trimV .Version}}_{{.OS}}_{{.Arch}}/ain'
+  replacements:
+    darwin: mac_os
+    amd64: x86_64
 - name: junegunn/fzf
   type: github_release
   repo_owner: junegunn
   repo_name: fzf
-  asset: 'fzf-{{.Package.Version}}-{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'fzf-{{.Version}}-{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/junegunn/fzf
   description: A command-line fuzzy finder
   files:
   - name: fzf
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 
 # init: k
 - name: kayac/ecspresso
   type: github_release
   repo_owner: kayac
   repo_name: ecspresso
-  asset: 'ecspresso_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'ecspresso_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/kayac/ecspresso
   description: ecspresso is a deployment tool for Amazon ECS
   files:
@@ -409,7 +453,7 @@ packages:
   type: github_release
   repo_owner: knqyf263
   repo_name: pet
-  asset: 'pet_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz' # TODO support ARM
+  asset: 'pet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz' # TODO support ARM
   link: https://github.com/knqyf263/pet
   description: Simple command-line snippet manager, written in Go
   files:
@@ -418,7 +462,7 @@ packages:
   type: github_release
   repo_owner: knqyf263
   repo_name: utern
-  asset: 'utern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.zip' # TODO support ARM
+  asset: 'utern_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip' # TODO support ARM
   link: https://github.com/knqyf263/utern
   description: Multi group and stream log tailing for AWS CloudWatch Logs
   files:
@@ -427,15 +471,15 @@ packages:
   type: github_release
   repo_owner: koalaman
   repo_name: shellcheck
-  asset: "shellcheck-{{.Package.Version}}.{{.OS}}.x86_64.tar.xz" # TODO fix arch
+  asset: "shellcheck-{{.Version}}.{{.OS}}.x86_64.tar.xz" # TODO fix arch
   link: https://github.com/koalaman/shellcheck
   description: ShellCheck, a static analysis tool for shell scripts
   files:
   - name: shellcheck
-    src: shellcheck-{{.Package.Version}}/shellcheck
+    src: shellcheck-{{.Version}}/shellcheck
 - name: kubectl
   type: http
-  url: https://storage.googleapis.com/kubernetes-release/release/{{.Package.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl
+  url: 'https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl'
   archive_type: raw
   link: https://kubernetes.io/docs/reference/kubectl/overview/
   description: The kubectl command line tool lets you control Kubernetes clusters
@@ -443,7 +487,7 @@ packages:
   - name: kubectl
 - name: kubernetes-sigs/kind
   type: http
-  url: 'https://kind.sigs.k8s.io/dl/{{.Package.Version}}/kind-{{.OS}}-{{.Arch}}'
+  url: 'https://kind.sigs.k8s.io/dl/{{.Version}}/kind-{{.OS}}-{{.Arch}}'
   archive_type: raw
   link: https://kind.sigs.k8s.io/
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
@@ -463,14 +507,14 @@ packages:
   type: github_release
   repo_owner: kubernetes-sigs
   repo_name: kustomize
-  asset: 'kustomize_{{trimPrefix "kustomize/" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/kubernetes-sigs/kustomize
   description: Customization of kubernetes YAML configurations
   files:
   - name: kustomize
 - name: kubernetes/minikube
   type: http
-  url: 'https://storage.googleapis.com/minikube/releases/{{.Package.Version}}/minikube-{{.OS}}-{{.Arch}}'
+  url: 'https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}'
   link: https://minikube.sigs.k8s.io/docs/
   description: Run Kubernetes locally
   files:
@@ -481,36 +525,46 @@ packages:
   type: github_release
   repo_owner: lima-vm
   repo_name: lima
-  asset: 'lima-{{trimPrefix "v" .Package.Version}}-{{title .OS}}-{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'lima-{{trimV .Version}}-{{title .OS}}-{{.Arch}}.tar.gz'
   link: https://github.com/lima-vm/lima
-  description: Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially)
+  description: 'Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially)'
   files:
   - name: lima
     src: bin/lima
   - name: limactl
     src: bin/limactl
+  replacements:
+    amd64: x86_64
 
 # init: m
 - name: mattn/goreman
   type: github_release
   repo_owner: mattn
   repo_name: goreman
-  asset: 'goreman_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'goreman_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/mattn/goreman
   description: foreman clone written in go language
   files:
   - name: goreman
-    src: 'goreman_{{.Package.Version}}_{{.OS}}_{{.Arch}}/goreman'
+    src: 'goreman_{{.Version}}_{{.OS}}_{{.Arch}}/goreman'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: mattn/memo
   type: github_release
   repo_owner: mattn
   repo_name: memo
-  asset: 'memo_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'memo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/mattn/memo
   description: Memo Life For You
   files:
   - name: memo
-    src: 'memo_{{.Package.Version}}_{{.OS}}_{{.Arch}}/memo'
+    src: 'memo_{{.Version}}_{{.OS}}_{{.Arch}}/memo'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: mikefarah/yq
   type: github_release
   repo_owner: mikefarah
@@ -524,7 +578,7 @@ packages:
   type: github_release
   repo_owner: minamijoyo
   repo_name: hcledit
-  asset: 'hcledit_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'hcledit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/minamijoyo/hcledit
   description: A command line editor for HCL
   files:
@@ -533,7 +587,7 @@ packages:
   type: github_release
   repo_owner: minamijoyo
   repo_name: tfmigrate
-  asset: 'tfmigrate_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'tfmigrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/minamijoyo/tfmigrate
   description: A Terraform state migration tool for GitOps
   files:
@@ -542,7 +596,7 @@ packages:
   type: github_release
   repo_owner: minamijoyo
   repo_name: tfschema
-  asset: 'tfschema_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'tfschema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/minamijoyo/tfschema
   description: A schema inspector for Terraform providers
   files:
@@ -551,7 +605,7 @@ packages:
   type: github_release
   repo_owner: minamijoyo
   repo_name: tfupdate
-  asset: 'tfupdate_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'tfupdate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/minamijoyo/tfupdate
   description: Update version constraints in your Terraform configurations
   files:
@@ -560,7 +614,7 @@ packages:
   type: github_release
   repo_owner: mumoshu
   repo_name: variant
-  asset: 'variant_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'variant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/mumoshu/variant
   description: Wrap up your bash scripts into a modern CLI today. Graduate to a full-blown golang app tomorrow
   files:
@@ -569,7 +623,7 @@ packages:
   type: github_release
   repo_owner: mumoshu
   repo_name: variant2
-  asset: 'variant_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'variant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/mumoshu/variant2
   description: Turn your bash scripts into a modern, single-executable CLI app today
   files:
@@ -578,7 +632,7 @@ packages:
   type: github_release
   repo_owner: mvdan
   repo_name: gofumpt
-  asset: 'gofumpt_{{.Package.Version}}_{{.OS}}_{{.Arch}}'
+  asset: 'gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}'
   archive_type: raw
   link: https://github.com/mvdan/gofumpt
   description: A stricter gofmt
@@ -589,7 +643,7 @@ packages:
   repo_owner: mvdan
   repo_name: sh
   archive_type: raw
-  asset: "shfmt_{{.Package.Version}}_{{.OS}}_{{.Arch}}"
+  asset: "shfmt_{{.Version}}_{{.OS}}_{{.Arch}}"
   link: https://github.com/mvdan/sh
   description: A shell parser, formatter, and interpreter with bash support; includes shfmt
   files:
@@ -600,11 +654,13 @@ packages:
   type: github_release
   repo_owner: nektos
   repo_name: act
-  asset: 'act_{{title .OS}}_{{if eq .Arch "amd64"}}x86_64{{else}}{{.Arch}}{{end}}.tar.gz'
+  asset: 'act_{{title .OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/nektos/act
   description: Run your GitHub Actions locally
   files:
   - name: act
+  replacements:
+    amd64: x86_64
 
 # init: o
 - name: open-policy-agent/conftest
@@ -612,7 +668,7 @@ packages:
   repo_owner: open-policy-agent
   repo_name: conftest
   # https://github.com/open-policy-agent/conftest/blob/f68c92599fa8fd1c2e81527aee351064f5419df5/.goreleaser.yml#L21-L31
-  asset: 'conftest_{{trimPrefix "v" .Package.Version}}_{{title .OS}}_x86_64.tar.gz'
+  asset: 'conftest_{{trimV .Version}}_{{title .OS}}_x86_64.tar.gz'
   link: https://www.conftest.dev/
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
   files:
@@ -632,21 +688,27 @@ packages:
   type: github_release
   repo_owner: peco
   repo_name: peco
-  asset: 'peco_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'peco_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/peco/peco
   description: Simplistic interactive filtering tool
   files:
   - name: peco
     src: 'peco_{{.OS}}_{{.Arch}}/peco'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: projectdiscovery/nuclei
   type: github_release
   repo_owner: projectdiscovery
   repo_name: nuclei
-  asset: 'nuclei_{{trimPrefix "v" .Package.Version}}_{{if eq .OS "darwin"}}macOS{{else}}{{.OS}}{{end}}_{{.Arch}}.zip'
+  asset: 'nuclei_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   link: https://nuclei.projectdiscovery.io/
   description: Fast and customizable vulnerability scanner based on simple YAML based DSL
   files:
   - name: nuclei
+  replacements:
+    darwin: macOS
 
 # init: q
 
@@ -668,82 +730,110 @@ packages:
   repo_owner: sahilm
   repo_name: yamldiff
   archive_type: raw
-  asset: 'yamldiff-v{{.Package.Version}}-{{.OS}}-{{.Arch}}'
+  asset: 'yamldiff-v{{.Version}}-{{.OS}}-{{.Arch}}'
   link: https://github.com/sahilm/yamldiff
   description: A CLI tool to diff two YAML files
   files:
   - name: yamldiff
-    src: 'yamldiff-v{{.Package.Version}}-{{.OS}}-{{.Arch}}'
+    src: 'yamldiff-v{{.Version}}-{{.OS}}-{{.Arch}}'
 - name: Songmu/ecschedule
   type: github_release
   repo_owner: Songmu
   repo_name: ecschedule
-  asset: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'ecschedule_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/ecschedule
   description: ecschedule is a tool to manage ECS Scheduled Tasks
   files:
   - name: ecschedule
-    src: 'ecschedule_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ecschedule'
+    src: 'ecschedule_{{.Version}}_{{.OS}}_{{.Arch}}/ecschedule'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/ghch
   type: github_release
   repo_owner: Songmu
   repo_name: ghch
-  asset: 'ghch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'ghch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/ghch
   description: Generate changelog from git history, tags and merged pull requests
   files:
   - name: ghch
-    src: 'ghch_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ghch'
+    src: 'ghch_{{.Version}}_{{.OS}}_{{.Arch}}/ghch'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/ghg
   type: github_release
   repo_owner: Songmu
   repo_name: ghg
-  asset: 'ghg_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'ghg_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/ghg
   description: Get the executable from github releases easily
   files:
   - name: ghg
-    src: 'ghg_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ghg'
+    src: 'ghg_{{.Version}}_{{.OS}}_{{.Arch}}/ghg'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/gocredits
   type: github_release
   repo_owner: Songmu
   repo_name: gocredits
-  asset: 'gocredits_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'gocredits_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/gocredits
   description: creates CREDITS file from LICENSE files of dependencies
   files:
   - name: gocredits
-    src: 'gocredits_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gocredits'
+    src: 'gocredits_{{.Version}}_{{.OS}}_{{.Arch}}/gocredits'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/gotesplit
   type: github_release
   repo_owner: Songmu
   repo_name: gotesplit
-  asset: 'gotesplit_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'gotesplit_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/gotesplit
   description: Splits the testing in Go into a subset and run it. It is useful for the CI environment
   files:
   - name: gotesplit
-    src: 'gotesplit_{{.Package.Version}}_{{.OS}}_{{.Arch}}/gotesplit'
+    src: 'gotesplit_{{.Version}}_{{.OS}}_{{.Arch}}/gotesplit'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/goxz
   type: github_release
   repo_owner: Songmu
   repo_name: goxz
-  asset: 'goxz_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'goxz_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/goxz
   description: Just do cross building and archiving go tools conventionally
   files:
   - name: goxz
-    src: 'goxz_{{.Package.Version}}_{{.OS}}_{{.Arch}}/goxz'
+    src: 'goxz_{{.Version}}_{{.OS}}_{{.Arch}}/goxz'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: Songmu/horenso
   type: github_release
   repo_owner: Songmu
   repo_name: horenso
-  asset: 'horenso_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'horenso_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/Songmu/horenso
   description: Command wrapper for reporting the result. It is useful for cron jobs
   files:
   - name: horenso
-    src: 'horenso_{{.Package.Version}}_{{.OS}}_{{.Arch}}/horenso'
+    src: 'horenso_{{.Version}}_{{.OS}}_{{.Arch}}/horenso'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: stackrox/kube-linter
   type: github_release
   repo_owner: stackrox
@@ -757,34 +847,38 @@ packages:
   type: github_release
   repo_owner: stedolan
   repo_name: jq
-  asset: 'jq-{{if eq .OS "darwin"}}osx-amd64{{else}}{{if eq .OS "linux"}}linux64{{else}}win64.exe{{end}}{{end}}'
+  asset: 'jq-{{.OS}}'
   archive_type: raw
   link: http://stedolan.github.io/jq/
   description: Command-line JSON processor
   files:
   - name: jq
+  replacements:
+    darwin: osx-amd64
+    linux: linux64
+    windows: win64.exe
 - name: stern/stern
   type: github_release
   repo_owner: stern
   repo_name: stern
-  asset: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'stern_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/stern/stern
   description: Multi pod and container log tailing for Kubernetes -- Friendly fork of https://github.com/wercker/stern
   files:
   - name: stern
-    src: 'stern_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}/stern'
+    src: 'stern_{{trimV .Version}}_{{.OS}}_{{.Arch}}/stern'
 - name: suzuki-shunsuke/akoi
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: akoi
-  asset: 'akoi_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'akoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/akoi
   description: binary installer
   files:
   - name: akoi
 - name: suzuki-shunsuke/aqua-installer
   type: http
-  url: "https://raw.githubusercontent.com/suzuki-shunsuke/aqua-installer/{{.Package.Version}}/aqua-installer"
+  url: "https://raw.githubusercontent.com/suzuki-shunsuke/aqua-installer/{{.Version}}/aqua-installer"
   link: https://github.com/suzuki-shunsuke/aqua-installer
   description: Install aqua quickly
   files:
@@ -793,7 +887,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: ci-info
-  asset: 'ci-info_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'ci-info_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/ci-info
   description: CLI tool to get CI related information
   files:
@@ -802,7 +896,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: circleci-config-merge
-  asset: 'circleci-config-merge_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'circleci-config-merge_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/circleci-config-merge
   description: Generate .circleci/config.yml by merging multiple files
   files:
@@ -811,7 +905,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: cmdx
-  asset: 'cmdx_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'cmdx_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/cmdx
   description: Task runner. It provides useful help messages and supports interactive prompts and validation of arguments
   files:
@@ -820,7 +914,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: git-rm-branch
-  asset: 'git-rm-branch_{{.Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'git-rm-branch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/git-rm-branch
   description: cli tool to remove merged branches
   files:
@@ -829,7 +923,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: github-comment
-  asset: 'github-comment_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'github-comment_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/github-comment
   description: CLI to create a GitHub comment
   files:
@@ -838,7 +932,7 @@ packages:
   type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: matchfile
-  asset: 'matchfile_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'matchfile_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/suzuki-shunsuke/matchfile
   description: CLI tool to check file paths are matched to the condition
   files:
@@ -858,17 +952,21 @@ packages:
   type: github_release
   repo_owner: tcnksm
   repo_name: ghr
-  asset: 'ghr_{{.Package.Version}}_{{.OS}}_{{.Arch}}.{{if eq .OS "darwin"}}zip{{else}}tar.gz{{end}}'
+  asset: 'ghr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
   link: https://github.com/tcnksm/ghr
   description: Upload multiple artifacts to GitHub Release in parallel
   files:
   - name: ghr
-    src: 'ghr_{{.Package.Version}}_{{.OS}}_{{.Arch}}/ghr'
+    src: 'ghr_{{.Version}}_{{.OS}}_{{.Arch}}/ghr'
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: darwin
+    archive_type: zip
 - name: terraform-docs/terraform-docs
   type: github_release
   repo_owner: terraform-docs
   repo_name: terraform-docs
-  asset: 'terraform-docs-{{.Package.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  asset: 'terraform-docs-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   link: https://terraform-docs.io/
   description: Generate documentation from Terraform modules in various output formats
   files:
@@ -895,7 +993,7 @@ packages:
   type: github_release
   repo_owner: thought-machine
   repo_name: please
-  asset: 'please_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'please_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://please.build/
   description: High-performance extensible build system for reproducible multi-language builds
   files:
@@ -905,7 +1003,7 @@ packages:
   type: github_release
   repo_owner: tsenart
   repo_name: vegeta
-  asset: 'vegeta_{{trimPrefix "v" .Package.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'vegeta_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   link: https://github.com/tsenart/vegeta
   description: HTTP load testing tool and library. It's over 9000!
   files:


### PR DESCRIPTION
## Breaking Change

aqua >= v0.6.0 is required.

https://github.com/suzuki-shunsuke/aqua/pull/247

`replacements` and `archive_type_overrides` are used.

## Others

#44 Cache `~/.aqua/pkgs` and `~/.aqua/registries` in CI