### PR TITLE
feat: add `liamg/traitor` and `liamg/gitjacker`

### DIFF
--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -2,6 +2,7 @@ packages:
 # init: l
 - name: Ladicle/kubectl-rolesum@v1.5.1
 - name: lc/gau@v2.0.9
+- name: liamg/extrude@v0.0.12
 - name: liamg/gitjacker@v0.1.0
 - name: liamg/memit@v0.0.3
 - name: liamg/pax@v0.2.2

--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -5,6 +5,7 @@ packages:
 - name: liamg/gitjacker@v0.1.0
 - name: liamg/memit@v0.0.3
 - name: liamg/pax@v0.2.2
+- name: liamg/scout@v0.15.1
 - name: liamg/traitor@v0.0.14
 - name: lima-vm/lima@v0.9.0
 - name: loft-sh/devspace@v5.18.4

--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -2,6 +2,7 @@ packages:
 # init: l
 - name: Ladicle/kubectl-rolesum@v1.5.1
 - name: lc/gau@v2.0.9
+- name: liamg/gitjacker@v0.1.0
 - name: liamg/memit@v0.0.3
 - name: liamg/traitor@v0.0.14
 - name: lima-vm/lima@v0.9.0

--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -3,6 +3,7 @@ packages:
 - name: Ladicle/kubectl-rolesum@v1.5.1
 - name: lc/gau@v2.0.9
 - name: liamg/memit@v0.0.3
+- name: liamg/traitor@v0.0.14
 - name: lima-vm/lima@v0.9.0
 - name: loft-sh/devspace@v5.18.4
 - name: loft-sh/vcluster@v0.6.0

--- a/pkgs/l.yaml
+++ b/pkgs/l.yaml
@@ -4,6 +4,7 @@ packages:
 - name: lc/gau@v2.0.9
 - name: liamg/gitjacker@v0.1.0
 - name: liamg/memit@v0.0.3
+- name: liamg/pax@v0.2.2
 - name: liamg/traitor@v0.0.14
 - name: lima-vm/lima@v0.9.0
 - name: loft-sh/devspace@v5.18.4

--- a/registry.yaml
+++ b/registry.yaml
@@ -2408,6 +2408,14 @@ packages:
   supported_if: GOOS == "linux"
 - type: github_release
   repo_owner: liamg
+  repo_name: pax
+  format: raw
+  description: CLI tool for PKCS7 padding oracle attacks
+  rosetta2: true
+  asset: 'pax-{{.OS}}-{{.Arch}}'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+- type: github_release
+  repo_owner: liamg
   repo_name: traitor
   asset: 'traitor-{{.Arch}}'
   format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -2416,6 +2416,14 @@ packages:
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
 - type: github_release
   repo_owner: liamg
+  repo_name: scout
+  format: raw
+  description: "Lightweight URL fuzzer and spider: Discover a web server's undisclosed files, directories and VHOSTs"
+  rosetta2: true
+  asset: 'scout-{{.OS}}-{{.Arch}}'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+- type: github_release
+  repo_owner: liamg
   repo_name: traitor
   asset: 'traitor-{{.Arch}}'
   format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -2399,6 +2399,13 @@ packages:
   description: Run binaries straight from memory in Linux
   supported_if: GOOS == "linux"
 - type: github_release
+  repo_owner: liamg
+  repo_name: traitor
+  asset: 'traitor-{{.Arch}}'
+  format: raw
+  description: Automatic Linux privesc via exploitation of low-hanging fruit e.g. gtfobins, pwnkit, dirty pipe, +w docker.sock
+  supported_if: GOOS == "linux"
+- type: github_release
   repo_owner: lima-vm
   repo_name: lima
   asset: 'lima-{{trimV .Version}}-{{title .OS}}-{{if and (eq .GOOS "linux") (eq .GOARCH "arm64")}}aarch64{{else}}{{.Arch}}{{end}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -2393,6 +2393,14 @@ packages:
     format: zip
 - type: github_release
   repo_owner: liamg
+  repo_name: gitjacker
+  format: raw
+  description: Leak git repositories from misconfigured websites
+  rosetta2: true
+  asset: 'gitjacker-{{.OS}}-{{.Arch}}'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+- type: github_release
+  repo_owner: liamg
   repo_name: memit
   asset: 'memit-{{.OS}}-{{.Arch}}'
   format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -2393,6 +2393,12 @@ packages:
     format: zip
 - type: github_release
   repo_owner: liamg
+  repo_name: extrude
+  format: raw
+  description: Analyse binaries for missing security features, information disclosure and more
+  asset: 'extrude-{{.OS}}-{{.Arch}}'
+- type: github_release
+  repo_owner: liamg
   repo_name: gitjacker
   format: raw
   description: Leak git repositories from misconfigured websites


### PR DESCRIPTION
* #2498 `liamg/extrude`
  * https://github.com/liamg/extrude
  * Analyse binaries for missing security features, information disclosure and more
* #2498 `liamg/gitjacker`
  * https://github.com/liamg/gitjacker
  * Leak git repositories from misconfigured websites
* #2498 `liamg/pax`
  * https://github.com/liamg/pax
  * CLI tool for PKCS7 padding oracle attacks
* #2498 `liamg/scout`
  * https://github.com/liamg/scout
  * Lightweight URL fuzzer and spider: Discover a web server's undisclosed files, directories and VHOSTs
* #2498 `liamg/traitor`
  * https://github.com/liamg/traitor
  * Automatic Linux privesc via exploitation of low-hanging fruit e.g. gtfobins, pwnkit, dirty pipe, +w docker.sock