### PR TITLE
feat: add hetznercloud/cli

### DIFF
--- a/pkgs/hetznercloud/cli/pkg.yaml
+++ b/pkgs/hetznercloud/cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hetznercloud/cli@v1.29.5

--- a/pkgs/hetznercloud/cli/registry.yaml
+++ b/pkgs/hetznercloud/cli/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: hetznercloud
+    repo_name: cli
+    asset: hcloud-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A command-line interface for Hetzner Cloud
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: hcloud

--- a/registry.yaml
+++ b/registry.yaml
@@ -3213,6 +3213,17 @@ packages:
       - name: helm
         src: "{{.OS}}-{{.Arch}}/helm"
   - type: github_release
+    repo_owner: hetznercloud
+    repo_name: cli
+    asset: hcloud-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A command-line interface for Hetzner Cloud
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: hcloud
+  - type: github_release
     repo_owner: hhatto
     repo_name: gocloc
     description: A little fast cloc(Count Lines Of Code)


### PR DESCRIPTION
#4181

#4350 [hetznercloud/cli](https://github.com/hetznercloud/cli): A command-line interface for Hetzner Cloud