### PR TITLE
feat: `grpc/grpc-go/protoc-gen-go-grpc`

### DIFF
--- a/pkgs/grpc/grpc-go/protoc-gen-go-grpc/pkg.yaml
+++ b/pkgs/grpc/grpc-go/protoc-gen-go-grpc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+- name: grpc/grpc-go/protoc-gen-go-grpc@v1.2.0

--- a/pkgs/grpc/grpc-go/protoc-gen-go-grpc/pkg.yaml
+++ b/pkgs/grpc/grpc-go/protoc-gen-go-grpc/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-- name: grpc/grpc-go/protoc-gen-go-grpc@v1.2.0
+- name: grpc/grpc-go/protoc-gen-go-grpc@cmd/protoc-gen-go-grpc/v1.2.0

--- a/pkgs/grpc/grpc-go/protoc-gen-go-grpc/registry.yaml
+++ b/pkgs/grpc/grpc-go/protoc-gen-go-grpc/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+- name: grpc/grpc-go/protoc-gen-go-grpc
+  type: github_release
+  repo_owner: grpc
+  repo_name: grpc-go
+  description: Generate Go language bindings of services in protobuf definition files for gRPC
+  asset: 'protoc-gen-go-grpc.{{.Version}}.{{.OS}}.{{.Arch}}.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
+  files:
+  - name: protoc-gen-go-grpc

--- a/pkgs/grpc/grpc-go/protoc-gen-go-grpc/registry.yaml
+++ b/pkgs/grpc/grpc-go/protoc-gen-go-grpc/registry.yaml
@@ -4,8 +4,9 @@ packages:
   repo_owner: grpc
   repo_name: grpc-go
   description: Generate Go language bindings of services in protobuf definition files for gRPC
-  asset: 'protoc-gen-go-grpc.{{.Version}}.{{.OS}}.{{.Arch}}.tar.gz'
+  asset: 'protoc-gen-go-grpc.{{trimPrefix "cmd/protoc-gen-go-grpc/" .Version}}.{{.OS}}.{{.Arch}}.tar.gz'
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  version_filter: 'Version startsWith "cmd/protoc-gen-go-grpc/"'
   rosetta2: true
   files:
   - name: protoc-gen-go-grpc

--- a/registry.yaml
+++ b/registry.yaml
@@ -2145,8 +2145,9 @@ packages:
   repo_owner: grpc
   repo_name: grpc-go
   description: Generate Go language bindings of services in protobuf definition files for gRPC
-  asset: 'protoc-gen-go-grpc.{{.Version}}.{{.OS}}.{{.Arch}}.tar.gz'
+  asset: 'protoc-gen-go-grpc.{{trimPrefix "cmd/protoc-gen-go-grpc/" .Version}}.{{.OS}}.{{.Arch}}.tar.gz'
   supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  version_filter: 'Version startsWith "cmd/protoc-gen-go-grpc/"'
   rosetta2: true
   files:
   - name: protoc-gen-go-grpc

--- a/registry.yaml
+++ b/registry.yaml
@@ -2140,6 +2140,16 @@ packages:
     asset: 'protoc-gen-swagger-{{.Version}}-{{.OS}}-{{.Arch}}'
     files:
     - name: protoc-gen-swagger
+- name: grpc/grpc-go/protoc-gen-go-grpc
+  type: github_release
+  repo_owner: grpc
+  repo_name: grpc-go
+  description: Generate Go language bindings of services in protobuf definition files for gRPC
+  asset: 'protoc-gen-go-grpc.{{.Version}}.{{.OS}}.{{.Arch}}.tar.gz'
+  supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  rosetta2: true
+  files:
+  - name: protoc-gen-go-grpc
 - type: github_release
   repo_owner: gruntwork-io
   repo_name: kubergrunt


### PR DESCRIPTION
Added package from:
- [grpc/grpc-go](https://github.com/grpc/grpc-go)

See also: https://grpc.io/docs/languages/go/quickstart/#prerequisites

Notes:
Download is failing in aqua cli v1.4.0.
If you can resolve the following error, we will release the draft.

```
INFO[0000] download and unarchive the package            aqua_version=1.4.0 package_name=grpc/grpc-go/protoc-gen-go-grpc package_version=v1.2.0 program=aqua registry=standard
ERRO[0000] install the package                           aqua_version=1.4.0 error="the asset isn't found: protoc-gen-go-grpc.v1.2.0.linux.amd64.tar.gz" package_name=grpc/grpc-go/protoc-gen-go-grpc package_version=v1.2.0 program=aqua registry=standard
FATA[0000] aqua failed                                   aqua_version=1.4.0 error="it failed to install some packages" program=aqua
```