### PR TITLE
feat: add cloudspannerecosystem/yo

### DIFF
--- a/pkgs/cloudspannerecosystem/yo/pkg.yaml
+++ b/pkgs/cloudspannerecosystem/yo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudspannerecosystem/yo@v0.5.2

--- a/pkgs/cloudspannerecosystem/yo/registry.yaml
+++ b/pkgs/cloudspannerecosystem/yo/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: cloudspannerecosystem
+    repo_name: yo
+    asset: yo-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: yo is a command-line tool to generate Go code for Google Cloud Spanner
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: yo
+        src: yo-{{trimV .Version}}-{{.OS}}-{{.Arch}}/yo

--- a/registry.yaml
+++ b/registry.yaml
@@ -1801,6 +1801,18 @@ packages:
       - darwin
     rosetta2: true
   - type: github_release
+    repo_owner: cloudspannerecosystem
+    repo_name: yo
+    asset: yo-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: yo is a command-line tool to generate Go code for Google Cloud Spanner
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: yo
+        src: yo-{{trimV .Version}}-{{.OS}}-{{.Arch}}/yo
+  - type: github_release
     repo_owner: cnrancher
     repo_name: autok3s
     rosetta2: true


### PR DESCRIPTION
#4497 [cloudspannerecosystem/yo](https://github.com/cloudspannerecosystem/yo): yo is a command-line tool to generate Go code for Google Cloud Spanner