### PR TITLE
fix: fix `goreleaser/goreleaser` >= v0.182.0 on MacOS X

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -818,11 +818,17 @@ packages:
 - type: github_release
   repo_owner: goreleaser
   repo_name: goreleaser
-  asset: 'goreleaser_{{title .OS}}_{{.Arch}}.tar.gz'
   link: https://goreleaser.com/
   description: Deliver Go binaries as fast and easily as possible
   replacements:
     amd64: x86_64
+  asset: 'goreleaser_{{title .OS}}_{{if eq .GOOS "darwin"}}all{{else}}{{.Arch}}{{end}}.tar.gz'
+  version_constraint: 'semver(">= 0.182.0")'
+  version_overrides:
+  # https://github.com/goreleaser/goreleaser/pull/2572
+  # macOS Universal binaries
+  - version_constraint: 'semver("< 0.182.0")'
+    asset: 'goreleaser_{{title .OS}}_{{.Arch}}.tar.gz'
 - type: github_release
   repo_owner: gotestyourself
   repo_name: gotestsum


### PR DESCRIPTION
Follow up https://github.com/goreleaser/goreleaser/pull/2572