### PR TITLE
feat: add `loft-sh/vcluster`

### DIFF
--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -3,4 +3,5 @@ packages:
 - name: lc/gau@v2.0.6
 - name: lima-vm/lima@v0.7.4
 - name: loft-sh/devspace@v5.17.0
+- name: loft-sh/vcluster@v0.4.5
 - name: lotabout/skim@v0.9.4

--- a/registry.yaml
+++ b/registry.yaml
@@ -1577,6 +1577,13 @@ packages:
   description: DevSpace - The Fastest Developer Tool for Kubernetes ⚡ Automate your deployment workflow with DevSpace and develop software directly inside Kubernetes.
   link: https://devspace.sh/
 - type: github_release
+  repo_owner: loft-sh
+  repo_name: vcluster
+  asset: 'vcluster-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: vcluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces
+  link: https://www.vcluster.com/
+- type: github_release
   repo_owner: lotabout
   repo_name: skim
   asset: 'skim-{{.Version}}-x86_64-{{.OS}}.tar.gz'


### PR DESCRIPTION
Close #1205 

* #858 #1205 #1282 `loft-sh/vcluster`
  * https://github.com/loft-sh/vcluster
  * https://www.vcluster.com/
  * vcluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces