### PR TITLE
feat: add `Kong/deck`

### DIFF
--- a/pkgs/a.yaml
+++ b/pkgs/a.yaml
@@ -13,6 +13,7 @@ packages:
   version: v0.9.4 # renovate: depName=ahmetb/kubectx
 - name: alexellis/arkade@0.8.11
 - name: alexellis/k3sup@0.11.0
+- name: amacneil/dbmate@v1.12.1
 - name: anchore/grype@v0.27.0
 - name: anchore/syft@v0.32.0
 - name: antonmedv/fx@20.0.2

--- a/pkgs/b.yaml
+++ b/pkgs/b.yaml
@@ -6,6 +6,7 @@ packages:
 - name: b4b4r07/gomi@v1.1.1
 - name: b4b4r07/iap_curl@v0.2.0
 - name: b4b4r07/stein@v0.3.4
+- name: bcicen/ctop@0.7.6
 - name: bcicen/slackcat@1.7.3
 - name: benbjohnson/litestream@v0.3.7
 - name: bootandy/dust@v0.7.5

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -17,4 +17,5 @@ packages:
 - name: cosmtrek/air@v1.27.8
 - name: crate-ci/typos@v1.3.1
 - name: create-go-app/cli@v3.2.2
+- name: crossplane/crossplane@v1.5.1
 - name: cue-lang/cue@v0.4.0

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -6,6 +6,7 @@ packages:
 - name: CircleCI-Public/circleci-cli@v0.1.16535
 - name: civo/cli@v1.0.5
 - name: cli/cli@v2.3.0
+- name: cloudfoundry/credhub-cli@2.9.1
 - name: cloudposse/atmos@v1.3.11
 - name: cnrancher/autok3s@v0.4.5
 - name: codeclimate/test-reporter@0.10.2

--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -18,6 +18,7 @@ packages:
 - name: golangci/golangci-lint@v1.43.0
 - name: golang-migrate/migrate@v4.15.1
 - name: GoodwayGroup/gwvault@v2.1.5
+- name: goodwithtech/dockle@v0.4.3
 - name: google/go-containerregistry@v0.7.0
 - name: google/jsonnet@v0.17.0
 - name: google/ko@v0.9.3

--- a/pkgs/k.yaml
+++ b/pkgs/k.yaml
@@ -13,6 +13,7 @@ packages:
 - name: knqyf263/pet@v0.4.0
 - name: knqyf263/utern@v0.1.5
 - name: koalaman/shellcheck@v0.8.0
+- name: Kong/deck@v1.9.0
 - name: ktr0731/evans@0.10.0
 - name: kubemq-io/kubemqctl@v3.5.1
 - name: kubernetes/kompose@v1.25

--- a/pkgs/s.yaml
+++ b/pkgs/s.yaml
@@ -10,6 +10,7 @@ packages:
 - name: Shopify/ejson@v1.3.0
 - name: sigstore/cosign@v1.4.1
 - name: sigstore/rekor@v0.3.0
+- name: six-ddc/plow@v1.1.0
 - name: slackhq/nebula@v1.5.0
 - name: slok/sloth@v0.9.0
 - name: snyk/driftctl@v0.17.0

--- a/pkgs/t.yaml
+++ b/pkgs/t.yaml
@@ -12,6 +12,7 @@ packages:
 - name: thazelart/terraform-validator@3.1.3
 - name: TheZoraiz/ascii-image-converter@v1.11.0
 - name: thought-machine/please@v16.17.0
+- name: tilt-dev/ctlptl@v0.6.2
 - name: tilt-dev/tilt@v0.23.3
 - name: tinygo-org/tinygo@v0.21.0
 - name: TomWright/dasel@v1.22.1

--- a/pkgs/t.yaml
+++ b/pkgs/t.yaml
@@ -1,5 +1,6 @@
 packages:
 # init: t
+- name: talos-systems/conform@v0.1.0-alpha.23
 - name: talos-systems/talos@v0.13.4
 - name: tcnksm/ghr@v0.14.0
 - name: tektoncd/cli@v0.21.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1688,6 +1688,11 @@ packages:
   - name: shellcheck
     src: shellcheck-{{.Version}}/shellcheck
 - type: github_release
+  repo_owner: Kong
+  repo_name: deck
+  asset: "deck_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+  description: 'decK: Configuration management and drift detection for Kong'
+- type: github_release
   repo_owner: ktr0731
   repo_name: evans
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -2904,6 +2904,12 @@ packages:
 # init: t
 - type: github_release
   repo_owner: talos-systems
+  repo_name: conform
+  asset: 'conform-{{.OS}}-{{.Arch}}'
+  description: Policy enforcement for your pipelines
+  format: raw
+- type: github_release
+  repo_owner: talos-systems
   repo_name: talos
   asset: 'talosctl-{{.OS}}-{{.Arch}}'
   description: Talos is a modern OS for Kubernetes. talosctl is a CLI for out-of-band management of Kubernetes nodes created by Talos

