### PR TITLE
fix: typo

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1519,7 +1519,7 @@ packages:
   asset: 'gleam-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}'
   overrides:
   - goos: darwin
-    gooarch: amd64
+    goarch: amd64
     asset: 'gleam-{{.Version}}-{{.OS}}.{{.Format}}'
   format_overrides:
   - goos: windows


### PR DESCRIPTION
Follow up #2708

https://github.com/aquaproj/aqua-registry/commit/7abc30e82e5335d5217c0979c39f71496124275c

https://ajv.js.org/packages/ajv-cli.html

```console
$ ajv validate -s json-schema/registry.json -d ../aqua-registry/registry.yaml --spec=draft2020 
../aqua-registry/registry.yaml invalid
[
  {
    instancePath: '/packages/140/overrides/0',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'gooarch' },
    message: 'must NOT have additional properties'
  }
]
```