### PR TITLE
chore: increment cache key

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,10 @@ jobs:
           path: |
             ~/.aqua/pkgs
             ~/.aqua/registries
-          key: v1-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-${{ hashFiles('aqua.yaml') }}
+          key: v2-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-${{ hashFiles('aqua.yaml') }}
           restore-keys: |
-            v1-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-
-            v1-${{ runner.os }}-
+            v2-${{ runner.os }}-${{ hashFiles('registry.yaml') }}-
+            v2-${{ runner.os }}-
 
       - uses: suzuki-shunsuke/aqua-installer@main
         with:


### PR DESCRIPTION
* AS IS
  * https://github.com/suzuki-shunsuke/aqua-registry/runs/3945613051#step:3:45
  * Cache Size: ~2622 MB (2748976719 B)
* TO BE
  * https://github.com/suzuki-shunsuke/aqua-registry/pull/466/checks?check_run_id=3945639656#step:9:3
  * Cache Size: ~1929 MB (2022478733 B)