### PR TITLE
Replace go to go install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,8 +49,7 @@ jobs:
           - runs-on: ubuntu-latest
             goos: darwin
             goarch: arm64
-          - runs-on: ubuntu-latest
-            goos: windows
+          - runs-on: windows-latest
             goarch: arm64
     runs-on: ${{ matrix.env.runs-on }}
     steps:

--- a/pkgs/anqiansong/github-compare/registry.yaml
+++ b/pkgs/anqiansong/github-compare/registry.yaml
@@ -1,8 +1,5 @@
 packages:
-  - type: go
+  - type: go_install
     repo_owner: anqiansong
     repo_name: github-compare
     description: A Command-line statistics tool to compare the GitHub repositories
-    files:
-      - name: github-compare
-        dir: "github-compare-{{trimV .Version}}"

--- a/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
+++ b/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
@@ -1,6 +1,5 @@
 packages:
   - type: go_install
-    name: golang.org/x/perf/cmd/benchstat
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks
     link: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat

--- a/pkgs/golang/tools/gopls/pkg.yaml
+++ b/pkgs/golang/tools/gopls/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: golang/tools/gopls@gopls/v0.8.4
+  - name: golang/tools/gopls@v0.8.4

--- a/pkgs/golang/tools/gopls/registry.yaml
+++ b/pkgs/golang/tools/gopls/registry.yaml
@@ -1,10 +1,10 @@
 packages:
-  - type: go
+  - type: go_install
     name: golang/tools/gopls
+    path: golang.org/x/tools/gopls
     repo_owner: golang
     repo_name: tools
     description: Go language server
     version_filter: 'Version startsWith "gopls/"'
     files:
       - name: gopls
-        dir: 'tools-gopls-{{trimPrefix "gopls/" .Version}}/gopls'

--- a/pkgs/google/wire/registry.yaml
+++ b/pkgs/google/wire/registry.yaml
@@ -1,9 +1,6 @@
 packages:
-  - type: go
+  - type: go_install
     repo_owner: google
     repo_name: wire
     description: Compile-time Dependency Injection for Go
-    files:
-      - name: wire
-        src: ./cmd/wire
-        dir: "wire-{{trimV .Version}}"
+    path: github.com/google/wire/cmd/wire

--- a/pkgs/katbyte/terrafmt/registry.yaml
+++ b/pkgs/katbyte/terrafmt/registry.yaml
@@ -1,8 +1,5 @@
 packages:
-  - type: go
+  - type: go_install
     repo_owner: katbyte
     repo_name: terrafmt
     description: Format terraform blocks embedded in files
-    files:
-      - name: terrafmt
-        dir: "terrafmt-{{trimV .Version}}"

--- a/pkgs/mitchellh/gox/registry.yaml
+++ b/pkgs/mitchellh/gox/registry.yaml
@@ -1,9 +1,6 @@
 packages:
-  - type: go
+  - type: go_install
     repo_owner: mitchellh
     repo_name: gox
     description: A dead simple, no frills Go cross compile tool
     version_source: github_tag
-    files:
-      - name: gox
-        dir: "gox-{{trimV .Version}}"

