### PR TITLE
add yamllint to catch errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,11 +66,3 @@ jobs:
           fi
           echo "[INFO] test all packages" >&2
           aqua -c aqua-all.yaml i --test
-  yamllint:
-    name: yamllint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v2
-      - name: Run yamllint
-        uses: frenck/action-yamllint@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,3 +66,11 @@ jobs:
           fi
           echo "[INFO] test all packages" >&2
           aqua -c aqua-all.yaml i --test
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: Run yamllint
+        uses: frenck/action-yamllint@v1

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,17 @@
+---
+name: yamllint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: Run yamllint
+        run: |
+          yamllint --no-warnings ./

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  line-length:
+    level: warning
+
+  indentation: disable

--- a/registry.yaml
+++ b/registry.yaml
@@ -1672,7 +1672,6 @@ packages:
 - type: github_release
   repo_owner: harelba
   repo_name: q
-  asset: 'q-{{.Arch}}-{{.OS}}'
   description: q - Run SQL directly on CSV or TSV files
   files:
   - name: q


### PR DESCRIPTION
Sorry, this is pretty noisy. I can configure the rules if you're interested in implementing this check.

This duplicate key in particular is problematic: 
https://github.com/aquaproj/aqua-registry/blob/main/registry.yaml#L1675-L1681
https://github.com/aquaproj/aqua-registry/runs/5256861370?check_suite_focus=true#step:4:227

Let me know if this change interests you and I can clean it up (and fix the errors).