### PR TITLE
feat: add webdevops/go-crond

### DIFF
--- a/pkgs/webdevops/go-crond/pkg.yaml
+++ b/pkgs/webdevops/go-crond/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: webdevops/go-crond@21.5.0

--- a/pkgs/webdevops/go-crond/registry.yaml
+++ b/pkgs/webdevops/go-crond/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: webdevops
+    repo_name: go-crond
+    description: Cron daemon written in golang (for eg. usage in docker images)
+    rosetta2: true
+    format: raw
+    asset: "go-crond-{{.Arch}}-{{.OS}}"
+    replacements:
+      amd64: "64"
+      darwin: osx

--- a/registry.json
+++ b/registry.json
@@ -7775,6 +7775,19 @@
       "type": "github_release"
     },
     {
+      "asset": "go-crond-{{.Arch}}-{{.OS}}",
+      "description": "Cron daemon written in golang (for eg. usage in docker images)",
+      "format": "raw",
+      "replacements": {
+        "amd64": "64",
+        "darwin": "osx"
+      },
+      "repo_name": "go-crond",
+      "repo_owner": "webdevops",
+      "rosetta2": true,
+      "type": "github_release"
+    },
+    {
       "asset": "gossh-{{.Version}}-{{.OS}}-{{.Arch}}",
       "description": "Gossh is a high-performance and high-concurrency ssh tool",
       "format": "raw",

--- a/registry.yaml
+++ b/registry.yaml
@@ -5236,6 +5236,16 @@ packages:
     asset: "eksctl_{{title .OS}}_{{.Arch}}.tar.gz"
     description: The official CLI for Amazon EKS
   - type: github_release
+    repo_owner: webdevops
+    repo_name: go-crond
+    description: Cron daemon written in golang (for eg. usage in docker images)
+    rosetta2: true
+    format: raw
+    asset: "go-crond-{{.Arch}}-{{.OS}}"
+    replacements:
+      amd64: "64"
+      darwin: osx
+  - type: github_release
     repo_owner: windvalley
     repo_name: gossh
     format: raw


### PR DESCRIPTION
#3912 [webdevops/go-crond](https://github.com/webdevops/go-crond): Cron daemon written in golang (for eg. usage in docker images)