### PR TITLE
Fix: correct some packages for arm64

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -2629,7 +2629,8 @@ packages:
   repo_name: skim
   asset: 'skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz'
   description: Fuzzy Finder in rust!
-  supported_if: not (GOARCH == "arm64")
+  rosetta2: true
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
   replacements:
     darwin: apple-darwin
     linux: unknown-linux-musl

--- a/registry.yaml
+++ b/registry.yaml
@@ -993,18 +993,24 @@ packages:
 - type: github_release
   repo_owner: dandavison
   repo_name: delta
-  asset: 'delta-{{.Version}}-x86_64-{{.OS}}.{{.Format}}'
+  asset: 'delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
   description: A syntax-highlighting pager for git
   format: tar.gz
-  format_overrides:
-  - goos: windows
-    format: zip
   replacements:
     darwin: apple-darwin
     linux: unknown-linux-musl
+    arm64: aarch64
+    amd64: x86_64
+  overrides:
+  - goos: windows
+    format: zip
+  - goos: linux
+    goarch: arm64
+    replacements:
+      linux: unknown-linux-gnu
   files:
   - name: delta
-    src: 'delta-{{.Version}}-x86_64-{{.OS}}/delta'
+    src: 'delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta'
 - type: github_release
   repo_owner: dapr
   repo_name: cli
@@ -2621,11 +2627,13 @@ packages:
 - type: github_release
   repo_owner: lotabout
   repo_name: skim
-  asset: 'skim-{{.Version}}-x86_64-{{.OS}}.tar.gz'
+  asset: 'skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz'
   description: Fuzzy Finder in rust!
+  supported_if: not (GOARCH == "arm64")
   replacements:
     darwin: apple-darwin
     linux: unknown-linux-musl
+    amd64: x86_64
   files:
   - name: sk
 - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -993,6 +993,7 @@ packages:
 - type: github_release
   repo_owner: dandavison
   repo_name: delta
+  rosetta2: true
   asset: 'delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
   description: A syntax-highlighting pager for git
   format: tar.gz


### PR DESCRIPTION
Corrected packages:
- [`dandavison/delta`](https://github.com/dandavison/delta) (use `overrides`)
- [`lotabout/skim`](https://github.com/lotabout/skim) (add `supported_if`)