### PR TITLE
feat: add `genuinetools/img` and `docker-slim/docker-slim`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -62,6 +62,9 @@ packages:
 - name: direnv/direnv
   registry: standard
   version: v2.28.0 # renovate: depName=direnv/direnv
+- name: docker-slim/docker-slim
+  registry: standard
+  version: 1.37.0 # renovate: depName=docker-slim/docker-slim
 - name: dty1er/kubecolor
   registry: standard
   version: v0.0.20 # renovate: depName=dty1er/kubecolor

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -95,6 +95,9 @@ packages:
   version: v0.11.8 # renovate: depName=fujiwara/lambroll
 
 # init: g
+- name: genuinetools/img
+  registry: standard
+  version: v0.5.11 # renovate: depName=genuinetools/img
 - name: getsentry/sentry-cli
   registry: standard
   version: 1.68.0 # renovate: depName=getsentry/sentry-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -177,6 +177,22 @@ packages:
   asset: 'direnv.{{.OS}}-{{.Arch}}'
   format: raw
   description: unclutter your .profile
+- name: docker-slim/docker-slim
+  type: github_release
+  type: http
+  url: 'https://downloads.dockerslim.com/releases/1.37.0/dist_{{.OS}}{{if ne .Arch "amd64"}}_{{if eq .OS "darwin"}}m1{{else}}{{.Arch}}{{end}}{{end}}.{{.Format}}'
+  replacements:
+    darwin: mac
+  format: tar.gz
+  format_overrides:
+  - goos: darwin
+    format: zip
+  description: "DockerSlim (docker-slim): Don't change anything in your Docker container image and minify it by up to 30x (and for compiled languages even more) making it secure too! (free and open source)"
+  files:
+  - name: docker-slim
+    src: 'dist_{{.OS}}{{if ne .Arch "amd64"}}_{{if eq .OS "darwin"}}m1{{else}}{{.Arch}}{{end}}{{end}}/docker-slim'
+  - name: docker-slim-sensor
+    src: 'dist_{{.OS}}{{if ne .Arch "amd64"}}_{{if eq .OS "darwin"}}m1{{else}}{{.Arch}}{{end}}{{end}}/docker-slim-sensor'
 - type: github_release
   repo_owner: dty1er
   repo_name: kubecolor

--- a/registry.yaml
+++ b/registry.yaml
@@ -251,6 +251,11 @@ packages:
 
 # init: g
 - type: github_release
+  repo_owner: genuinetools
+  repo_name: img
+  asset: 'img-linux-amd64' # img supports only Linux
+  description: Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder
+- type: github_release
   repo_owner: getsentry
   repo_name: sentry-cli
   asset: 'sentry-cli-{{.OS}}-{{.Arch}}'


### PR DESCRIPTION
* #251 `docker-slim/docker-slim`
  * https://github.com/docker-slim/docker-slim
  * https://dockersl.im/
  * DockerSlim (docker-slim): Don't change anything in your Docker container image and minify it by up to 30x (and for compiled languages even more) making it secure too! (free and open source)
* #251 `genuinetools/img`
  * https://github.com/genuinetools/img
  * https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/
  * Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder

Note that `img` only supports Linux.