### PR TITLE
feat: add `BurntSushi/ripgrep` and `lotabout/skim`, etc

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -34,6 +34,9 @@ packages:
 - name: bcicen/slackcat
   registry: standard
   version: 1.7.3 # renovate: depName=bcicen/slackcat
+- name: BurntSushi/ripgrep
+  registry: standard
+  version: 13.0.0 # renovate: depName=BurntSushi/ripgrep
 
 # init: c
 - name: che-incubator/chectl

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -286,6 +286,9 @@ packages:
 - name: lima-vm/lima
   registry: standard
   version: v0.6.4 # renovate: depName=lima-vm/lima
+- name: lotabout/skim
+  registry: standard
+  version: v0.9.4 # renovate: depName=lotabout/skim
 
 # init: m
 - name: mattn/goreman

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -343,6 +343,9 @@ packages:
 - name: oam-dev/kubevela/kubectl-plugin
   registry: standard
   version: v1.1.1 # renovate: depName=oam-dev/kubevela/kubectl-plugin
+- name: ogham/exa
+  registry: standard
+  version: v0.10.1 # renovate: depName=ogham/exa
 - name: open-policy-agent/conftest
   registry: standard
   version: v0.28.1 # renovate: depName=open-policy-agent/conftest

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -68,6 +68,9 @@ packages:
   version: v0.4.0 # renovate: depName=cue-lang/cue
 
 # init: d
+- name: dandavison/delta
+  registry: standard
+  version: 0.8.3 # renovate: depName=dandavison/delta
 - name: dapr/cli
   registry: standard
   version: v1.4.0 # renovate: depName=dapr/cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -945,6 +945,18 @@ packages:
   - name: kubectl-vela
     src: "{{.OS}}-{{.Arch}}/kubectl-vela"
 - type: github_release
+  repo_owner: ogham
+  repo_name: exa
+  asset: 'exa-{{.OS}}-{{.Version}}.zip'
+  description: "A modern replacement for 'ls'"
+  link: https://the.exa.website/
+  replacements:
+    darwin: macos-x86_64
+    linux: linux-x86_64-musl
+  files:
+  - name: exa
+    src: bin/exa
+- type: github_release
   repo_owner: open-policy-agent
   repo_name: conftest
   # https://github.com/open-policy-agent/conftest/blob/f68c92599fa8fd1c2e81527aee351064f5419df5/.goreleaser.yml#L21-L31

--- a/registry.yaml
+++ b/registry.yaml
@@ -797,6 +797,16 @@ packages:
     src: bin/limactl
   replacements:
     amd64: x86_64
+- type: github_release
+  repo_owner: lotabout
+  repo_name: skim
+  asset: 'skim-{{.Version}}-x86_64-{{.OS}}.tar.gz'
+  description: Fuzzy Finder in rust!
+  replacements:
+    darwin: apple-darwin
+    linux: unknown-linux-musl
+  files:
+  - name: sk
 
 # init: m
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -103,6 +103,21 @@ packages:
   asset: 'slackcat-{{.Version}}-{{.OS}}-{{.Arch}}'
   description: CLI utility to post files and command output to slack
   format: raw
+- type: github_release
+  repo_owner: BurntSushi
+  repo_name: ripgrep
+  asset: 'ripgrep-{{.Version}}-x86_64-{{.OS}}.{{.Format}}'
+  description: ripgrep recursively searches directories for a regex pattern while respecting your gitignore
+  replacements:
+    darwin: apple-darwin
+    linux: unknown-linux-musl
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - name: rg
+    src: 'ripgrep-{{.Version}}-x86_64-{{.OS}}/rg'
 
 # init: c
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -214,6 +214,21 @@ packages:
 
 # init: d
 - type: github_release
+  repo_owner: dandavison
+  repo_name: delta
+  asset: 'delta-{{.Version}}-x86_64-{{.OS}}.{{.Format}}'
+  description: A syntax-highlighting pager for git
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    darwin: apple-darwin
+    linux: unknown-linux-musl
+  files:
+  - name: delta
+    src: 'delta-{{.Version}}-x86_64-{{.OS}}/delta'
+- type: github_release
   repo_owner: dapr
   repo_name: cli
   asset: 'dapr_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
Close #106
Close #176
Close #177
Close #178

* #176 #272 `BurntSushi/ripgrep`
  * https://github.com/BurntSushi/ripgrep
  * ripgrep recursively searches directories for a regex pattern while respecting your gitignore
* #178 #272 `dandavison/delta`
  * https://github.com/dandavison/delta
  * A viewer for git and diff output
* #106 #272 `lotabout/skim`
  * https://github.com/lotabout/skim
  * Fuzzy Finder in rust!
* #177 #272 `ogham/exa`
  * https://github.com/ogham/exa
  * https://the.exa.website/
  * A modern replacement for ‘ls’