### PR TITLE
ci: support testing only specific packages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,20 @@ jobs:
       - uses: aquaproj/aqua-installer@main
         with:
           version: v0.8.0 # renovate: depName=aquaproj/aqua
-      - run: aqua -c aqua-all.yaml i --test
+
+      - name: test (pull request)
+        run: |
+          if [ -f "$PR_FILE" ]; then
+            echo "[INFO] + aqua -c $PR_FILE i --test" >&2
+            aqua -c "$PR_FILE" i --test
+            exit 0
+          fi
+          echo "[INFO] test all packages, because $PR_FILE isn't found" >&2
+          aqua -c aqua-all.yaml i --test
+        if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_FILE: "prs/${{ github.event.number }}.yaml"
+
+      - name: test all packages (push)
+        run: aqua -c aqua-all.yaml i --test
+        if: github.event_name == 'push'

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -4,6 +4,7 @@ registries:
   path: registry.yaml
 
 packages:
+- import: "prs/*.yaml"
 # init: a
 - name: abiosoft/colima@v0.2.2
 - name: abs-lang/abs@2.5.1


### PR DESCRIPTION
## Problem to solve

Currently, every time all packages are installed in CI for testing.
It takes a long time.

So in this pull request, I add the support to test only specific packages.

## How to use

Instead of adding test data in `aqua-all.yaml`, add the test data to `prs/<pr number>.yaml`.

```yaml
packages:
- "<tested package>@<version>"
# ...
```

If the file `prs/<pr number>.yaml` exists, only packages in the file are installed.