### PR TITLE
feat: add kopia/kopia

### DIFF
--- a/pkgs/kopia/kopia/pkg.yaml
+++ b/pkgs/kopia/kopia/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kopia/kopia@v0.10.7

--- a/pkgs/kopia/kopia/registry.yaml
+++ b/pkgs/kopia/kopia/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: kopia
+    repo_name: kopia
+    asset: kopia-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Cross-platform backup tool for Windows, macOS & Linux with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication. CLI and GUI included
+    replacements:
+      amd64: x64
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: kopia
+        src: kopia-{{trimV .Version}}-{{.OS}}-{{.Arch}}/kopia

--- a/registry.yaml
+++ b/registry.yaml
@@ -3916,6 +3916,25 @@ packages:
     format: raw
     asset: "kool-{{.OS}}-{{.Arch}}"
   - type: github_release
+    repo_owner: kopia
+    repo_name: kopia
+    asset: kopia-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Cross-platform backup tool for Windows, macOS & Linux with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication. CLI and GUI included
+    replacements:
+      amd64: x64
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: kopia
+        src: kopia-{{trimV .Version}}-{{.OS}}-{{.Arch}}/kopia
+  - type: github_release
     repo_owner: kreuzwerker
     repo_name: awsu
     description: Enhanced account switching for AWS, supports Yubikey as MFA source


### PR DESCRIPTION
#4181

#4363 [kopia/kopia](https://github.com/kopia/kopia): Cross-platform backup tool for Windows, macOS & Linux with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication. CLI and GUI included