### PR TITLE
feat: add pemistahl/grex

### DIFF
--- a/pkgs/pemistahl/grex/pkg.yaml
+++ b/pkgs/pemistahl/grex/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pemistahl/grex@v1.3.0

--- a/pkgs/pemistahl/grex/registry.yaml
+++ b/pkgs/pemistahl/grex/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: pemistahl
+    repo_name: grex
+    asset: grex-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A command-line tool and library for generating regular expressions from user-provided test cases
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -4806,6 +4806,24 @@ packages:
       - goos: linux
         format: tar.gz
   - type: github_release
+    repo_owner: pemistahl
+    repo_name: grex
+    asset: grex-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A command-line tool and library for generating regular expressions from user-provided test cases
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: pen-lang
     repo_name: pen
     asset: "pen-{{trimV .Version}}-{{.Arch}}-{{.OS}}.tar.xz"


### PR DESCRIPTION
#4181 

#4346 [pemistahl/grex](https://github.com/pemistahl/grex): A command-line tool and library for generating regular expressions from user-provided test cases