### PR TITLE
refactor: remove link and files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Packages are sorted in the dictionary order of the package name.
 
 ## Style Guide
 
+* Remove spaces in the template `{{ ` and ` }}`
+* Remove a period from the end of the description
+* `link` is unneeded if `repo_owner` and `repo_name` are set
+
 ### Remove spaces in the template `{{ ` and ` }}`
 
 :thumbsup:

--- a/registry.yaml
+++ b/registry.yaml
@@ -661,15 +661,12 @@ packages:
   asset: 'autok3s_{{.OS}}_{{.Arch}}'
   description: Run K3s Everywhere
   format: raw
-- name: codeclimate/test-reporter
-  type: http
-  format: raw
+- type: http
   repo_owner: codeclimate
   repo_name: test-reporter
+  format: raw
   url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Version}}-{{.OS}}-amd64
   description: Code Climate Test Reporter
-  files:
-  - name: test-reporter
 - type: github_release
   repo_owner: codesenberg
   repo_name: bombardier
@@ -751,11 +748,10 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
-- name: crossplane/crossplane
-  type: http
-  format: raw
+- type: http
   repo_owner: crossplane
   repo_name: crossplane
+  format: raw
   url: 'https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank'
   description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
   files:
@@ -877,9 +873,7 @@ packages:
   asset: 'direnv.{{.OS}}-{{.Arch}}'
   format: raw
   description: unclutter your .profile
-- name: docker-slim/docker-slim
-  type: github_release
-  type: http
+- type: http
   repo_owner: docker-slim
   repo_name: docker-slim
   # https://downloads.dockerslim.com/releases/1.37.2/dist_mac_m1.zip
@@ -1060,11 +1054,10 @@ packages:
   format: raw
   asset: vsh_{{.OS}}_{{.Arch}}
   description: vsh - HashiCorp Vault interactive shell and cli tool
-- name: fishworks/gofish
-  type: http
-  rosetta2: true
+- type: http
   repo_owner: fishworks
   repo_name: gofish
+  rosetta2: true
   url: 'https://gofi.sh/releases/gofish-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
   description: GoFish is a cross-platform systems package manager, bringing the ease of use of Homebrew to Linux and Windows
   files:
@@ -1261,6 +1254,8 @@ packages:
   asset: 'minimock_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: Powerful mock generation tool for Go programming language
 - name: golang/go
+  # repo_owner: golang
+  # repo_name: go
   type: http
   url: https://golang.org/dl/go{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz
   link: https://golang.org/
@@ -1381,8 +1376,7 @@ packages:
   files:
   - name: terraformer
     src: 'terraformer-aws-{{.OS}}-{{.Arch}}'
-- name: GoogleContainerTools/container-diff
-  type: http
+- type: http
   repo_owner: GoogleContainerTools
   repo_name: container-diff
   url: 'https://storage.googleapis.com/container-diff/{{.Version}}/container-diff-{{.OS}}-amd64'
@@ -1390,8 +1384,7 @@ packages:
   files:
   - name: container-diff
     src: 'container-diff-{{.OS}}-amd64'
-- name: GoogleContainerTools/container-structure-test
-  type: http
+- type: http
   repo_owner: GoogleContainerTools
   repo_name: container-structure-test
   rosetta2: true
@@ -1408,8 +1401,7 @@ packages:
   files:
   - name: kpt
     src: 'kpt_{{.OS}}_{{.Arch}}'
-- name: GoogleContainerTools/skaffold
-  type: http
+- type: http
   repo_owner: GoogleContainerTools
   repo_name: skaffold
   url: 'https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}'
@@ -1543,24 +1535,18 @@ packages:
   description: Command Line Tools for Drone CI
   files:
   - name: drone
-- name: hashicorp/levant
-  type: http
-  rosetta2: true
+- type: http
   repo_owner: hashicorp
   repo_name: levant
+  rosetta2: true
   url: 'https://releases.hashicorp.com/levant/{{trimV .Version}}/levant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: An open source templating and deployment tool for HashiCorp Nomad jobs
-  files:
-  - name: levant
-- name: hashicorp/consul
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: consul
   rosetta2: true
   url: 'https://releases.hashicorp.com/consul/{{trimV .Version}}/consul_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
-  files:
-  - name: consul
 - type: github_release
   repo_owner: hashicorp
   repo_name: go-getter
@@ -1568,52 +1554,37 @@ packages:
   supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
   asset: 'go-getter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Package for downloading things from a string URL using a variety of protocols
-- name: hashicorp/nomad
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: nomad
   rosetta2: true
   url: 'https://releases.hashicorp.com/nomad/{{trimV .Version}}/nomad_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations
