### PR TITLE
fix: fix `blacknon/hwatch`

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -499,6 +499,28 @@ packages:
   - name: hwatch
     src: bin/hwatch
   version_overrides:
+  - version_constraint: 'semver("= 0.2.1") || semver("= 0.1.6")'
+    supported_if: 'false'
+  - version_constraint: 'semver("= 0.1.0")'
+    asset: 'hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+    rosetta2: true
+    replacements:
+      amd64: amd64
+      darwin: darwin
+      linux: linux
+    files:
+    - name: hwatch
+      src: 'hwatch_{{.Version}}_{{.OS}}_{{.Arch}}/hwatch'
+  - version_constraint: 'semver("<= 0.1.2")'
+    asset: 'hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
+    rosetta2: true
+    replacements:
+      amd64: amd64
+      darwin: darwin
+      linux: linux
+    files:
+    - name: hwatch
+      src: hwatch
   - version_constraint: 'semver("< 0.3.1")'
     asset: 'hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz'
     rosetta2: true


### PR DESCRIPTION
Follow up #2194
Fix the support of the old version of `blacknon/hwatch`.