### PR TITLE
feat: add `swaggo/swag`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -420,6 +420,9 @@ packages:
 - name: suzuki-shunsuke/tfcmt
   registry: standard
   version: v1.1.0 # renovate: depName=suzuki-shunsuke/tfcmt
+- name: swaggo/swag
+  registry: standard
+  version: v1.7.3 # renovate: depName=swaggo/swag
 
 # init: t
 - name: tcnksm/ghr

--- a/registry.yaml
+++ b/registry.yaml
@@ -1142,6 +1142,18 @@ packages:
   repo_name: tfcmt
   asset: 'tfcmt_{{.OS}}_{{.Arch}}.tar.gz'
   description: Fork of mercari/tfnotify
+- type: github_release
+  repo_owner: swaggo
+  repo_name: swag
+  asset: 'swag_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: Automatically generate RESTful API documentation with Swagger 2.0 for Go
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+    arm64: aarch64
 
 # init: t
 - type: github_release


### PR DESCRIPTION
* #262 `swaggo/swag`
  * https://github.com/swaggo/swag
  * Automatically generate RESTful API documentation with Swagger 2.0 for Go