### PR TITLE
fix: fix overrides of faas-cli

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3009,7 +3009,7 @@ packages:
   overrides:
   - goos: darwin
     asset: faas-cli-darwin
-  - goos: amd64
+  - goarch: amd64
     asset: faas-cli
 - type: github_release
   repo_owner: operator-framework


### PR DESCRIPTION
Follow up https://github.com/aquaproj/aqua-registry/pull/2708