### PR TITLE
feat: add `helm/chart-releaser`

### DIFF
--- a/pkgs/a.yaml
+++ b/pkgs/a.yaml
@@ -13,6 +13,7 @@ packages:
   version: v0.9.4 # renovate: depName=ahmetb/kubectx
 - name: alexellis/arkade@0.8.11
 - name: alexellis/k3sup@0.11.0
+- name: anchore/grype@v0.27.0
 - name: anchore/syft@v0.32.0
 - name: antonmedv/fx@20.0.2
 - name: aquaproj/aqua-installer@v0.3.0

--- a/pkgs/f.yaml
+++ b/pkgs/f.yaml
@@ -13,3 +13,4 @@ packages:
 - name: flosell/iam-policy-json-to-terraform@1.8.0
 - name: fluxcd/flux2@v0.24.1
 - name: fujiwara/lambroll@v0.12.4
+- name: fullstorydev/grpcurl@v1.8.5

--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -15,6 +15,7 @@ packages:
 - name: golang/mock@v1.6.0
 - name: golangci/golangci-lint@v1.43.0
 - name: golang-migrate/migrate@v4.15.1
+- name: GoodwayGroup/gwvault@v2.1.5
 - name: google/go-containerregistry@v0.7.0
 - name: google/jsonnet@v0.17.0
 - name: google/ko@v0.9.3

--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -7,6 +7,7 @@ packages:
 - name: ginuerzh/gost@v2.11.1
 - name: github/hub@v2.14.2
 - name: git-lfs/git-lfs@v3.0.2
+- name: go-jira/jira@v1.0.27
 - name: go-task/task@v3.9.2
 - name: gohugoio/hugo@v0.90.1
 - name: gojuno/minimock@v3.0.10

--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -27,6 +27,7 @@ packages:
 - name: GoogleContainerTools/container-structure-test@v1.11.0
 - name: GoogleContainerTools/kpt@v1.0.0-beta.9
 - name: GoogleContainerTools/skaffold@v1.35.1
+- name: gopasspw/gopass@v1.13.0
 - name: goreleaser/goreleaser@v1.1.0
 - name: gotestyourself/gotestsum@v1.7.0
 - name: grafana/k6@v0.35.0

--- a/pkgs/h.yaml
+++ b/pkgs/h.yaml
@@ -11,5 +11,6 @@ packages:
 - name: hashicorp/terraform-ls@v0.25.0
 - name: hashicorp/vault@v1.9.1
 - name: hashicorp/waypoint@v0.6.3
+- name: helm/chart-releaser@v1.3.0
 - name: helm/helm@v3.7.2
 - name: homeport/dyff@v1.4.6

--- a/pkgs/h.yaml
+++ b/pkgs/h.yaml
@@ -11,6 +11,7 @@ packages:
 - name: hashicorp/terraform-ls@v0.25.0
 - name: hashicorp/vault@v1.9.1
 - name: hashicorp/waypoint@v0.6.3
+- name: hasura/graphql-engine@v2.0.10
 - name: helm/chart-releaser@v1.3.0
 - name: helm/helm@v3.7.2
 - name: homeport/dyff@v1.4.6

--- a/pkgs/h.yaml
+++ b/pkgs/h.yaml
@@ -4,6 +4,7 @@ packages:
 - name: harelba/q@v3.1.6
 - name: harness/drone-cli@v1.4.0
 - name: hashicorp/consul@v1.10.4
+- name: hashicorp/go-getter@v1.5.9
 - name: hashicorp/levant@v0.3.0
 - name: hashicorp/nomad@v1.2.2
 - name: hashicorp/packer@v1.7.8

--- a/pkgs/i.yaml
+++ b/pkgs/i.yaml
@@ -15,4 +15,5 @@ packages:
 - name: iovisor/kubectl-trace@v0.1.2
 - name: istio/istio/istioctl
   version: 1.12.1 # renovate: depName=istio/istio
+- name: itchyny/gojq@v0.12.6
 - name: itchyny/mmv@v0.1.4

--- a/registry.yaml
+++ b/registry.yaml
@@ -113,6 +113,17 @@ packages:
   asset: 'k3sup{{if eq .GOOS "darwin"}}-darwin{{else}}{{if ne .GOARCH "amd64"}}-{{.Arch}}{{end}}{{end}}'
 - type: github_release
   repo_owner: anchore
+  repo_name: grype
+  asset: 'grype_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: A vulnerability scanner for container images and filesystems
+  format: tar.gz
+  format_overrides:
+  - goos: darwin
+    format: zip
+  - goos: windows
+    format: zip
+- type: github_release
+  repo_owner: anchore
   repo_name: syft
   asset: 'syft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems

--- a/registry.yaml
+++ b/registry.yaml
@@ -1227,6 +1227,17 @@ packages:
   description: A tool to build, deploy, and release any application on any platform
   files:
   - name: waypoint
+- type: github_release
+  repo_owner: helm
+  repo_name: chart-releaser
+  asset: 'chart-releaser_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Hosting Helm Charts via GitHub Pages and Releases
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - name: cr
 - name: helm/helm
   type: http
   url: 'https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1428,6 +1428,18 @@ packages:
     darwin: osx
 - type: github_release
   repo_owner: itchyny
