### PR TITLE
feat: add `liamg/memit`

### DIFF
--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -2,6 +2,7 @@ packages:
 # init: l
 - name: Ladicle/kubectl-rolesum@v1.5.1
 - name: lc/gau@v2.0.6
+- name: liamg/memit@v0.0.3
 - name: lima-vm/lima@v0.8.0
 - name: loft-sh/devspace@v5.18.1
 - name: loft-sh/vcluster@v0.4.5

--- a/pkgs/u.yaml
+++ b/pkgs/u.yaml
@@ -1,3 +1,4 @@
 packages:
 # init: u
 - name: up9inc/mizu@0.21.0
+- name: uptrace/uptrace@v0.1.1

--- a/pkgs/x.yaml
+++ b/pkgs/x.yaml
@@ -2,5 +2,6 @@ packages:
 # init: x
 - name: x-motemen/ghq@v1.2.1
 - name: XAMPPRocky/tokei@v12.1.2
+- name: xiecat/fofax@v0.1.19
 - name: xo/usql@v0.9.5
 - name: xtaci/kcptun@v20210922

--- a/registry.yaml
+++ b/registry.yaml
@@ -2201,6 +2201,13 @@ packages:
   - goos: windows
     format: zip
 - type: github_release
+  repo_owner: liamg
+  repo_name: memit
+  asset: 'memit-{{.OS}}-{{.Arch}}'
+  format: raw
+  description: Run binaries straight from memory in Linux
+  supported_if: GOOS == "linux"
+- type: github_release
   repo_owner: lima-vm
   repo_name: lima
   asset: 'lima-{{trimV .Version}}-{{title .OS}}-{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -3770,6 +3770,15 @@ packages:
     linux: unknown-linux-gnu
     amd64: x86_64
 - type: github_release
+  repo_owner: xiecat
+  repo_name: fofax
+  asset: 'fofax_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: 'fofaX is a command line query tool based on the API of https://fofa.so/, simple is the best'
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- type: github_release
   repo_owner: xo
   repo_name: usql
   description: Universal command-line interface for SQL databases

--- a/registry.yaml
+++ b/registry.yaml
@@ -3576,6 +3576,12 @@ packages:
   asset: "mizu_{{.OS}}_{{.Arch}}"
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   description: API traffic viewer for Kubernetes. Think TCPDump and Wireshark re-invented for Kubernetes
+- type: github_release
+  repo_owner: uptrace
+  repo_name: uptrace
+  format: raw
+  asset: "uptrace_{{.OS}}_{{.Arch}}"
+  description: Distributed tracing using OpenTelemetry and ClickHouse
 
 # init: v
 - type: github_release


### PR DESCRIPTION
Close #807

* #807 #1606 `liamg/memit`
  * https://github.com/liamg/memit
  * Run binaries straight from memory in Linux
* #1606 `uptrace/uptrace`
  * https://github.com/uptrace/uptrace
  * Distributed tracing using OpenTelemetry and ClickHouse
* #1606 `xiecat/fofax`
  * https://github.com/xiecat/fofax
  * fofaX is a command line query tool based on the API of https://fofa.so/ , simple is the best