### PR TITLE
fix: support `fishworks/gofish` in M1 Mac

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -633,12 +633,12 @@ packages:
   description: vsh - HashiCorp Vault interactive shell and cli tool
 - name: fishworks/gofish
   type: http
-  url: 'https://gofi.sh/releases/gofish-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  url: 'https://gofi.sh/releases/gofish-{{.Version}}-{{.OS}}-{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}.tar.gz'
   link: https://gofi.sh/
   description: GoFish is a cross-platform systems package manager, bringing the ease of use of Homebrew to Linux and Windows
   files:
   - name: gofish
-    src: '{{.OS}}-{{.Arch}}/gofish'
+    src: '{{.OS}}-{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}/gofish'
 - type: github_release
   repo_owner: fission
   repo_name: fission


### PR DESCRIPTION
Close #830