### PR TITLE
feat: add `rancher/rke`

### DIFF
--- a/pkgs/r.yaml
+++ b/pkgs/r.yaml
@@ -3,6 +3,7 @@ packages:
 - name: rancher/cli@v2.4.13
 - name: rancher/k3d@v5.2.1
 - name: rancher/kim@v0.1.0-beta.7
+- name: rancher/rke@v1.3.2
 - name: rclone/rclone@v1.57.0
 - name: replicatedhq/outdated@v0.4.1
 - name: restic/restic@v0.12.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -2037,6 +2037,14 @@ packages:
   format: raw
   description: In ur kubernetes, buildin ur imagez
 - type: github_release
+  repo_owner: rancher
+  repo_name: rke
+  asset: 'rke_{{.OS}}-{{.Arch}}'
+  rosetta2: true
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  format: raw
+  description: Rancher Kubernetes Engine (RKE), an extremely simple, lightning fast Kubernetes distribution that runs entirely within containers
+- type: github_release
   repo_owner: rclone
   repo_name: rclone
   asset: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip'


### PR DESCRIPTION
Close #1150 

* #858 #1150 #1311 `rancher/rke`
  * https://github.com/rancher/rke
  * Rancher Kubernetes Engine (RKE), an extremely simple, lightning fast Kubernetes distribution that runs entirely within containers