### PR TITLE
feat: add iann0036/iamlive

### DIFF
--- a/pkgs/iann0036/iamlive/pkg.yaml
+++ b/pkgs/iann0036/iamlive/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: iann0036/iamlive@v0.47.3

--- a/pkgs/iann0036/iamlive/registry.yaml
+++ b/pkgs/iann0036/iamlive/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: iann0036
+    repo_name: iamlive
+    asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3294,6 +3294,19 @@ packages:
       - darwin
       - linux
   - type: github_release
+    repo_owner: iann0036
+    repo_name: iamlive
+    asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: iawia002
     repo_name: lux
     description: Fast and simple video download library and CLI tool written in Go


### PR DESCRIPTION
#4181

#4354 [iann0036/iamlive](https://github.com/iann0036/iamlive): Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy