### PR TITLE
feat: add `jetstack/cert-manager/cmctl`

### DIFF
--- a/pkgs/j.yaml
+++ b/pkgs/j.yaml
@@ -4,6 +4,7 @@ packages:
 - name: jesseduffield/horcrux@v0.2
 - name: jesseduffield/lazydocker@v0.12
 - name: jesseduffield/lazygit@v0.29
+- name: jetstack/cert-manager@v1.6.1
 - name: johanhaleby/kubetail@1.6.13
 - name: jonaslu/ain@v1.2.2
 - name: jreleaser/jreleaser@v0.10.0

--- a/pkgs/j.yaml
+++ b/pkgs/j.yaml
@@ -4,7 +4,7 @@ packages:
 - name: jesseduffield/horcrux@v0.2
 - name: jesseduffield/lazydocker@v0.12
 - name: jesseduffield/lazygit@v0.29
-- name: jetstack/cert-manager@v1.6.1
+- name: jetstack/cert-manager/cmctl@v1.6.1
 - name: johanhaleby/kubetail@1.6.13
 - name: jonaslu/ain@v1.2.2
 - name: jreleaser/jreleaser@v0.10.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -1876,7 +1876,8 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
-- type: github_release
+- name: jetstack/cert-manager/cmctl
+  type: github_release
   repo_owner: jetstack
   repo_name: cert-manager
   asset: 'cmctl-{{.OS}}-{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -1876,6 +1876,13 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
+- type: github_release
+  repo_owner: jetstack
+  repo_name: cert-manager
+  asset: 'cmctl-{{.OS}}-{{.Arch}}.tar.gz'
+  description: cmctl is a CLI tool that can help you to manage cert-manager resources inside your cluster
+  files:
+  - name: cmctl
 - type: github_content
   repo_owner: johanhaleby
   repo_name: kubetail


### PR DESCRIPTION
Close #944

* #944 #1595 `jetstack/cert-manager/cmctl`
  * https://cert-manager.io/docs/usage/cmctl
  * https://github.com/jetstack/cert-manager
  * cmctl is a CLI tool that can help you to manage cert-manager resources inside your cluster