### PR TITLE
feat: add `newrelic/newrelic-cli`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -129,6 +129,9 @@ packages:
 - name: grafana/k6
   registry: standard
   version: v0.34.1 # renovate: depName=grafana/k6
+- name: gruntwork-io/terragrunt
+  registry: standard
+  version: v0.32.2 # renovate: depName=gruntwork-io/terragrunt
 
 # init: h
 - name: hairyhenderson/gomplate

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -263,6 +263,9 @@ packages:
 - name: nektos/act
   registry: standard
   version: v0.2.24 # renovate: depName=nektos/act
+- name: newrelic/newrelic-cli
+  registry: standard
+  version: v0.35.1 # renovate: depName=newrelic/newrelic-cli
 
 # init: o
 - name: open-policy-agent/conftest

--- a/registry.yaml
+++ b/registry.yaml
@@ -676,6 +676,24 @@ packages:
   description: Run your GitHub Actions locally
   replacements:
     amd64: x86_64
+- type: github_release
+  repo_owner: newrelic
+  repo_name: newrelic-cli
+  asset: 'newrelic-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: The New Relic Command Line Interface
+  link: https://newrelic.github.io/developer-toolkit/
+  files:
+  - name: newrelic
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 
 # init: o
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -355,6 +355,12 @@ packages:
   format_overrides:
   - goos: darwin
     format: zip
+- type: github_release
+  repo_owner: gruntwork-io
+  repo_name: terragrunt
+  asset: 'terragrunt_{{.OS}}_{{.Arch}}'
+  link: https://terragrunt.gruntwork.io/
+  description: Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules
 
 # init: h
 - type: github_release


### PR DESCRIPTION
* #198 #199 `newrelic/newrelic-cli`
  * https://github.com/newrelic/newrelic-cli
  * https://newrelic.github.io/developer-toolkit/
  * The New Relic Command Line Interface
* #197 #199 `gruntwork-io/terragrunt`
  * https://terragrunt.gruntwork.io/
  * https://github.com/gruntwork-io/terragrunt
  * Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules