### PR TITLE
feat: add `cloudflare/cloudflared`

### DIFF
--- a/pkgs/b.yaml
+++ b/pkgs/b.yaml
@@ -11,6 +11,7 @@ packages:
 - name: benbjohnson/litestream@v0.3.7
 - name: bootandy/dust@v0.7.5
 - name: boz/kail@v0.15.0
+- name: brigadecore/brigade@v2.0.0
 - name: bufbuild/buf@v1.0.0-rc8
 - name: buildpacks/pack@v0.23.0
 - name: BurntSushi/ripgrep@13.0.0

--- a/pkgs/b.yaml
+++ b/pkgs/b.yaml
@@ -11,4 +11,5 @@ packages:
 - name: benbjohnson/litestream@v0.3.7
 - name: bootandy/dust@v0.7.5
 - name: boz/kail@v0.15.0
+- name: buildpacks/pack@v0.23.0
 - name: BurntSushi/ripgrep@13.0.0

--- a/pkgs/b.yaml
+++ b/pkgs/b.yaml
@@ -11,5 +11,6 @@ packages:
 - name: benbjohnson/litestream@v0.3.7
 - name: bootandy/dust@v0.7.5
 - name: boz/kail@v0.15.0
+- name: bufbuild/buf@v1.0.0-rc8
 - name: buildpacks/pack@v0.23.0
 - name: BurntSushi/ripgrep@13.0.0

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -16,6 +16,7 @@ packages:
 - name: cloudposse/atmos@v1.3.11
 - name: cnrancher/autok3s@v0.4.5
 - name: codeclimate/test-reporter@0.10.2
+- name: codesenberg/bombardier@v1.2.5
 - name: containerd/nerdctl@v0.14.0
 - name: controlplaneio/kubesec@v2.11.4
 - name: corneliusweig/ketall@v1.3.8

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -7,6 +7,9 @@ packages:
 - name: CircleCI-Public/circleci-cli@v0.1.16535
 - name: civo/cli@v1.0.5
 - name: cli/cli@v2.3.0
+- name: cloudflare/cfssl@v1.6.1
+- name: cloudflare/cfssl/mkbundle
+  version: v1.6.1 # renovate: depName=cloudflare/cfssl
 - name: cloudflare/cloudflared@2021.11.0
 - name: cloudfoundry/credhub-cli@2.9.1
 - name: cloudposse/atmos@v1.3.11

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -6,6 +6,7 @@ packages:
 - name: CircleCI-Public/circleci-cli@v0.1.16535
 - name: civo/cli@v1.0.5
 - name: cli/cli@v2.3.0
+- name: cloudflare/cloudflared@2021.11.0
 - name: cloudfoundry/credhub-cli@2.9.1
 - name: cloudposse/atmos@v1.3.11
 - name: cnrancher/autok3s@v0.4.5

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -11,6 +11,7 @@ packages:
 - name: cloudflare/cfssl/mkbundle
   version: v1.6.1 # renovate: depName=cloudflare/cfssl
 - name: cloudflare/cloudflared@2021.11.0
+- name: cloudfoundry/bosh-cli@v6.4.8
 - name: cloudfoundry/credhub-cli@2.9.1
 - name: cloudposse/atmos@v1.3.11
 - name: cnrancher/autok3s@v0.4.5

--- a/pkgs/c.yaml
+++ b/pkgs/c.yaml
@@ -2,6 +2,7 @@ packages:
 # init: c
 - name: c-bata/kube-prompt@v1.0.11
 - name: che-incubator/chectl@20210915111912
+- name: cheat/cheat@4.2.3
 - name: chriswalz/bit@v1.1.2
 - name: CircleCI-Public/circleci-cli@v0.1.16535
 - name: civo/cli@v1.0.5

--- a/pkgs/s.yaml
+++ b/pkgs/s.yaml
@@ -5,6 +5,7 @@ packages:
 - name: scaleway/scaleway-cli@v2.4.0
 - name: schollz/croc@v9.5.0
 - name: sclevine/yj@v5.0.0