-  files:
-  - name: nomad
-- name: hashicorp/packer
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: packer
   url: 'https://releases.hashicorp.com/packer/{{trimV .Version}}/packer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Packer is a tool for creating identical machine images for multiple platforms from a single source configuration
-  files:
-  - name: packer
-- name: hashicorp/terraform
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: terraform
   url: 'https://releases.hashicorp.com/terraform/{{trimV .Version}}/terraform_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned
-  files:
-  - name: terraform
 - type: github_release
   repo_owner: hashicorp
   repo_name: terraform-ls
   asset: 'terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: Terraform Language Server
-- name: hashicorp/vault
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: vault
   url: 'https://releases.hashicorp.com/vault/{{trimV .Version}}/vault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: A tool for secrets management, encryption as a service, and privileged access management
-  files:
-  - name: vault
-- name: hashicorp/waypoint
-  type: http
+- type: http
   repo_owner: hashicorp
   repo_name: waypoint
   url: 'https://releases.hashicorp.com/waypoint/{{trimV .Version}}/waypoint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
   description: A tool to build, deploy, and release any application on any platform
-  files:
-  - name: waypoint
 - type: github_release
   repo_owner: hasura
   repo_name: graphql-engine
@@ -1633,8 +1604,7 @@ packages:
     format: zip
   files:
   - name: cr
-- name: helm/helm
-  type: http
+- type: http
   repo_owner: helm
   repo_name: helm
   url: 'https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
@@ -1689,8 +1659,7 @@ packages:
   repo_name: goimports-reviser
   asset: 'goimports-reviser_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   description: 'Right imports sorting & code formatting tool (goimports alternative)'
-- name: influxdata/influx-cli
-  type: http
+- type: http
   repo_owner: influxdata
   repo_name: influx-cli
   rosetta2: true
@@ -2083,14 +2052,11 @@ packages:
   description: The kubectl command line tool lets you control Kubernetes clusters
   files:
   - name: kubectl
-- name: kubernetes/minikube
-  type: http
+- type: http
   repo_owner: kubernetes
   repo_name: minikube
   url: 'https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}'
   description: Run Kubernetes locally
-  files:
-  - name: minikube
 - type: github_release
   repo_owner: kubernetes-sigs
   repo_name: cluster-api
@@ -2100,15 +2066,12 @@ packages:
   files:
   - name: clusterctl
     src: 'clusterctl-{{.OS}}-{{.Arch}}'
-- name: kubernetes-sigs/kind
-  type: http
+- type: http
   repo_owner: kubernetes-sigs
   repo_name: kind
   url: 'https://kind.sigs.k8s.io/dl/{{.Version}}/kind-{{.OS}}-{{.Arch}}'
   format: raw
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
-  files:
-  - name: kind
 - type: github_release
   repo_owner: kubernetes-sigs
   repo_name: krew

--- a/registry.yaml
+++ b/registry.yaml
@@ -25,12 +25,10 @@ packages:
   description: 'Home of the ABS programming language: the joy of shell scripting'
   rosetta2: true
   asset: abs-{{.OS}}-{{.Arch}}
-  link: https://www.abs-lang.org/
 - type: github_release
   repo_owner: accurics
   repo_name: terrascan
   asset: 'terrascan_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://docs.accurics.com/projects/accurics-terrascan/en/latest/
   description: Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure
   replacements:
     darwin: Darwin
@@ -51,7 +49,6 @@ packages:
   repo_owner: aelsabbahy
   repo_name: goss
   path: extras/dgoss/dgoss
-  link: https://github.com/aelsabbahy/goss/tree/master/extras/dgoss
   description: dgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker containers
   files:
   - name: dgoss
@@ -60,7 +57,6 @@ packages:
   repo_owner: aelsabbahy
   repo_name: goss
   path: extras/dcgoss/dcgoss
-  link: https://github.com/aelsabbahy/goss/tree/master/extras/dcgoss
   description: dcgoss is a convenience wrapper around goss that aims to bring the simplicity of goss to docker-compose managed containers
   files:
   - name: dcgoss
@@ -69,7 +65,6 @@ packages:
   repo_owner: aelsabbahy
   repo_name: goss
   path: extras/kgoss/kgoss
-  link: https://github.com/aelsabbahy/goss/tree/master/extras/kgoss
   description: kgoss is a wrapper for goss that aims to bring the simplicity of testing with goss to containers running in pods in Kubernetes
   files:
   - name: kgoss
@@ -227,7 +222,6 @@ packages:
   repo_owner: aquasecurity
   repo_name: tfsec
   asset: "tfsec-{{.OS}}-{{.Arch}}"
-  link: https://tfsec.dev/
   description: A static analysis security scanner for your Terraform code
 - type: github_release
   repo_owner: aquasecurity
