### PR TITLE
feat: add turbot/steampipe

### DIFF
--- a/pkgs/turbot/steampipe/pkg.yaml
+++ b/pkgs/turbot/steampipe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: turbot/steampipe@v0.15.0

--- a/pkgs/turbot/steampipe/registry.yaml
+++ b/pkgs/turbot/steampipe/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: turbot
+    repo_name: steampipe
+    asset: steampipe_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Use SQL to instantly query your cloud services (AWS, Azure, GCP and more). Open source CLI. No DB required
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7188,6 +7188,18 @@ packages:
     supported_envs: ["darwin", "linux/amd64"]
     asset: "vegeta_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz"
   - type: github_release
+    repo_owner: turbot
+    repo_name: steampipe
+    asset: steampipe_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Use SQL to instantly query your cloud services (AWS, Azure, GCP and more). Open source CLI. No DB required
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
     repo_owner: twpayne
     repo_name: chezmoi
     description: Manage your dotfiles across multiple diverse machines, securely


### PR DESCRIPTION
#4597 [turbot/steampipe](https://github.com/turbot/steampipe): Use SQL to instantly query your cloud services (AWS, Azure, GCP and more). Open source CLI. No DB required