### PR TITLE
feat: add packages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:
-          version: v0.6.1 # renovate: depName=suzuki-shunsuke/aqua
+          version: v0.6.2 # renovate: depName=suzuki-shunsuke/aqua
       - run: aqua i --test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -34,6 +34,9 @@ packages:
 - name: codeclimate/test-reporter
   registry: standard
   version: 0.10.1 # renovate: depName=codeclimate/test-reporter
+- name: create-go-app/cli
+  registry: standard
+  version: v3.0.1 # renovate: depName=create-go-app/cli
 - name: direnv/direnv
   registry: standard
   version: v2.28.0 # renovate: depName=direnv/direnv
@@ -67,6 +70,9 @@ packages:
 - name: golang-migrate/migrate
   registry: standard
   version: v4.14.1 # renovate: depName=golang-migrate/migrate
+- name: google/ko
+  registry: standard
+  version: v0.8.3 # renovate: depName=google/ko
 - name: GoogleCloudPlatform/terraformer
   registry: standard
   version: 0.8.16 # renovate: depName=GoogleCloudPlatform/terraformer
@@ -125,6 +131,9 @@ packages:
 - name: int128/yamlpatch
   registry: standard
   version: v0.1.1 # renovate: depName=int128/yamlpatch
+- name: iawia002/annie
+  registry: standard
+  version: v0.11.0 # renovate: depName=iawia002/annie
 - name: jonaslu/ain
   registry: standard
   version: v1.1.0 # renovate: depName=jonaslu/ain
@@ -209,6 +218,12 @@ packages:
 - name: projectdiscovery/nuclei
   registry: standard
   version: v2.5.1 # renovate: depName=projectdiscovery/nuclei
+- name: rclone/rclone
+  registry: standard
+  version: v1.56.0 # renovate: depName=rclone/rclone
+- name: restic/restic
+  registry: standard
+  version: v0.12.1 # renovate: depName=restic/restic
 - name: roboll/helmfile
   registry: standard
   version: v0.140.0 # renovate: depName=roboll/helmfile
@@ -284,6 +299,9 @@ packages:
 - name: tfmigrator/cli
   registry: standard
   version: v0.2.0 # renovate: depName=tfmigrator/cli
+- name: TheZoraiz/ascii-image-converter
+  registry: standard
+  version: v1.10.0 # renovate: depName=TheZoraiz/ascii-image-converter
 - name: thought-machine/please
   registry: standard
   version: v16.7.0 # renovate: depName=thought-machine/please

--- a/registry.yaml
+++ b/registry.yaml
@@ -123,6 +123,24 @@ packages:
   description: Code Climate Test Reporter
   files:
   - name: test-reporter
+- name: create-go-app/cli
+  type: github_release
+  repo_owner: create-go-app
+  repo_name: cli
+  asset: 'cgapp_{{.Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
+  link: https://github.com/create-go-app/cli
+  description: Create a new production-ready project with backend, frontend and deploy automation by running one CLI command!
+  files:
+  - name: cgapp
+  replacements:
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    amd64: x86_64
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: windows
+    format: zip
 
 # init: d
 - name: direnv/direnv
@@ -245,6 +263,21 @@ packages:
   files:
   - name: migrate
     src: 'migrate.{{.OS}}-{{.Arch}}'
+- name: google/ko
+  type: github_release
+  repo_owner: google
+  repo_name: ko
+  asset: 'ko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/google/ko
+  description: Build and deploy Go applications on Kubernetes
+  files:
+  - name: ko
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
 - name: GoogleCloudPlatform/terraformer
   link: https://github.com/GoogleCloudPlatform/terraformer
   description: CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
@@ -410,6 +443,30 @@ packages:
   description: Apply JSON Patch to YAML Document preserving positions and comments
   files:
   - name: yamlpatch
+- name: iawia002/annie
+  type: github_release
+  repo_owner: iawia002
+  repo_name: annie
+  asset: 'annie_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.ArchiveType}}'
+  link: https://github.com/iawia002/annie
+  description: Fast and simple video download library and CLI tool written in Go
+  files:
+  - name: annie
+  archive_type: tar.gz
+  archive_type_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    amd64: 64-bit
+    386: 32-bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
 
 # init: j
 - name: jonaslu/ain
@@ -713,6 +770,28 @@ packages:
 # init: q
 
 # init: r
+- name: rclone/rclone
+  type: github_release
+  repo_owner: rclone
+  repo_name: rclone
+  asset: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip'
+  link: https://rclone.org/
+  description: '"rsync for cloud storage" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files'
+  files:
+  - name: rclone
+    src: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}/rclone'
+  replacements:
+    darwin: osx
+- name: restic/restic
+  type: github_release
+  repo_owner: restic
+  repo_name: restic
+  asset: 'restic_{{trimV .Version}}_{{.OS}}_{{.Arch}}.bz2'
+  link: https://restic.net/
+  description: Fast, secure, efficient backup program
+  files:
+  - name: restic
+    src: 'restic_{{trimV .Version}}_{{.OS}}_{{.Arch}}'
 - name: roboll/helmfile
   type: github_release
   repo_owner: roboll
@@ -989,6 +1068,27 @@ packages:
   description: CLI to migrate Terraform Configuration and State
   files:
   - name: tfmigrator
+- name: TheZoraiz/ascii-image-converter
+  type: github_release
+  repo_owner: TheZoraiz
+  repo_name: ascii-image-converter
+  asset: 'ascii-image-converter_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://github.com/TheZoraiz/ascii-image-converter
+  description: A cross-platform command-line tool to convert images into ascii art and print them on the console. Now supports braille art!
+  files:
+  - name: ascii-image-converter
+    src: 'ascii-image-converter_{{.OS}}_{{.Arch}}/ascii-image-converter'
+  archive_type_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    linux: Linux
+    windows: Windows
+    darwin: macOS
+    amd64: amd64_64bit
+    arm64: arm64_64bit
+    386: i386_32bit
+    arm: armv6_32bit
 - name: thought-machine/please
   type: github_release
   repo_owner: thought-machine


### PR DESCRIPTION
## New Packages

* #139 `iawia002/annie`
  * https://github.com/iawia002/annie
  * Fast and simple video download library and CLI tool written in Go
* #138 `TheZoraiz/ascii-image-converter`
  * https://github.com/TheZoraiz/ascii-image-converter
  * A cross-platform command-line tool to convert images into ascii art and print them on the console. Now supports braille art!
* #137 `rclone/rclone`
  * https://rclone.org/
  * https://github.com/rclone/rclone
  * "rsync for cloud storage" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files
* #136 `google/ko`
  * https://github.com/google/ko
  * Build and deploy Go applications on Kubernetes
* #135 `create-go-app/cli`
  * https://github.com/create-go-app/cli
  * Create a new production-ready project with backend, frontend and deploy automation by running one CLI command!
* #134 `restic/restic`
  * https://restic.net/
  * https://github.com/restic/restic
  * Fast, secure, efficient backup program