### PR TITLE
feat: add `projectdiscovery/subfinder`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -369,6 +369,9 @@ packages:
 - name: projectdiscovery/nuclei
   registry: standard
   version: v2.5.2 # renovate: depName=projectdiscovery/nuclei
+- name: projectdiscovery/subfinder
+  registry: standard
+  version: v2.4.9 # renovate: depName=projectdiscovery/subfinder
 - name: pulumi/pulumi
   registry: standard
   version: v3.13.0 # renovate: depName=pulumi/pulumi

--- a/registry.yaml
+++ b/registry.yaml
@@ -1042,6 +1042,14 @@ packages:
   replacements:
     darwin: macOS
 - type: github_release
+  repo_owner: projectdiscovery
+  repo_name: subfinder
+  asset: 'subfinder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
+  link: https://github.com/projectdiscovery/subfinder
+  description: Subfinder is a subdomain discovery tool that discovers valid subdomains for websites. Designed as a passive framework to be useful for bug bounties and safe for penetration testing
+  replacements:
+    darwin: macOS
+- type: github_release
   repo_owner: pulumi 
   repo_name: pulumi
   asset: 'pulumi-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #274 `projectdiscovery/subfinder`
  * https://github.com/projectdiscovery/subfinder
  * Subfinder is a subdomain discovery tool that discovers valid subdomains for websites. Designed as a passive framework to be useful for bug bounties and safe for penetration testing