### PR TITLE
fix: Correct asset format and supported_envs

### DIFF
--- a/pkgs/b4b4r07/gomi/pkg.yaml
+++ b/pkgs/b4b4r07/gomi/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: b4b4r07/gomi@v1.1.3
+  - name: b4b4r07/gomi
+    version: v1.1.1
+  - name: b4b4r07/gomi
+    version: v0.1.7

--- a/pkgs/b4b4r07/gomi/registry.yaml
+++ b/pkgs/b4b4r07/gomi/registry.yaml
@@ -11,7 +11,7 @@ packages:
       - darwin
     version_constraint: 'semver(">= 1.1.3")'
     version_overrides:
-      - version_constraint: 'semver("< 1.1.3")'
+      - version_constraint: 'semver(">= 1.0.0, < 1.1.3")'
         supported_envs:
           - linux/amd64
           - darwin

--- a/pkgs/b4b4r07/gomi/registry.yaml
+++ b/pkgs/b4b4r07/gomi/registry.yaml
@@ -2,14 +2,16 @@ packages:
   - type: github_release
     repo_owner: b4b4r07
     repo_name: gomi
-    rosetta2: true
-    asset: "gomi_{{.OS}}_{{.Arch}}.{{.Format}}"
-    description: Replacement for UNIX rm command!
-    supported_envs: ["darwin", "linux/amd64"]
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
+    asset: "gomi_{{.OS}}_{{.Arch}}.tar.gz"
+    description: Replacement for UNIX rm command
     replacements:
-      386: i386
       amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    version_constraint: 'semver(">= 1.1.3")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.1.3")'
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/pkgs/b4b4r07/gomi/registry.yaml
+++ b/pkgs/b4b4r07/gomi/registry.yaml
@@ -15,3 +15,11 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: 'semver("< 1.0.0")'
+        asset: "gomi_{{.OS}}_{{.Arch}}"
+        format: raw
+        replacements: {}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/pkgs/b4b4r07/gomi/registry.yaml
+++ b/pkgs/b4b4r07/gomi/registry.yaml
@@ -11,7 +11,7 @@ packages:
       - darwin
     version_constraint: 'semver(">= 1.1.3")'
     version_overrides:
-      - version_constraint: 'semver(">= 1.0.0, < 1.1.3")'
+      - version_constraint: 'semver(">= 1.0.0")'
         supported_envs:
           - linux/amd64
           - darwin

--- a/pkgs/b4b4r07/gomi/registry.yaml
+++ b/pkgs/b4b4r07/gomi/registry.yaml
@@ -15,6 +15,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        rosetta2: true
       - version_constraint: 'semver("< 1.0.0")'
         asset: "gomi_{{.OS}}_{{.Arch}}"
         format: raw

--- a/pkgs/ogham/exa/registry.yaml
+++ b/pkgs/ogham/exa/registry.yaml
@@ -2,12 +2,19 @@ packages:
   - type: github_release
     repo_owner: ogham
     repo_name: exa
-    description: "A modern replacement for 'ls'"
-    supported_envs: ["darwin", "linux"]
-    asset: "exa-{{.OS}}-{{.Version}}.zip"
+    asset: "exa-{{.OS}}-{{.Arch}}-musl-{{.Version}}.{{.Format}}"
+    format: zip
+    description: A modern replacement for ‘ls’
     replacements:
-      darwin: macos-x86_64
-      linux: linux-x86_64-musl
+      amd64: x86_64
+      darwin: macos
+    overrides:
+      - goos: darwin
+        asset: "exa-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}"
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
     files:
       - name: exa
         src: bin/exa

--- a/pkgs/x-motemen/ghq/pkg.yaml
+++ b/pkgs/x-motemen/ghq/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: x-motemen/ghq@v1.3.0
+  - name: x-motemen/ghq
+    version: v1.2.1

--- a/pkgs/x-motemen/ghq/registry.yaml
+++ b/pkgs/x-motemen/ghq/registry.yaml
@@ -2,8 +2,13 @@ packages:
   - type: github_release
     repo_owner: x-motemen
     repo_name: ghq
