### PR TITLE
feat: add taskctl/taskctl

### DIFF
--- a/pkgs/taskctl/taskctl/pkg.yaml
+++ b/pkgs/taskctl/taskctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: taskctl/taskctl@1.4.2

--- a/pkgs/taskctl/taskctl/registry.yaml
+++ b/pkgs/taskctl/taskctl/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: taskctl
+    repo_name: taskctl
+    asset: taskctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Concurrent task runner, developer's routine tasks automation toolkit. Simple modern alternative to GNU Make
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6415,6 +6415,19 @@ packages:
       - name: kube-psp-advisor
         src: kubectl-advise-psp
   - type: github_release
+    repo_owner: taskctl
+    repo_name: taskctl
+    asset: taskctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Concurrent task runner, developer's routine tasks automation toolkit. Simple modern alternative to GNU Make
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: tcnksm
     repo_name: ghr
     description: Upload multiple artifacts to GitHub Release in parallel


### PR DESCRIPTION
#4181

#4392 [taskctl/taskctl](https://github.com/taskctl/taskctl): Concurrent task runner, developer's routine tasks automation toolkit. Simple modern alternative to GNU Make