### PR TITLE
feat: add aws/amazon-ec2-instance-selector

### DIFF
--- a/pkgs/a.yaml
+++ b/pkgs/a.yaml
@@ -34,6 +34,7 @@ packages:
 - name: argoproj/argo-workflows@v3.2.8
 - name: aristocratos/btop@v1.2.3
 - name: armosec/kubescape@v2.0.148
+- name: aws/amazon-ec2-instance-selector@v2.0.3
 - name: aws/copilot-cli@v1.15.0
 - name: awslabs/git-secrets@1.3.0
 - name: awslabs/ssosync@v1.0.0-rc.9

--- a/registry.yaml
+++ b/registry.yaml
@@ -332,6 +332,13 @@ packages:
   description: 'kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA'
 - type: github_release
   repo_owner: aws
+  repo_name: amazon-ec2-instance-selector
+  asset: 'ec2-instance-selector-{{.OS}}-{{.Arch}}.tar.gz'
+  description: A CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory
+  files:
+  - name: ec2-instance-selector
+- type: github_release
+  repo_owner: aws
   repo_name: copilot-cli
   asset: 'copilot_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'
   description: The AWS Copilot CLI is a tool for developers to build, release and operate production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate


### PR DESCRIPTION
I'd like to add the below tool since it is useful for getting the ec2 instance list that suits my usecase.

- https://github.com/aws/amazon-ec2-instance-selector
   - A CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory