### PR TITLE
feat: add ktock/buildg

### DIFF
--- a/pkgs/ktock/buildg/pkg.yaml
+++ b/pkgs/ktock/buildg/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ktock/buildg@v0.3.0

--- a/pkgs/ktock/buildg/registry.yaml
+++ b/pkgs/ktock/buildg/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: github_release
+    repo_owner: ktock
+    repo_name: buildg
+    asset: buildg-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: Interactive debugger for Dockerfile, with support for IDEs (VS Code, Emacs, Neovim, etc.)
+    supported_envs:
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -4459,6 +4459,13 @@ packages:
     replacements:
       darwin: Darwin
   - type: github_release
+    repo_owner: ktock
+    repo_name: buildg
+    asset: buildg-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: Interactive debugger for Dockerfile, with support for IDEs (VS Code, Emacs, Neovim, etc.)
+    supported_envs:
+      - linux
+  - type: github_release
     repo_owner: ktr0731
     repo_name: evans
     rosetta2: true


### PR DESCRIPTION
#4579 [ktock/buildg](https://github.com/ktock/buildg): Interactive debugger for Dockerfile, with support for IDEs (VS Code, Emacs, Neovim, etc.)