### PR TITLE
feat: add kubesphere/kubeeye

### DIFF
--- a/pkgs/kubesphere/kubeeye/pkg.yaml
+++ b/pkgs/kubesphere/kubeeye/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubesphere/kubeeye@v0.5.0

--- a/pkgs/kubesphere/kubeeye/registry.yaml
+++ b/pkgs/kubesphere/kubeeye/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: kubesphere
+    repo_name: kubeeye
+    asset: kubeeye-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: KubeEye aims to find various problems on Kubernetes, such as application misconfiguration, unhealthy cluster components and node problems
+    supported_envs:
+      - linux
+    files:
+      - name: kubeeye
+        src: ke

--- a/registry.yaml
+++ b/registry.yaml
@@ -4099,6 +4099,16 @@ packages:
       - amd64
     url: "https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}"
   - type: github_release
+    repo_owner: kubesphere
+    repo_name: kubeeye
+    asset: kubeeye-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: KubeEye aims to find various problems on Kubernetes, such as application misconfiguration, unhealthy cluster components and node problems
+    supported_envs:
+      - linux
+    files:
+      - name: kubeeye
+        src: ke
+  - type: github_release
     repo_owner: kudobuilder
     repo_name: kuttl
     description: KUbernetes Test TooL (kuttl)


### PR DESCRIPTION
#4181

#4366 [kubesphere/kubeeye](https://github.com/kubesphere/kubeeye): KubeEye aims to find various problems on Kubernetes, such as application misconfiguration, unhealthy cluster components and node problems