@@ -251,7 +245,6 @@ packages:
   repo_name: argocd-autopilot
   rosetta2: true
   asset: 'argocd-autopilot-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://argocd-autopilot.readthedocs.io/en/stable/
   description: Argo-CD Autopilot
   files:
   - name: argocd-autopilot
@@ -260,7 +253,6 @@ packages:
   repo_owner: argoproj
   repo_name: argo-cd
   asset: 'argocd-{{.OS}}-amd64'
-  link: https://argo-cd.readthedocs.io/
   description: Declarative continuous deployment for Kubernetes
   files:
   - name: argocd
@@ -269,7 +261,6 @@ packages:
   repo_owner: argoproj
   repo_name: argo-rollouts
   asset: 'kubectl-argo-rollouts-{{.OS}}-amd64'
-  link: https://argoproj.github.io/argo-rollouts/
   description: Progressive Delivery for Kubernetes
   files:
   - name: kubectl-argo-rollouts
@@ -278,7 +269,6 @@ packages:
   repo_name: argo-workflows
   rosetta2: true
   asset: 'argo-{{.OS}}-{{.Arch}}.gz'
-  link: https://argoproj.github.io/argo-workflows/
   description: 'Argo Worfkflows CLI. Workflow engine for Kubernetes'
   files:
   - name: argo
@@ -295,7 +285,6 @@ packages:
   repo_owner: aws
   repo_name: copilot-cli
   asset: 'copilot_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://aws.github.io/copilot-cli/
   description: The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate
   replacements:
     darwin: macOS
@@ -377,7 +366,6 @@ packages:
   repo_name: gomi
   asset: 'gomi_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Replacement for UNIX rm command!
-  link: https://babarot.me/gomi/
   format: tar.gz
   format_overrides:
   - goos: windows
@@ -404,7 +392,6 @@ packages:
   repo_name: stein
   asset: 'stein_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: A linter for config files with a customizable rule set
-  link: https://babarot.me/stein/
   format: tar.gz
   format_overrides:
   - goos: windows
@@ -454,7 +441,6 @@ packages:
   - goos: darwin
     format: zip
   description: Streaming replication for SQLite
-  link: https://litestream.io/
 - type: github_release
   repo_owner: benchkram
   repo_name: bob
@@ -612,7 +598,6 @@ packages:
   repo_name: cli
   rosetta2: true
   asset: 'gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://cli.github.com/
   description: GitHub’s official command line tool
   files:
   - name: gh
@@ -682,7 +667,6 @@ packages:
   repo_owner: codeclimate
   repo_name: test-reporter
   url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Version}}-{{.OS}}-amd64
-  link: https://github.com/codeclimate/test-reporter
   description: Code Climate Test Reporter
   files:
   - name: test-reporter
@@ -706,7 +690,6 @@ packages:
   repo_name: kubesec
   asset: 'kubesec_{{.OS}}_{{.Arch}}.tar.gz'
   description: Security risk analysis for Kubernetes resources
-  link: https://kubesec.io/
 - type: github_release
   repo_owner: corneliusweig
   repo_name: ketall
@@ -775,7 +758,6 @@ packages:
   repo_name: crossplane
   url: 'https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank'
   description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
-  link: https://github.com/crossplane/crossplane
   files:
   - name: kubectl-crossplane
 - type: github_release
@@ -784,7 +766,6 @@ packages:
   rosetta2: true
   asset: 'cue_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: The new home of the CUE language! Validate and define text-based and dynamic configuration
-  link: https://cuelang.org/
   format: tar.gz
   format_overrides:
   - goos: windows
@@ -818,7 +799,6 @@ packages:
   repo_name: datree
   rosetta2: true
   asset: 'datree-cli_{{.Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://datree.io/
   description: Prevent Kubernetes misconfigurations from reaching production! Datree is a CLI tool to ensure K8s manifests and Helm charts follow best practices as well as your organization’s policies
   replacements:
     darwin: Darwin
@@ -827,7 +807,6 @@ packages:
 - type: github_release
   repo_owner: ddosify
   repo_name: ddosify
-  link: https://ddosify.com/
   description: High-performance load testing tool, written in Golang
   replacements:
     darwin: macos
@@ -850,7 +829,6 @@ packages:
   repo_owner: derailed
   repo_name: k9s
   asset: 'k9s_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://k9scli.io/
   description: Kubernetes CLI To Manage Your Clusters In Style!
   replacements:
     darwin: Darwin
@@ -878,7 +856,6 @@ packages:
   repo_name: dhall-haskell
   asset: 'dhall-{{.Version}}-x86_64-{{.OS}}.tar.bz2'
   description: Maintainable configuration files
-  link: https://dhall-lang.org/
   replacements:
     darwin: macos
     amd64: x86_64
