### PR TITLE
feat: add Rigellute/spotify-tui

### DIFF
--- a/pkgs/Rigellute/spotify-tui/pkg.yaml
+++ b/pkgs/Rigellute/spotify-tui/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Rigellute/spotify-tui@v0.25.0

--- a/pkgs/Rigellute/spotify-tui/registry.yaml
+++ b/pkgs/Rigellute/spotify-tui/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: Rigellute
+    repo_name: spotify-tui
+    asset: spotify-tui-{{.OS}}.tar.gz
+    description: Spotify for the terminal written in Rust
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: spt

--- a/registry.yaml
+++ b/registry.yaml
@@ -415,6 +415,19 @@ packages:
     supported_envs: ["windows", "darwin", "linux/amd64"]
     description: Helmsman is a Helm Charts (k8s applications) as Code tool which allows you to automate the deployment/management of your Helm charts from version controlled code
   - type: github_release
+    repo_owner: Rigellute
+    repo_name: spotify-tui
+    asset: spotify-tui-{{.OS}}.tar.gz
+    description: Spotify for the terminal written in Rust
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: spt
+  - type: github_release
     repo_owner: Schniz
     repo_name: fnm
     description: Fast and simple Node.js version manager, built in Rust


### PR DESCRIPTION
#4181

#4389 [Rigellute/spotify-tui](https://github.com/Rigellute/spotify-tui): Spotify for the terminal written in Rust