### PR TITLE
feat: add bridgecrewio/yor

### DIFF
--- a/pkgs/bridgecrewio/yor/pkg.yaml
+++ b/pkgs/bridgecrewio/yor/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bridgecrewio/yor@0.1.146

--- a/pkgs/bridgecrewio/yor/registry.yaml
+++ b/pkgs/bridgecrewio/yor/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: bridgecrewio
+    repo_name: yor
+    asset: yor_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Extensible auto-tagger for your IaC files. The ultimate way to link entities in the cloud back to the codified resource which created it
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -1431,6 +1431,15 @@ packages:
     description: kubernetes log viewer
     supported_envs: ["darwin", "linux"]
   - type: github_release
+    repo_owner: bridgecrewio
+    repo_name: yor
+    asset: yor_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Extensible auto-tagger for your IaC files. The ultimate way to link entities in the cloud back to the codified resource which created it
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: brigadecore
     repo_name: brigade
     format: raw


### PR DESCRIPTION
#4181

#4398 [bridgecrewio/yor](https://github.com/bridgecrewio/yor): Extensible auto-tagger for your IaC files. The ultimate way to link entities in the cloud back to the codified resource which created it