@@ -890,7 +867,6 @@ packages:
   repo_name: doctl
   asset: 'doctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}'
   description: The official command line interface for the DigitalOcean API
-  link: https://docs.digitalocean.com/reference/doctl/
   format: tar.gz
   format_overrides:
   - goos: windows
@@ -970,7 +946,6 @@ packages:
   repo_owner: earthly
   repo_name: earthly
   asset: 'earthly-{{.OS}}-{{.Arch}}'
-  link: https://earthly.dev/
   description: Repeatable builds
 - type: github_release
   repo_owner: editorconfig-checker
@@ -997,7 +972,6 @@ packages:
   repo_owner: env0
   repo_name: terratag
   asset: 'terratag_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
-  link: https://www.terratag.io/
   description: Terratag is a CLI tool that enables users of Terraform to automatically create and maintain tags across their entire set of AWS, Azure, and GCP resources
 - type: github_release
   repo_owner: ernoaapa
@@ -1092,7 +1066,6 @@ packages:
   repo_owner: fishworks
   repo_name: gofish
   url: 'https://gofi.sh/releases/gofish-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://gofi.sh/
   description: GoFish is a cross-platform systems package manager, bringing the ease of use of Homebrew to Linux and Windows
   files:
   - name: gofish
@@ -1102,7 +1075,6 @@ packages:
   repo_name: fission
   asset: 'fission-{{.Version}}-{{.OS}}-{{.Arch}}'
   description: Fast and Simple Serverless Functions for Kubernetes
-  link: https://fission.io/
   format: raw
 - type: github_release
   repo_owner: flosell
@@ -1174,7 +1146,6 @@ packages:
   repo_owner: getsentry
   repo_name: sentry-cli
   asset: 'sentry-cli-{{.OS}}-{{.Arch}}'
-  link: https://docs.sentry.io/product/cli/
   description: A command line utility to work with Sentry
   replacements:
     darwin: Darwin
@@ -1220,7 +1191,6 @@ packages:
   repo_name: hub
   rosetta2: true
   asset: 'hub-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}'
-  link: https://hub.github.com/
   description: A command-line tool that makes git easier to use with GitHub
   format: tgz
   format_overrides:
@@ -1234,7 +1204,6 @@ packages:
   repo_name: git-lfs
   asset: 'git-lfs-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}'
   description: Git extension for versioning large files
-  link: https://git-lfs.github.com/
   format: tar.gz
   format_overrides:
   - goos: darwin
@@ -1262,13 +1231,11 @@ packages:
   repo_owner: go-task
   repo_name: task
   asset: 'task_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://taskfile.dev/
   description: A task runner / simpler Make alternative written in Go
 - type: github_release
   repo_owner: gohugoio
   repo_name: hugo
   asset: 'hugo_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}'
-  link: https://gohugo.io
   description: The world’s fastest framework for building websites
   files:
   - name: hugo
@@ -1315,7 +1282,6 @@ packages:
   repo_owner: golangci
   repo_name: golangci-lint
   asset: 'golangci-lint-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://golangci-lint.run/
   description: Fast linters Runner for Go
   files:
   - name: golangci-lint
@@ -1420,7 +1386,6 @@ packages:
   repo_owner: GoogleContainerTools
   repo_name: container-diff
   url: 'https://storage.googleapis.com/container-diff/{{.Version}}/container-diff-{{.OS}}-amd64'
-  link: https://github.com/GoogleContainerTools/container-diff
   description: 'container-diff: Diff your Docker containers'
   files:
   - name: container-diff
@@ -1431,7 +1396,6 @@ packages:
   repo_name: container-structure-test
   rosetta2: true
   url: 'https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}'
-  link: https://github.com/GoogleContainerTools/container-structure-test
   description: validate the structure of your container images
   files:
   - name: container-structure-test
@@ -1439,7 +1403,6 @@ packages:
 - type: github_release
   repo_owner: GoogleContainerTools
   repo_name: kpt
-  link: https://kpt.dev/
   description: A Git-native, schema-aware, extensible client-side tool for packaging, customizing, validating, and applying Kubernetes resources
   asset: 'kpt_{{.OS}}_{{.Arch}}'
   files:
@@ -1450,7 +1413,6 @@ packages:
   repo_owner: GoogleContainerTools
   repo_name: skaffold
   url: 'https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}'
-  link: https://skaffold.dev/
   description: Easy and Repeatable Kubernetes Development
   files:
   - name: skaffold
@@ -1467,7 +1429,6 @@ packages:
 - type: github_release
   repo_owner: goreleaser
   repo_name: goreleaser
-  link: https://goreleaser.com/
   description: Deliver Go binaries as fast and easily as possible
   replacements:
     amd64: x86_64
@@ -1502,7 +1463,6 @@ packages:
   repo_owner: grafana
   repo_name: k6
   asset: 'k6-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}'
-  link: https://k6.io/
   description: A modern load testing tool, using Go and JavaScript
   files:
   - name: k6
@@ -1525,7 +1485,6 @@ packages:
 - type: github_release
   repo_owner: grafana
   repo_name: tanka
-  link: https://tanka.dev/
   description: Flexible, reusable and concise configuration for Kubernetes
   rosetta2: true
   asset: 'tk-{{.OS}}-{{.Arch}}'
@@ -1542,7 +1501,6 @@ packages:
   repo_owner: gruntwork-io
   repo_name: terragrunt
   asset: 'terragrunt_{{.OS}}_{{.Arch}}'
-  link: https://terragrunt.gruntwork.io/
   description: Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules
 - type: github_release
   repo_owner: gsamokovarov
@@ -1558,13 +1516,11 @@ packages:
   repo_owner: hairyhenderson
   repo_name: gomplate
   asset: "gomplate_{{.OS}}-{{.Arch}}"
-  link: https://docs.gomplate.ca/
   description: A flexible commandline tool for template rendering. Supports lots of local and remote datasources
 - type: github_release
   repo_owner: harelba
   repo_name: q
   asset: 'q-{{.Arch}}-{{.OS}}'
-  link: http://harelba.github.io/q/
   description: q - Run SQL directly on CSV or TSV files
   files:
   - name: q
@@ -1593,7 +1549,6 @@ packages:
   repo_owner: hashicorp
   repo_name: levant
   url: 'https://releases.hashicorp.com/levant/{{trimV .Version}}/levant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://github.com/hashicorp/levant
   description: An open source templating and deployment tool for HashiCorp Nomad jobs
   files:
   - name: levant
@@ -1603,7 +1558,6 @@ packages:
   repo_name: consul
   rosetta2: true
   url: 'https://releases.hashicorp.com/consul/{{trimV .Version}}/consul_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.consul.io/
   description: Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure
   files:
   - name: consul
@@ -1620,7 +1574,6 @@ packages:
   repo_name: nomad
   rosetta2: true
   url: 'https://releases.hashicorp.com/nomad/{{trimV .Version}}/nomad_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.nomadproject.io/
   description: Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice, batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul and Vault integrations
   files:
   - name: nomad
@@ -1629,7 +1582,6 @@ packages:
   repo_owner: hashicorp
   repo_name: packer
   url: 'https://releases.hashicorp.com/packer/{{trimV .Version}}/packer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.packer.io/
   description: Packer is a tool for creating identical machine images for multiple platforms from a single source configuration
   files:
   - name: packer
@@ -1638,7 +1590,6 @@ packages:
   repo_owner: hashicorp
   repo_name: terraform
   url: 'https://releases.hashicorp.com/terraform/{{trimV .Version}}/terraform_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.terraform.io/
   description: Terraform enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned
   files:
   - name: terraform
@@ -1652,7 +1603,6 @@ packages:
   repo_owner: hashicorp
   repo_name: vault
   url: 'https://releases.hashicorp.com/vault/{{trimV .Version}}/vault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.vaultproject.io/
   description: A tool for secrets management, encryption as a service, and privileged access management
   files:
   - name: vault
@@ -1661,7 +1611,6 @@ packages:
   repo_owner: hashicorp
   repo_name: waypoint
   url: 'https://releases.hashicorp.com/waypoint/{{trimV .Version}}/waypoint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://www.waypointproject.io/
   description: A tool to build, deploy, and release any application on any platform
   files:
   - name: waypoint
@@ -1689,7 +1638,6 @@ packages:
   repo_owner: helm
   repo_name: helm
   url: 'https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://helm.sh/
   description: The Kubernetes Package Manager
   files:
   - name: helm
@@ -1782,7 +1730,6 @@ packages:
   repo_name: kubeval
   rosetta2: true
   asset: 'kubeval-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://www.kubeval.com/
   description: Validate your Kubernetes configuration files, supports multiple Kubernetes versions
 - type: github_release
   repo_owner: int128
@@ -2114,7 +2061,6 @@ packages:
   repo_owner: kubernetes
   repo_name: kompose
   description: Go from Docker Compose to Kubernetes
-  link: https://kompose.io/
   format: raw
   version_constraint: 'semver(">= 1.26.0")'
   asset: 'kompose-{{.OS}}-{{.Arch}}'
@@ -2127,7 +2073,6 @@ packages:
   repo_name: kops
   asset: 'kops-{{.OS}}-{{.Arch}}'
   description: Kubernetes Operations (kops) - Production Grade K8s Installation, Upgrades, and Management
-  link: https://kops.sigs.k8s.io/
 - name: kubernetes/kubectl
   type: http
   # repo_owner: kubernetes
@@ -2143,7 +2088,6 @@ packages:
   repo_owner: kubernetes
   repo_name: minikube
   url: 'https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}'
-  link: https://minikube.sigs.k8s.io/docs/
   description: Run Kubernetes locally
   files:
   - name: minikube
@@ -2162,7 +2106,6 @@ packages:
   repo_name: kind
   url: 'https://kind.sigs.k8s.io/dl/{{.Version}}/kind-{{.OS}}-{{.Arch}}'
   format: raw
-  link: https://kind.sigs.k8s.io/
   description: Kubernetes IN Docker - local clusters for testing Kubernetes
   files:
   - name: kind
@@ -2170,7 +2113,6 @@ packages:
   repo_owner: kubernetes-sigs
   repo_name: krew
   asset: krew-{{.OS}}_{{.Arch}}.tar.gz
-  link: https://krew.sigs.k8s.io/
   description: Find and install kubectl plugins
   files:
   - name: krew
@@ -2212,7 +2154,6 @@ packages:
   repo_name: kuttl
   asset: 'kuttl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: KUbernetes Test TooL (kuttl)
-  link: https://kuttl.dev/
   files:
   - name: kubectl-kuttl
   replacements:
@@ -2278,14 +2219,12 @@ packages:
   asset: 'devspace-{{.OS}}-{{.Arch}}'
   format: raw
   description: DevSpace - The Fastest Developer Tool for Kubernetes ⚡ Automate your deployment workflow with DevSpace and develop software directly inside Kubernetes
-  link: https://devspace.sh/
 - type: github_release
   repo_owner: loft-sh
   repo_name: vcluster
   asset: 'vcluster-{{.OS}}-{{.Arch}}'
   format: raw
   description: vcluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces
-  link: https://www.vcluster.com/
 - type: github_release
   repo_owner: lotabout
   repo_name: skim
@@ -2304,7 +2243,6 @@ packages:
   asset: 'mage_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}'
   rosetta2: true
   description: a Make/rake-like dev tool using Go
-  link: https://magefile.org/
   replacements:
     amd64: 64bit
     386: 32bit
@@ -2380,7 +2318,6 @@ packages:
   repo_owner: mikefarah
   repo_name: yq
   asset: "yq_{{.OS}}_{{.Arch}}"
-  link: https://mikefarah.gitbook.io/yq/
   description: yq is a portable command-line YAML processor
 - type: github_release
   repo_owner: miku
@@ -2505,7 +2442,6 @@ packages:
   repo_name: neovim
   asset: 'nvim-{{.OS}}.tar.gz'
   description: Hyperextensible Vim-based text editor
-  link: https://neovim.io/
   replacements:
     linux: linux64
     darwin: macos
@@ -2517,7 +2453,6 @@ packages:
   repo_name: newrelic-cli
   asset: 'newrelic-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: The New Relic Command Line Interface
-  link: https://newrelic.github.io/developer-toolkit/
   files:
   - name: newrelic
   replacements:
@@ -2572,7 +2507,6 @@ packages:
   repo_owner: oam-dev
   repo_name: kubevela
   asset: vela-{{.Version}}-{{.OS}}-amd64.tar.gz
-  link: https://kubevela.io/
   description: The Modern Application Deployment System Based on OAM
   files:
   - name: vela
@@ -2582,7 +2516,6 @@ packages:
   repo_owner: oam-dev
   repo_name: kubevela
   asset: kubectl-vela-{{.Version}}-{{.OS}}-amd64.tar.gz
-  link: https://kubevela.io/
   description: The Modern Application Deployment System Based on OAM
   files:
   - name: kubectl-vela
@@ -2592,7 +2525,6 @@ packages:
   repo_name: dog
   asset: 'dog-{{.Version}}-{{.OS}}.zip'
   description: 'A command-line DNS client.'
-  link: https://dns.lookup.dog
   replacements:
     darwin: x86_64-apple-darwin
     linux: x86_64-unknown-linux-gnu
@@ -2604,7 +2536,6 @@ packages:
   repo_name: exa
   asset: 'exa-{{.OS}}-{{.Version}}.zip'
   description: "A modern replacement for 'ls'"
-  link: https://the.exa.website/
   replacements:
     darwin: macos-x86_64
     linux: linux-x86_64-musl
@@ -2616,7 +2547,6 @@ packages:
   repo_name: okteto
   asset: 'okteto-{{.OS}}-{{.Arch}}'
   description: Develop your applications directly in your Kubernetes Cluster
-  link: https://okteto.com/
   format: raw
   replacements:
     amd64: x86_64
