### PR TITLE
feat: add `moby/buildkit/buildctl` and `moby/buildkit/buildkitd`

### DIFF
--- a/pkgs/m.yaml
+++ b/pkgs/m.yaml
@@ -13,6 +13,8 @@ packages:
 - name: minamijoyo/tfschema@v0.7.2
 - name: minamijoyo/tfupdate@v0.6.4
 - name: minishift/minishift@v1.34.3
+- name: moby/buildkit/buildctl@v0.9.3
+- name: moby/buildkit/buildkitd@v0.9.3
 - name: mongodb/mongocli@v1.21.0
 - name: mozilla/sops@v3.7.1
 - name: mumoshu/variant@v0.37.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -2389,6 +2389,25 @@ packages:
   files:
   - name: minishift
     src: 'minishift-{{trimV .Version}}-{{.OS}}-{{.Arch}}/minishift'
+- name: moby/buildkit/buildctl
+  type: github_release
+  repo_owner: moby
+  repo_name: buildkit
+  description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+  asset: 'buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz'
+  files:
+  - name: buildctl
+    src: bin/buildctl
+- name: moby/buildkit/buildkitd
+  type: github_release
+  repo_owner: moby
+  repo_name: buildkit
+  description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+  asset: 'buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz'
+  supported_if: GOOS == "linux"
+  files:
+  - name: buildkitd
+    src: bin/buildkitd
 - type: github_release
   repo_owner: mongodb
   repo_name: mongocli


### PR DESCRIPTION
Close #1870 

* #1870 #1876 `moby/buildkit/buildctl` and `moby/buildkit/buildkitd`
  * https://github.com/moby/buildkit
  * concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit