### PR TITLE
feat: add `talos-systems/talos`

### DIFF
--- a/pkgs/t.yaml
+++ b/pkgs/t.yaml
@@ -1,5 +1,6 @@
 packages:
 # init: t
+- name: talos-systems/talos@v0.13.4
 - name: tcnksm/ghr@v0.14.0
 - name: tektoncd/cli@v0.21.0
 - name: telepresenceio/telepresence@v2.4.2

--- a/registry.yaml
+++ b/registry.yaml
@@ -2382,6 +2382,14 @@ packages:
 
 # init: t
 - type: github_release
+  repo_owner: talos-systems
+  repo_name: talos
+  asset: 'talosctl-{{.OS}}-{{.Arch}}'
+  description: Talos is a modern OS for Kubernetes. talosctl is a CLI for out-of-band management of Kubernetes nodes created by Talos
+  files:
+  - name: talosctl
+  format: raw
+- type: github_release
   repo_owner: tcnksm
   repo_name: ghr
   asset: 'ghr_{{.Version}}_{{.OS}}_amd64.{{.Format}}'


### PR DESCRIPTION
Close #1191 

* #858 #1191 #1294 `talos-systems/talos`
  * https://www.talos.dev/
  * https://github.com/talos-systems/talos
  * Talos is a modern OS for Kubernetes. talosctl is a CLI for out-of-band management of Kubernetes nodes created by Talos