### PR TITLE
feat: add suzuki-shunsuke/discussion-slack-notifier

### DIFF
--- a/pkgs/suzuki-shunsuke/discussion-slack-notifier/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/discussion-slack-notifier/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+- name: suzuki-shunsuke/discussion-slack-notifier@v0.1.0-1

--- a/pkgs/suzuki-shunsuke/discussion-slack-notifier/registry.yaml
+++ b/pkgs/suzuki-shunsuke/discussion-slack-notifier/registry.yaml
@@ -1,0 +1,5 @@
+- type: github_release
+  repo_owner: suzuki-shunsuke
+  repo_name: discussion-slack-notifier
+  asset: 'discussion-slack-notifier_{{.OS}}_{{.Arch}}.tar.gz'
+  description: 'Notify GitHub Discussions events to Slack with GitHub Actions'

--- a/registry.yaml
+++ b/registry.yaml
@@ -3925,6 +3925,11 @@ packages:
   description: CLI tool to post the command execution time as time-series data to DataDog
 - type: github_release
   repo_owner: suzuki-shunsuke
+  repo_name: discussion-slack-notifier
+  asset: 'discussion-slack-notifier_{{.OS}}_{{.Arch}}.tar.gz'
+  description: 'Notify GitHub Discussions events to Slack with GitHub Actions'
+- type: github_release
+  repo_owner: suzuki-shunsuke
   repo_name: durl
   asset: 'durl_{{trimV .Version}}_{{.OS}}_amd64.tar.gz'
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")


### PR DESCRIPTION
* #2894 [suzuki-shunsuke/discussion-slack-notifier](https://github.com/suzuki-shunsuke/discussion-slack-notifier): Notify GitHub Discussions events to Slack with GitHub Actions