### PR TITLE
feat: add s0md3v/Smap

### DIFF
--- a/pkgs/s0md3v/Smap/pkg.yaml
+++ b/pkgs/s0md3v/Smap/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+- name: s0md3v/Smap@0.1.0

--- a/pkgs/s0md3v/Smap/registry.yaml
+++ b/pkgs/s0md3v/Smap/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+- type: github_release
+  repo_owner: s0md3v
+  repo_name: Smap
+  description: a drop-in replacement for Nmap powered by shodan.io
+  asset: "smap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+  format: tar.xz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    darwin: macOS
+  files:
+  - name: smap
+    src: "smap_{{.Version}}_{{.OS}}_{{.Arch}}/smap"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3542,6 +3542,20 @@ packages:
   - goos: darwin
     asset: 'kfilt_{{trimV .Version}}_{{.OS}}_all'
 - type: github_release
+  repo_owner: s0md3v
+  repo_name: Smap
+  description: a drop-in replacement for Nmap powered by shodan.io
+  asset: "smap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+  format: tar.xz
+  format_overrides:
+  - goos: windows
+    format: zip
+  replacements:
+    darwin: macOS
+  files:
+  - name: smap
+    src: "smap_{{.Version}}_{{.OS}}_{{.Arch}}/smap"
+- type: github_release
   repo_owner: sachaos
   repo_name: viddy
   asset: 'viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'


### PR DESCRIPTION
* #2863 [s0md3v/Smap](https://github.com/s0md3v/Smap): a drop-in replacement for Nmap powered by shodan.io