### PR TITLE
fix: support ajeetdsouza/zoxide >= v0.8.2

### DIFF
--- a/pkgs/ajeetdsouza/zoxide/pkg.yaml
+++ b/pkgs/ajeetdsouza/zoxide/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: ajeetdsouza/zoxide@v0.8.1
+  - name: ajeetdsouza/zoxide@v0.8.2
+  - name: ajeetdsouza/zoxide
+    version: v0.8.1

--- a/pkgs/ajeetdsouza/zoxide/registry.yaml
+++ b/pkgs/ajeetdsouza/zoxide/registry.yaml
@@ -3,7 +3,6 @@ packages:
     repo_owner: ajeetdsouza
     repo_name: zoxide
     description: A smarter cd command. Supports all major shells
-    asset: "zoxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
     format: tar.gz
     overrides:
       - goos: windows
@@ -14,3 +13,8 @@ packages:
       darwin: apple-darwin
       amd64: x86_64
       arm64: aarch64
+    version_constraint: 'semver(">= 0.8.2")'
+    asset: "zoxide-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+    version_overrides:
+      - version_constraint: 'true'
+        asset: "zoxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"

--- a/registry.yaml
+++ b/registry.yaml
@@ -742,7 +742,6 @@ packages:
     repo_owner: ajeetdsouza
     repo_name: zoxide
     description: A smarter cd command. Supports all major shells
-    asset: "zoxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
     format: tar.gz
     overrides:
       - goos: windows
@@ -753,6 +752,11 @@ packages:
       darwin: apple-darwin
       amd64: x86_64
       arm64: aarch64
+    version_constraint: 'semver(">= 0.8.2")'
+    asset: "zoxide-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+    version_overrides:
+      - version_constraint: 'true'
+        asset: "zoxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
   - type: github_release
     repo_owner: alexellis
     repo_name: arkade


### PR DESCRIPTION
Follow up #4371

Asset name format has been changed.

https://github.com/ajeetdsouza/zoxide/releases/tag/v0.8.2
https://github.com/ajeetdsouza/zoxide/releases/tag/v0.8.1