### PR TITLE
feat: add `grafana/loki/logcli`

### DIFF
--- a/pkgs/g.yaml
+++ b/pkgs/g.yaml
@@ -36,6 +36,7 @@ packages:
 - name: goreleaser/nfpm@v2.11.3
 - name: gotestyourself/gotestsum@v1.7.0
 - name: grafana/k6@v0.35.0
+- name: grafana/loki/logcli@v2.4.1
 - name: grafana/tanka@v0.19.0
 - name: gruntwork-io/kubergrunt@v0.7.11
 - name: gruntwork-io/terragrunt@v0.35.16

--- a/registry.yaml
+++ b/registry.yaml
@@ -1499,6 +1499,15 @@ packages:
   format_overrides:
   - goos: darwin
     format: zip
+- name: grafana/loki/logcli
+  type: github_release
+  repo_owner: grafana
+  repo_name: loki
+  asset: 'logcli-{{.OS}}-{{.Arch}}.zip'
+  description: LogCLI is the command-line interface to Grafana Loki
+  files:
+  - name: logcli
+    src: 'logcli-{{.OS}}-{{.Arch}}'
 - type: github_release
   repo_owner: grafana
   repo_name: tanka


### PR DESCRIPTION
Close #1088

* #1088 #1594 `grafana/loki/logcli`
  * https://github.com/grafana/loki
  * https://grafana.com/docs/loki/latest/getting-started/logcli/
  * LogCLI is the command-line interface to Grafana Loki