@@ -2627,13 +2557,11 @@ packages:
   repo_name: conftest
   # https://github.com/open-policy-agent/conftest/blob/f68c92599fa8fd1c2e81527aee351064f5419df5/.goreleaser.yml#L21-L31
   asset: 'conftest_{{trimV .Version}}_{{title .OS}}_x86_64.tar.gz'
-  link: https://www.conftest.dev/
   description: Write tests against structured configuration data using the Open Policy Agent Rego query language
 - type: github_release
   repo_owner: open-policy-agent
   repo_name: opa
   asset: "opa_{{.OS}}_amd64"
-  link: https://www.openpolicyagent.org/
   description: An open source, general-purpose policy engine
 - type: github_release
   repo_owner: openfaas
@@ -2745,7 +2673,6 @@ packages:
   repo_name: glab
   rosetta2: true
   asset: 'glab_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
-  link: https://glab.readthedocs.io/en/latest/
   description: An open-source GitLab command line tool bringing GitLab's cool features to your command line
   format: tar.gz
   format_overrides:
@@ -2764,7 +2691,6 @@ packages:
   repo_owner: projectdiscovery
   repo_name: nuclei
   asset: 'nuclei_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://nuclei.projectdiscovery.io/
   description: Fast and customizable vulnerability scanner based on simple YAML based DSL
   replacements:
     darwin: macOS
@@ -2772,7 +2698,6 @@ packages:
   repo_owner: projectdiscovery
   repo_name: subfinder
   asset: 'subfinder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip'
-  link: https://github.com/projectdiscovery/subfinder
   description: Subfinder is a subdomain discovery tool that discovers valid subdomains for websites. Designed as a passive framework to be useful for bug bounties and safe for penetration testing
   replacements:
     darwin: macOS
@@ -2787,7 +2712,6 @@ packages:
   repo_owner: pulumi
   repo_name: pulumi
   asset: 'pulumi-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://www.pulumi.com/
   description: Pulumi - Modern Infrastructure as Code. Any cloud, any language
   replacements:
     amd64: x64
@@ -2817,7 +2741,6 @@ packages:
   asset: 'k3d-{{.OS}}-{{.Arch}}'
   format: raw
   description: Little helper to run Rancher Lab's k3s in Docker
-  link: https://k3d.io/
 - type: github_release
   repo_owner: rancher
   repo_name: kim
@@ -2836,7 +2759,6 @@ packages:
   repo_owner: rclone
   repo_name: rclone
   asset: 'rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip'
-  link: https://rclone.org/
   description: '"rsync for cloud storage" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Yandex Files'
   files:
   - name: rclone
@@ -2871,7 +2793,6 @@ packages:
   repo_owner: restic
   repo_name: restic
   asset: 'restic_{{trimV .Version}}_{{.OS}}_{{.Arch}}.bz2'
-  link: https://restic.net/
   description: Fast, secure, efficient backup program
   files:
   - name: restic
@@ -2976,7 +2897,6 @@ packages:
   asset: 'scw-{{trimV .Version}}-{{.OS}}-{{.Arch}}'
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   description: Command Line Interface for Scaleway
-  link: https://www.scaleway.com/en/cli/
   files:
   - name: scw
   replacements:
@@ -3114,7 +3034,6 @@ packages:
   repo_name: sloth
   asset: 'sloth-{{.OS}}-{{.Arch}}'
   description: Easy and simple Prometheus SLO (service level objectives) generator
-  link: https://sloth.dev/
   format: raw
 - type: github_release
   repo_owner: snyk
@@ -3215,7 +3134,6 @@ packages:
   # repo_name: spin
   rosetta2: true
   url: 'https://storage.googleapis.com/spinnaker-artifacts/spin/{{trimV .Version}}/{{.OS}}/{{.Arch}}/spin'
-  link: https://github.com/spinnaker/spin
   description: Spinnaker CLI
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   files:
@@ -3224,7 +3142,6 @@ packages:
   repo_owner: squat
   repo_name: kilo
   asset: 'kgctl-{{.OS}}-{{.Arch}}'
-  link: https://kilo.squat.ai/docs/kgctl
   description: 'kgctl - Manage a Kilo network. Kilo is a multi-cloud network overlay built on WireGuard and designed for Kubernetes (k8s + wg = kg)'
   format: raw
   files:
@@ -3233,7 +3150,6 @@ packages:
   repo_owner: stackrox
   repo_name: kube-linter
   asset: 'kube-linter-{{.OS}}.tar.gz'
-  link: https://docs.kubelinter.io/#/
   description: KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices
 - type: github_release
   repo_owner: starship
@@ -3254,7 +3170,6 @@ packages:
   repo_name: jq
   asset: 'jq-{{.OS}}'
   format: raw