--- a/registry.yaml
+++ b/registry.yaml
@@ -2598,6 +2598,11 @@ packages:
   files:
   - name: rekor-cli
 - type: github_release
+  repo_owner: six-ddc
+  repo_name: plow
+  asset: 'plow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+  description: A high-performance HTTP benchmarking tool with real-time web UI and terminal displaying
+- type: github_release
   repo_owner: slackhq
   repo_name: nebula
   asset: 'nebula-{{.OS}}{{if ne .GOOS "darwin"}}-{{.Arch}}{{end}}.{{.Format}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1047,6 +1047,27 @@ packages:
   - goos: windows
     format: zip
 - type: github_release
+  repo_owner: goodwithtech
+  repo_name: dockle
+  asset: 'dockle_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}'
+  description: Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
+- type: github_release
   repo_owner: google
   repo_name: go-containerregistry
   asset: 'go-containerregistry_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -374,6 +374,13 @@ packages:
     arm64: x86_64
 - type: github_release
   repo_owner: bcicen
+  repo_name: ctop
+  rosetta2: true
+  asset: 'ctop-{{.Version}}-{{.OS}}-{{.Arch}}'
+  description: Top-like interface for container metrics
+  format: raw
+- type: github_release
+  repo_owner: bcicen
   repo_name: slackcat
   rosetta2: true
   asset: 'slackcat-{{.Version}}-{{.OS}}-{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -112,6 +112,14 @@ packages:
   format: raw
   asset: 'k3sup{{if eq .GOOS "darwin"}}-darwin{{else}}{{if ne .GOARCH "amd64"}}-{{.Arch}}{{end}}{{end}}'
 - type: github_release
+  repo_owner: amacneil
+  repo_name: dbmate
+  description: A lightweight, framework-agnostic database migration tool
+  format: raw
+  asset: 'dbmate-{{.OS}}-{{.Arch}}'
+  replacements:
+    darwin: macos
+- type: github_release
   repo_owner: anchore
   repo_name: grype
   asset: 'grype_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -495,6 +495,15 @@ packages:
   replacements:
     darwin: macOS
 - type: github_release
+  repo_owner: cloudfoundry
+  repo_name: credhub-cli
+  asset: 'credhub-{{.OS}}-{{.Version}}.tgz'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  rosetta2: true
+  description: CredHub CLI provides a command line interface to interact with CredHub servers
+  files:
+  - name: credhub
+- type: github_release
   repo_owner: cloudposse
   repo_name: atmos
   asset: 'atmos_{{trimV .Version}}_{{.OS}}_{{.Arch}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -590,6 +590,14 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
+- name: crossplane/crossplane
+  type: http
+  format: raw
+  url: 'https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank'
+  description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
+  link: https://github.com/crossplane/crossplane
+  files:
+  - name: kubectl-crossplane
 - type: github_release
   repo_owner: cue-lang
   repo_name: cue

--- a/registry.yaml
+++ b/registry.yaml
@@ -3013,6 +3013,19 @@ packages:
     src: please/please
 - type: github_release
   repo_owner: tilt-dev
+  repo_name: ctlptl
+  description: Making local Kubernetes clusters fun and easy to set up
+  asset: 'ctlptl.{{trimV .Version}}.{{.OS}}.{{.Arch}}.{{.Format}}'
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    darwin: mac
+    386: i386
+    amd64: x86_64
+- type: github_release
+  repo_owner: tilt-dev
   repo_name: tilt
   link: https://tilt.dev/
   description: Define your dev environment as code. For microservice apps on Kubernetes


### PR DESCRIPTION
Close #950
Close #955
Close #956
Close #958
Close #959
Close #961
Close #962 
Close #970 
Close #1337

* #858 #961 #1339 `amacneil/dbmate`
  * https://github.com/amacneil/dbmate
  * A lightweight, framework-agnostic database migration tool
* #858 #959 #1339 `bcicen/ctop`
  * https://github.com/bcicen/ctop
  * Top-like interface for container metrics
* #858 #955 #1339 `cloudfoundry/credhub-cli`
  * https://github.com/cloudfoundry/credhub-cli
  * CredHub CLI provides a command line interface to interact with CredHub servers
* #858 #956 #1339 `crossplane/crossplane`
  * https://github.com/crossplane/crossplane
  * The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
* #858 #970 #1339 `goodwithtech/dockle`
  * https://github.com/goodwithtech/dockle
  * Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start
* #858 #962 #1339 `Kong/deck`
  * https://github.com/Kong/deck
  * decK: Configuration management and drift detection for Kong
* #858 #1337 #1339 `six-ddc/plow`
  * https://github.com/six-ddc/plow
  * A high-performance HTTP benchmarking tool with real-time web UI and terminal displaying
* #858 #950 #1339 `talos-systems/conform`
  * https://github.com/talos-systems/conform
  * Policy enforcement for your pipelines
* #858 #958 #1339 `tilt-dev/ctlptl`
  * https://github.com/tilt-dev/ctlptl
  * Making local Kubernetes clusters fun and easy to set up