### PR TITLE
feat: add `kvaps/kubectl-node-shell`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 aqua-test.yaml
+aqua.yaml

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -163,6 +163,7 @@ packages:
 - name: kubernetes-sigs/krew@v0.4.2
 - name: kubernetes-sigs/kubebuilder@v3.2.0
 - name: kubernetes-sigs/kustomize@kustomize/v4.3.0
+- name: kvaps/kubectl-node-shell@v1.5.3
 
 # init: l
 - name: lc/gau@v2.0.6

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -213,6 +213,7 @@ packages:
 # init: r
 - name: rancher/cli@v2.4.13
 - name: rclone/rclone@v1.57.0
+- name: replicatedhq/outdated@v0.4.1
 - name: restic/restic@v0.12.1
 - name: reviewdog/reviewdog@v0.13.0
 - name: rikatz/kubepug@v1.3.2

--- a/registry.yaml
+++ b/registry.yaml
@@ -1577,6 +1577,18 @@ packages:
   replacements:
     darwin: osx
 - type: github_release
+  repo_owner: replicatedhq
+  repo_name: outdated
+  asset: 'outdated_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Kubectl plugin to find and report outdated images running in a Kubernetes cluster
+  files:
+  - name: kubectl-outdated
+    src: outdated
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: restic
   repo_name: restic
   asset: 'restic_{{trimV .Version}}_{{.OS}}_{{.Arch}}.bz2'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1231,6 +1231,13 @@ packages:
   repo_name: kustomize
   asset: 'kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Customization of kubernetes YAML configurations
+- type: github_content
+  repo_owner: kvaps
+  repo_name: kubectl-node-shell
+  path: kubectl-node_shell
+  description: Exec into node via kubectl
+  files:
+  - name: kubectl-node_shell
 
 # init: l
 - type: github_release


### PR DESCRIPTION
* #810 `kvaps/kubectl-node-shell`
  * https://github.com/kvaps/kubectl-node-shell
  * Exec into node via kubectl
* #810 `replicatedhq/outdated`
  * https://github.com/replicatedhq/outdated
  * Kubectl plugin to find and report outdated images running in a Kubernetes cluster