### PR TITLE
feat: add `b4b4r07/git-bump`, `b4b4r07/github-labeler`, `b4b4r07/stein`, and etc

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -28,6 +28,7 @@ packages:
 # init: b
 - name: b4b4r07/git-bump@v0.1.1
 - name: b4b4r07/github-labeler@v0.2.1
+- name: b4b4r07/stein@v0.3.4
 - name: bcicen/slackcat@1.7.3
 - name: BurntSushi/ripgrep@13.0.0
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -26,6 +26,7 @@ packages:
 - name: awslabs/ssosync@v1.0.0-rc.9
 
 # init: b
+- name: b4b4r07/git-bump@v0.1.1
 - name: bcicen/slackcat@1.7.3
 - name: BurntSushi/ripgrep@13.0.0
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -26,6 +26,7 @@ packages:
 - name: awslabs/ssosync@v1.0.0-rc.9
 
 # init: b
+- name: b4b4r07/gist@v1.2.4
 - name: b4b4r07/git-bump@v0.1.1
 - name: b4b4r07/github-labeler@v0.2.1
 - name: b4b4r07/iap_curl@v0.2.0

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -27,6 +27,7 @@ packages:
 
 # init: b
 - name: b4b4r07/git-bump@v0.1.1
+- name: b4b4r07/github-labeler@v0.2.1
 - name: bcicen/slackcat@1.7.3
 - name: BurntSushi/ripgrep@13.0.0
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -28,6 +28,7 @@ packages:
 # init: b
 - name: b4b4r07/git-bump@v0.1.1
 - name: b4b4r07/github-labeler@v0.2.1
+- name: b4b4r07/iap_curl@v0.2.0
 - name: b4b4r07/stein@v0.3.4
 - name: bcicen/slackcat@1.7.3
 - name: BurntSushi/ripgrep@13.0.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -213,6 +213,19 @@ packages:
     386: i386
     amd64: x86_64
 - type: github_release
+  repo_owner: b4b4r07
+  repo_name: stein
+  asset: 'stein_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: A linter for config files with a customizable rule set
+  link: https://babarot.me/stein/
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: bcicen
   repo_name: slackcat
   asset: 'slackcat-{{.Version}}-{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -189,6 +189,18 @@ packages:
 
 # init: b
 - type: github_release
+  repo_owner: b4b4r07
+  repo_name: git-bump
+  asset: 'git-bump_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Bump version (git tag) to next one with semver
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: bcicen
   repo_name: slackcat
   asset: 'slackcat-{{.Version}}-{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -201,6 +201,18 @@ packages:
     386: i386
     amd64: x86_64
 - type: github_release
+  repo_owner: b4b4r07
+  repo_name: github-labeler
+  asset: 'github-labeler_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Declarative way to configure GitHub labels
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: bcicen
   repo_name: slackcat
   asset: 'slackcat-{{.Version}}-{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -214,6 +214,18 @@ packages:
     amd64: x86_64
 - type: github_release
   repo_owner: b4b4r07
+  repo_name: iap_curl
+  asset: 'iap_curl_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: A CLI that is curl wrapper for making HTTP request to IAP-protected app, more easier than curl
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    386: i386
+    amd64: x86_64
+- type: github_release
+  repo_owner: b4b4r07
   repo_name: stein
   asset: 'stein_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: A linter for config files with a customizable rule set

--- a/registry.yaml
+++ b/registry.yaml
@@ -190,6 +190,18 @@ packages:
 # init: b
 - type: github_release
   repo_owner: b4b4r07
+  repo_name: gist
+  asset: 'gist_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: A simple gist editor for CLI
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    386: i386
+    amd64: x86_64
+- type: github_release
+  repo_owner: b4b4r07
   repo_name: git-bump
   asset: 'git-bump_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Bump version (git tag) to next one with semver


### PR DESCRIPTION
* #532 #537 `b4b4r07/gist`
  * https://github.com/b4b4r07/gist
  * A simple gist editor for CLI
* #536 #537 `b4b4r07/git-bump`
  * https://github.com/b4b4r07/git-bump
  * Bump version (git tag) to next one with semver
* #535 #537 `b4b4r07/github-labeler`
  * https://github.com/b4b4r07/github-labeler
  * Declarative way to configure GitHub labels
* #533 #537 `b4b4r07/iap_curl`
  * https://github.com/b4b4r07/iap_curl
  * A CLI that is curl wrapper for making HTTP request to IAP-protected app, more easier than curl
* #534 #537 `b4b4r07/stein`
  * https://github.com/b4b4r07/stein
  * https://babarot.me/stein
  * A linter for config files with a customizable rule set