### PR TITLE
feat: add `argoproj-labs/argocd-image-updater`

### DIFF
--- a/pkgs/a.yaml
+++ b/pkgs/a.yaml
@@ -28,6 +28,7 @@ packages:
 - name: aquasecurity/tfsec@v1.0.11
 - name: aquasecurity/trivy@v0.23.0
 - name: argoproj-labs/argocd-autopilot@v0.2.28
+- name: argoproj-labs/argocd-image-updater@v0.11.3
 - name: argoproj/argo-cd@v2.2.5
 - name: argoproj/argo-rollouts@v1.1.1
 - name: argoproj/argo-workflows@v3.2.8

--- a/registry.yaml
+++ b/registry.yaml
@@ -273,6 +273,13 @@ packages:
   - name: argocd-autopilot
     src: 'argocd-autopilot-{{.OS}}-{{.Arch}}'
 - type: github_release
+  repo_owner: argoproj-labs
+  repo_name: argocd-image-updater
+  asset: 'argocd-image-updater_{{.Version}}_{{.OS}}-{{.Arch}}'
+  description: "Automatic container image update for Argo CD"
+  format: raw
+  supported_if: GOOS == "linux" and GOARCH == "amd64"
+- type: github_release
   repo_owner: argoproj
   repo_name: argo-cd
   asset: 'argocd-{{.OS}}-amd64'


### PR DESCRIPTION
Add https://github.com/argoproj-labs/argocd-image-updater
I have tested locally.

I used `format: raw` works fine, but others (eg. `argoproj/argo-cd`) uses `files` section.
Is there preferred notation for here?

https://github.com/aquaproj/aqua-registry/blob/d5f5792df06d46807ec530151d66725f647dd03e/registry.yaml#L275-L280


https://github.com/aquaproj/aqua-registry/blob/d5f5792df06d46807ec530151d66725f647dd03e/registry.yaml#L282-L289