### PR TITLE
feat: add `vmware-tanzu/carvel-imgpkg`

### DIFF
--- a/pkgs/e.yaml
+++ b/pkgs/e.yaml
@@ -1,6 +1,7 @@
 packages:
 # init: e
 - name: earthly/earthly@v0.6.2
+- name: editorconfig-checker/editorconfig-checker@2.4.0
 - name: emirozer/kubectl-doctor@0.3.0
 - name: env0/terratag@v0.1.31
 - name: ernoaapa/kubectl-warp@v0.0.2

--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -5,8 +5,9 @@ packages:
 - name: geofffranks/spruce@v1.29.0
 - name: getsentry/sentry-cli@1.71.0
 - name: ginuerzh/gost@v2.11.1
-- name: github/hub@v2.14.2
+- name: git-chglog/git-chglog@v0.15.0
 - name: git-lfs/git-lfs@v3.0.2
+- name: github/hub@v2.14.2
 - name: go-jira/jira@v1.0.27
 - name: go-task/task@v3.9.2
 - name: gohugoio/hugo@v0.90.1

--- a/pkgs/m.yaml
+++ b/pkgs/m.yaml
@@ -16,5 +16,6 @@ packages:
 - name: mozilla/sops@v3.7.1
 - name: mumoshu/variant@v0.37.0
 - name: mumoshu/variant2@v0.38.0
+- name: muesli/duf@v0.6.2
 - name: mvdan/gofumpt@v0.2.0
 - name: mvdan/sh@v3.4.1

--- a/pkgs/n.yaml
+++ b/pkgs/n.yaml
@@ -6,3 +6,4 @@ packages:
 - name: noborus/trdsql@v0.9.0
 - name: nodejs/node@v17.2.0
 - name: nojima/httpie-go@v0.7.0
+- name: norwoodj/helm-docs@v1.5.0

--- a/pkgs/n.yaml
+++ b/pkgs/n.yaml
@@ -5,3 +5,4 @@ packages:
 - name: newrelic/newrelic-cli@v0.40.2
 - name: noborus/trdsql@v0.9.0
 - name: nodejs/node@v17.2.0
+- name: nojima/httpie-go@v0.7.0

--- a/pkgs/p.yaml
+++ b/pkgs/p.yaml
@@ -9,6 +9,7 @@ packages:
 - name: plexsystems/sinker@v0.14.3
 - name: porter-dev/porter@v0.12.4
 - name: postfinance/kubectl-sudo@v1.1.0
+- name: Praqma/helmsman@v3.7.7
 - name: profclems/glab@v1.21.1
 - name: projectdiscovery/nuclei@v2.5.4
 - name: projectdiscovery/subfinder@v2.4.9

--- a/pkgs/s.yaml
+++ b/pkgs/s.yaml
@@ -7,6 +7,7 @@ packages:
 - name: sclevine/yj@v5.0.0
 - name: sharkdp/bat@v0.18.3
 - name: sharkdp/fd@v8.3.0
+- name: Shopify/ejson@v1.3.0
 - name: sigstore/cosign@v1.4.1
 - name: sigstore/rekor@v0.3.0
 - name: slackhq/nebula@v1.5.0

--- a/pkgs/s.yaml
+++ b/pkgs/s.yaml
@@ -12,6 +12,7 @@ packages:
 - name: sigstore/rekor@v0.3.0
 - name: slackhq/nebula@v1.5.0
 - name: slok/sloth@v0.9.0
+- name: snyk/driftctl@v0.17.0
 - name: Songmu/ecschedule@v0.3.1
 - name: Songmu/ghch@v0.10.2
 - name: Songmu/ghg@v0.2.0

--- a/pkgs/v.yaml
+++ b/pkgs/v.yaml
@@ -3,6 +3,7 @@ packages:
 - name: variantdev/vals@v0.14.0
 - name: vektra/mockery@v2.9.4
 - name: Versent/saml2aws@v2.33.0
+- name: vmware-tanzu/carvel-imgpkg@v0.23.1
 - name: vmware-tanzu/carvel-kapp@v0.43.0
 - name: vmware-tanzu/carvel-kbld@v0.31.0
 - name: vmware-tanzu/carvel-kwt@v0.0.6

--- a/registry.yaml
+++ b/registry.yaml
@@ -2551,6 +2551,12 @@ packages:
   - name: fd
     src: 'fd-{{.Version}}-{{if eq .GOOS "darwin"}}x86_64{{else}}{{.Arch}}{{end}}-{{.OS}}/fd'
 - type: github_release
+  repo_owner: Shopify
+  repo_name: ejson
+  format: raw
+  asset: '{{.OS}}-{{.Arch}}'
+  description: EJSON is a small library to manage encrypted secrets using asymmetric encryption
+- type: github_release
   repo_owner: sigstore
   repo_name: cosign
   format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -2029,6 +2029,20 @@ packages:
   files:
   - name: variant
 - type: github_release
+  repo_owner: muesli
+  repo_name: duf
+  asset: 'duf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: Disk Usage/Free Utility - a better 'df' alternative
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    windows: Windows
+    darwin: Darwin
+    386: i386
+    amd64: x86_64
+- type: github_release
   repo_owner: mvdan
   repo_name: gofumpt
   asset: 'gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -731,6 +731,14 @@ packages:
   link: https://earthly.dev/
   description: Repeatable builds
 - type: github_release
