### PR TITLE
feat: add liggitt/audit2rbac

### DIFF
--- a/pkgs/liggitt/audit2rbac/pkg.yaml
+++ b/pkgs/liggitt/audit2rbac/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: liggitt/audit2rbac@v0.9.0

--- a/pkgs/liggitt/audit2rbac/registry.yaml
+++ b/pkgs/liggitt/audit2rbac/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: liggitt
+    repo_name: audit2rbac
+    description: Autogenerate RBAC policies based on Kubernetes audit logs
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: "audit2rbac-{{.OS}}-{{.Arch}}.tar.gz"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3827,6 +3827,15 @@ packages:
     description: Automatic Linux privesc via exploitation of low-hanging fruit e.g. gtfobins, pwnkit, dirty pipe, +w docker.sock
     supported_envs: ["linux"]
   - type: github_release
+    repo_owner: liggitt
+    repo_name: audit2rbac
+    description: Autogenerate RBAC policies based on Kubernetes audit logs
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: "audit2rbac-{{.OS}}-{{.Arch}}.tar.gz"
+  - type: github_release
     repo_owner: lima-vm
     repo_name: lima
     description: 'Linux virtual machines, on macOS (aka "Linux-on-Mac", "macOS subsystem for Linux", "containerd for Mac", unofficially)'


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/issues/4181

#4280 [liggitt/audit2rbac](https://github.com/liggitt/audit2rbac): Autogenerate RBAC policies based on Kubernetes audit logs