### PR TITLE
chore: increment the cache key to decreate the size of cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,10 @@ jobs:
           path: |
             ~/.aqua/pkgs
             ~/.aqua/registries
-          key: ${{ runner.os }}-${{ hashFiles('registry.yaml') }}-${{ hashFiles('aqua.yaml') }}
+          key: v1-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-${{ hashFiles('aqua.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('registry.yaml') }}-
-            ${{ runner.os }}-
+            v1-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-
+            v1-${{ runner.os }}-
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:


### PR DESCRIPTION
Compare `Post cache ~/.aqua`

* AS IS
  * https://github.com/suzuki-shunsuke/aqua-registry/runs/3706923017#step:9:3
  * `Cache Size: ~1927 MB (2020930200 B)`
  * `1m31s`
* TO BE
  * https://github.com/suzuki-shunsuke/aqua-registry/runs/3706945012#step:9:3
  * `Cache Size: ~1645 MB (1725306851 B)`
  * `1m5s`

1645 * 100 / 1927 = 85.4%