### PR TITLE
fix: enable rosetta2

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3180,6 +3180,8 @@ packages:
   repo_owner: suzuki-shunsuke
   repo_name: akoi
   asset: 'akoi_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
   description: binary installer
 - type: github_content
   repo_owner: suzuki-shunsuke
@@ -3192,6 +3194,8 @@ packages:
   repo_owner: suzuki-shunsuke
   repo_name: ci-info
   asset: 'ci-info_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
   description: CLI tool to get CI related information
 - type: github_content
   repo_owner: suzuki-shunsuke
@@ -3202,11 +3206,15 @@ packages:
   repo_owner: suzuki-shunsuke
   repo_name: circleci-config-merge
   asset: 'circleci-config-merge_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
   description: Generate .circleci/config.yml by merging multiple files
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: cmdx
+  rosetta2: true
   asset: 'cmdx_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   description: Task runner. It provides useful help messages and supports interactive prompts and validation of arguments
   version_constraint: 'semver(">= 1.6.1")'
   version_overrides:
@@ -3216,27 +3224,37 @@ packages:
   repo_owner: suzuki-shunsuke
   repo_name: dd-time
   asset: 'dd-time_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
   description: CLI tool to post the command execution time as time-series data to DataDog
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: durl
   asset: 'durl_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
   description: CLI to check whether dead urls are included in files
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: git-rm-branch
+  rosetta2: true
   asset: 'git-rm-branch_{{.Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   description: cli tool to remove merged branches
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: github-comment
+  rosetta2: true
   asset: 'github-comment_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   description: CLI to create a GitHub comment
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: matchfile
+  rosetta2: true
   asset: 'matchfile_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: CLI tool to check file paths are matched to the condition
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
 - type: github_release
   repo_owner: suzuki-shunsuke
   repo_name: tfcmt


### PR DESCRIPTION
Enable `rosetta2` to install some tools on M1 Mac.

* `suzuki-shunsuke/akoi`
* `suzuki-shunsuke/ci-info`
* `suzuki-shunsuke/circleci-config-merge`
* `suzuki-shunsuke/cmdx`
* `suzuki-shunsuke/dd-time`
* `suzuki-shunsuke/durl`
* `suzuki-shunsuke/git-rm-branch`
* `suzuki-shunsuke/github-comment`
* `suzuki-shunsuke/matchfile`