### PR TITLE
feat: add `Versent/saml2aws`

### DIFF
--- a/pkgs/v.yaml
+++ b/pkgs/v.yaml
@@ -1,6 +1,7 @@
 packages:
 # init: v
 - name: variantdev/vals@v0.14.0
+- name: Versent/saml2aws@v2.33.0
 - name: vmware-tanzu/carvel-vendir@v0.23.0
 - name: vmware-tanzu/carvel-ytt@v0.38.0
 - name: vmware-tanzu/velero@v1.7.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -2665,6 +2665,16 @@ packages:
   asset: "vals_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
   description: Helm-like configuration values loader with support for various sources
 - type: github_release
+  repo_owner: Versent
+  repo_name: saml2aws
+  rosetta2: true
+  asset: "saml2aws_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+  description: CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: vmware-tanzu
   repo_name: carvel-vendir
   rosetta2: true


### PR DESCRIPTION
Close #1154 

* #858 #1154 #1310 `Versent/saml2aws`
  * https://github.com/Versent/saml2aws
  * CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP