### PR TITLE
feat: add `kastenhq/external-tools/k10multicluster`

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -163,8 +163,10 @@ packages:
 # init: k
 - name: k0sproject/k0s@v1.22.4+k0s.1
 - name: k0sproject/k0sctl@v0.11.4
-- name: kastenhq/external-tools/k10multicluster@4.5.4
-- name: kastenhq/external-tools/k10tools@4.5.4
+- name: kastenhq/external-tools/k10multicluster
+  version: 4.5.4 # renovate: depName=kastenhq/external-tools
+- name: kastenhq/external-tools/k10tools
+  version: 4.5.4 # renovate: depName=kastenhq/external-tools
 - name: kayac/ecspresso@v1.7.1
 - name: knqyf263/pet@v0.4.0
 - name: knqyf263/utern@v0.1.5

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -237,6 +237,7 @@ packages:
 
 # init: r
 - name: rancher/cli@v2.4.13
+- name: rancher/k3d@v5.2.0
 - name: rclone/rclone@v1.57.0
 - name: replicatedhq/outdated@v0.4.1
 - name: restic/restic@v0.12.1

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -164,6 +164,7 @@ packages:
 - name: k0sproject/k0s@v1.22.4+k0s.1
 - name: k0sproject/k0sctl@v0.11.4
 - name: kastenhq/external-tools/k10multicluster@4.5.4
+- name: kastenhq/external-tools/k10tools@4.5.4
 - name: kayac/ecspresso@v1.7.1
 - name: knqyf263/pet@v0.4.0
 - name: knqyf263/utern@v0.1.5

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -163,6 +163,7 @@ packages:
 # init: k
 - name: k0sproject/k0s@v1.22.4+k0s.1
 - name: k0sproject/k0sctl@v0.11.4
+- name: kastenhq/external-tools/k10multicluster@4.5.4
 - name: kayac/ecspresso@v1.7.1
 - name: knqyf263/pet@v0.4.0
 - name: knqyf263/utern@v0.1.5

--- a/registry.yaml
+++ b/registry.yaml
@@ -1281,6 +1281,16 @@ packages:
   replacements:
     amd64: x64
     windows: win
+- name: kastenhq/external-tools/k10multicluster
+  type: github_release
+  repo_owner: kastenhq
+  repo_name: external-tools
+  asset: 'k10multicluster_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: The k10multicluster tool is used to setup and maintain a multi-cluster setup within K10
+  replacements:
+    darwin: macOS
+  files:
+  - name: k10multicluster
 - type: github_release
   repo_owner: kayac
   repo_name: ecspresso

--- a/registry.yaml
+++ b/registry.yaml
@@ -1804,6 +1804,13 @@ packages:
   - name: rancher
     src: rancher-{{.Version}}/rancher
 - type: github_release
+  repo_owner: rancher
+  repo_name: k3d
+  asset: 'k3d-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: Little helper to run Rancher Lab's k3s in Docker
+  link: https://k3d.io/
+- type: github_release
   repo_owner: rclone
   repo_name: rclone
   asset: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1291,6 +1291,16 @@ packages:
     darwin: macOS
   files:
   - name: k10multicluster
+- name: kastenhq/external-tools/k10tools
+  type: github_release
+  repo_owner: kastenhq
+  repo_name: external-tools
+  asset: 'k10tools_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: "The k10tools binary has commands that can help with validating if a cluster is setup correctly before installing K10 and for debugging K10's micro services"
+  replacements:
+    darwin: macOS
+  files:
+  - name: k10tools
 - type: github_release
   repo_owner: kayac
   repo_name: ecspresso


### PR DESCRIPTION
* #863 #871 `kastenhq/external-tools/k10multicluster`
  * https://github.com/kastenhq/external-tools
  * https://docs.kasten.io/latest/multicluster/k10multicluster.html
  * The k10multicluster tool is used to setup and maintain a multi-cluster setup within K10
* #863 #871 `kastenhq/external-tools/k10tools`
  * https://github.com/kastenhq/external-tools
  * https://docs.kasten.io/latest/operating/k10tools.html
  * The k10tools binary has commands that can help with validating if a cluster is setup correctly before installing K10 and for debugging K10's micro services
* #863 #871 `rancher/k3d`
  * https://k3d.io/
  * https://github.com/rancher/k3d
  * Little helper to run Rancher Lab's k3s in Docker