### PR TITLE
feat: add devops-works/dw-query-digest

### DIFF
--- a/pkgs/devops-works/dw-query-digest/pkg.yaml
+++ b/pkgs/devops-works/dw-query-digest/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: devops-works/dw-query-digest@v0.9.6

--- a/pkgs/devops-works/dw-query-digest/registry.yaml
+++ b/pkgs/devops-works/dw-query-digest/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: devops-works
+    repo_name: dw-query-digest
+    description: MySQL slow log analyzer. Alternative to pt-query-digest
+    rosetta2: true
+    asset: dw-query-digest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - darwin
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1961,6 +1961,15 @@ packages:
       - darwin
       - linux
   - type: github_release
+    repo_owner: devops-works
+    repo_name: dw-query-digest
+    description: MySQL slow log analyzer. Alternative to pt-query-digest
+    rosetta2: true
+    asset: dw-query-digest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+  - type: github_release
     repo_owner: dhall-lang
     repo_name: dhall-haskell
     description: Maintainable configuration files


### PR DESCRIPTION
#4181 

#4314 [devops-works/dw-query-digest](https://github.com/devops-works/dw-query-digest): MySQL slow log analyzer. Alternative to pt-query-digest