### PR TITLE
feat: add sharkdp/hyperfine

### DIFF
--- a/pkgs/sharkdp/hyperfine/pkg.yaml
+++ b/pkgs/sharkdp/hyperfine/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+- name: sharkdp/hyperfine@v1.13.0

--- a/pkgs/sharkdp/hyperfine/registry.yaml
+++ b/pkgs/sharkdp/hyperfine/registry.yaml
@@ -6,8 +6,8 @@ packages:
   asset: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
   format: tar.gz
   format_overrides:
-    - goos: windows
-      format: zip
+  - goos: windows
+    format: zip
   rosetta2: true
   replacements:
     amd64: x86_64

--- a/pkgs/sharkdp/hyperfine/registry.yaml
+++ b/pkgs/sharkdp/hyperfine/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+- type: github_release
+  repo_owner: sharkdp
+  repo_name: hyperfine
+  description: A command-line benchmarking tool
+  asset: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  rosetta2: true
+  replacements:
+    amd64: x86_64
+    arm64: aarch64
+    darwin: apple-darwin
+    linux: unknown-linux-musl
+    windows: pc-windows-msvc
+    386: i686
+  overrides:
+  - goos: linux
+    goarch: arm64
+    replacements:
+      linux: unknown-linux-gnu
+  files:
+  - name: hyperfine
+    src: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}/hyperfine"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3826,6 +3826,31 @@ packages:
   - name: fd
     src: 'fd-{{.Version}}-{{.Arch}}-{{.OS}}/fd'
 - type: github_release
+  repo_owner: sharkdp
+  repo_name: hyperfine
+  description: A command-line benchmarking tool
+  asset: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  rosetta2: true
+  replacements:
+    amd64: x86_64
+    arm64: aarch64
+    darwin: apple-darwin
+    linux: unknown-linux-musl
+    windows: pc-windows-msvc
+    386: i686
+  overrides:
+  - goos: linux
+    goarch: arm64
+    replacements:
+      linux: unknown-linux-gnu
+  files:
+  - name: hyperfine
+    src: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}/hyperfine"
+- type: github_release
   repo_owner: sheepla
   repo_name: fzwiki
   asset: 'fzwiki_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz'

--- a/registry.yaml
+++ b/registry.yaml
@@ -3832,8 +3832,8 @@ packages:
   asset: "hyperfine-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
   format: tar.gz
   format_overrides:
-    - goos: windows
-      format: zip
+  - goos: windows
+    format: zip
   rosetta2: true
   replacements:
     amd64: x86_64


### PR DESCRIPTION
https://github.com/sharkdp/hyperfine
https://github.com/sharkdp/hyperfine/releases/tag/v1.13.0

```
# discovered assets:
# - hyperfine-musl_1.13.0_amd64.deb
# - hyperfine-musl_1.13.0_i686.deb
# - hyperfine-v1.13.0-aarch64-unknown-linux-gnu.tar.gz
# - hyperfine-v1.13.0-arm-unknown-linux-gnueabihf.tar.gz
# - hyperfine-v1.13.0-arm-unknown-linux-musleabihf.tar.gz
# - hyperfine-v1.13.0-i686-pc-windows-msvc.zip
# - hyperfine-v1.13.0-i686-unknown-linux-gnu.tar.gz
# - hyperfine-v1.13.0-i686-unknown-linux-musl.tar.gz
# - hyperfine-v1.13.0-x86_64-apple-darwin.tar.gz
# - hyperfine-v1.13.0-x86_64-pc-windows-gnu.zip
# - hyperfine-v1.13.0-x86_64-pc-windows-msvc.zip
# - hyperfine-v1.13.0-x86_64-unknown-linux-gnu.tar.gz
# - hyperfine-v1.13.0-x86_64-unknown-linux-musl.tar.gz
# - hyperfine_1.13.0_amd64.deb
# - hyperfine_1.13.0_arm64.deb
# - hyperfine_1.13.0_armhf.deb
# - hyperfine_1.13.0_i686.deb
```
