### PR TITLE
feat: add helmwave/helmwave

### DIFF
--- a/pkgs/helmwave/helmwave/pkg.yaml
+++ b/pkgs/helmwave/helmwave/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: helmwave/helmwave@v0.19.5

--- a/pkgs/helmwave/helmwave/registry.yaml
+++ b/pkgs/helmwave/helmwave/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: helmwave
+    repo_name: helmwave
+    asset: helmwave_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: "Helmwave is the true release manager"
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -3213,6 +3213,15 @@ packages:
       - name: helm
         src: "{{.OS}}-{{.Arch}}/helm"
   - type: github_release
+    repo_owner: helmwave
+    repo_name: helmwave
+    asset: helmwave_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: "Helmwave is the true release manager"
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: hetznercloud
     repo_name: cli
     asset: hcloud-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
#4181

#4351 [helmwave/helmwave](https://github.com/helmwave/helmwave): Helmwave is the true release manager