### PR TITLE
fix: support `replicatedhq/kots` < 1.59.2

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -2814,10 +2814,16 @@ packages:
   repo_owner: replicatedhq
   repo_name: kots
   description: KOTS provides the framework, tools and integrations that enable the delivery and management of 3rd-party Kubernetes applications, a.k.a. Kubernetes Off-The-Shelf (KOTS) Software
-  asset: 'kots_{{.OS}}_{{if eq .GOOS "darwin"}}all{{else}}{{.Arch}}{{end}}.tar.gz'
   files:
   - name: kubectl-kots
     src: kots
+  version_constraint: 'semver(">= 1.59.2")'
+  asset: 'kots_{{.OS}}_{{if eq .GOOS "darwin"}}all{{else}}{{.Arch}}{{end}}.tar.gz'
+  version_overrides:
+  - version_constraint: 'semver("< 1.59.2")'
+    rosetta2: true
+    asset: 'kots_{{.OS}}_{{.Arch}}.tar.gz'
+    supported_if: not (GOOS == "linux" and GOARCH == "arm64")
 - type: github_release
   repo_owner: replicatedhq
   repo_name: outdated


### PR DESCRIPTION
Follow up #1851

## Bug Fixes

`replicatedhq/kots` can't be installed.

Affected aqua-registy version: v0.14.2

```yaml
registries:
- name: standard
  type: local
  path: registry.yaml

packages:
- name: replicatedhq/kots@v1.59.1
```

```console
$ kubectl kots --help
INFO[0000] download and unarchive the package            aqua_version=0.10.1 package_name=replicatedhq/kots package_version=v1.59.1 program=aqua registry=standard
FATA[0000] aqua failed                                   aqua_version=0.10.1 error="the asset isn't found: kots_darwin_all.tar.gz" program=aqua
```