### PR TITLE
feat: add aporia-ai/kubesurvival

### DIFF
--- a/pkgs/aporia-ai/kubesurvival/pkg.yaml
+++ b/pkgs/aporia-ai/kubesurvival/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aporia-ai/kubesurvival@v1.0.1

--- a/pkgs/aporia-ai/kubesurvival/registry.yaml
+++ b/pkgs/aporia-ai/kubesurvival/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: aporia-ai
+    repo_name: kubesurvival
+    asset: KubeSurvival_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Significantly reduce Kubernetes costs by finding the cheapest machine types that can run your workloads
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -867,6 +867,24 @@ packages:
       amd64: 64bit
       arm64: arm64bit
       darwin: mac
+  - type: github_release
+    repo_owner: aporia-ai
+    repo_name: kubesurvival
+    asset: KubeSurvival_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Significantly reduce Kubernetes costs by finding the cheapest machine types that can run your workloads
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
   - type: github_content
     repo_owner: aquaproj
     repo_name: aqua-installer


### PR DESCRIPTION
#4181

#4370 [aporia-ai/kubesurvival](https://github.com/aporia-ai/kubesurvival): Significantly reduce Kubernetes costs by finding the cheapest machine types that can run your workloads