### PR TITLE
fix: enable rosetta2 for kustomize

### DIFF
--- a/pkgs/k.yaml
+++ b/pkgs/k.yaml
@@ -26,7 +26,8 @@ packages:
 - name: kubernetes-sigs/krew@v0.4.2
 - name: kubernetes-sigs/kubebuilder@v3.2.0
 - name: kubernetes-sigs/kubefed@v0.9.0
-- name: kubernetes-sigs/kustomize@kustomize/v4.3.0
+- name: kubernetes-sigs/kustomize
+  version: kustomize/v4.4.1
 - name: kudobuilder/kuttl@v0.11.1
 - name: kvaps/kubectl-node-shell@v1.5.3
 - name: kyoh86/richgo@v0.3.10

--- a/registry.yaml
+++ b/registry.yaml
@@ -2018,6 +2018,11 @@ packages:
 - type: github_release
   repo_owner: kubernetes-sigs
   repo_name: kustomize
+  # From kustomize/v4.2.0, darwin/arm64 is provided so rosetta2 isn't needed.
+  # https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.2.0
+  # But kustomize tag isn't semver, so you have to enable rosetta2.
+  # You have to fix the problem.
+  rosetta2: true
   asset: 'kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Customization of kubernetes YAML configurations
 - type: github_release


### PR DESCRIPTION
Close #1353

From kustomize/v4.2.0, darwin/arm64 is provided so rosetta2 isn't needed.
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.2.0
But kustomize tag isn't semver, so you have to enable rosetta2.
You have to fix the problem.

https://github.com/aquaproj/aqua/issues/462