### PR TITLE
lsd: replace arm64->aarch64

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -2762,6 +2762,7 @@ packages:
     format: zip
   replacements:
     amd64: x86_64
+    arm64: aarch64
     darwin: apple-darwin
     linux: unknown-linux-musl # Set musl as default. If architecture matchs, this can be executable without relying on external libraries
   files:


### PR DESCRIPTION
lsd builds binaries for aarch64: https://github.com/Peltoche/lsd/releases/tag/0.21.0
