### PR TITLE
feat: add optiv/Mangle

### DIFF
--- a/pkgs/optiv/Mangle/pkg.yaml
+++ b/pkgs/optiv/Mangle/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: optiv/Mangle@v1.0

--- a/pkgs/optiv/Mangle/registry.yaml
+++ b/pkgs/optiv/Mangle/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: optiv
+    repo_name: Mangle
+    asset: Mangle_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Mangle is a tool that manipulates aspects of compiled executables (.exe or DLL) to avoid detection from EDRs
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: mangle

--- a/registry.yaml
+++ b/registry.yaml
@@ -5140,6 +5140,18 @@ packages:
     supported_envs: ["darwin", "linux"]
     asset: "operator-sdk_{{.OS}}_{{.Arch}}"
   - type: github_release
+    repo_owner: optiv
+    repo_name: Mangle
+    asset: Mangle_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Mangle is a tool that manipulates aspects of compiled executables (.exe or DLL) to avoid detection from EDRs
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: mangle
+  - type: github_release
     repo_owner: orf
     repo_name: gping
     description: Ping, but with a graph


### PR DESCRIPTION
#4400 [optiv/Mangle](https://github.com/optiv/Mangle): Mangle is a tool that manipulates aspects of compiled executables (.exe or DLL) to avoid detection from EDRs