### PR TITLE
feat: add aquasecurity/chain-bench

### DIFF
--- a/pkgs/aquasecurity/chain-bench/pkg.yaml
+++ b/pkgs/aquasecurity/chain-bench/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aquasecurity/chain-bench@v0.1.0

--- a/pkgs/aquasecurity/chain-bench/registry.yaml
+++ b/pkgs/aquasecurity/chain-bench/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: aquasecurity
+    repo_name: chain-bench
+    asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: An open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -997,6 +997,19 @@ packages:
     supported_envs: ["darwin", "linux"]
   - type: github_release
     repo_owner: aquasecurity
+    repo_name: chain-bench
+    asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: An open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
+    repo_owner: aquasecurity
     repo_name: kube-bench
     asset: "kube-bench_{{trimV .Version}}_linux_{{.Arch}}.tar.gz"
     description: Checks whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark


### PR DESCRIPTION
#4688 [aquasecurity/chain-bench](https://github.com/aquasecurity/chain-bench): An open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark