### PR TITLE
feat: add `awslabs/ssosync`

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -23,6 +23,7 @@ packages:
 - name: armosec/kubescape@v1.0.120
 - name: aws/copilot-cli@v1.11.0
 - name: awslabs/git-secrets@1.3.0
+- name: awslabs/ssosync@v1.0.0-rc.9
 
 # init: b
 - name: bcicen/slackcat@1.7.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -171,6 +171,21 @@ packages:
   repo_name: git-secrets 
   path: git-secrets 
   description: Prevents you from committing secrets and credentials into git repositories
+- type: github_release
+  repo_owner: awslabs
+  repo_name: ssosync
+  asset: 'ssosync_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 
 # init: b
 - type: github_release


### PR DESCRIPTION
* #447 `awslabs/ssosync`
  * https://github.com/awslabs/ssosync
  * Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda