### PR TITLE
feat: add `loft-sh/devspace`

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -139,6 +139,7 @@ packages:
 - name: iawia002/annie@v0.11.0
 - name: im2nguyen/rover@v0.2.2
 - name: incu6us/goimports-reviser@v2.4.6
+- name: influxdata/influx-cli@v2.2.1
 - name: instrumenta/kubeval@v0.16.1
 - name: int128/ghcp@v1.13.0
 - name: int128/kauthproxy@v1.2.1

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -178,6 +178,7 @@ packages:
 # init: l
 - name: lc/gau@v2.0.6
 - name: lima-vm/lima@v0.7.4
+- name: loft-sh/devspace@v5.17.0
 - name: lotabout/skim@v0.9.4
 
 # init: m

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -69,6 +69,7 @@ packages:
 - name: derailed/k9s@v0.25.8
 - name: dhall-lang/dhall-haskell
   version: 1.40.1 # https://github.com/aquaproj/aqua-registry/issues/805
+- name: digitalocean/doctl@v1.67.0
 - name: direnv/direnv@v2.29.0
 - name: docker-slim/docker-slim@1.37.2
 - name: hidetatz/kubecolor@v0.0.20

--- a/registry.yaml
+++ b/registry.yaml
@@ -580,6 +580,16 @@ packages:
   - name: dhall
     src: bin/dhall
 - type: github_release
+  repo_owner: digitalocean
+  repo_name: doctl
+  asset: 'doctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}'
+  description: The official command line interface for the DigitalOcean API
+  link: https://docs.digitalocean.com/reference/doctl/
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: direnv
   repo_name: direnv
   asset: 'direnv.{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1371,6 +1371,13 @@ packages:
   replacements:
     amd64: x86_64
 - type: github_release
+  repo_owner: loft-sh
+  repo_name: devspace
+  asset: 'devspace-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: DevSpace - The Fastest Developer Tool for Kubernetes ⚡ Automate your deployment workflow with DevSpace and develop software directly inside Kubernetes.
+  link: https://devspace.sh/
+- type: github_release
   repo_owner: lotabout
   repo_name: skim
   asset: 'skim-{{.Version}}-x86_64-{{.OS}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1096,6 +1096,17 @@ packages:
   repo_name: goimports-reviser
   asset: 'goimports-reviser_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: 'Right imports sorting & code formatting tool (goimports alternative)'
+- name: influxdata/influx-cli
+  type: http
+  url: 'https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{trimV .Version}}-{{.OS}}-{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}.{{.Format}}'
+  description: CLI for managing resources in InfluxDB v2
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - name: influx
+    src: 'influxdb2-client-{{trimV .Version}}-{{.OS}}-{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}/influx'
 - type: github_release
   repo_owner: instrumenta
   repo_name: kubeval


### PR DESCRIPTION
* #863 #865 `digitalocean/doctl`
  * https://docs.digitalocean.com/reference/doctl/
  * https://github.com/digitalocean/doctl
  * The official command line interface for the DigitalOcean API
* #863 #865 `influxdata/influx-cli`
  * https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/
  * https://docs.influxdata.com/influxdb/cloud/tools/influx-cli/
  * https://github.com/influxdata/influx-cli
  * CLI for managing resources in InfluxDB v2
* #863 #865 `loft-sh/devspace`
  * https://github.com/loft-sh/devspace
  * https://devspace.sh/
  * DevSpace - The Fastest Developer Tool for Kubernetes ⚡ Automate your deployment workflow with DevSpace and develop software directly inside Kubernetes.