### PR TITLE
feat: support suzuki-shunsuke/cmdx >= v1.6.1

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -210,7 +210,7 @@ packages:
 - name: suzuki-shunsuke/ci-info@v2.0.1
 - name: suzuki-shunsuke/ci-renovate-config-validator@v0.1.0-0
 - name: suzuki-shunsuke/circleci-config-merge@v1.0.0
-- name: suzuki-shunsuke/cmdx@v1.6.0
+- name: suzuki-shunsuke/cmdx@v1.6.1
 - name: suzuki-shunsuke/dd-time@v1.0.0
 - name: suzuki-shunsuke/durl@v1.0.0
 - name: suzuki-shunsuke/git-rm-branch@1.0.5

--- a/registry.yaml
+++ b/registry.yaml
@@ -1530,8 +1530,12 @@ packages:
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: cmdx
-  asset: 'cmdx_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  asset: 'cmdx_{{.OS}}_{{.Arch}}.tar.gz'
   description: Task runner. It provides useful help messages and supports interactive prompts and validation of arguments
+  version_constraint: 'semver(">= 1.6.1")'
+  version_overrides:
+  - version_constraint: 'semver("< 1.6.1")'
+    asset: 'cmdx_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: dd-time


### PR DESCRIPTION
Asset name has been changed from v1.6.1

https://github.com/suzuki-shunsuke/cmdx/releases/tag/v1.6.1