### PR TITLE
feat: add `replicatedhq/kots`

### DIFF
--- a/pkgs/r.yaml
+++ b/pkgs/r.yaml
@@ -6,6 +6,7 @@ packages:
 - name: rancher/rke@v1.3.4
 - name: rclone/rclone@v1.57.0
 - name: rebuy-de/aws-nuke@v2.16.0
+- name: replicatedhq/kots@v1.59.1
 - name: replicatedhq/outdated@v0.4.1
 - name: restic/restic@v0.12.1
 - name: reviewdog/reviewdog@v0.13.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -2802,6 +2802,11 @@ packages:
     src: 'aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}'
 - type: github_release
   repo_owner: replicatedhq
+  repo_name: kots
+  asset: 'kots_{{.OS}}_{{.Arch}}.tar.gz'
+  description: KOTS provides the framework, tools and integrations that enable the delivery and management of 3rd-party Kubernetes applications, a.k.a. Kubernetes Off-The-Shelf (KOTS) Software
+- type: github_release
+  repo_owner: replicatedhq
   repo_name: outdated
   asset: 'outdated_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Kubectl plugin to find and report outdated images running in a Kubernetes cluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -2805,6 +2805,9 @@ packages:
   repo_name: kots
   asset: 'kots_{{.OS}}_{{.Arch}}.tar.gz'
   description: KOTS provides the framework, tools and integrations that enable the delivery and management of 3rd-party Kubernetes applications, a.k.a. Kubernetes Off-The-Shelf (KOTS) Software
+  files:
+  - name: kubectl-kots
+    src: kots
 - type: github_release
   repo_owner: replicatedhq
   repo_name: outdated


### PR DESCRIPTION
- `replicatedhq/kots`
  - https://github.com/replicatedhq/kots
  - KOTS provides the framework, tools and integrations that enable the delivery and management of 3rd-party Kubernetes applications, a.k.a. Kubernetes Off-The-Shelf (KOTS) Software