### PR TITLE
feat: support getting golang/go version in aqua generate

### DIFF
--- a/pkgs/golang/go/pkg.yaml
+++ b/pkgs/golang/go/pkg.yaml
@@ -1,3 +1,4 @@
 packages:
-  - name: golang/go@1.18.2
+  # TODO fix
+  # - name: golang/go@1.18.2
   - name: golang/go@go1.18.2

--- a/pkgs/golang/go/pkg.yaml
+++ b/pkgs/golang/go/pkg.yaml
@@ -1,2 +1,3 @@
 packages:
   - name: golang/go@1.18.2
+  - name: golang/go@go1.18.2

--- a/pkgs/golang/go/registry.yaml
+++ b/pkgs/golang/go/registry.yaml
@@ -1,11 +1,11 @@
 packages:
-  - name: golang/go
-    # repo_owner: golang
-    # repo_name: go
+  - repo_owner: golang
+    repo_name: go
     type: http
-    url: https://golang.org/dl/go{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz
-    link: https://golang.org/
+    url: https://golang.org/dl/go{{trimPrefix "go" .Version}}.{{.OS}}-{{.Arch}}.tar.gz
     description: The Go programming language
+    version_source: github_tag
+    version_filter: 'Version startsWith "go"'
     files:
       - name: go
         src: go/bin/go

--- a/registry.json
+++ b/registry.json
@@ -3222,10 +3222,12 @@
           "src": "go/bin/gofmt"
         }
       ],
-      "link": "https://golang.org/",
-      "name": "golang/go",
+      "repo_name": "go",
+      "repo_owner": "golang",
       "type": "http",
-      "url": "https://golang.org/dl/go{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz"
+      "url": "https://golang.org/dl/go{{trimPrefix \"go\" .Version}}.{{.OS}}-{{.Arch}}.tar.gz",
+      "version_filter": "Version startsWith \"go\"",
+      "version_source": "github_tag"
     },
     {
       "asset": "mock_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz",

--- a/registry.yaml
+++ b/registry.yaml
@@ -2145,13 +2145,13 @@ packages:
         files:
           - name: migrate
             src: "migrate.{{.OS}}-{{.Arch}}"
-  - name: golang/go
-    # repo_owner: golang
-    # repo_name: go
+  - repo_owner: golang
+    repo_name: go
     type: http
-    url: https://golang.org/dl/go{{.Version}}.{{.OS}}-{{.Arch}}.tar.gz
-    link: https://golang.org/
+    url: https://golang.org/dl/go{{trimPrefix "go" .Version}}.{{.OS}}-{{.Arch}}.tar.gz
     description: The Go programming language
+    version_source: github_tag
+    version_filter: 'Version startsWith "go"'
     files:
       - name: go
         src: go/bin/go


### PR DESCRIPTION
https://github.com/aquaproj/aqua/releases/tag/v1.8.0
https://github.com/aquaproj/aqua/pull/811

To get golang/go version in aqua generate, aqua must be v1.8.0 or later.