### PR TITLE
feat: add goccy/kubetest

### DIFF
--- a/pkgs/goccy/kubetest/pkg.yaml
+++ b/pkgs/goccy/kubetest/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: goccy/kubetest@v0.8.2

--- a/pkgs/goccy/kubetest/registry.yaml
+++ b/pkgs/goccy/kubetest/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: go_install
+    repo_owner: goccy
+    repo_name: kubetest
+    description: A CLI for distributed execution of tasks on Kubernetes
+    path: github.com/goccy/kubetest/cmd/kubetest

--- a/registry.yaml
+++ b/registry.yaml
@@ -2880,6 +2880,11 @@ packages:
     overrides:
       - goos: windows
         format: zip
+  - type: go_install
+    repo_owner: goccy
+    repo_name: kubetest
+    description: A CLI for distributed execution of tasks on Kubernetes
+    path: github.com/goccy/kubetest/cmd/kubetest
   - type: github_release
     repo_owner: gocruncher
     repo_name: jenkins-job-cli


### PR DESCRIPTION
#4493 [goccy/kubetest](https://github.com/goccy/kubetest): A CLI for distributed execution of tasks on Kubernetes