### PR TITLE
feat: add compose/transporter

### DIFF
--- a/pkgs/compose/transporter/pkg.yaml
+++ b/pkgs/compose/transporter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: compose/transporter@v1.1.0

--- a/pkgs/compose/transporter/registry.yaml
+++ b/pkgs/compose/transporter/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: github_release
+    repo_owner: compose
+    repo_name: transporter
+    description: Sync data between persistence engines, like ETL only not stodgy
+    format: raw
+    asset: "transporter-{{trimV .Version}}-{{.OS}}-{{.Arch}}"
+    supported_if: not (GOOS == "linux" and GOARCH == "arm64")

--- a/registry.json
+++ b/registry.json
@@ -2109,6 +2109,15 @@
       "type": "github_release"
     },
     {
+      "asset": "transporter-{{trimV .Version}}-{{.OS}}-{{.Arch}}",
+      "description": "Sync data between persistence engines, like ETL only not stodgy",
+      "format": "raw",
+      "repo_name": "transporter",
+      "repo_owner": "compose",
+      "supported_if": "not (GOOS == \"linux\" and GOARCH == \"arm64\")",
+      "type": "github_release"
+    },
+    {
       "asset": "nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz",
       "description": "contaiNERD CTL - Docker-compatible CLI for containerd, with support for Compose, Rootless, eStargz, OCIcrypt, IPFS, ...",
       "replacements": {

--- a/registry.yaml
+++ b/registry.yaml
@@ -1405,6 +1405,13 @@ packages:
     description: Fast cross-platform HTTP benchmarking tool written in Go
     format: raw
   - type: github_release
+    repo_owner: compose
+    repo_name: transporter
+    description: Sync data between persistence engines, like ETL only not stodgy
+    format: raw
+    asset: "transporter-{{trimV .Version}}-{{.OS}}-{{.Arch}}"
+    supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  - type: github_release
     repo_owner: containerd
     repo_name: nerdctl
     asset: "nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz"


### PR DESCRIPTION
Close #3806

#3806 [compose/transporter](https://github.com/compose/transporter): Sync data between persistence engines, like ETL only not stodgy