### PR TITLE
feat: support krew >= v0.4.2

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -919,12 +919,19 @@ packages:
 - type: github_release
   repo_owner: kubernetes-sigs
   repo_name: krew
-  asset: krew.tar.gz
+  asset: krew-{{.OS}}_{{.Arch}}.tar.gz
   link: https://krew.sigs.k8s.io/
   description: Find and install kubectl plugins
   files:
   - name: krew
     src: 'krew-{{.OS}}_{{.Arch}}'
+  version_constraint: 'semver(">= 0.4.2")'
+  version_overrides:
+  - version_constraint: 'semver("< 0.4.2")'
+    asset: krew.tar.gz
+    files:
+    - name: krew
+      src: 'krew-{{.OS}}_{{.Arch}}'
 - type: github_release
   repo_owner: kubernetes-sigs
   repo_name: kubebuilder


### PR DESCRIPTION
The asset name was changed from v0.4.2.

* https://github.com/kubernetes-sigs/krew/releases/tag/v0.4.2
* https://github.com/kubernetes-sigs/krew/releases/tag/v0.4.1