### PR TITLE
chore: udpate issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,3 +2,4 @@ blank_issues_enabled: true
 contact_links:
 - name: Issue of aqua
   url: https://github.com/aquaproj/aqua/issues
+  about: Please report issues about aqua itself


### PR DESCRIPTION
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

Issue Template config doesn't work now.
The attribute `about` may be required.