+  repo_name: gojq
+  asset: 'gojq_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Pure Go implementation of jq
+  format: zip
+  format_overrides:
+  - goos: linux
+    format: tar.gz
+  files:
+  - name: gojq
+    src: 'gojq_{{.Version}}_{{.OS}}_{{.Arch}}/gojq'
+- type: github_release
+  repo_owner: itchyny
   repo_name: mmv
   asset: 'mmv_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: rename multiple files with editor

--- a/registry.yaml
+++ b/registry.yaml
@@ -859,6 +859,19 @@ packages:
   format_overrides:
   - goos: darwin
     format: zip
+- type: github_release
+  repo_owner: fullstorydev
+  repo_name: grpcurl
+  rosetta2: true
+  asset: 'grpcurl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: 'Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers'
+  replacements:
+    amd64: x86_64
+    darwin: osx
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 
 # init: g
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -1238,6 +1238,13 @@ packages:
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
   files:
   - name: consul
+- type: github_release
+  repo_owner: hashicorp
+  repo_name: go-getter
+  rosetta2: true
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  asset: 'go-getter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
+  description: Package for downloading things from a string URL using a variety of protocols
 - name: hashicorp/nomad
   type: http
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -987,6 +987,18 @@ packages:
     - name: migrate
       src: 'migrate.{{.OS}}-{{.Arch}}'
 - type: github_release
+  repo_owner: GoodwayGroup
+  repo_name: gwvault
+  asset: 'gwvault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: ansible-vault CLI reimplemented in go
+  files:
+  - name: gwvault
+    src: 'gwvault_{{trimV .Version}}_{{.OS}}_{{.Arch}}/gwvault'
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: google
   repo_name: go-containerregistry
   asset: 'go-containerregistry_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -951,7 +951,7 @@ packages:
   description: The world’s fastest framework for building websites
   files:
   - name: hugo
-  replacements: # https://github.com/gohugoio/hugo/blob/10f60de89a5a53528f1e3a47a77224e5c7915e4e/goreleaser.yml#L99-L110
+  replacements:
     amd64: 64bit
     386: 32bit
     arm: ARM
@@ -1107,6 +1107,15 @@ packages:
   files:
   - name: skaffold
     src: 'skaffold-{{.OS}}-{{.Arch}}'
+- type: github_release
+  repo_owner: gopasspw
+  repo_name: gopass
+  description: The slightly more awesome standard unix password manager for teams
+  asset: 'gopass-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}'
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
 - type: github_release
   repo_owner: goreleaser
   repo_name: goreleaser

--- a/registry.yaml
+++ b/registry.yaml
@@ -938,6 +938,13 @@ packages:
   - goos: darwin
     format: zip
 - type: github_release
+  repo_owner: go-jira
+  repo_name: jira
+  rosetta2: true
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  asset: 'jira-{{.OS}}-{{.Arch}}'
+  description: simple jira command line client in Go
+- type: github_release
   repo_owner: go-task
   repo_name: task
   asset: 'task_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1228,6 +1228,14 @@ packages:
   files:
   - name: waypoint
 - type: github_release
+  repo_owner: hasura
+  repo_name: graphql-engine
+  asset: 'cli-hasura-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: Hasura GraphQL Engine CLI
+  files:
+  - name: hasura
+- type: github_release
   repo_owner: helm
   repo_name: chart-releaser
   asset: 'chart-releaser_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'


### PR DESCRIPTION
Close #1005
Close #1006
Close #1009
Close #1010
Close #1018
Close #1019
Close #1021
Close #1026 
Close #1028 

* #858 #1019 #1333 `anchore/grype`
  * https://github.com/anchore/grype
  * A vulnerability scanner for container images and filesystems
* #858 #1018 #1333 `fullstorydev/grpcurl`
  * https://github.com/fullstorydev/grpcurl
  * Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
* #858 #1006 #1333 `go-jira/jira`
  * https://github.com/go-jira/jira
  * simple jira command line client in Go
* #858 #1021 #1333 `GoodwayGroup/gwvault`
  * https://github.com/GoodwayGroup/gwvault
  * ansible-vault CLI reimplemented in go
* #858 #1010 #1333 `gopasspw/gopass`
  * https://github.com/gopasspw/gopass
  * The slightly more awesome standard unix password manager for teams
* #858 #1005 #1333 `hashicorp/go-getter`
  * https://github.com/hashicorp/go-getter
  * Package for downloading things from a string URL using a variety of protocols
* #858 #1026 #1333 `hasura/graphql-engine`
  * https://github.com/hasura/graphql-engine
  * Hasura GraphQL Engine CLI
* #858 #1028 #1333 `helm/chart-releaser`
  * https://github.com/helm/chart-releaser
  * Hosting Helm Charts via GitHub Pages and Releases
* #858 #1009 #1333 `itchyny/gojq`
  * https://github.com/itchyny/gojq
  * Pure Go implementation of jq