### PR TITLE
feat: add `kubemq-io/kubemqctl`

### DIFF
--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -16,6 +16,7 @@ packages:
 - name: golangci/golangci-lint@v1.43.0
 - name: golang-migrate/migrate@v4.15.1
 - name: google/go-containerregistry@v0.7.0
+- name: google/jsonnet@v0.17.0
 - name: google/ko@v0.9.3
 - name: GoogleCloudPlatform/terraformer@0.8.17
 # comment out because this conflict with `GoogleCloudPlatform/terraformer`

--- a/pkgs/j.yaml
+++ b/pkgs/j.yaml
@@ -8,5 +8,6 @@ packages:
 - name: jreleaser/jreleaser@v0.9.1
 - name: jreleaser/jreleaser/standalone
   version: v0.9.1 # renovate: depName=jreleaser/jreleaser
+- name: jsonnet-bundler/jsonnet-bundler@v0.4.0
 - name: juliosueiras/terraform-lsp@v0.0.12
 - name: junegunn/fzf@0.28.0

--- a/pkgs/k.yaml
+++ b/pkgs/k.yaml
@@ -9,6 +9,7 @@ packages:
   version: 4.5.5 # renovate: depName=kastenhq/external-tools
 - name: kastenhq/kubestr@v0.4.31
 - name: kayac/ecspresso@v1.7.2
+- name: knative/client@knative-v1.0.0
 - name: knqyf263/pet@v0.4.0
 - name: knqyf263/utern@v0.1.5
 - name: koalaman/shellcheck@v0.8.0

--- a/pkgs/k.yaml
+++ b/pkgs/k.yaml
@@ -13,6 +13,7 @@ packages:
 - name: knqyf263/utern@v0.1.5
 - name: koalaman/shellcheck@v0.8.0
 - name: ktr0731/evans@0.10.0
+- name: kubemq-io/kubemqctl@v3.5.1
 - name: kubernetes/kompose@v1.25
 - name: kubernetes/kops@v1.22.2
 - name: kubernetes/kubectl

--- a/pkgs/k.yaml
+++ b/pkgs/k.yaml
@@ -23,6 +23,7 @@ packages:
 - name: kubernetes-sigs/kind@v0.11.1
 - name: kubernetes-sigs/krew@v0.4.2
 - name: kubernetes-sigs/kubebuilder@v3.2.0
+- name: kubernetes-sigs/kubefed@v0.9.0
 - name: kubernetes-sigs/kustomize@kustomize/v4.3.0
 - name: kudobuilder/kuttl@v0.11.1
 - name: kvaps/kubectl-node-shell@v1.5.3

--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -1,5 +1,6 @@
 packages:
 # init: l
+- name: Ladicle/kubectl-rolesum@v1.5.1
 - name: lc/gau@v2.0.6
 - name: lima-vm/lima@v0.7.4
 - name: loft-sh/devspace@v5.17.0

--- a/pkgs/p.yaml
+++ b/pkgs/p.yaml
@@ -1,5 +1,6 @@
 packages:
 # init: p
+- name: particledecay/kconf@v1.11.0
 - name: peco/peco@v0.5.10
 - name: Peltoche/lsd@0.20.1
 - name: pglet/pglet@v0.4.6

--- a/pkgs/v.yaml
+++ b/pkgs/v.yaml
@@ -3,6 +3,7 @@ packages:
 - name: variantdev/vals@v0.14.0
 - name: vektra/mockery@v2.9.4
 - name: Versent/saml2aws@v2.33.0
+- name: vmware-tanzu/carvel-kapp@v0.43.0
 - name: vmware-tanzu/carvel-kbld@v0.31.0
 - name: vmware-tanzu/carvel-kwt@v0.0.6
 - name: vmware-tanzu/carvel-vendir@v0.23.0

--- a/pkgs/v.yaml
+++ b/pkgs/v.yaml
@@ -3,6 +3,7 @@ packages:
 - name: variantdev/vals@v0.14.0
 - name: vektra/mockery@v2.9.4
 - name: Versent/saml2aws@v2.33.0
+- name: vmware-tanzu/carvel-kbld@v0.31.0
 - name: vmware-tanzu/carvel-kwt@v0.0.6
 - name: vmware-tanzu/carvel-vendir@v0.23.0
 - name: vmware-tanzu/carvel-ytt@v0.38.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1002,6 +1002,15 @@ packages:
   - name: gcrane
 - type: github_release
   repo_owner: google
+  repo_name: jsonnet
+  asset: 'jsonnet-bin-{{.Version}}-linux.tar.gz'
+  supported_if: GOOS == "linux" and GOARCH == "amd64"
+  description: Jsonnet - The data templating language
+  files:
+  - name: jsonnet
+  - name: jsonnetfmt
+- type: github_release
+  repo_owner: google
   repo_name: ko
   asset: 'ko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Build and deploy Go applications on Kubernetes

--- a/registry.yaml
+++ b/registry.yaml
@@ -1537,6 +1537,14 @@ packages:
   asset: 'ecspresso_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: ecspresso is a deployment tool for Amazon ECS
 - type: github_release
+  repo_owner: knative
+  repo_name: client
+  format: raw
+  asset: 'kn-{{.OS}}-{{.Arch}}'
+  description: Knative developer experience, docs, reference Knative CLI implementation
+  files:
+  - name: kn
+- type: github_release
   repo_owner: knqyf263
   repo_name: pet
   asset: 'pet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz' # TODO support ARM

--- a/registry.yaml
+++ b/registry.yaml
@@ -2885,6 +2885,15 @@ packages:
     format: zip
 - type: github_release
   repo_owner: vmware-tanzu
