### PR TITLE
feat: add `tinygo-org/tinygo`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -437,6 +437,9 @@ packages:
 - name: thought-machine/please
   registry: standard
   version: v16.9.0 # renovate: depName=thought-machine/please
+- name: tinygo-org/tinygo
+  registry: standard
+  version: v0.20.0 # renovate: depName=tinygo-org/tinygo
 - name: tsenart/vegeta
   registry: standard
   version: v12.8.4 # renovate: depName=tsenart/vegeta

--- a/registry.yaml
+++ b/registry.yaml
@@ -1188,6 +1188,19 @@ packages:
   - name: please
     src: please/please
 - type: github_release
+  repo_owner: tinygo-org
+  repo_name: tinygo
+  asset: 'tinygo{{trimV .Version}}.{{.OS}}-{{.Arch}}.{{.Format}}'
+  link: https://tinygo.org/
+  description: Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - name: tinygo
+    src: tinygo/bin/tinygo
+- type: github_release
   repo_owner: tsenart
   repo_name: vegeta
   asset: 'vegeta_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #249 `tinygo-org/tinygo`
  * https://tinygo.org/
  * https://github.com/tinygo-org/tinygo
  * Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM