### PR TITLE
feat: add ko1nksm/shdotenv

### DIFF
--- a/pkgs/ko1nksm/shdotenv/pkg.yaml
+++ b/pkgs/ko1nksm/shdotenv/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ko1nksm/shdotenv@v0.13.0

--- a/pkgs/ko1nksm/shdotenv/registry.yaml
+++ b/pkgs/ko1nksm/shdotenv/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: ko1nksm
+    repo_name: shdotenv
+    description: dotenv for shells with support for POSIX-compliant and multiple .env file syntax
+    asset: shdotenv
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -4042,6 +4042,14 @@ packages:
     asset: "utern_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip"
     description: Multi group and stream log tailing for AWS CloudWatch Logs
   - type: github_release
+    repo_owner: ko1nksm
+    repo_name: shdotenv
+    description: dotenv for shells with support for POSIX-compliant and multiple .env file syntax
+    asset: shdotenv
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts


### PR DESCRIPTION
#4181

#4384 [ko1nksm/shdotenv](https://github.com/ko1nksm/shdotenv): dotenv for shells with support for POSIX-compliant and multiple .env file syntax