### PR TITLE
feat: support abiosoft/colima >= v0.2.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:
-          version: v0.7.6 # renovate: depName=suzuki-shunsuke/aqua
+          version: v0.7.7-0 # renovate: depName=suzuki-shunsuke/aqua
       - run: aqua i --test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -5,7 +5,7 @@ registries:
 
 packages:
 # init: a
-- name: abiosoft/colima@v0.2.1
+- name: abiosoft/colima@v0.2.2
 - name: accurics/terrascan@v1.11.0
 - name: aelsabbahy/goss@v0.3.16
 - name: aelsabbahy/goss/dgoss@v0.3.16

--- a/registry.yaml
+++ b/registry.yaml
@@ -1,10 +1,15 @@
 packages:
 # init: a
-- type: github_content
+- type: github_release
   repo_owner: abiosoft
   repo_name: colima
-  path: colima
   description: Docker (and Kubernetes) on MacOS with minimal setup
+  asset: "colima-amd64"
+  version_constraint: 'semver(">= 0.2.0")'
+  version_overrides:
+  - version_constraint: 'semver("< 0.2.0")'
+    type: github_content
+    path: colima
 - type: github_release
   repo_owner: accurics
   repo_name: terrascan


### PR DESCRIPTION
BREAKING CHANGE: aqua >= v0.7.7-0 is required

https://github.com/suzuki-shunsuke/aqua/pull/358

---

From v0.2.0, `abiosoft/colima` was written in Go. https://github.com/abiosoft/colima/releases/tag/v0.2.0
And how to install was changed from GitHub Content to GitHub Release.