### PR TITLE
fix: generate-registry.sh doesn't output the registry in the same order of pkgs

### DIFF
--- a/generate-registry.sh
+++ b/generate-registry.sh
@@ -3,6 +3,9 @@
 set -eu
 set -o pipefail
 
+# Make sure sort output the same order on different environments
+export LC_COLLATE=C
+
 cp registry-header.yaml registry.yaml
 # shellcheck disable=SC2094
 find pkgs -name registry.yaml | sort | xargs cat |


### PR DESCRIPTION
Fix #4603