### PR TITLE
feat: add helm/chart-testing

### DIFF
--- a/pkgs/helm/chart-testing/pkg.yaml
+++ b/pkgs/helm/chart-testing/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: helm/chart-testing@v3.6.0

--- a/pkgs/helm/chart-testing/registry.yaml
+++ b/pkgs/helm/chart-testing/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: helm
+    repo_name: chart-testing
+    description: CLI tool for linting and testing Helm charts
+    asset: chart-testing_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: ct

--- a/registry.yaml
+++ b/registry.yaml
@@ -3017,6 +3017,17 @@ packages:
         format: zip
     files:
       - name: cr
+  - type: github_release
+    repo_owner: helm
+    repo_name: chart-testing
+    description: CLI tool for linting and testing Helm charts
+    asset: chart-testing_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: ct
   - type: http
     repo_owner: helm
     repo_name: helm


### PR DESCRIPTION
#4181

#4285 [helm/chart-testing](https://github.com/helm/chart-testing): CLI tool for linting and testing Helm charts