--- a/registry.json
+++ b/registry.json
@@ -1276,15 +1276,9 @@
     },
     {
       "description": "A Command-line statistics tool to compare the GitHub repositories",
-      "files": [
-        {
-          "dir": "github-compare-{{trimV .Version}}",
-          "name": "github-compare"
-        }
-      ],
       "repo_name": "github-compare",
       "repo_owner": "anqiansong",
-      "type": "go"
+      "type": "go_install"
     },
     {
       "asset": "fx_{{.OS}}_{{.Arch}}",
@@ -4240,7 +4234,6 @@
     {
       "description": "Benchstat computes and compares statistics about benchmarks",
       "link": "https://pkg.go.dev/golang.org/x/perf/cmd/benchstat",
-      "name": "golang.org/x/perf/cmd/benchstat",
       "path": "golang.org/x/perf/cmd/benchstat",
       "type": "go_install"
     },
@@ -4294,14 +4287,14 @@
       "description": "Go language server",
       "files": [
         {
-          "dir": "tools-gopls-{{trimPrefix \"gopls/\" .Version}}/gopls",
           "name": "gopls"
         }
       ],
       "name": "golang/tools/gopls",
+      "path": "golang.org/x/tools/gopls",
       "repo_name": "tools",
       "repo_owner": "golang",
-      "type": "go",
+      "type": "go_install",
       "version_filter": "Version startsWith \"gopls/\""
     },
     {
@@ -4442,16 +4435,10 @@
     },
     {
       "description": "Compile-time Dependency Injection for Go",
-      "files": [
-        {
-          "dir": "wire-{{trimV .Version}}",
-          "name": "wire",
-          "src": "./cmd/wire"
-        }
-      ],
+      "path": "github.com/google/wire/cmd/wire",
       "repo_name": "wire",
       "repo_owner": "google",
-      "type": "go"
+      "type": "go_install"
     },
     {
       "asset": "gopass-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}",
@@ -5819,15 +5806,9 @@
     },
     {
       "description": "Format terraform blocks embedded in files",
-      "files": [
-        {
-          "dir": "terrafmt-{{trimV .Version}}",
-          "name": "terrafmt"
-        }
-      ],
       "repo_name": "terrafmt",
       "repo_owner": "katbyte",
-      "type": "go"
+      "type": "go_install"
     },
     {
       "asset": "ecspresso_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz",
@@ -6723,15 +6704,9 @@
     },
     {
       "description": "A dead simple, no frills Go cross compile tool",
-      "files": [
-        {
-          "dir": "gox-{{trimV .Version}}",
-          "name": "gox"
-        }
-      ],
       "repo_name": "gox",
       "repo_owner": "mitchellh",
-      "type": "go",
+      "type": "go_install",
       "version_source": "github_tag"
     },
     {

--- a/registry.yaml
+++ b/registry.yaml
@@ -762,13 +762,10 @@ packages:
             format: zip
           - goos: darwin
             format: zip
-  - type: go
+  - type: go_install
     repo_owner: anqiansong
     repo_name: github-compare
     description: A Command-line statistics tool to compare the GitHub repositories
-    files:
-      - name: github-compare
-        dir: "github-compare-{{trimV .Version}}"
   - type: github_release
     repo_owner: antonmedv
     repo_name: fx
@@ -2517,7 +2514,6 @@ packages:
               - name: migrate
                 src: "migrate.{{.OS}}-{{.Arch}}.exe"
   - type: go_install
-    name: golang.org/x/perf/cmd/benchstat
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks
     link: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
@@ -2550,15 +2546,15 @@ packages:
     files:
       - name: mockgen
         src: "mock_{{trimV .Version}}_{{.OS}}_{{.Arch}}/mockgen"
-  - type: go
+  - type: go_install
     name: golang/tools/gopls
+    path: golang.org/x/tools/gopls
     repo_owner: golang
     repo_name: tools
     description: Go language server
     version_filter: 'Version startsWith "gopls/"'
     files:
       - name: gopls
-        dir: 'tools-gopls-{{trimPrefix "gopls/" .Version}}/gopls'
   - type: github_release
     repo_owner: golangci
     repo_name: golangci-lint
@@ -2647,14 +2643,11 @@ packages:
     repo_owner: google
     repo_name: pprof
     description: pprof is a tool for visualization and analysis of profiling data
-  - type: go
+  - type: go_install
     repo_owner: google
     repo_name: wire
     description: Compile-time Dependency Injection for Go
-    files:
-      - name: wire
-        src: ./cmd/wire
-        dir: "wire-{{trimV .Version}}"
+    path: github.com/google/wire/cmd/wire
   - type: github_release
     repo_owner: gopasspw
     repo_name: gopass
@@ -3482,13 +3475,10 @@ packages:
       darwin: MacOS
       linux: Linux
       windows: Windows
-  - type: go
+  - type: go_install
     repo_owner: katbyte
     repo_name: terrafmt
     description: Format terraform blocks embedded in files
-    files:
-      - name: terrafmt
-        dir: "terrafmt-{{trimV .Version}}"
   - type: github_release
     repo_owner: kayac
     repo_name: ecspresso
@@ -4048,14 +4038,11 @@ packages:
     files:
       - name: minishift
         src: "minishift-{{trimV .Version}}-{{.OS}}-{{.Arch}}/minishift"
-  - type: go
+  - type: go_install
     repo_owner: mitchellh
     repo_name: gox
     description: A dead simple, no frills Go cross compile tool
     version_source: github_tag
-    files:
-      - name: gox
-        dir: "gox-{{trimV .Version}}"
   - type: github_release
     repo_owner: mkchoi212
     repo_name: fac


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/3759

## Breaking Changes

aqua >= v1.10.0 is required.

### How to migrate

Please upgrade aqua to v1.10.0 or later.