### PR TITLE
feat: add `aws/copilot-cl`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -16,6 +16,7 @@ packages:
 - name: argoproj/argo-cd@v2.1.3
 - name: argoproj/argo-rollouts@v1.0.7
 - name: argoproj/argo-workflows@v3.1.13
+- name: aws/copilot-cli@v1.11.0
 
 # init: b
 - name: bcicen/slackcat@1.7.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -109,6 +109,16 @@ packages:
   files:
   - name: argo
     src: 'argo-{{.OS}}-{{.Arch}}'
+- type: github_release
+  repo_owner: aws
+  repo_name: copilot-cli
+  asset: 'copilot_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  link: https://aws.github.io/copilot-cli/
+  description: The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate
+  replacements:
+    darwin: macOS
+  files:
+  - name: copilot
 
 # init: b
 - type: github_release


### PR DESCRIPTION
* #356 `aws/copilot-cl`
  * https://aws.github.io/copilot-cli/
  * https://github.com/aws/copilot-cli
  * The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate