### PR TITLE
feat: add `FairwindsOps/rbac-lookup`

### DIFF
--- a/pkgs/f.yaml
+++ b/pkgs/f.yaml
@@ -2,6 +2,7 @@ packages:
 # init: f
 - name: FairwindsOps/nova@2.3.4
 - name: FairwindsOps/polaris@4.2.0
+- name: FairwindsOps/rbac-lookup@v0.7.1
 - name: fatedier/frp@v0.38.0
 - name: FiloSottile/age@v1.0.0
 - name: FiloSottile/mkcert@v1.4.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -736,6 +736,17 @@ packages:
   asset: 'polaris_{{.OS}}_{{.Arch}}.tar.gz'
   description: Validation of best practices in your Kubernetes clusters
 - type: github_release
+  repo_owner: FairwindsOps
+  repo_name: rbac-lookup
+  asset: 'rbac-lookup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: Easily find roles and cluster roles attached to any user, service account, or group name in your Kubernetes cluster
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: fatedier
   repo_name: frp
   asset: 'frp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
Close #1141 

* #858 #1141 #1314 `FairwindsOps/rbac-lookup`
  * https://github.com/FairwindsOps/rbac-lookup
  * Easily find roles and cluster roles attached to any user, service account, or group name in your Kubernetes cluster