### PR TITLE
feat: add visma-prodsec/confused

### DIFF
--- a/pkgs/visma-prodsec/confused/pkg.yaml
+++ b/pkgs/visma-prodsec/confused/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: visma-prodsec/confused@v0.4

--- a/pkgs/visma-prodsec/confused/registry.yaml
+++ b/pkgs/visma-prodsec/confused/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: visma-prodsec
+    repo_name: confused
+    description: Tool to check for dependency confusion vulnerabilities in multiple package management systems
+    rosetta2: true
+    asset: confused_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    supported_envs:
+      - linux
+      - darwin
+      - amd64
+    format: tar.gz
+    replacements:
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -6083,6 +6083,22 @@ packages:
           linux: linux64
           windows: win64
   - type: github_release
+    repo_owner: visma-prodsec
+    repo_name: confused
+    description: Tool to check for dependency confusion vulnerabilities in multiple package management systems
+    rosetta2: true
+    asset: confused_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    supported_envs:
+      - linux
+      - darwin
+      - amd64
+    format: tar.gz
+    replacements:
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: vmware-tanzu
     repo_name: carvel-imgpkg
     rosetta2: true


### PR DESCRIPTION
#4181 

#4295 [visma-prodsec/confused](https://github.com/visma-prodsec/confused): Tool to check for dependency confusion vulnerabilities in multiple package management systems