### PR TITLE
feat: add grafana/grizzly

### DIFF
--- a/pkgs/grafana/grizzly/pkg.yaml
+++ b/pkgs/grafana/grizzly/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grafana/grizzly@v0.2.0

--- a/pkgs/grafana/grizzly/registry.yaml
+++ b/pkgs/grafana/grizzly/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: grizzly
+    asset: grr-{{.OS}}-{{.Arch}}
+    description: A utility for managing Jsonnet dashboards against the Grafana API
+    supported_envs:
+      - darwin
+      - linux
+    files:
+      - name: grr

--- a/registry.yaml
+++ b/registry.yaml
@@ -2878,6 +2878,16 @@ packages:
       - amd64
   - type: github_release
     repo_owner: grafana
+    repo_name: grizzly
+    asset: grr-{{.OS}}-{{.Arch}}
+    description: A utility for managing Jsonnet dashboards against the Grafana API
+    supported_envs:
+      - darwin
+      - linux
+    files:
+      - name: grr
+  - type: github_release
+    repo_owner: grafana
     repo_name: k6
     description: A modern load testing tool, using Go and JavaScript
     supported_envs: ["darwin", "linux", "windows/amd64"]


### PR DESCRIPTION
#4181

#4347 [grafana/grizzly](https://github.com/grafana/grizzly): A utility for managing Jsonnet dashboards against the Grafana API