### PR TITLE
feat: add `dhall-lang/dhall-haskell` and `cue-lang/cue`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -54,6 +54,9 @@ packages:
 - name: create-go-app/cli
   registry: standard
   version: v3.1.0 # renovate: depName=create-go-app/cli
+- name: cue-lang/cue
+  registry: standard
+  version: v0.4.0 # renovate: depName=cue-lang/cue
 
 # init: d
 - name: dapr/cli

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -59,6 +59,9 @@ packages:
 - name: dapr/cli
   registry: standard
   version: v1.4.0 # renovate: depName=dapr/cli
+- name: dhall-lang/dhall-haskell
+  registry: standard
+  version: 1.40.1 # renovate: depName=dhall-lang/dhall-haskell
 - name: direnv/direnv
   registry: standard
   version: v2.28.0 # renovate: depName=direnv/direnv

--- a/registry.yaml
+++ b/registry.yaml
@@ -162,6 +162,16 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
+- type: github_release
+  repo_owner: cue-lang
+  repo_name: cue
+  asset: 'cue_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: The new home of the CUE language! Validate and define text-based and dynamic configuration
+  link: https://cuelang.org/
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 
 # init: d
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -172,6 +172,18 @@ packages:
   files:
   - name: dapr
 - type: github_release
+  repo_owner: dhall-lang
+  repo_name: dhall-haskell
+  asset: 'dhall-{{.Version}}-{{.Arch}}-{{.OS}}.tar.bz2'
+  description: Maintainable configuration files
+  link: https://dhall-lang.org/
+  replacements:
+    darwin: macos
+    amd64: x86_64
+  files:
+  - name: dhall
+    src: bin/dhall
+- type: github_release
   repo_owner: direnv
   repo_name: direnv
   asset: 'direnv.{{.OS}}-{{.Arch}}'


### PR DESCRIPTION
* #263 `cue-lang/cue`
  * https://cuelang.org/
  * https://github.com/cue-lang/cue
  * The new home of the CUE language! Validate and define text-based and dynamic configuration
* #263 `dhall-lang/dhall-haskell`
  * https://dhall-lang.org/
  * https://github.com/dhall-lang/dhall-haskell
  * Maintainable configuration files