### PR TITLE
feat: add `datreeio/datree`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -62,6 +62,9 @@ packages:
 - name: dapr/cli
   registry: standard
   version: v1.4.0 # renovate: depName=dapr/cli
+- name: datreeio/datree
+  registry: standard
+  version: 0.13.0 # renovate: depName=datreeio/datree
 - name: dhall-lang/dhall-haskell
   registry: standard
   version: 1.40.1 # renovate: depName=dhall-lang/dhall-haskell

--- a/registry.yaml
+++ b/registry.yaml
@@ -182,6 +182,16 @@ packages:
   files:
   - name: dapr
 - type: github_release
+  repo_owner: datreeio
+  repo_name: datree
+  asset: 'datree-cli_{{.Version}}_{{.OS}}_{{.Arch}}.zip'
+  link: https://datree.io/
+  description: Prevent Kubernetes misconfigurations from reaching production! Datree is a CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    amd64: x86_64
+- type: github_release
   repo_owner: dhall-lang
   repo_name: dhall-haskell
   asset: 'dhall-{{.Version}}-{{.Arch}}-{{.OS}}.tar.bz2'


### PR DESCRIPTION
* #264 `datreeio/datree`
  * https://www.datree.io/
  * https://github.com/datreeio/datree
  * Prevent Kubernetes misconfigurations from reaching production (again 😤 )! Datree is a CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies