### PR TITLE
feat: add megaease/easeprobe

### DIFF
--- a/pkgs/megaease/easeprobe/pkg.yaml
+++ b/pkgs/megaease/easeprobe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+- name: megaease/easeprobe@v1.1.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -2577,6 +2577,14 @@ packages:
   - goos: darwin
     format: zip
 - type: github_release
+  repo_owner: megaease
+  repo_name: easeprobe
+  description: A simple, standalone, and lightWeight tool that can do health/status checking, written in Go
+  asset: 'easeprobe-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz'
+  files:
+  - name: easeprobe
+    src: bin/easeprobe
+- type: github_release
   repo_owner: mercari
   repo_name: tfnotify
   rosetta2: true


### PR DESCRIPTION
* #2691 `megaease/easeprobe`
  * https://github.com/megaease/easeprobe
  * A simple, standalone, and lightWeight tool that can do health/status checking, written in Go