### PR TITLE
feat: add `Trendyol/kink`

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -258,6 +258,7 @@ packages:
 - name: thought-machine/please@v16.14.0
 - name: tinygo-org/tinygo@v0.21.0
 - name: TomWright/dasel@v1.22.1
+- name: Trendyol/kink@v0.1.1
 - name: trufflesecurity/driftwood@v1.0.0
 - name: tsenart/vegeta@v12.8.4
 - name: twpayne/chezmoi@v2.7.5

--- a/registry.yaml
+++ b/registry.yaml
@@ -1948,6 +1948,17 @@ packages:
   link: https://daseldocs.tomwright.me/
   description: Select, put and delete data from JSON, TOML, YAML, XML and CSV files with a single tool. Supports conversion between formats and can be used as a Go package
 - type: github_release
+  repo_owner: Trendyol
+  repo_name: kink
+  asset: 'kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.tar.gz'
+  description: KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: trufflesecurity
   repo_name: driftwood
   asset: 'driftwood_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #709 #712 `Trendyol/kink`
  * https://github.com/Trendyol/kink
  * KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind