### PR TITLE
feat: add `armosec/kubescape`, `fishworks/gofish`, `im2nguyen/rover`, and `jesseduffield/lazygit`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -52,6 +52,7 @@ packages:
 # init: f
 - name: fatedier/frp@v0.37.1
 - name: FiloSottile/mkcert@v1.4.3
+- name: fishworks/gofish@v0.14.0
 - name: fluxcd/flux2@v0.17.2
 - name: fission/fission@1.14.1
 - name: fujiwara/lambroll@v0.11.9

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -109,6 +109,7 @@ packages:
 - name: itchyny/mmv@v0.1.4
 
 # init: j
+- name: jesseduffield/lazygit@v0.29
 - name: jonaslu/ain@v1.1.0
 - name: junegunn/fzf@0.27.2
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -97,6 +97,7 @@ packages:
 
 # init: i
 - name: iawia002/annie@v0.11.0
+- name: im2nguyen/rover@v0.2.2
 - name: incu6us/goimports-reviser@v2.4.4
 - name: instrumenta/kubeval@v0.16.1
 - name: int128/ghcp@v1.13.0

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -16,6 +16,7 @@ packages:
 - name: argoproj/argo-cd@v2.1.3
 - name: argoproj/argo-rollouts@v1.0.7
 - name: argoproj/argo-workflows@v3.1.13
+- name: armosec/kubescape@v1.0.109
 - name: aws/copilot-cli@v1.11.0
 
 # init: b

--- a/registry.yaml
+++ b/registry.yaml
@@ -362,6 +362,14 @@ packages:
   format: raw
   asset: "mkcert-{{.Version}}-{{.OS}}-{{.Arch}}"
   description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
+- name: fishworks/gofish
+  type: http
+  url: 'https://gofi.sh/releases/gofish-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  link: https://gofi.sh/
+  description: GoFish is a cross-platform systems package manager, bringing the ease of use of Homebrew to Linux and Windows
+  files:
+  - name: gofish
+    src: '{{.OS}}-{{.Arch}}/gofish'
 - type: github_release
   repo_owner: fluxcd
   repo_name: flux2

--- a/registry.yaml
+++ b/registry.yaml
@@ -110,6 +110,14 @@ packages:
   - name: argo
     src: 'argo-{{.OS}}-{{.Arch}}'
 - type: github_release
+  repo_owner: armosec
+  repo_name: kubescape
+  asset: 'kubescape-{{.OS}}-latest'
+  replacements:
+    linux: ubuntu
+    darwin: macos
+  description: 'kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA'
+- type: github_release
   repo_owner: aws
   repo_name: copilot-cli
   asset: 'copilot_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -696,6 +696,14 @@ packages:
     netbsd: NetBSD
     freebsd: FreeBSD
 - type: github_release
+  repo_owner: im2nguyen
+  repo_name: rover
+  asset: "rover_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip"
+  description: Interactive Terraform visualization. State and configuration explorer
+  files:
+  - name: rover
+    src: rover_{{.Version}}
+- type: github_release
   repo_owner: incu6us
   repo_name: goimports-reviser
   asset: 'goimports-reviser_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -765,6 +765,21 @@ packages:
 
 # init: j
 - type: github_release
+  repo_owner: jesseduffield
+  repo_name: lazygit
+  asset: 'lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: simple terminal UI for git commands
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: 32-bit
+    amd64: x86_64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: jonaslu
   repo_name: ain
   asset: 'ain_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #380 `armosec/kubescape`
  * https://github.com/armosec/kubescape
  * kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA
* #380 `fishworks/gofish`
  * https://gofi.sh/
  * https://github.com/fishworks/gofish
  * GoFish is a cross-platform systems package manager, bringing the ease of use of Homebrew to Linux and Windows
* #380 `im2nguyen/rover`
  * https://github.com/im2nguyen/rover
  * Interactive Terraform visualization. State and configuration explorer
* #380 `jesseduffield/lazygit`
  * https://github.com/jesseduffield/lazygit
  * simple terminal UI for git commands