### PR TITLE
feat: Add microsoft/ripgrep-prebuilt and more

### DIFF
--- a/pkgs/mgdm/htmlq/pkg.yaml
+++ b/pkgs/mgdm/htmlq/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mgdm/htmlq@v0.4.0

--- a/pkgs/mgdm/htmlq/registry.yaml
+++ b/pkgs/mgdm/htmlq/registry.yaml
@@ -3,6 +3,7 @@ packages:
     repo_owner: mgdm
     repo_name: htmlq
     asset: "htmlq-{{.Arch}}-{{.OS}}.{{.Format}}"
+    rosetta2: true
     supported_if: GOOS == "darwin" or GOARCH == "amd64"
     description: Like jq, but for HTML
     replacements:

--- a/pkgs/mgdm/htmlq/registry.yaml
+++ b/pkgs/mgdm/htmlq/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: mgdm
+    repo_name: htmlq
+    asset: "htmlq-{{.Arch}}-{{.OS}}.{{.Format}}"
+    supported_if: GOOS == "darwin" or GOARCH == "amd64"
+    description: Like jq, but for HTML
+    replacements:
+      amd64: x86_64
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip

--- a/pkgs/microsoft/ripgrep-prebuilt/pkg.yaml
+++ b/pkgs/microsoft/ripgrep-prebuilt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: microsoft/ripgrep-prebuilt@v13.0.0-4

--- a/pkgs/microsoft/ripgrep-prebuilt/registry.yaml
+++ b/pkgs/microsoft/ripgrep-prebuilt/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: microsoft
+    repo_name: ripgrep-prebuilt
+    asset: "ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+    description: Builds ripgrep on Azure Pipelines for multiple platforms and makes the binaries available as Github releases
+    format: tar.gz
+    replacements:
+      darwin: apple-darwin
+      windows: pc-windows-msvc
+      linux: unknown-linux-musl
+      arm64: aarch64
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: rg

--- a/pkgs/pen-lang/pen/pkg.yaml
+++ b/pkgs/pen-lang/pen/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pen-lang/pen@v0.3.15

--- a/pkgs/pen-lang/pen/registry.yaml
+++ b/pkgs/pen-lang/pen/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: pen-lang
+    repo_name: pen
+    asset: "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz"
+    rosetta2: true
+    supported_if: GOOS == "darwin" or (GOOS == "linux" and GOARCH == "amd64")
+    description: The programming language for scalable software development
+    replacements:
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      amd64: x86_64
+    files:
+      - name: pen
+        src: target/release/pen

--- a/pkgs/pen-lang/pen/registry.yaml
+++ b/pkgs/pen-lang/pen/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: pen-lang
     repo_name: pen
-    asset: "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz"
+    asset: "pen-{{trimV .Version}}-{{.Arch}}-{{.OS}}.tar.xz"
     rosetta2: true
     supported_if: GOOS == "darwin" or (GOOS == "linux" and GOARCH == "amd64")
     description: The programming language for scalable software development

--- a/registry.json
+++ b/registry.json
@@ -5265,6 +5265,7 @@
       },
       "repo_name": "htmlq",
       "repo_owner": "mgdm",
+      "rosetta2": true,
       "supported_if": "GOOS == \"darwin\" or GOARCH == \"amd64\"",
       "type": "github_release"
     },

--- a/registry.json
+++ b/registry.json
@@ -5879,7 +5879,7 @@
       "type": "github_release"
     },
     {
-      "asset": "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz",
+      "asset": "pen-{{trimV .Version}}-{{.Arch}}-{{.OS}}.tar.xz",
       "description": "The programming language for scalable software development",
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -5251,6 +5251,50 @@
       "type": "github_release"
     },
     {
+      "asset": "htmlq-{{.Arch}}-{{.OS}}.{{.Format}}",
+      "description": "Like jq, but for HTML",
+      "format": "tar.gz",
+      "overrides": [
+        {
+          "format": "zip",
+          "goos": "windows"
+        }
+      ],
+      "replacements": {
+        "amd64": "x86_64"
+      },
+      "repo_name": "htmlq",
+      "repo_owner": "mgdm",
+      "supported_if": "GOOS == \"darwin\" or GOARCH == \"amd64\"",
+      "type": "github_release"
+    },
+    {
+      "asset": "ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}",
+      "description": "Builds ripgrep on Azure Pipelines for multiple platforms and makes the binaries available as Github releases",
+      "files": [
+        {
+          "name": "rg"
+        }
+      ],
+      "format": "tar.gz",
+      "overrides": [
+        {
+          "format": "zip",
+          "goos": "windows"
+        }
+      ],
+      "replacements": {
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+        "darwin": "apple-darwin",
+        "linux": "unknown-linux-musl",
+        "windows": "pc-windows-msvc"
+      },
+      "repo_name": "ripgrep-prebuilt",
+      "repo_owner": "microsoft",
+      "type": "github_release"
+    },
+    {
       "asset": "yq_{{.OS}}_{{.Arch}}",
       "description": "yq is a portable command-line YAML processor",
       "repo_name": "yq",
@@ -5832,6 +5876,26 @@
       ],
       "repo_name": "peco",
       "repo_owner": "peco",