-  link: http://stedolan.github.io/jq/
   description: Command-line JSON processor
   replacements:
     darwin: osx-amd64
@@ -3457,7 +3372,6 @@ packages:
   repo_owner: temporalio
   repo_name: temporal
   asset: 'temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://docs.temporal.io/
   description: Temporal service and CLI
   files:
   - name: tctl
@@ -3465,7 +3379,6 @@ packages:
   repo_owner: terraform-docs
   repo_name: terraform-docs
   asset: 'terraform-docs-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
-  link: https://terraform-docs.io/
   description: Generate documentation from Terraform modules in various output formats
 - type: github_release
   repo_owner: terraform-linters
@@ -3527,7 +3440,6 @@ packages:
   repo_owner: thought-machine
   repo_name: please
   asset: 'please_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://please.build/
   description: High-performance extensible build system for reproducible multi-language builds
   files:
   - name: please
@@ -3548,7 +3460,6 @@ packages:
 - type: github_release
   repo_owner: tilt-dev
   repo_name: tilt
-  link: https://tilt.dev/
   description: Define your dev environment as code. For microservice apps on Kubernetes
   asset: 'tilt.{{trimV .Version}}.{{.OS}}.{{.Arch}}.{{.Format}}'
   format: tar.gz
@@ -3568,7 +3479,6 @@ packages:
   repo_name: tinygo
   rosetta2: true
   asset: 'tinygo{{trimV .Version}}.{{.OS}}-{{.Arch}}.{{.Format}}'
-  link: https://tinygo.org/
   description: Go compiler for small places. Microcontrollers, WebAssembly, and command-line tools. Based on LLVM
   format: tar.gz
   format_overrides:
@@ -3590,7 +3500,6 @@ packages:
   rosetta2: true
   asset: 'dasel_{{.OS}}_{{.Arch}}'
   format: raw
-  link: https://daseldocs.tomwright.me/
   description: Select, put and delete data from JSON, TOML, YAML, XML and CSV files with a single tool. Supports conversion between formats and can be used as a Go package
 - type: github_release
   repo_owner: Traackr
@@ -3684,7 +3593,6 @@ packages:
   format: raw
   asset: "imgpkg-{{.OS}}-{{.Arch}}"
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
-  link: https://carvel.dev/imgpkg/
   description: 'Store application configuration files in Docker/OCI registries'
   files:
   - name: imgpkg
@@ -3693,7 +3601,6 @@ packages:
   repo_name: carvel-kapp
   format: raw
   asset: "kapp-{{.OS}}-{{.Arch}}"
-  link: https://carvel.dev/kapp/
   description: 'kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label'
   files:
   - name: kapp
@@ -3702,7 +3609,6 @@ packages:
   repo_name: carvel-kbld
   format: raw
   asset: "kbld-{{.OS}}-{{.Arch}}"
-  link: https://carvel.dev/kbld/
   description: kbld seamlessly incorporates image building and image pushing into your development and deployment workflows
   files:
   - name: kbld
@@ -3721,7 +3627,6 @@ packages:
   repo_name: carvel-vendir
   rosetta2: true
   asset: "vendir-{{.OS}}-{{.Arch}}"
-  link: https://carvel.dev/vendir/
   description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
   files:
   - name: vendir
@@ -3729,14 +3634,12 @@ packages:
   repo_owner: vmware-tanzu
   repo_name: carvel-ytt
   asset: "ytt-{{.OS}}-{{.Arch}}"
-  link: https://carvel.dev/ytt/
   description: YAML templating tool that works on YAML structure instead of text
   files:
   - name: ytt
 - type: github_release
   repo_owner: vmware-tanzu
   repo_name: velero
-  link: https://velero.io/
   description: Backup and migrate Kubernetes applications and their persistent volumes
   rosetta2: true
   asset: "velero-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz"
@@ -3787,7 +3690,6 @@ packages:
   repo_owner: weaveworks
   repo_name: eksctl
   asset: 'eksctl_{{title .OS}}_{{.Arch}}.tar.gz'
-  link: https://eksctl.io/
   description: The official CLI for Amazon EKS
 - type: github_release
   repo_owner: windvalley
@@ -3801,7 +3703,6 @@ packages:
   repo_owner: wtfutil
   repo_name: wtf
   asset: 'wtf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
-  link: https://wtfutil.com/
   description: WTF is the personal information dashboard for your terminal
   files:
   - name: wtfutil


### PR DESCRIPTION
## ⚠️ Breaking Changes

Some fields are removed.

* `name`
* `link`
* `files`

aqua can get them from `repo_owner` and `repo_name` by default.

### How to migrate

Upgrade aqua to `>= v0.8.12`. https://github.com/aquaproj/aqua/releases/tag/v0.8.12