### PR TITLE
feat: add danielfoehrKn/kubeswitch

### DIFF
--- a/pkgs/danielfoehrKn/kubeswitch/pkg.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: danielfoehrKn/kubeswitch@0.7.1

--- a/pkgs/danielfoehrKn/kubeswitch/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: danielfoehrKn
+    repo_name: kubeswitch
+    asset: switcher_{{.OS}}_{{.Arch}}
+    format: raw
+    description: The kubectx for operators
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: switcher

--- a/pkgs/danielfoehrKn/kubeswitch/switch-sh/pkg.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/switch-sh/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: danielfoehrKn/kubeswitch/switch-sh@0.7.1

--- a/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
@@ -10,4 +10,4 @@ packages:
       - linux/amd64
       - darwin
     files:
-      - name: switch.sh
+      - name: kubeswitch.sh

--- a/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - name: danielfoehrKn/kubeswitch/switch-sh
+    type: github_release
+    repo_owner: danielfoehrKn
+    repo_name: kubeswitch
+    asset: switch.sh
+    format: raw
+    description: The kubectx for operators
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: switch.sh

--- a/registry.yaml
+++ b/registry.yaml
@@ -1907,6 +1907,29 @@ packages:
       - name: delta
         src: "delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta"
   - type: github_release
+    repo_owner: danielfoehrKn
+    repo_name: kubeswitch
+    asset: switcher_{{.OS}}_{{.Arch}}
+    format: raw
+    description: The kubectx for operators
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: switcher
+  - name: danielfoehrKn/kubeswitch/switch-sh
+    type: github_release
+    repo_owner: danielfoehrKn
+    repo_name: kubeswitch
+    asset: switch.sh
+    format: raw
+    description: The kubectx for operators
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: switch.sh
+  - type: github_release
     repo_owner: dapr
     repo_name: cli
     description: Command-line tools for Dapr

--- a/registry.yaml
+++ b/registry.yaml
@@ -1928,7 +1928,7 @@ packages:
       - linux/amd64
       - darwin
     files:
-      - name: switch.sh
+      - name: kubeswitch.sh
   - type: github_release
     repo_owner: dapr
     repo_name: cli


### PR DESCRIPTION
#4181 

#4373 [danielfoehrKn/kubeswitch](https://github.com/danielfoehrKn/kubeswitch): The kubectx for operators

## How to use `danielfoehrKn/kubeswitch/switch-sh`

```console
if aqua which kubeswithc.sh >/dev/null 2>&1; then
  source "$(aqua which kubeswitch.sh)"
fi
```