### PR TITLE
feat: add `google/go-jsonnet`

### DIFF
--- a/pkgs/google/go-jsonnet/pkg.yaml
+++ b/pkgs/google/go-jsonnet/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/go-jsonnet@v0.18.0

--- a/pkgs/google/go-jsonnet/registry.yaml
+++ b/pkgs/google/go-jsonnet/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: go-jsonnet
+    rosetta2: true
+    asset: 'go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+    format: tar.gz
+    description: Jsonnet - The data templating language
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    files:
+      - name: jsonnet
+      - name: jsonnetfmt

--- a/pkgs/google/go-jsonnet/registry.yaml
+++ b/pkgs/google/go-jsonnet/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: google
     repo_name: go-jsonnet
     rosetta2: true
-    asset: 'go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+    asset: "go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
     format: tar.gz
     description: Jsonnet - The data templating language
     replacements:

--- a/registry.json
+++ b/registry.json
@@ -3394,7 +3394,7 @@
         "amd64": "x86_64",
         "darwin": "Darwin",
         "linux": "Linux",
-        "windows": "Windows",
+        "windows": "Windows"
       },
       "repo_name": "go-jsonnet",
       "repo_owner": "google",

--- a/registry.json
+++ b/registry.json
@@ -3378,6 +3378,30 @@
       "type": "github_release"
     },
     {
+      "asset": "go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}",
+      "description": "Jsonnet - The data templating language",
+      "files": [
+        {
+          "name": "jsonnet"
+        },
+        {
+          "name": "jsonnetfmt"
+        }
+      ],
+      "format": "tar.gz",
+      "replacements": {
+        "386": "i386",
+        "amd64": "x86_64",
+        "darwin": "Darwin",
+        "linux": "Linux",
+        "windows": "Windows",
+      },
+      "repo_name": "go-jsonnet",
+      "repo_owner": "google",
+      "rosetta2": true,
+      "type": "github_release"
+    },
+    {
       "asset": "jsonnet-bin-{{.Version}}-linux.tar.gz",
       "description": "Jsonnet - The data templating language",
       "files": [

--- a/registry.yaml
+++ b/registry.yaml
@@ -2260,6 +2260,22 @@ packages:
       - name: gcrane
   - type: github_release
     repo_owner: google
+    repo_name: go-jsonnet
+    rosetta2: true
+    asset: 'go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+    format: tar.gz
+    description: Jsonnet - The data templating language
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    files:
+      - name: jsonnet
+      - name: jsonnetfmt
+  - type: github_release
+    repo_owner: google
     repo_name: jsonnet
     asset: "jsonnet-bin-{{.Version}}-linux.tar.gz"
     supported_if: GOOS == "linux" and GOARCH == "amd64"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2262,7 +2262,7 @@ packages:
     repo_owner: google
     repo_name: go-jsonnet
     rosetta2: true
-    asset: 'go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}'
+    asset: "go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
     format: tar.gz
     description: Jsonnet - The data templating language
     replacements:


### PR DESCRIPTION
go-jsonnet is an implementation of Jsonnnet in Go.
It is compatible with the original Jsonnet C++ implementation.
`google/jsonnet` is already registered but no longer provides binaries.