### PR TITLE
feat: add quarkslab/kdigger

### DIFF
--- a/pkgs/quarkslab/kdigger/pkg.yaml
+++ b/pkgs/quarkslab/kdigger/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: quarkslab/kdigger@v1.2.1

--- a/pkgs/quarkslab/kdigger/registry.yaml
+++ b/pkgs/quarkslab/kdigger/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: quarkslab
+    repo_name: kdigger
+    asset: kdigger-{{.OS}}-{{.Arch}}.tar.gz
+    description: Kubernetes focused container assessment tool for penetration testing
+    supported_envs:
+      - darwin
+      - linux
+    rosetta2: true
+    files:
+      - name: kdigger
+        src: kdigger-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -5105,6 +5105,18 @@ packages:
           - name: pulumi
             src: pulumi/bin/pulumi.exe
   - type: github_release
+    repo_owner: quarkslab
+    repo_name: kdigger
+    asset: kdigger-{{.OS}}-{{.Arch}}.tar.gz
+    description: Kubernetes focused container assessment tool for penetration testing
+    supported_envs:
+      - darwin
+      - linux
+    rosetta2: true
+    files:
+      - name: kdigger
+        src: kdigger-{{.OS}}-{{.Arch}}
+  - type: github_release
     repo_owner: rancher
     repo_name: cli
     description: Rancher CLI


### PR DESCRIPTION
#4181

#4358 [quarkslab/kdigger](https://github.com/quarkslab/kdigger): Kubernetes focused container assessment tool for penetration testing