### PR TITLE
feat: add `tfutils/tfenv`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:
-          version: v0.7.5 # renovate: depName=suzuki-shunsuke/aqua
+          version: v0.7.6 # renovate: depName=suzuki-shunsuke/aqua
       - run: aqua i --test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -204,6 +204,7 @@ packages:
 - name: terraform-docs/terraform-docs@v0.16.0
 - name: terraform-linters/tflint@v0.32.1
 - name: tfmigrator/cli@v0.2.0
+- name: tfutils/tfenv@v2.2.2
 - name: TheZoraiz/ascii-image-converter@v1.11.0
 - name: thought-machine/please@v16.11.0
 - name: tinygo-org/tinygo@v0.20.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1417,6 +1417,15 @@ packages:
   description: CLI to migrate Terraform Configuration and State
   files:
   - name: tfmigrator
+- type: github_archive
+  repo_owner: tfutils
+  repo_name: tfenv
+  description: Terraform version manager
+  files:
+  - name: tfenv
+    src: tfenv-{{trimV .Version}}/bin/tfenv
+  - name: terraform
+    src: tfenv-{{trimV .Version}}/bin/terraform
 - type: github_release
   repo_owner: TheZoraiz
   repo_name: ascii-image-converter


### PR DESCRIPTION
* #359 `tfutils/tfenv`
  * https://github.com/tfutils/tfenv
  * Terraform version manager

## Breaking Change

aqua >= v0.7.6 is required.
You only have to upgrade aqua.