### PR TITLE
feat: add kreuzwerker/envplate

### DIFF
--- a/pkgs/kreuzwerker/envplate/pkg.yaml
+++ b/pkgs/kreuzwerker/envplate/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kreuzwerker/envplate@v1.0.2

--- a/pkgs/kreuzwerker/envplate/registry.yaml
+++ b/pkgs/kreuzwerker/envplate/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: kreuzwerker
+    repo_name: envplate
+    description: Docker-friendly trivial templating for configuration files using environment keys
+    asset: "envplate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+    files:
+      - name: ep
+        src: envplate

--- a/registry.json
+++ b/registry.json
@@ -4617,6 +4617,25 @@
       "type": "github_release"
     },
     {
+      "asset": "envplate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz",
+      "description": "Docker-friendly trivial templating for configuration files using environment keys",
+      "files": [
+        {
+          "name": "ep",
+          "src": "envplate"
+        }
+      ],
+      "replacements": {
+        "386": "i386",
+        "amd64": "x86_64",
+        "darwin": "Darwin",
+        "linux": "Linux"
+      },
+      "repo_name": "envplate",
+      "repo_owner": "kreuzwerker",
+      "type": "github_release"
+    },
+    {
       "asset": "evans_{{.OS}}_{{.Arch}}.tar.gz",
       "description": "Evans: more expressive universal gRPC client",
       "repo_name": "evans",

--- a/registry.yaml
+++ b/registry.yaml
@@ -3089,6 +3089,19 @@ packages:
     format: raw
     asset: "kool-{{.OS}}-{{.Arch}}"
   - type: github_release
+    repo_owner: kreuzwerker
+    repo_name: envplate
+    description: Docker-friendly trivial templating for configuration files using environment keys
+    asset: "envplate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+    files:
+      - name: ep
+        src: envplate
+  - type: github_release
     repo_owner: ktr0731
     repo_name: evans
     rosetta2: true


### PR DESCRIPTION
#3891 [kreuzwerker/envplate](https://github.com/kreuzwerker/envplate): Docker-friendly trivial templating for configuration files using environment keys