### PR TITLE
feat: add `containerd/nerdctl`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: install ci-info
         run: aqua -c aqua-ci.yaml i --test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run ci-info and update environment variables
         run: ci-info run | sed -E "s/^export //" >> $GITHUB_ENV
@@ -56,3 +58,5 @@ jobs:
           fi
           echo "[INFO] test all packages" >&2
           aqua -c aqua-all.yaml i --test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/registry.yaml
+++ b/registry.yaml
@@ -433,6 +433,13 @@ packages:
   files:
   - name: test-reporter
 - type: github_release
+  repo_owner: containerd
+  repo_name: nerdctl
+  asset: 'nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  description: 'contaiNERD CTL - Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...'
+  replacements:
+    darwin: linux # nerdctl doesn't support macOS
+- type: github_release
   repo_owner: corneliusweig
   repo_name: ketall
   asset: 'ketall-{{.Arch}}-{{.OS}}.tar.gz'

--- a/tests/c.yaml
+++ b/tests/c.yaml
@@ -9,6 +9,7 @@ packages:
 - name: cloudposse/atmos@v1.3.9
 - name: cnrancher/autok3s@v0.4.5
 - name: codeclimate/test-reporter@0.10.1
+- name: containerd/nerdctl@v0.14.0
 - name: corneliusweig/ketall@v1.3.8
 - name: corneliusweig/rakkess@v0.5.0
 - name: corneliusweig/rakkess/access-matrix@v0.5.0


### PR DESCRIPTION
* #863 #882 #1233 `containerd/nerdctl`
  * https://github.com/containerd/nerdctl
  * contaiNERD CTL - Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...