### PR TITLE
feat: add `kanisterio/kanister`

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -163,6 +163,7 @@ packages:
 # init: k
 - name: k0sproject/k0s@v1.22.4+k0s.1
 - name: k0sproject/k0sctl@v0.11.4
+- name: kanisterio/kanister@0.70.0
 - name: kastenhq/external-tools/k10multicluster
   version: 4.5.4 # renovate: depName=kastenhq/external-tools
 - name: kastenhq/external-tools/k10tools

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -239,6 +239,7 @@ packages:
 # init: r
 - name: rancher/cli@v2.4.13
 - name: rancher/k3d@v5.2.0
+- name: rancher/kim@v0.1.0-beta.7
 - name: rclone/rclone@v1.57.0
 - name: replicatedhq/outdated@v0.4.1
 - name: restic/restic@v0.12.1

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -261,6 +261,7 @@ packages:
 - name: Songmu/gotesplit@v0.1.2
 - name: Songmu/goxz@v0.7.0
 - name: Songmu/horenso@v0.9.1
+- name: squat/kilo@0.3.1
 - name: stackrox/kube-linter@0.2.5
 - name: stedolan/jq@jq-1.6
 - name: stern/stern@v1.20.1

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -19,6 +19,7 @@ packages:
 - name: alexellis/arkade@0.8.11
 - name: antonmedv/fx@20.0.2
 - name: aquaproj/aqua-installer@v0.3.0
+- name: aquasecurity/kube-bench@v0.6.5
 - name: aquasecurity/kubectl-who-can@v0.3.0
 - name: aquasecurity/tfsec@v0.61.3
 - name: aquasecurity/trivy@v0.21.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -121,6 +121,12 @@ packages:
   description: Install aqua quickly
 - type: github_release
   repo_owner: aquasecurity
+  repo_name: kube-bench
+  # Support only Linux
+  asset: "kube-bench_{{trimV .Version}}_linux_{{.Arch}}.tar.gz"
+  description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
+- type: github_release
+  repo_owner: aquasecurity
   repo_name: kubectl-who-can
   asset: "kubectl-who-can_{{.OS}}_x86_64.{{.Format}}"
   description: Show who has RBAC permissions to perform actions on different resources in Kubernetes

--- a/registry.yaml
+++ b/registry.yaml
@@ -1281,6 +1281,13 @@ packages:
   replacements:
     amd64: x64
     windows: win
+- type: github_release
+  repo_owner: kanisterio
+  repo_name: kanister
+  asset: 'kanister_{{trimV .Version}}_{{.OS}}_{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}.tar.gz'
+  description: An extensible framework for application-level data management on Kubernetes
+  files:
+  - name: kanctl
 - name: kastenhq/external-tools/k10multicluster
   type: github_release
   repo_owner: kastenhq

--- a/registry.yaml
+++ b/registry.yaml
@@ -1600,7 +1600,7 @@ packages:
 - type: github_release
   repo_owner: neovim
   repo_name: neovim
-  asset: 'nvim-{{ .OS }}.tar.gz'
+  asset: 'nvim-{{.OS}}.tar.gz'
   description: Hyperextensible Vim-based text editor
   link: https://neovim.io/
   replacements:
@@ -1608,7 +1608,7 @@ packages:
     darwin: macos
   files:
   - name: nvim
-    src: 'nvim-{{ if eq .GOOS "darwin" }}osx64{{ else }}{{ .OS }}{{ end }}/bin/nvim'
+    src: 'nvim-{{if eq .GOOS "darwin"}}osx64{{else}}{{.OS}}{{end}}/bin/nvim'
 - type: github_release
   repo_owner: newrelic
   repo_name: newrelic-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -1818,6 +1818,12 @@ packages:
   description: Little helper to run Rancher Lab's k3s in Docker
   link: https://k3d.io/
 - type: github_release
+  repo_owner: rancher
+  repo_name: kim
+  asset: 'kim-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: In ur kubernetes, buildin ur imagez
+- type: github_release
   repo_owner: rclone
   repo_name: rclone
   asset: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip'

--- a/registry.yaml
+++ b/registry.yaml
@@ -2058,6 +2058,16 @@ packages:
   format_overrides:
   - goos: darwin
     format: zip
+
+- type: github_release
+  repo_owner: squat
+  repo_name: kilo
+  asset: 'kgctl-{{.OS}}-{{.Arch}}'
+  link: https://kilo.squat.ai/docs/kgctl
+  description: 'kgctl - Manage a Kilo network. Kilo is a multi-cloud network overlay built on WireGuard and designed for Kubernetes (k8s + wg = kg)'
+  format: raw
+  files:
+  - name: kgctl
 - type: github_release
   repo_owner: stackrox
   repo_name: kube-linter


### PR DESCRIPTION
* #863 #873 `aquasecurity/kube-bench`
  * https://github.com/aquasecurity/kube-bench
  * Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark
* #863 #873 `kanisterio/kanister`
  * https://github.com/kanisterio/kanister
  * An extensible framework for application-level data management on Kubernetes
  * commands
    * kanctl
* #863 #873 `rancher/kim`
  * https://github.com/rancher/kim
  * In ur kubernetes, buildin ur imagez
* #863 #873 `squat/kilo`
  * https://github.com/squat/kilo
  * https://kilo.squat.ai/docs/kgctl
  * kgctl - Manage a Kilo network. Kilo is a multi-cloud network overlay built on WireGuard and designed for Kubernetes (k8s + wg = kg)