### PR TITLE
fix: rename the command of codeclimate/test-reporter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,21 @@ jobs:
 
       - name: install packages for testing
         run: |
+          if grep -E "target:all" "$CI_INFO_TEMP_DIR/labels.txt" > /dev/null 2>&1; then
+            echo "[INFO] test all packages" >&2
+            aqua -c aqua-all.yaml i --test
+            exit 0
+          fi
+          empty=true
+          if grep -E "target:" "$CI_INFO_TEMP_DIR/labels.txt" > /dev/null 2>&1; then
+            grep -E "target:" "$CI_INFO_TEMP_DIR/labels.txt" | sed "s|^target:\(.*\)|- import: pkgs/\1.yaml|" >> aqua-ci.yaml
+            empty=false
+          fi
           if grep -E "^pkgs/.*\.yaml" < "$CI_INFO_TEMP_DIR/pr_all_filenames.txt" > /dev/null 2>&1; then
             grep -E "^pkgs/.*\.yaml" < "$CI_INFO_TEMP_DIR/pr_all_filenames.txt" | sed "s/^/- import: /" >> aqua-ci.yaml
+            empty=false
+          fi
+          if [ "$empty" = "false" ]; then
             echo "[INFO] aqua-ci.yaml" >&2
             cat aqua-ci.yaml >&2
             echo "[INFO] + aqua -c aqua-ci.yaml i --test" >&2

--- a/registry.yaml
+++ b/registry.yaml
@@ -667,6 +667,9 @@ packages:
   format: raw
   url: https://codeclimate.com/downloads/test-reporter/test-reporter-{{.Version}}-{{.OS}}-amd64
   description: Code Climate Test Reporter
+  files:
+  - name: cc-test-reporter
+    src: test-reporter
 - type: github_release
   repo_owner: codesenberg
   repo_name: bombardier


### PR DESCRIPTION
## ⚠️ Breaking Change

The command name of the package `codeclimate/test-reporter` is changed from `test-reporter` to `cc-test-reporter`.
If you don't use the package `codeclimate/test-reporter`, you can ignore this change.