+- name: segmentio/chamber@v2.10.7
 - name: sharkdp/bat@v0.18.3
 - name: sharkdp/fd@v8.3.0
 - name: Shopify/ejson@v1.3.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -495,6 +495,12 @@ packages:
   replacements:
     darwin: macOS
 - type: github_release
+  repo_owner: cloudflare
+  repo_name: cloudflared
+  rosetta2: true
+  asset: 'cloudflared-{{.OS}}-{{.Arch}}{{if eq .GOOS "darwin"}}.tgz{{end}}'
+  description: cloudflared connects your machine or user identity to Cloudflare's global network
+- type: github_release
   repo_owner: cloudfoundry
   repo_name: credhub-cli
   asset: 'credhub-{{.OS}}-{{.Version}}.tgz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -2610,6 +2610,14 @@ packages:
   replacements:
     darwin: macos
 - type: github_release
+  repo_owner: segmentio
+  repo_name: chamber
+  format: raw
+  rosetta2: true
+  asset: 'chamber-{{.Version}}-{{.OS}}-{{.Arch}}'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  description: CLI for managing secrets
+- type: github_release
   repo_owner: sharkdp
   repo_name: bat
   rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -607,6 +607,13 @@ packages:
   files:
   - name: test-reporter
 - type: github_release
+  repo_owner: codesenberg
+  repo_name: bombardier
+  rosetta2: true
+  asset: 'bombardier-{{.OS}}-{{.Arch}}'
+  description: Fast cross-platform HTTP benchmarking tool written in Go
+  format: raw
+- type: github_release
   repo_owner: containerd
   repo_name: nerdctl
   asset: 'nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -425,6 +425,14 @@ packages:
   asset: 'kail_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: kubernetes log viewer
 - type: github_release
+  repo_owner: buildpacks
+  repo_name: pack
+  asset: 'pack-{{.Version}}-{{.OS}}{{if and (eq .GOOS "darwin") (eq .GOARCH "arm64")}}-{{.Arch}}{{end}}.tgz'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  description: CLI for building apps using Cloud Native Buildpacks
+  replacements:
+    darwin: macos
+- type: github_release
   repo_owner: BurntSushi
   repo_name: ripgrep
   asset: 'ripgrep-{{.Version}}-x86_64-{{.OS}}.{{.Format}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -568,6 +568,16 @@ packages:
   description: cloudflared connects your machine or user identity to Cloudflare's global network
 - type: github_release
   repo_owner: cloudfoundry
+  repo_name: bosh-cli
+  format: raw
+  asset: 'bosh-cli-{{trimV .Version}}-{{.OS}}-{{.Arch}}'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  rosetta2: true
+  description: The bosh CLI is the command line tool used for interacting with all things BOSH, from deployment operations to software release management
+  files:
+  - name: bosh
+- type: github_release
+  repo_owner: cloudfoundry
   repo_name: credhub-cli
   asset: 'credhub-{{.OS}}-{{.Version}}.tgz'
   supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))

--- a/registry.yaml
+++ b/registry.yaml
@@ -425,6 +425,14 @@ packages:
   asset: 'kail_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: kubernetes log viewer
 - type: github_release
+  repo_owner: brigadecore
+  repo_name: brigade
+  format: raw
+  asset: 'brig-{{.OS}}-{{.Arch}}'
+  description: Brigade CLI. Event-driven scripting for Kubernetes
+  files:
+  - name: brig
+- type: github_release
   repo_owner: bufbuild
   repo_name: buf
   asset: 'buf-{{.OS}}-{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -425,6 +425,24 @@ packages:
   asset: 'kail_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: kubernetes log viewer
 - type: github_release
+  repo_owner: bufbuild
+  repo_name: buf
+  asset: 'buf-{{.OS}}-{{.Arch}}.tar.gz'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  description: A new way of working with Protocol Buffers
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    amd64: x86_64
+  files:
+  - name: buf
+    src: buf/bin/buf
+  - name: protoc-gen-buf-breaking
+    src: buf/bin/protoc-gen-buf-breaking
+  - name: protoc-gen-buf-lint
+    src: buf/bin/protoc-gen-buf-lint
+- type: github_release
   repo_owner: buildpacks
   repo_name: pack
   asset: 'pack-{{.Version}}-{{.OS}}{{if and (eq .GOOS "darwin") (eq .GOARCH "arm64")}}-{{.Arch}}{{end}}.tgz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -459,6 +459,19 @@ packages:
   - name: chectl
     src: chectl/bin/chectl
 - type: github_release
+  repo_owner: cheat
+  repo_name: cheat
+  rosetta2: true
+  asset: 'cheat-{{.OS}}-{{.Arch}}.{{.Format}}'
+  description: 'cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember'
+  format: gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+  - name: cheat
+    src: 'cheat-{{.OS}}-{{.Arch}}'
+- type: github_release
   repo_owner: chriswalz
   repo_name: bit 
   asset: 'bit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -509,6 +509,25 @@ packages:
     darwin: macOS
 - type: github_release
   repo_owner: cloudflare
+  repo_name: cfssl
+  rosetta2: true
+  format: raw
+  asset: 'cfssl_{{trimV .Version}}_{{.OS}}_{{.Arch}}'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  description: "CFSSL: Cloudflare's PKI and TLS toolkit"
+- name: cloudflare/cfssl/mkbundle
+  type: github_release
+  repo_owner: cloudflare
+  repo_name: cfssl
+  rosetta2: true
+  format: raw
+  asset: 'mkbundle_{{trimV .Version}}_{{.OS}}_{{.Arch}}'
+  supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+  description: "CFSSL: Cloudflare's PKI and TLS toolkit"
+  files:
+  - name: mkbundle
+- type: github_release
+  repo_owner: cloudflare
   repo_name: cloudflared
   rosetta2: true
   asset: 'cloudflared-{{.OS}}-{{.Arch}}{{if eq .GOOS "darwin"}}.tgz{{end}}'


### PR DESCRIPTION
Close #922
Close #923
Close #925
Close #927
Close #928
Close #934
Close #935
Close #936
Close #940 

* #858 #925 #1340 `brigadecore/brigade`
  * https://github.com/brigadecore/brigade
  * Brigade CLI. Event-driven scripting for Kubernetes
* #858 #927 #1340 `bufbuild/buf`
  * https://github.com/bufbuild/buf
  * A new way of working with Protocol Buffers
* #858 #928 #1340 `buildpacks/pack`
  * https://github.com/buildpacks/pack
  * CLI for building apps using Cloud Native Buildpacks
* #858 #936 #1340 `cheat/cheat`
  * https://github.com/cheat/cheat
  * cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember
* #858 #934 #1340 `cloudflare/cfssl`
  * https://github.com/cloudflare/cfssl
  * CFSSL: Cloudflare's PKI and TLS toolkit
* #858 #934 #1340 `cloudflare/cfssl/mkbundle`
  * https://github.com/cloudflare/cfssl
  * CFSSL: Cloudflare's PKI and TLS toolkit
* #858 #940 #1340 `cloudflare/cloudflared`
  * https://github.com/cloudflare/cloudflared
  * cloudflared connects your machine or user identity to Cloudflare's global network
* #858 #923 #1340 `cloudfoundry/bosh-cli`
  * https://github.com/cloudfoundry/bosh-cli
  * The bosh CLI is the command line tool used for interacting with all things BOSH, from deployment operations to software release management
* #858 #922 #1340 `codesenberg/bombardier`
  * https://github.com/codesenberg/bombardier
  * Fast cross-platform HTTP benchmarking tool written in Go
* #858 #935 #1340 `segmentio/chamber`
  * https://github.com/segmentio/chamber
  * CLI for managing secrets