### PR TITLE
feat: add `aelsabbahy/goss`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -7,6 +7,8 @@ packages:
 # init: a
 - name: abiosoft/colima@v0.1.10
 - name: accurics/terrascan@v1.11.0
+- name: aelsabbahy/goss@v0.3.16
+- name: aelsabbahy/goss/dgoss@v0.3.16
 - name: ahmetb/kubectl-tree@v0.4.1
 - name: ahmetb/kubectx@v0.9.4
 - name: ahmetb/kubens

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,6 +9,8 @@ packages:
 - name: accurics/terrascan@v1.11.0
 - name: aelsabbahy/goss@v0.3.16
 - name: aelsabbahy/goss/dgoss@v0.3.16
+- name: aelsabbahy/goss/dcgoss@v0.3.16
+- name: aelsabbahy/goss/kgoss@v0.3.16
 - name: ahmetb/kubectl-tree@v0.4.1
 - name: ahmetb/kubectx@v0.9.4
 - name: ahmetb/kubens

--- a/registry.yaml
+++ b/registry.yaml
@@ -25,13 +25,29 @@ packages:
   replacements:
     darwin: alpha-darwin
 - name: aelsabbahy/goss/dgoss
-  type: github_release
+  type: github_content
   repo_owner: aelsabbahy
   repo_name: goss
-  asset: dgoss
-  description: Quick and Easy server testing/validation
+  path: extras/dgoss/dgoss
+  description: dgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker containers
   files:
   - name: dgoss
+- name: aelsabbahy/goss/dcgoss
+  type: github_content
+  repo_owner: aelsabbahy
+  repo_name: goss
+  path: extras/dcgoss/dcgoss
+  description: dcgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker-compose managed containers
+  files:
+  - name: dcgoss
+- name: aelsabbahy/goss/kgoss
+  type: github_content
+  repo_owner: aelsabbahy
+  repo_name: goss
+  path: extras/kgoss/kgoss
+  description: kgoss is a wrapper for goss that aims to bring the simplicity of testing with goss to containers running in pods in Kubernetes
+  files:
+  - name: kgoss
 - type: github_release
   repo_owner: ahmetb
   repo_name: kubectl-tree

--- a/registry.yaml
+++ b/registry.yaml
@@ -18,6 +18,21 @@ packages:
     386: i386
     amd64: x86_64
 - type: github_release
+  repo_owner: aelsabbahy
+  repo_name: goss
+  asset: 'goss-{{.OS}}-{{.Arch}}'
+  description: Quick and Easy server testing/validation
+  replacements:
+    darwin: alpha-darwin
+- name: aelsabbahy/goss/dgoss
+  type: github_release
+  repo_owner: aelsabbahy
+  repo_name: goss
+  asset: dgoss
+  description: Quick and Easy server testing/validation
+  files:
+  - name: dgoss
+- type: github_release
   repo_owner: ahmetb
   repo_name: kubectl-tree
   asset: 'kubectl-tree_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #388 `aelsabbahy/goss`
  * https://github.com/aelsabbahy/goss
  * Quick and Easy server testing/validation
* #388 `aelsabbahy/goss/dgoss`
  * https://github.com/aelsabbahy/goss/tree/master/extras/dgoss
  * dgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker containers
* #388 `aelsabbahy/goss/dcgoss`
  * https://github.com/aelsabbahy/goss/tree/master/extras/dcgoss
  * dcgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker-compose managed containers
* #388 `aelsabbahy/goss/kgoss`
  * https://github.com/aelsabbahy/goss/tree/master/extras/kgoss
  * kgoss is a wrapper for goss that aims to bring the simplicity of testing with goss to containers running in pods in Kubernetes