### PR TITLE
feat: add gomods/athens

### DIFF
--- a/pkgs/gomods/athens/pkg.yaml
+++ b/pkgs/gomods/athens/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: gomods/athens@v0.11.0

--- a/pkgs/gomods/athens/registry.yaml
+++ b/pkgs/gomods/athens/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: gomods
+    repo_name: athens
+    description: A Go module datastore and proxy
+    rosetta2: true
+    supported_envs: ["darwin", "linux/amd64"]
+    asset: "athens_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    version_constraint: 'semver(">= 0.11.0")'
+    version_overrides:
+      - version_constraint: 'true'
+        supported_envs: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -2572,6 +2572,17 @@ packages:
       - goos: windows
         format: zip
   - type: github_release
+    repo_owner: gomods
+    repo_name: athens
+    description: A Go module datastore and proxy
+    rosetta2: true
+    supported_envs: ["darwin", "linux/amd64"]
+    asset: "athens_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+    version_constraint: 'semver(">= 0.11.0")'
+    version_overrides:
+      - version_constraint: 'true'
+        supported_envs: []
+  - type: github_release
     repo_owner: goodwithtech
     repo_name: dockle
     description: Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/issues/4181

#4278 [gomods/athens](https://github.com/gomods/athens): A Go module datastore and proxy