### PR TITLE
feat: add `ahmetb/kubectx/kubens`

### DIFF
--- a/pkgs/a.yaml
+++ b/pkgs/a.yaml
@@ -9,8 +9,10 @@ packages:
 - name: aelsabbahy/goss/kgoss@v0.3.16
 - name: ahmetb/kubectl-tree@v0.4.1
 - name: ahmetb/kubectx@v0.9.4
-- name: ahmetb/kubens
-  version: v0.9.4 # renovate: depName=ahmetb/kubectx
+- name: ahmetb/kubectx/kubens@v0.9.4
+# comment out because this conflict with `ahmetb/kubectx/kubens`
+# - name: ahmetb/kubens
+#   version: v0.9.4 # renovate: depName=ahmetb/kubectx
 - name: ajeetdsouza/zoxide@v0.8.0
 - name: alexellis/arkade@0.8.11
 - name: alexellis/k3sup@0.11.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -85,12 +85,27 @@ packages:
   format_overrides:
   - goos: windows
     format: zip
-- name: ahmetb/kubens
+- name: ahmetb/kubectx/kubens
   type: github_release
   repo_owner: ahmetb
   repo_name: kubectx
   asset: 'kubens_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Faster way to switch between clusters and namespaces in kubectl
+  files:
+  - name: kubens
+  replacements:
+    386: i386
+    amd64: x86_64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+- name: ahmetb/kubens
+  type: github_release
+  repo_owner: ahmetb
+  repo_name: kubectx
+  asset: 'kubens_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+  description: DEPRECATED. PLEASE USE ahmetb/kubectx/kubens
   files:
   - name: kubens
   replacements:


### PR DESCRIPTION
Deprecate `ahmetb/kubens`.

* #1691 `ahmetb/kubectx/kubens`
  * https://github.com/ahmetb/kubectx
  * Faster way to switch between clusters and namespaces in kubectl

The content is equivalent to `ahmetb/kubens`.
Rename the package to update it with Renovate without annotation.