### PR TITLE
feat: add `Hackmanit/Web-Cache-Vulnerability-Scanner`

### DIFF
--- a/pkgs/h.yaml
+++ b/pkgs/h.yaml
@@ -1,5 +1,6 @@
 packages:
 # init: h
+- name: Hackmanit/Web-Cache-Vulnerability-Scanner@1.0.0
 - name: hairyhenderson/gomplate@v3.10.0
 - name: harelba/q@v3.1.6
 - name: harness/drone-cli@v1.4.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1517,6 +1517,19 @@ packages:
 
 # init: h
 - type: github_release
+  repo_owner: Hackmanit
+  repo_name: Web-Cache-Vulnerability-Scanner
+  description: Web Cache Vulnerability Scanner is a Go-based CLI tool for testing for web cache poisoning. It is developed by Hackmanit GmbH
+  asset: "web-cache-vulnerability-scanner_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+  replacements:
+    darwin: macOS_darwin
+  files:
+  - name: wcvs
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: hairyhenderson
   repo_name: gomplate
   asset: "gomplate_{{.OS}}-{{.Arch}}"


### PR DESCRIPTION
* #1554 `Hackmanit/Web-Cache-Vulnerability-Scanner`
  * https://github.com/Hackmanit/Web-Cache-Vulnerability-Scanner
  * Web Cache Vulnerability Scanner is a Go-based CLI tool for testing for web cache poisoning. It is developed by Hackmanit GmbH