### PR TITLE
feat: add deepmap/oapi-codegen

### DIFF
--- a/pkgs/deepmap/oapi-codegen/pkg.yaml
+++ b/pkgs/deepmap/oapi-codegen/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: deepmap/oapi-codegen@v1.11.0

--- a/pkgs/deepmap/oapi-codegen/registry.yaml
+++ b/pkgs/deepmap/oapi-codegen/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: go_install
+    repo_owner: deepmap
+    repo_name: oapi-codegen
+    path: github.com/deepmap/oapi-codegen/cmd/oapi-codegen
+    description: Generate Go client and server boilerplate from OpenAPI 3 specifications

--- a/registry.json
+++ b/registry.json
@@ -2413,6 +2413,13 @@
       ]
     },
     {
+      "description": "Generate Go client and server boilerplate from OpenAPI 3 specifications",
+      "path": "github.com/deepmap/oapi-codegen/cmd/oapi-codegen",
+      "repo_name": "oapi-codegen",
+      "repo_owner": "deepmap",
+      "type": "go_install"
+    },
+    {
       "asset": "navi-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}",
       "description": "An interactive cheatsheet tool for the command-line",
       "format": "tar.gz",

--- a/registry.yaml
+++ b/registry.yaml
@@ -1609,6 +1609,11 @@ packages:
       # macOS Universal binaries
       - version_constraint: 'semver("< 0.5.0")'
         overrides: []
+  - type: go_install
+    repo_owner: deepmap
+    repo_name: oapi-codegen
+    path: github.com/deepmap/oapi-codegen/cmd/oapi-codegen
+    description: Generate Go client and server boilerplate from OpenAPI 3 specifications
   - type: github_release
     repo_owner: denisidoro
     repo_name: navi


### PR DESCRIPTION
#3826 [deepmap/oapi-codegen](https://github.com/deepmap/oapi-codegen): Generate Go client and server boilerplate from OpenAPI 3 specifications