### PR TITLE
feat: add golang.org/x/perf/cmd/benchstat

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aquaproj/aqua-installer@v1.0.0
         with:
-          aqua_version: v1.10.0-1
+          aqua_version: v1.10.0
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aquaproj/aqua-installer@v1.0.0
         with:
-          aqua_version: v1.10.0-1
+          aqua_version: v1.10.0
       - run: bash generate-registry.sh
       - run: git add .
       - run: git --no-pager diff --cached
@@ -69,7 +69,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@v1.0.0
         with:
-          aqua_version: v1.10.0-1
+          aqua_version: v1.10.0
         env:
           AQUA_CONFIG: aqua-ci.yaml
 

--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -5,4 +5,5 @@ registries:
 packages:
   - import: pkgs/*/*/pkg.yaml
   - import: pkgs/*/*/*/pkg.yaml
+  - import: pkgs/*/*/*/*/*/pkg.yaml # golang.org/x/perf/cmd/benchstat
 # Don't add packages here.

--- a/pkgs/golang.org/x/perf/cmd/benchstat/pkg.yaml
+++ b/pkgs/golang.org/x/perf/cmd/benchstat/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: golang.org/x/perf/cmd/benchstat
+    version: 84e58bfe0a7e5416369e236afa007d5d9c58a0fa

--- a/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
+++ b/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
@@ -1,0 +1,4 @@
+packages:
+  - type: go_install
+    path: golang.org/x/perf/cmd/benchstat
+    description: Benchstat computes and compares statistics about benchmarks

--- a/pkgs/golang.org/x/tools/cmd/goimports/pkg.yaml
+++ b/pkgs/golang.org/x/tools/cmd/goimports/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: golang.org/x/tools/cmd/goimports
+    version: "3dd056a8c5c49942ae3511fdebcf8eea0c685486"

--- a/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
+++ b/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
@@ -1,0 +1,4 @@
+packages:
+  - type: go_install
+    path: golang.org/x/tools/cmd/goimports
+    description: updates your Go import lines, adding missing ones and removing unreferenced ones

--- a/pkgs/google/pprof/pkg.yaml
+++ b/pkgs/google/pprof/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: google/pprof
+    version: "d04f2422c8a17569c14e84da0fae252d9529826b"

--- a/pkgs/google/pprof/registry.yaml
+++ b/pkgs/google/pprof/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: google
+    repo_name: pprof
+    description: pprof is a tool for visualization and analysis of profiling data

--- a/registry.json
+++ b/registry.json
@@ -3247,6 +3247,11 @@
       "type": "go_install"
     },
     {
+      "description": "updates your Go import lines, adding missing ones and removing unreferenced ones",
+      "path": "golang.org/x/tools/cmd/goimports",
+      "type": "go_install"
+    },
+    {
       "description": "The Go programming language",
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -3242,6 +3242,11 @@
       ]
     },
     {
+      "description": "Benchstat computes and compares statistics about benchmarks",
+      "path": "golang.org/x/perf/cmd/benchstat",
+      "type": "go_install"
+    },
+    {
       "description": "The Go programming language",
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -3385,6 +3385,12 @@
       "type": "github_release"
     },
     {
+      "description": "pprof is a tool for visualization and analysis of profiling data",
+      "repo_name": "pprof",
+      "repo_owner": "google",
+      "type": "go_install"
+    },
+    {
       "description": "Compile-time Dependency Injection for Go",
       "files": [
         {

--- a/registry.yaml
+++ b/registry.yaml
@@ -2166,6 +2166,9 @@ packages:
         files:
           - name: migrate
             src: "migrate.{{.OS}}-{{.Arch}}"
+  - type: go_install
+    path: golang.org/x/perf/cmd/benchstat
+    description: Benchstat computes and compares statistics about benchmarks
   - repo_owner: golang
     repo_name: go
     type: http

--- a/registry.yaml
+++ b/registry.yaml
@@ -2261,6 +2261,10 @@ packages:
       windows: Windows
       386: i386
       amd64: x86_64
+  - type: go_install
+    repo_owner: google
+    repo_name: pprof
+    description: pprof is a tool for visualization and analysis of profiling data
   - type: go
     repo_owner: google
     repo_name: wire

--- a/registry.yaml
+++ b/registry.yaml
@@ -2169,6 +2169,9 @@ packages:
   - type: go_install
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks
+  - type: go_install
+    path: golang.org/x/tools/cmd/goimports
+    description: updates your Go import lines, adding missing ones and removing unreferenced ones
   - repo_owner: golang
     repo_name: go
     type: http


### PR DESCRIPTION
#3759 [golang.org/x/perf/cmd/benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat): Benchstat computes and compares statistics about benchmarks
#3759 [google/pprof](https://github.com/google/pprof): pprof is a tool for visualization and analysis of profiling data
#3759 [golang.org/x/tools/cmd/goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports): updates your Go import lines, adding missing ones and removing unreferenced ones