### PR TITLE
feat: add apache/camel-k (kamel)

### DIFF
--- a/pkgs/apache/camel-k/pkg.yaml
+++ b/pkgs/apache/camel-k/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: apache/camel-k@v1.9.2

--- a/pkgs/apache/camel-k/registry.yaml
+++ b/pkgs/apache/camel-k/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_name: camel-k
     asset: "camel-k-client-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz"
     description: Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers
+    supported_if: GOARCH == "amd64" or GOOS == "darwin"
     files:
       - name: kamel
     replacements:

--- a/pkgs/apache/camel-k/registry.yaml
+++ b/pkgs/apache/camel-k/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: apache
+    repo_name: camel-k
+    asset: "camel-k-client-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz"
+    description: Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers
+    files:
+      - name: kamel
+    replacements:
+      amd64: 64bit
+      arm64: arm64bit
+      darwin: mac

--- a/registry.json
+++ b/registry.json
@@ -1157,6 +1157,23 @@
       "type": "github_release"
     },
     {
+      "asset": "camel-k-client-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz",
+      "description": "Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers",
+      "files": [
+        {
+          "name": "kamel"
+        }
+      ],
+      "replacements": {
+        "amd64": "64bit",
+        "arm64": "arm64bit",
+        "darwin": "mac"
+      },
+      "repo_name": "camel-k",
+      "repo_owner": "apache",
+      "type": "github_release"
+    },
+    {
       "description": "Install aqua quickly",
       "path": "aqua-installer",
       "repo_name": "aqua-installer",

--- a/registry.json
+++ b/registry.json
@@ -1171,6 +1171,7 @@
       },
       "repo_name": "camel-k",
       "repo_owner": "apache",
+      "supported_if": "GOARCH == \"amd64\" or GOOS == \"darwin\"",
       "type": "github_release"
     },
     {

--- a/registry.yaml
+++ b/registry.yaml
@@ -760,6 +760,17 @@ packages:
     asset: "llama_{{.OS}}_{{.Arch}}"
     description: Terminal file manager
     supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+  - type: github_release
+    repo_owner: apache
+    repo_name: camel-k
+    asset: "camel-k-client-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz"
+    description: Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers
+    files:
+      - name: kamel
+    replacements:
+      amd64: 64bit
+      arm64: arm64bit
+      darwin: mac
   - type: github_content
     repo_owner: aquaproj
     repo_name: aqua-installer

--- a/registry.yaml
+++ b/registry.yaml
@@ -765,6 +765,7 @@ packages:
     repo_name: camel-k
     asset: "camel-k-client-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz"
     description: Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers
+    supported_if: GOARCH == "amd64" or GOOS == "darwin"
     files:
       - name: kamel
     replacements:


### PR DESCRIPTION
#3945 [apache/camel-k](https://github.com/apache/camel-k): Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers

This is my first contribution. Thank you!