### PR TITLE
fix: Use rosetta2 instead

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -398,10 +398,10 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: b4b4r07
   repo_name: git-bump
+  rosetta2: true
   asset: 'git-bump_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Bump version (git tag) to next one with semver
   format: tar.gz
@@ -411,10 +411,10 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: b4b4r07
   repo_name: github-labeler
+  rosetta2: true
   asset: 'github-labeler_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Declarative way to configure GitHub labels
   format: tar.gz
@@ -424,10 +424,10 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: b4b4r07
   repo_name: gomi
+  rosetta2: true
   asset: 'gomi_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: Replacement for UNIX rm command!
   format: tar.gz
@@ -437,10 +437,10 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: b4b4r07
   repo_name: iap_curl
+  rosetta2: true
   asset: 'iap_curl_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: A CLI that is curl wrapper for making HTTP request to IAP-protected app, more easier than curl
   format: tar.gz
@@ -450,10 +450,10 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: b4b4r07
   repo_name: stein
+  rosetta2: true
   asset: 'stein_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: A linter for config files with a customizable rule set
   format: tar.gz
@@ -463,7 +463,6 @@ packages:
   replacements:
     386: i386
     amd64: x86_64
-    arm64: x86_64
 - type: github_release
   repo_owner: batchcorp
   repo_name: plumber

--- a/registry.yaml
+++ b/registry.yaml
@@ -389,6 +389,7 @@ packages:
 - type: github_release
   repo_owner: b4b4r07
   repo_name: gist
+  rosetta2: true
   asset: 'gist_{{.OS}}_{{.Arch}}.{{.Format}}'
   description: A simple gist editor for CLI
   format: tar.gz


### PR DESCRIPTION
Fixed packages:

- https://github.com/b4b4r07/gist
- https://github.com/b4b4r07/git-bump
- https://github.com/b4b4r07/github-labeler
- https://github.com/b4b4r07/gomi
- https://github.com/b4b4r07/iap_curl
- https://github.com/b4b4r07/stein