### PR TITLE
feat: add `env0/terratag`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -70,6 +70,9 @@ packages:
   version: v1.4.0 # renovate: depName=drone/drone-cli
 
 # init: e
+- name: env0/terratag
+  registry: standard
+  version: v0.1.29 # renovate: depName=env0/terratag
 - name: erroneousboat/slack-term
   registry: standard
   version: v0.5.0 # renovate: depName=erroneousboat/slack-term

--- a/registry.yaml
+++ b/registry.yaml
@@ -194,6 +194,12 @@ packages:
 
 # init: e
 - type: github_release
+  repo_owner: env0
+  repo_name: terratag
+  asset: 'terratag_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://www.terratag.io/
+  description: Terratag is a CLI tool that enables users of Terraform to automatically create and maintain tags across their entire set of AWS, Azure, and GCP resources
+- type: github_release
   repo_owner: erroneousboat
   repo_name: slack-term
   asset: 'slack-term-{{.OS}}-{{.Arch}}'


### PR DESCRIPTION
* #239 `env0/terratag`
  * https://www.terratag.io/
  * https://github.com/env0/terratag
  * Terratag is a CLI tool that enables users of Terraform to automatically create and maintain tags across their entire set of AWS, Azure, and GCP resources