### PR TITLE
fix: set the package name explicitly to keep the compatibility

### DIFF
--- a/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
+++ b/pkgs/golang.org/x/perf/cmd/benchstat/registry.yaml
@@ -1,4 +1,5 @@
 packages:
   - type: go_install
+    name: golang.org/x/perf/cmd/benchstat
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks

--- a/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
+++ b/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
@@ -1,4 +1,5 @@
 packages:
   - type: go_install
+    name: golang.org/x/tools/cmd/goimports
     path: golang.org/x/tools/cmd/goimports
     description: updates your Go import lines, adding missing ones and removing unreferenced ones

--- a/registry.json
+++ b/registry.json
@@ -3259,11 +3259,13 @@
     },
     {
       "description": "Benchstat computes and compares statistics about benchmarks",
+      "name": "golang.org/x/perf/cmd/benchstat",
       "path": "golang.org/x/perf/cmd/benchstat",
       "type": "go_install"
     },
     {
       "description": "updates your Go import lines, adding missing ones and removing unreferenced ones",
+      "name": "golang.org/x/tools/cmd/goimports",
       "path": "golang.org/x/tools/cmd/goimports",
       "type": "go_install"
     },

--- a/registry.yaml
+++ b/registry.yaml
@@ -2179,9 +2179,11 @@ packages:
           - name: migrate
             src: "migrate.{{.OS}}-{{.Arch}}"
   - type: go_install
+    name: golang.org/x/perf/cmd/benchstat
     path: golang.org/x/perf/cmd/benchstat
     description: Benchstat computes and compares statistics about benchmarks
   - type: go_install
+    name: golang.org/x/tools/cmd/goimports
     path: golang.org/x/tools/cmd/goimports
     description: updates your Go import lines, adding missing ones and removing unreferenced ones
   - repo_owner: golang


### PR DESCRIPTION
Set the package name explicitly to keep the compatibility

* golang.org/x/perf/cmd/benchstat
* golang.org/x/tools/cmd/goimports