### PR TITLE
feat: Add buildkite/cli and buildkite/agent.

### DIFF
--- a/pkgs/buildkite/agent/pkg.yaml
+++ b/pkgs/buildkite/agent/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: buildkite/agent@v3.36.1

--- a/pkgs/buildkite/agent/registry.yaml
+++ b/pkgs/buildkite/agent/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: buildkite
     repo_name: agent
-    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
+    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network"
     asset: "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz"
     files:
       - name: buildkite-agent

--- a/pkgs/buildkite/agent/registry.yaml
+++ b/pkgs/buildkite/agent/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: github_release
+    repo_owner: buildkite
+    repo_name: agent
+    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
+    asset: "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz"
+    files:
+      - name: buildkite-agent

--- a/pkgs/buildkite/cli/pkg.yaml
+++ b/pkgs/buildkite/cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: buildkite/cli@v1.2.0
+  - name: buildkite/cli
+    version: v1.1.0

--- a/pkgs/buildkite/cli/registry.yaml
+++ b/pkgs/buildkite/cli/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: buildkite
+    repo_name: cli
+    description: "A command line interface for Buildkite."
+    asset: "cli-{{.OS}}-{{.Arch}}"
+    format: raw
+    files:
+      - name: bk
+        src: cli
+    version_constraint: 'semver(">= 1.2.0")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.2.0")'
+        supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+        rosetta2: true
+        asset: "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}"
+        files:
+          - name: bk
+            src: bk

--- a/pkgs/buildkite/cli/registry.yaml
+++ b/pkgs/buildkite/cli/registry.yaml
@@ -14,6 +14,3 @@ packages:
         supported_if: not (GOOS == "linux" and GOARCH == "arm64")
         rosetta2: true
         asset: "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}"
-        files:
-          - name: bk
-            src: bk

--- a/registry.json
+++ b/registry.json
@@ -1853,7 +1853,7 @@
     },
     {
       "asset": "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz",
-      "description": "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network.",
+      "description": "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network",
       "files": [
         {
           "name": "buildkite-agent"
@@ -1880,12 +1880,6 @@
       "version_overrides": [
         {
           "asset": "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}",
-          "files": [
-            {
-              "name": "bk",
-              "src": "bk"
-            }
-          ],
           "rosetta2": true,
           "supported_if": "not (GOOS == \"linux\" and GOARCH == \"arm64\")",
           "version_constraint": "semver(\"\u003c 1.2.0\")"

--- a/registry.json
+++ b/registry.json
@@ -1852,6 +1852,35 @@
       "type": "github_release"
     },
     {
+      "asset": "cli-{{.OS}}-{{.Arch}}",
+      "description": "A command line interface for Buildkite.",
+      "files": [
+        {
+          "name": "bk",
+          "src": "cli"
+        }
+      ],
+      "format": "raw",
+      "repo_name": "cli",
+      "repo_owner": "buildkite",
+      "type": "github_release",
+      "version_constraint": "semver(\"\u003e= 1.2.0\")",
+      "version_overrides": [
+        {
+          "asset": "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}",
+          "files": [
+            {
+              "name": "bk",
+              "src": "bk"
+            }
+          ],
+          "rosetta2": true,
+          "supported_if": "not (GOOS == \"linux\" and GOARCH == \"arm64\")",
+          "version_constraint": "semver(\"\u003c 1.2.0\")"
+        }
+      ]
+    },
+    {
       "asset": "pack-{{.Version}}-{{.OS}}.tgz",
       "description": "CLI for building apps using Cloud Native Buildpacks",
       "overrides": [

--- a/registry.json
+++ b/registry.json
@@ -1852,6 +1852,18 @@
       "type": "github_release"
     },
     {
+      "asset": "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz",
+      "description": "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network.",
+      "files": [
+        {
+          "name": "buildkite-agent"
+        }
+      ],
+      "repo_name": "agent",
+      "repo_owner": "buildkite",
+      "type": "github_release"
+    },
+    {
       "asset": "cli-{{.OS}}-{{.Arch}}",
       "description": "A command line interface for Buildkite.",
       "files": [

--- a/registry.yaml
+++ b/registry.yaml
@@ -1232,7 +1232,7 @@ packages:
   - type: github_release
     repo_owner: buildkite
     repo_name: agent
-    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
+    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network"
     asset: "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz"
     files:
       - name: buildkite-agent
@@ -1251,9 +1251,6 @@ packages:
         supported_if: not (GOOS == "linux" and GOARCH == "arm64")
         rosetta2: true
         asset: "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}"
-        files:
-          - name: bk
-            src: bk
   - type: github_release
     repo_owner: buildpacks
     repo_name: pack

--- a/registry.yaml
+++ b/registry.yaml
@@ -1230,6 +1230,24 @@ packages:
       - name: protoc-gen-buf-lint
         src: buf/bin/protoc-gen-buf-lint
   - type: github_release
+    repo_owner: buildkite
+    repo_name: cli
+    description: "A command line interface for Buildkite."
+    asset: "cli-{{.OS}}-{{.Arch}}"
+    format: raw
+    files:
+      - name: bk
+        src: cli
+    version_constraint: 'semver(">= 1.2.0")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.2.0")'
+        supported_if: not (GOOS == "linux" and GOARCH == "arm64")
+        rosetta2: true
+        asset: "bk-{{.OS}}-{{.Arch}}-{{.Version|trimV}}"
+        files:
+          - name: bk
+            src: bk
+  - type: github_release
     repo_owner: buildpacks
     repo_name: pack
     supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))

--- a/registry.yaml
+++ b/registry.yaml
@@ -1231,6 +1231,13 @@ packages:
         src: buf/bin/protoc-gen-buf-lint
   - type: github_release
     repo_owner: buildkite
+    repo_name: agent
+    description: "The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network."
+    asset: "buildkite-agent-{{.OS}}-{{.Arch}}-{{.Version|trimV}}.tar.gz"
+    files:
+      - name: buildkite-agent
+  - type: github_release
+    repo_owner: buildkite
     repo_name: cli
     description: "A command line interface for Buildkite."
     asset: "cli-{{.OS}}-{{.Arch}}"


### PR DESCRIPTION
#3973 [buildkite/agent](https://github.com/buildkite/agent): The Buildkite Agent is an open-source toolkit written in Golang for securely running build jobs on any device or network
#3973 [buildkite/cli](https://github.com/buildkite/cli): A command line interface for Buildkite

---

Registry definitions to get the build agent and cli tool for the Buildkite CI system.