-    asset: "ghq_{{.OS}}_amd64.zip"
+    asset: "ghq_{{.OS}}_{{.Arch}}.zip"
     description: Remote repository management made easy
     files:
       - name: ghq
-        src: ghq_{{.OS}}_amd64/ghq
+        src: "ghq_{{.OS}}_{{.Arch}}/ghq"
+    version_constraint: 'semver(">= 1.3.0")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.3.0")'
+        supported_envs:
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1277,7 +1277,7 @@ packages:
       - darwin
     version_constraint: 'semver(">= 1.1.3")'
     version_overrides:
-      - version_constraint: 'semver("< 1.1.3")'
+      - version_constraint: 'semver(">= 1.0.0, < 1.1.3")'
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -1281,6 +1281,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        rosetta2: true
       - version_constraint: 'semver("< 1.0.0")'
         asset: "gomi_{{.OS}}_{{.Arch}}"
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -1268,17 +1268,19 @@ packages:
   - type: github_release
     repo_owner: b4b4r07
     repo_name: gomi
-    rosetta2: true
-    asset: "gomi_{{.OS}}_{{.Arch}}.{{.Format}}"
-    description: Replacement for UNIX rm command!
-    supported_envs: ["darwin", "linux/amd64"]
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
+    asset: "gomi_{{.OS}}_{{.Arch}}.tar.gz"
+    description: Replacement for UNIX rm command
     replacements:
-      386: i386
       amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    version_constraint: 'semver(">= 1.1.3")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.1.3")'
+        supported_envs:
+          - linux/amd64
+          - darwin
   - type: github_release
     repo_owner: b4b4r07
     repo_name: iap_curl
@@ -5347,12 +5349,19 @@ packages:
   - type: github_release
     repo_owner: ogham
     repo_name: exa
-    description: "A modern replacement for 'ls'"
-    supported_envs: ["darwin", "linux"]
-    asset: "exa-{{.OS}}-{{.Version}}.zip"
+    asset: "exa-{{.OS}}-{{.Arch}}-musl-{{.Version}}.{{.Format}}"
+    format: zip
+    description: A modern replacement for ‘ls’
     replacements:
-      darwin: macos-x86_64
-      linux: linux-x86_64-musl
+      amd64: x86_64
+      darwin: macos
+    overrides:
+      - goos: darwin
+        asset: "exa-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}"
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
     files:
       - name: exa
         src: bin/exa
@@ -7437,11 +7446,16 @@ packages:
   - type: github_release
     repo_owner: x-motemen
     repo_name: ghq
-    asset: "ghq_{{.OS}}_amd64.zip"
+    asset: "ghq_{{.OS}}_{{.Arch}}.zip"
     description: Remote repository management made easy
     files:
       - name: ghq
-        src: ghq_{{.OS}}_amd64/ghq
+        src: "ghq_{{.OS}}_{{.Arch}}/ghq"
+    version_constraint: 'semver(">= 1.3.0")'
+    version_overrides:
+      - version_constraint: 'semver("< 1.3.0")'
+        supported_envs:
+          - amd64
   - type: github_release
     repo_owner: xiecat
     repo_name: fofax

--- a/registry.yaml
+++ b/registry.yaml
@@ -1277,7 +1277,7 @@ packages:
       - darwin
     version_constraint: 'semver(">= 1.1.3")'
     version_overrides:
-      - version_constraint: 'semver(">= 1.0.0, < 1.1.3")'
+      - version_constraint: 'semver(">= 1.0.0")'
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -1281,6 +1281,14 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: 'semver("< 1.0.0")'
+        asset: "gomi_{{.OS}}_{{.Arch}}"
+        format: raw
+        replacements: {}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: b4b4r07
     repo_name: iap_curl


### PR DESCRIPTION
Corrected packages:

- [`b4b4r07/gomi`](https://github.com/b4b4r07/gomi) (support `linux/arm64`)
- [`ogham/exa`](https://github.com/ogham/exa) (exclude `linux/arm64`)
- [`x-motemen/ghq`](https://github.com/x-motemen/ghq) (support `linux/arm64`)