### PR TITLE
feat: add barnybug/cli53

### DIFF
--- a/pkgs/barnybug/cli53/pkg.yaml
+++ b/pkgs/barnybug/cli53/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: barnybug/cli53@0.8.18

--- a/pkgs/barnybug/cli53/registry.yaml
+++ b/pkgs/barnybug/cli53/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: barnybug
+    repo_name: cli53
+    description: Command line tool for Amazon Route 53
+    rosetta2: true
+    format: raw
+    replacements:
+      darwin: mac
+    asset: cli53-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - linux
+      - darwin
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1114,6 +1114,19 @@ packages:
       386: i386
       amd64: x86_64
   - type: github_release
+    repo_owner: barnybug
+    repo_name: cli53
+    description: Command line tool for Amazon Route 53
+    rosetta2: true
+    format: raw
+    replacements:
+      darwin: mac
+    asset: cli53-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - linux
+      - darwin
+      - amd64
+  - type: github_release
     repo_owner: batchcorp
     repo_name: plumber
     rosetta2: true


### PR DESCRIPTION
#4181

#4290 [barnybug/cli53](https://github.com/barnybug/cli53): Command line tool for Amazon Route 53