### PR TITLE
feat: add `gruntwork-io/kubergrunt`

### DIFF
--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -29,5 +29,6 @@ packages:
 - name: gotestyourself/gotestsum@v1.7.0
 - name: grafana/k6@v0.35.0
 - name: grafana/tanka@v0.19.0
+- name: gruntwork-io/kubergrunt@v0.7.11
 - name: gruntwork-io/terragrunt@v0.35.14
 - name: gsamokovarov/jump@v0.40.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1108,6 +1108,12 @@ packages:
   - name: tk
 - type: github_release
   repo_owner: gruntwork-io
+  repo_name: kubergrunt
+  asset: 'kubergrunt_{{.OS}}_{{.Arch}}'
+  format: raw
+  description: Kubergrunt is a standalone go binary with a collection of commands to fill in the gaps between Terraform, Helm, and Kubectl
+- type: github_release
+  repo_owner: gruntwork-io
   repo_name: terragrunt
   asset: 'terragrunt_{{.OS}}_{{.Arch}}'
   link: https://terragrunt.gruntwork.io/


### PR DESCRIPTION
Close #1072 

* #858 #1072 #1331 `gruntwork-io/kubergrunt`
  * https://github.com/gruntwork-io/kubergrunt
  * Kubergrunt is a standalone go binary with a collection of commands to fill in the gaps between Terraform, Helm, and Kubectl