+  repo_owner: editorconfig-checker
+  repo_name: editorconfig-checker
+  asset: 'ec-{{.OS}}-{{.Arch}}.tar.gz'
+  description: A tool to verify that your files are in harmony with your .editorconfig
+  files:
+  - name: ec
+    src: 'bin/ec-{{.OS}}-{{.Arch}}'
+- type: github_release
   repo_owner: emirozer
   repo_name: kubectl-doctor
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -2993,6 +2993,17 @@ packages:
     format: zip
 - type: github_release
   repo_owner: vmware-tanzu
+  repo_name: carvel-imgpkg
+  rosetta2: true
+  format: raw
+  asset: "imgpkg-{{.OS}}-{{.Arch}}"
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  link: https://carvel.dev/imgpkg/
+  description: 'Store application configuration files in Docker/OCI registries'
+  files:
+  - name: imgpkg
+- type: github_release
+  repo_owner: vmware-tanzu
   repo_name: carvel-kapp
   format: raw
   asset: "kapp-{{.OS}}-{{.Arch}}"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2259,6 +2259,13 @@ packages:
   description: Run kubernetes commands with the security privileges of another user
   path: bash/kubectl-sudo
 - type: github_release
+  repo_owner: Praqma
+  repo_name: helmsman
+  rosetta2: true
+  asset: 'helmsman_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  description: Helmsman is a Helm Charts (k8s applications) as Code tool which allows you to automate the deployment/management of your Helm charts from version controlled code
+- type: github_release
   repo_owner: profclems
   repo_name: glab
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -2089,6 +2089,15 @@ packages:
     src: 'node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npm'
   - name: npx
     src: 'node-{{.Version}}-{{.OS}}-{{.Arch}}/bin/npx'
+- type: github_release
+  repo_owner: nojima
+  repo_name: httpie-go
+  rosetta2: true
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  asset: 'httpie-go_{{.OS}}_{{.Arch}}'
+  description: httpie-like HTTP client written in Go
+  files:
+  - name: ht
 
 # init: o
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -914,6 +914,15 @@ packages:
   - name: gost
     src: 'gost-{{.OS}}-{{if eq .GOOS "darwin"}}amd64{{else}}{{.Arch}}{{end}}-{{trimV .Version}}'
 - type: github_release
+  repo_owner: git-chglog
+  repo_name: git-chglog
+  asset: 'git-chglog_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: CHANGELOG generator implemented in Go (Golang)
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: github
   repo_name: hub
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -2612,6 +2612,14 @@ packages:
   link: https://sloth.dev/
   format: raw
 - type: github_release
+  repo_owner: snyk
+  repo_name: driftctl
+  asset: 'driftctl_{{.OS}}_{{.Arch}}'
+  description: Detect, track and alert on infrastructure drift
+  format: raw
+  replacements:
+    armv6: arm
+- type: github_release
   repo_owner: Songmu
   repo_name: ecschedule
   asset: 'ecschedule_{{.Version}}_{{.OS}}_amd64.{{.Format}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -2098,6 +2098,18 @@ packages:
   description: httpie-like HTTP client written in Go
   files:
   - name: ht
+- type: github_release
+  repo_owner: norwoodj
+  repo_name: helm-docs
+  rosetta2: true
+  asset: 'helm-docs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: A tool for automatically generating markdown documentation for helm charts
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
 
 # init: o
 - type: github_release


### PR DESCRIPTION
Close #978
Close #979
Close #980
Close #981
Close #1001
Close #1031
Close #1032
Close #1034
Close #1040 

* #858 #980 #1335 `editorconfig-checker/editorconfig-checker`
  * https://github.com/editorconfig-checker/editorconfig-checker
  * A tool to verify that your files are in harmony with your .editorconfig
* #858 #1001 #1335 `git-chglog/git-chglog`
  * https://github.com/git-chglog/git-chglog
  * CHANGELOG generator implemented in Go (Golang)
* #858 #979 #1335 `muesli/duf`
  * https://github.com/muesli/duf
  * Disk Usage/Free Utility - a better 'df' alternative
* #858 #1034 #1335 `nojima/httpie-go`
  * https://github.com/nojima/httpie-go
  * httpie-like HTTP client written in Go
* #858 #1031 #1335 `norwoodj/helm-docs`
  * https://github.com/norwoodj/helm-docs
  * A tool for automatically generating markdown documentation for helm charts
* #858 #1032 #1335 `Praqma/helmsman`
  * https://github.com/Praqma/helmsman
  * Helmsman is a Helm Charts (k8s applications) as Code tool which allows you to automate the deployment/management of your Helm charts from version controlled code
* #858 #981 #1335 `Shopify/ejson`
  * https://github.com/Shopify/ejson
  * EJSON is a small library to manage encrypted secrets using asymmetric encryption
* #858 #978 #1335 `snyk/driftctl`
  * https://github.com/snyk/driftctl
  * Detect, track and alert on infrastructure drift
* #858 #1040 #1335 `vmware-tanzu/carvel-imgpkg`
  * https://github.com/vmware-tanzu/carvel-imgpkg
  * Store application configuration files in Docker/OCI registries