### PR TITLE
feat: add `int128/kubectl-external-forward`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -181,6 +181,9 @@ packages:
 - name: int128/kubectl-external-forward
   registry: standard
   version: v0.5.0 # renovate: depName=int128/kubectl-external-forward
+- name: int128/kubelogin
+  registry: standard
+  version: v1.25.0 # renovate: depName=int128/kubelogin
 - name: int128/yamlpatch
   registry: standard
   version: v0.1.1 # renovate: depName=int128/yamlpatch

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -175,6 +175,9 @@ packages:
 - name: int128/ghcp
   registry: standard
   version: v1.13.0 # renovate: depName=int128/ghcp
+- name: int128/kauthproxy
+  registry: standard
+  version: v1.1.1 # renovate: depName=int128/kauthproxy
 - name: int128/kubectl-external-forward
   registry: standard
   version: v0.5.0 # renovate: depName=int128/kubectl-external-forward

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -175,6 +175,9 @@ packages:
 - name: int128/ghcp
   registry: standard
   version: v1.13.0 # renovate: depName=int128/ghcp
+- name: int128/kubectl-external-forward
+  registry: standard
+  version: v0.5.0 # renovate: depName=int128/kubectl-external-forward
 - name: int128/yamlpatch
   registry: standard
   version: v0.1.1 # renovate: depName=int128/yamlpatch

--- a/registry.yaml
+++ b/registry.yaml
@@ -472,6 +472,15 @@ packages:
   description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
 - type: github_release
   repo_owner: int128
+  repo_name: kauthproxy
+  asset: "kauthproxy_{{.OS}}_{{.Arch}}.zip"
+  description: Local authentication proxy for Kubernetes Dashboard (kubectl auth-proxy)
+  files:
+  - name: kauthproxy
+  - name: kubectl-auth_proxy
+    src: kauthproxy
+- type: github_release
+  repo_owner: int128
   repo_name: kubectl-external-forward
   asset: "kubectl-external_forward_{{.OS}}_{{.Arch}}.zip"
   description: kubectl plugin to connect to external host via Envoy Proxy in Kubernetes cluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -472,6 +472,13 @@ packages:
   description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
 - type: github_release
   repo_owner: int128
+  repo_name: kubectl-external-forward
+  asset: "kubectl-external_forward_{{.OS}}_{{.Arch}}.zip"
+  description: kubectl plugin to connect to external host via Envoy Proxy in Kubernetes cluster
+  files:
+  - name: kubectl-external_forward
+- type: github_release
+  repo_owner: int128
   repo_name: yamlpatch
   asset: 'yamlpatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Apply JSON Patch to YAML Document preserving positions and comments

--- a/registry.yaml
+++ b/registry.yaml
@@ -488,6 +488,14 @@ packages:
   - name: kubectl-external_forward
 - type: github_release
   repo_owner: int128
+  repo_name: kubelogin
+  asset: 'kubelogin_{{.OS}}_{{.Arch}}.zip'
+  description: kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
+  files:
+  - name: kubectl-oidc_login
+    src: kubelogin
+- type: github_release
+  repo_owner: int128
   repo_name: yamlpatch
   asset: 'yamlpatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Apply JSON Patch to YAML Document preserving positions and comments


### PR DESCRIPTION
Close #195 
Close #194
Close #193

* #195 #196 `int128/kubectl-external-forward`
  * https://github.com/int128/kubectl-external-forward
  * kubectl plugin to connect to external host via Envoy Proxy in Kubernetes cluster
* #194 #196 `int128/kauthproxy`
  * https://github.com/int128/kauthproxy
  * Local authentication proxy for Kubernetes Dashboard (kubectl auth-proxy)
* #193 #196 `int128/kubelogin`
  * https://github.com/int128/kubelogin
  * kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)