### PR TITLE
feat: add naggie/dstask

### DIFF
--- a/pkgs/naggie/dstask/dstask-import/pkg.yaml
+++ b/pkgs/naggie/dstask/dstask-import/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: naggie/dstask/dstask-import@v0.25

--- a/pkgs/naggie/dstask/dstask-import/registry.yaml
+++ b/pkgs/naggie/dstask/dstask-import/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    name: naggie/dstask/dstask-import
+    repo_owner: naggie
+    repo_name: dstask
+    description: Git powered terminal-based todo manager -- markdown note page per task. Single binary
+    rosetta2: true
+    asset: dstask-import-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux/amd64
+    files:
+      - name: dstask-import

--- a/pkgs/naggie/dstask/pkg.yaml
+++ b/pkgs/naggie/dstask/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: naggie/dstask@v0.25

--- a/pkgs/naggie/dstask/registry.yaml
+++ b/pkgs/naggie/dstask/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: naggie
+    repo_name: dstask
+    description: Git powered terminal-based todo manager -- markdown note page per task. Single binary
+    rosetta2: true
+    asset: dstask-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4370,6 +4370,15 @@ packages:
     files:
       - name: shfmt
   - type: github_release
+    repo_owner: naggie
+    repo_name: dstask
+    description: Git powered terminal-based todo manager -- markdown note page per task. Single binary
+    rosetta2: true
+    asset: dstask-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux/amd64
+  - type: github_release
     repo_owner: nakabonne
     repo_name: ali
     description: Generate HTTP load and plot the results in real-time

--- a/registry.yaml
+++ b/registry.yaml
@@ -4370,6 +4370,18 @@ packages:
     files:
       - name: shfmt
   - type: github_release
+    name: naggie/dstask/dstask-import
+    repo_owner: naggie
+    repo_name: dstask
+    description: Git powered terminal-based todo manager -- markdown note page per task. Single binary
+    rosetta2: true
+    asset: dstask-import-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux/amd64
+    files:
+      - name: dstask-import
+  - type: github_release
     repo_owner: naggie
     repo_name: dstask
     description: Git powered terminal-based todo manager -- markdown note page per task. Single binary


### PR DESCRIPTION
#4181 

#4313 [naggie/dstask](https://github.com/naggie/dstask): Git powered terminal-based todo manager -- markdown note page per task. Single binary