+  repo_name: carvel-kapp
+  format: raw
+  asset: "kapp-{{.OS}}-{{.Arch}}"
+  link: https://carvel.dev/kapp/
+  description: 'kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label'
+  files:
+  - name: kapp
+- type: github_release
+  repo_owner: vmware-tanzu
   repo_name: carvel-kbld
   format: raw
   asset: "kbld-{{.OS}}-{{.Arch}}"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2885,6 +2885,15 @@ packages:
     format: zip
 - type: github_release
   repo_owner: vmware-tanzu
+  repo_name: carvel-kbld
+  format: raw
+  asset: "kbld-{{.OS}}-{{.Arch}}"
+  link: https://carvel.dev/kbld/
+  description: kbld seamlessly incorporates image building and image pushing into your development and deployment workflows
+  files:
+  - name: kbld
+- type: github_release
+  repo_owner: vmware-tanzu
   repo_name: carvel-kwt
   rosetta2: true
   format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -1641,6 +1641,15 @@ packages:
   description: Kubebuilder - SDK for building Kubernetes APIs using CRDs
 - type: github_release
   repo_owner: kubernetes-sigs
+  repo_name: kubefed
+  rosetta2: true
+  asset: 'kubefedctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tgz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  description: kubefedctl controls a Kubernetes Cluster Federation
+  files:
+  - name: kubefedctl
+- type: github_release
+  repo_owner: kubernetes-sigs
   repo_name: kustomize
   asset: 'kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Customization of kubernetes YAML configurations

--- a/registry.yaml
+++ b/registry.yaml
@@ -1466,6 +1466,15 @@ packages:
   - name: rmiregistry
     src: 'jreleaser-standalone-{{trimV .Version}}-{{.OS}}-{{.Arch}}/bin/rmiregistry'
 - type: github_release
+  repo_owner: jsonnet-bundler
+  repo_name: jsonnet-bundler
+  rosetta2: true
+  asset: 'jb-{{.OS}}-{{.Arch}}'
+  description: A jsonnet package manager
+  format: raw
+  files:
+  - name: jb
+- type: github_release
   repo_owner: juliosueiras
   repo_name: terraform-lsp
   asset: 'terraform-lsp_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1679,6 +1679,15 @@ packages:
 
 # init: l
 - type: github_release
+  repo_owner: Ladicle
+  repo_name: kubectl-rolesum
+  rosetta2: true
+  asset: 'kubectl-rolesum_{{.OS}}-{{.Arch}}.tar.gz'
+  description: Summarize Kubernetes RBAC roles for the specified subjects
+  files:
+  - name: kubectl-rolesum
+    src: 'kubectl-rolesum_{{.OS}}-{{.Arch}}/kubectl-rolesum'
+- type: github_release
   repo_owner: lc
   repo_name: gau
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -1561,6 +1561,13 @@ packages:
   asset: 'evans_{{.OS}}_{{.Arch}}.tar.gz'
   description: 'Evans: more expressive universal gRPC client'
 - type: github_release
+  repo_owner: kubemq-io
+  repo_name: kubemqctl
+  rosetta2: true
+  asset: 'kubemqctl_{{.OS}}_{{.Arch}}'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  description: Kubemqctl is a command line interface (CLI) for KubeMQ, Kubernetes Message Broker
+- type: github_release
   repo_owner: kubernetes
   repo_name: kompose
   description: Go from Docker Compose to Kubernetes

--- a/registry.yaml
+++ b/registry.yaml
@@ -2059,6 +2059,15 @@ packages:
 
 # init: p
 - type: github_release
+  repo_owner: particledecay
+  repo_name: kconf
+  asset: 'kconf-{{.OS}}-{{.Arch}}-{{trimV .Version}}.tar.gz'
+  description: Manage multiple kubeconfigs easily
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    amd64: x86_64
+- type: github_release
   repo_owner: peco
   repo_name: peco
   asset: 'peco_{{.OS}}_{{.Arch}}.{{.Format}}'


### PR DESCRIPTION
Close #1045
Close #1052
Close #1058
Close #1059
Close #1060
Close #1062
Close #1069
Close #1070
Close #1071

* #858 #1052 #1332 `google/jsonnet`
  * https://jsonnet.org/
  * https://github.com/google/jsonnet
  * Jsonnet - The data templating language
* #858 #1045 #1332 `jsonnet-bundler/jsonnet-bundler`
  * https://github.com/jsonnet-bundler/jsonnet-bundler
  * A jsonnet package manager
* #858 #1062 #1332 `knative/client`
  * https://github.com/knative/client
  * Knative developer experience, docs, reference Knative CLI implementation
* #858 #1070 #1332 `kubernetes-sigs/kubefed`
  * https://github.com/kubernetes-sigs/kubefed
  * kubefedctl controls a Kubernetes Cluster Federation
* #858 #1071 #1332 `kubemq-io/kubemqctl`
  * https://github.com/kubemq-io/kubemqctl
  * Kubemqctl is a command line interface (CLI) for KubeMQ , Kubernetes Message Broker
* #858 #1069 #1332 `Ladicle/kubectl-rolesum`
  * https://github.com/Ladicle/kubectl-rolesum
  * Summarize Kubernetes RBAC roles for the specified subjects
* #858 #1060 #1332 `particledecay/kconf`
  * https://github.com/particledecay/kconf
  * Manage multiple kubeconfigs easily
* #858 #1058 #1332 `vmware-tanzu/carvel-kapp`
  * https://github.com/vmware-tanzu/carvel-kapp
  * https://carvel.dev/kapp/
  * kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label
* #858 #1059 #1332 `vmware-tanzu/carvel-kbld`
  * https://github.com/vmware-tanzu/carvel-kbld
  * https://carvel.dev/kbld/
  * kbld seamlessly incorporates image building and image pushing into your development and deployment workflows