### PR TITLE
feat: add `corneliusweig/rakkess` and `corneliusweig/rakkess/access-matrix`

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -45,6 +45,8 @@ packages:
 - name: cloudposse/atmos@v1.3.3
 - name: codeclimate/test-reporter@0.10.1
 - name: corneliusweig/ketall@v1.3.8
+- name: corneliusweig/rakkess@v0.5.0
+- name: corneliusweig/rakkess/access-matrix@v0.5.0
 - name: cosmtrek/air@v1.27.3
 - name: crate-ci/typos@v1.2.0
 - name: create-go-app/cli@v3.2.1

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -235,6 +235,7 @@ packages:
 - name: suzuki-shunsuke/matchfile@v1.0.0
 - name: suzuki-shunsuke/tfcmt@v2.0.2
 - name: swaggo/swag@v1.7.4
+- name: sysdiglabs/kube-psp-advisor@v2.0.1
 
 # init: t
 - name: tcnksm/ghr@v0.14.0

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -65,6 +65,7 @@ packages:
 
 # init: e
 - name: earthly/earthly@v0.5.24
+- name: emirozer/kubectl-doctor@0.3.0
 - name: env0/terratag@v0.1.30
 - name: erroneousboat/slack-term@v0.5.0
 

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -204,6 +204,7 @@ packages:
 - name: rclone/rclone@v1.57.0
 - name: restic/restic@v0.12.1
 - name: reviewdog/reviewdog@v0.13.0
+- name: rikatz/kubepug@v1.2.2
 - name: roboll/helmfile@v0.141.0
 - name: robscott/kube-capacity@v0.6.1
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -1735,6 +1735,16 @@ packages:
     386: i386
     amd64: x86_64
     arm64: aarch64
+- type: github_release
+  repo_owner: sysdiglabs
+  repo_name: kube-psp-advisor
+  asset: 'kube-psp-advisor_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: Help building an adaptive and fine-grained pod security policy
+  files:
+  - name: kubectl-advise_psp
+    src: kubectl-advise-psp
+  - name: kube-psp-advisor
+    src: kubectl-advise-psp
 
 # init: t
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -1489,6 +1489,15 @@ packages:
     386: i386
     amd64: x86_64
 - type: github_release
+  repo_owner: rikatz
+  repo_name: kubepug
+  asset: 'kubepug_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Kubernetes PreUpGrade (Checker)
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: roboll
   repo_name: helmfile
   asset: 'helmfile_{{.OS}}_{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -529,6 +529,11 @@ packages:
   link: https://earthly.dev/
   description: Repeatable builds
 - type: github_release
+  repo_owner: emirozer
+  repo_name: kubectl-doctor
+  asset: 'kubectl-doctor_{{.OS}}_{{.Arch}}.zip'
+  description: kubectl cluster triage plugin for k8s - (brew doctor equivalent)
+- type: github_release
   repo_owner: env0
   repo_name: terratag
   asset: 'terratag_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -355,6 +355,23 @@ packages:
   - name: kubectl-get_all
     src: 'ketall-{{.Arch}}-{{.OS}}'
 - type: github_release
+  repo_owner: corneliusweig
+  repo_name: rakkess
+  asset: 'rakkess-{{.Arch}}-{{.OS}}.tar.gz'
+  description: Review Access - kubectl plugin to show an access matrix for k8s server resources
+  files:
+  - name: rakkess
+    src: 'rakkess-{{.Arch}}-{{.OS}}'
+- name: corneliusweig/rakkess/access-matrix
+  type: github_release
+  repo_owner: corneliusweig
+  repo_name: rakkess
+  asset: 'access-matrix-{{.Arch}}-{{.OS}}.tar.gz'
+  description: Review Access - kubectl plugin to show an access matrix for k8s server resources
+  files:
+  - name: kubectl-access_matrix
+    src: 'access-matrix-{{.Arch}}-{{.OS}}'
+- type: github_release
   repo_owner: cosmtrek
   repo_name: air
   asset: 'air_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #589 `corneliusweig/rakkess`, `corneliusweig/rakkess/access-matrix`
  * https://github.com/corneliusweig/rakkess
  * Review Access - kubectl plugin to show an access matrix for k8s server resources
* #589 `emirozer/kubectl-doctor`
  * https://github.com/emirozer/kubectl-doctor
  * kubectl cluster triage plugin for k8s - 🏥 (brew doctor equivalent)
* #589 `rikatz/kubepug`
  * https://github.com/rikatz/kubepug
  * Kubernetes PreUpGrade (Checker)
* #589 `sysdiglabs/kube-psp-advisor`
  * https://github.com/sysdiglabs/kube-psp-advisor
  * Help building an adaptive and fine-grained pod security policy