### PR TITLE
ADD: amazon-ecr-credential-helper

### DIFF
--- a/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: awslabs/amazon-ecr-credential-helper@v0.6.0

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -6,10 +6,8 @@ packages:
     format: raw
     url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login
     supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
-      - windows/amd64
+      - linux
+      - darwin
+      - amd64
     files:
       - name: docker-credential-ecr-login

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: http
+    repo_owner: awslabs
+    repo_name: amazon-ecr-credential-helper
+    description: Automatically gets credentials for Amazon ECR on docker push/docker pull
+    format: raw
+    url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+      - windows/amd64
+    files:
+      - name: docker-credential-ecr-login

--- a/registry.yaml
+++ b/registry.yaml
@@ -1186,6 +1186,20 @@ packages:
       darwin: macOS
     files:
       - name: copilot
+  - type: http
+    repo_owner: awslabs
+    repo_name: amazon-ecr-credential-helper
+    description: Automatically gets credentials for Amazon ECR on docker push/docker pull
+    format: raw
+    url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+      - windows/amd64
+    files:
+      - name: docker-credential-ecr-login
   - type: github_content
     repo_owner: awslabs
     repo_name: git-secrets

--- a/registry.yaml
+++ b/registry.yaml
@@ -1193,11 +1193,9 @@ packages:
     format: raw
     url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login
     supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
-      - windows/amd64
+      - linux
+      - darwin
+      - amd64
     files:
       - name: docker-credential-ecr-login
   - type: github_content


### PR DESCRIPTION
#4613 [awslabls/amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper): Automatically gets credentials for Amazon ECR on docker push/docker pull

```console
$ aqua g -i awslabls/amazon-ecr-credential-helper
```

---

Added [awslabls/amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper)