### PR TITLE
Revert "fix: support `int128/kauthproxy` >= v1.2.0"

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1036,16 +1036,12 @@ packages:
 - type: github_release
   repo_owner: int128
   repo_name: kauthproxy
+  asset: "kauthproxy_{{.OS}}_{{.Arch}}.zip"
   description: Local authentication proxy for Kubernetes Dashboard (kubectl auth-proxy)
   files:
   - name: kauthproxy
   - name: kubectl-auth_proxy
     src: kauthproxy
-  version_constraint: 'semver(">= 1.2.0")'
-  asset: "kauthproxy-{{.OS}}-{{.Arch}}.zip"
-  version_overrides:
-  - version_constraint: 'semver("< 1.2.0")'
-    asset: "kauthproxy_{{.OS}}_{{.Arch}}.zip"
 - type: github_release
   repo_owner: int128
   repo_name: kubectl-external-forward


### PR DESCRIPTION
This reverts commit 99ff3bd62b9c169c0d59623c24c22094b909953c.

The asset name was changed.