### PR TITLE
feat: add operator-framework/operator-registry (opm)

### DIFF
--- a/pkgs/operator-framework/operator-registry/pkg.yaml
+++ b/pkgs/operator-framework/operator-registry/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: operator-framework/operator-registry@v1.23.2

--- a/pkgs/operator-framework/operator-registry/registry.yaml
+++ b/pkgs/operator-framework/operator-registry/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: operator-framework
+    repo_name: operator-registry
+    asset: '{{.OS}}-{{.Arch}}-opm'
+    format: raw
+    description: Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to Operator Lifecycle Manager
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: opm

--- a/registry.yaml
+++ b/registry.yaml
@@ -5470,6 +5470,18 @@ packages:
         asset: faas-cli
   - type: github_release
     repo_owner: operator-framework
+    repo_name: operator-registry
+    asset: '{{.OS}}-{{.Arch}}-opm'
+    format: raw
+    description: Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to Operator Lifecycle Manager
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: opm
+  - type: github_release
+    repo_owner: operator-framework
     repo_name: operator-sdk
     description: SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding
     rosetta2: true


### PR DESCRIPTION
#4602 [operator-framework/operator-registry](https://github.com/operator-framework/operator-registry): Operator Registry runs in a Kubernetes or OpenShift cluster to provide operator catalog data to Operator Lifecycle Manager

```console
$ aqua g -i operator-framework/operator-registry
```

---

Thank you!