### PR TITLE
feat: add kreuzwerker/m1-terraform-provider-helper

### DIFF
--- a/pkgs/kreuzwerker/m1-terraform-provider-helper/pkg.yaml
+++ b/pkgs/kreuzwerker/m1-terraform-provider-helper/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kreuzwerker/m1-terraform-provider-helper@0.6.0

--- a/pkgs/kreuzwerker/m1-terraform-provider-helper/registry.yaml
+++ b/pkgs/kreuzwerker/m1-terraform-provider-helper/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: github_release
+    repo_owner: kreuzwerker
+    repo_name: m1-terraform-provider-helper
+    description: CLI to support with downloading and compiling terraform providers for Mac with M1 chip
+    asset: "m1-terraform-provider-helper_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    replacements:
+      darwin: Darwin

--- a/registry.json
+++ b/registry.json
@@ -4636,6 +4636,16 @@
       "type": "github_release"
     },
     {
+      "asset": "m1-terraform-provider-helper_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz",
+      "description": "CLI to support with downloading and compiling terraform providers for Mac with M1 chip",
+      "replacements": {
+        "darwin": "Darwin"
+      },
+      "repo_name": "m1-terraform-provider-helper",
+      "repo_owner": "kreuzwerker",
+      "type": "github_release"
+    },
+    {
       "asset": "evans_{{.OS}}_{{.Arch}}.tar.gz",
       "description": "Evans: more expressive universal gRPC client",
       "repo_name": "evans",

--- a/registry.yaml
+++ b/registry.yaml
@@ -3102,6 +3102,13 @@ packages:
       - name: ep
         src: envplate
   - type: github_release
+    repo_owner: kreuzwerker
+    repo_name: m1-terraform-provider-helper
+    description: CLI to support with downloading and compiling terraform providers for Mac with M1 chip
+    asset: "m1-terraform-provider-helper_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    replacements:
+      darwin: Darwin
+  - type: github_release
     repo_owner: ktr0731
     repo_name: evans
     rosetta2: true


### PR DESCRIPTION
#3892 [kreuzwerker/m1-terraform-provider-helper](https://github.com/kreuzwerker/m1-terraform-provider-helper): CLI to support with downloading and compiling terraform providers for Mac with M1 chip