### PR TITLE
fix(cheat/cheat): support cheat windows >= v4.2.4

### DIFF
--- a/pkgs/cheat/cheat/pkg.yaml
+++ b/pkgs/cheat/cheat/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: cheat/cheat@4.2.3
+  - name: cheat/cheat@4.2.4
+  - name: cheat/cheat
+    version: 4.2.3

--- a/pkgs/cheat/cheat/registry.yaml
+++ b/pkgs/cheat/cheat/registry.yaml
@@ -4,14 +4,23 @@ packages:
     repo_name: cheat
     description: "cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember"
     rosetta2: true
-    supported_envs: ["darwin", "linux", "windows/amd64"]
-    asset: "cheat-{{.OS}}-{{.Arch}}.gz"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cheat-{{.OS}}-{{.Arch}}.gz
     files:
       - name: cheat
-        src: "cheat-{{.OS}}-{{.Arch}}"
+        src: cheat-{{.OS}}-{{.Arch}}
     overrides:
       - goos: windows
         asset: cheat-windows-amd64.exe.zip
-        files:
-          - name: cheat
-            src: dist/cheat-windows-amd64.exe
+    version_constraint: semver(">= 4.2.4")
+    version_overrides:
+      - version_constraint: 'true'
+        overrides:
+          - goos: windows
+            asset: cheat-windows-amd64.exe.zip
+            files:
+              - name: cheat
+                src: dist/cheat-windows-amd64.exe

--- a/registry.yaml
+++ b/registry.yaml
@@ -1720,17 +1720,26 @@ packages:
     repo_name: cheat
     description: "cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind *nix system administrators of options for commands that they use frequently, but not frequently enough to remember"
     rosetta2: true
-    supported_envs: ["darwin", "linux", "windows/amd64"]
-    asset: "cheat-{{.OS}}-{{.Arch}}.gz"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cheat-{{.OS}}-{{.Arch}}.gz
     files:
       - name: cheat
-        src: "cheat-{{.OS}}-{{.Arch}}"
+        src: cheat-{{.OS}}-{{.Arch}}
     overrides:
       - goos: windows
         asset: cheat-windows-amd64.exe.zip
-        files:
-          - name: cheat
-            src: dist/cheat-windows-amd64.exe
+    version_constraint: semver(">= 4.2.4")
+    version_overrides:
+      - version_constraint: 'true'
+        overrides:
+          - goos: windows
+            asset: cheat-windows-amd64.exe.zip
+            files:
+              - name: cheat
+                src: dist/cheat-windows-amd64.exe
   - type: github_release
     repo_owner: chmln
     repo_name: sd


### PR DESCRIPTION
https://github.com/cheat/cheat/releases/tag/4.2.4

> Fix an issue whereby the Windows zip release contained an extraneous (and annoying) dist parent directory.