### PR TITLE
feat(bufbuild/buf): windows support

### DIFF
--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -2,9 +2,14 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: buf
-    asset: "buf-{{.OS}}-{{.Arch}}.tar.gz"
-    supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
     description: A new way of working with Protocol Buffers
+    supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+    asset: "buf-{{.OS}}-{{.Arch}}.tar.gz"
+    overrides:
+      - goos: windows
+        asset: "buf-Windows-{{.Arch}}.exe"
+        files:
+          - name: buf
     replacements:
       darwin: Darwin
       linux: Linux

--- a/registry.json
+++ b/registry.json
@@ -1952,6 +1952,17 @@
           "src": "buf/bin/protoc-gen-buf-lint"
         }
       ],
+      "overrides": [
+        {
+          "asset": "buf-Windows-{{.Arch}}.exe",
+          "files": [
+            {
+              "name": "buf"
+            }
+          ],
+          "goos": "windows"
+        }
+      ],
       "replacements": {
         "amd64": "x86_64",
         "darwin": "Darwin",

--- a/registry.yaml
+++ b/registry.yaml
@@ -1293,9 +1293,14 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: buf
-    asset: "buf-{{.OS}}-{{.Arch}}.tar.gz"
-    supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
     description: A new way of working with Protocol Buffers
+    supported_if: not ((GOOS == "linux") and (GOARCH == "arm64"))
+    asset: "buf-{{.OS}}-{{.Arch}}.tar.gz"
+    overrides:
+      - goos: windows
+        asset: "buf-Windows-{{.Arch}}.exe"
+        files:
+          - name: buf
     replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
https://github.com/aquaproj/aqua/issues/850

## ⚠️ The following tools aren't installed on Windows

* protoc-gen-buf-breaking
* protoc-gen-buf-lint