+      "type": "github_release"
+    },
+    {
+      "asset": "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz",
+      "description": "The programming language for scalable software development",
+      "files": [
+        {
+          "name": "pen",
+          "src": "target/release/pen"
+        }
+      ],
+      "replacements": {
+        "amd64": "x86_64",
+        "darwin": "apple-darwin",
+        "linux": "unknown-linux-gnu"
+      },
+      "repo_name": "pen",
+      "repo_owner": "pen-lang",
+      "rosetta2": true,
+      "supported_if": "GOOS == \"darwin\" or (GOOS == \"linux\" and GOARCH == \"amd64\")",
       "type": "github_release"
     },
     {

--- a/registry.yaml
+++ b/registry.yaml
@@ -3527,6 +3527,7 @@ packages:
     repo_owner: mgdm
     repo_name: htmlq
     asset: "htmlq-{{.Arch}}-{{.OS}}.{{.Format}}"
+    rosetta2: true
     supported_if: GOOS == "darwin" or GOARCH == "amd64"
     description: Like jq, but for HTML
     replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -3949,7 +3949,7 @@ packages:
   - type: github_release
     repo_owner: pen-lang
     repo_name: pen
-    asset: "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz"
+    asset: "pen-{{trimV .Version}}-{{.Arch}}-{{.OS}}.tar.xz"
     rosetta2: true
     supported_if: GOOS == "darwin" or (GOOS == "linux" and GOARCH == "amd64")
     description: The programming language for scalable software development

--- a/registry.yaml
+++ b/registry.yaml
@@ -3524,6 +3524,35 @@ packages:
     replacements:
       darwin: macos
   - type: github_release
+    repo_owner: mgdm
+    repo_name: htmlq
+    asset: "htmlq-{{.Arch}}-{{.OS}}.{{.Format}}"
+    supported_if: GOOS == "darwin" or GOARCH == "amd64"
+    description: Like jq, but for HTML
+    replacements:
+      amd64: x86_64
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
+    repo_owner: microsoft
+    repo_name: ripgrep-prebuilt
+    asset: "ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+    description: Builds ripgrep on Azure Pipelines for multiple platforms and makes the binaries available as Github releases
+    format: tar.gz
+    replacements:
+      darwin: apple-darwin
+      windows: pc-windows-msvc
+      linux: unknown-linux-musl
+      arm64: aarch64
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: rg
+  - type: github_release
     repo_owner: mikefarah
     repo_name: yq
     asset: "yq_{{.OS}}_{{.Arch}}"
@@ -3917,6 +3946,20 @@ packages:
     format_overrides:
       - goos: darwin
         format: zip
+  - type: github_release
+    repo_owner: pen-lang
+    repo_name: pen
+    asset: "pen-{{trimV .Version}}-{{.Arch}}-{.OS}.tar.xz"
+    rosetta2: true
+    supported_if: GOOS == "darwin" or (GOOS == "linux" and GOARCH == "amd64")
+    description: The programming language for scalable software development
+    replacements:
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      amd64: x86_64
+    files:
+      - name: pen
+        src: target/release/pen
   - type: github_release
     repo_owner: pglet
     repo_name: pglet


### PR DESCRIPTION
Added packages:
- [`microsoft/ripgrep-prebuilt`](https://github.com/microsoft/ripgrep-prebuilt)
- [`mgdm/htmlq`](https://github.com/mgdm/htmlq)
- [`pen-lang/pen`](https://github.com/pen-lang/pen)

**NOTE:** As I said before (https://github.com/aquaproj/aqua/issues/850#issuecomment-1153113333I), I think almost all of `supported_if` which value is `not (GOOS == "linux" and GOARCH == "arm64")` in aqua-registry should be rewritten.
There are two pattern in this pull request: [htmlq](https://github.com/mgdm/htmlq) and [pen](https://github.com/pen-lang/pen).
htmlq support 3 OS of `amd64`, so I wrote this `supported_if`:

```yaml
supported_if: GOOS == "darwin" or GOARCH == "amd64"
```

pen support only `darwin` and `linux` which are `amd64`, so I wrote this `supported_if`:

```yaml
supported_if: GOOS == "darwin" or (GOOS == "linux" and GOARCH == "amd64")
```

We have to think of these pattern.
