### PR TITLE
fix: support schollz/croc v9.6.0

### DIFF
--- a/pkgs/schollz/croc/pkg.yaml
+++ b/pkgs/schollz/croc/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: schollz/croc@v9.5.6
+  - name: schollz/croc@v9.6.0
+  - name: schollz/croc
+    version: v9.5.6

--- a/pkgs/schollz/croc/registry.yaml
+++ b/pkgs/schollz/croc/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: schollz
     repo_name: croc
-    asset: "croc_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}"
+    asset: croc_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     description: Easily and securely send things from one computer to another
     format: tar.gz
     overrides:
@@ -20,3 +20,11 @@ packages:
       netbsd: NetBSD
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
+    version_constraint: semver("!= 9.6.0")
+    version_overrides:
+      - version_constraint: 'true'
+        rosetta2: true
+        supported_envs:
+          - linux
+          - darwin
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6393,7 +6393,7 @@ packages:
   - type: github_release
     repo_owner: schollz
     repo_name: croc
-    asset: "croc_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}"
+    asset: croc_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     description: Easily and securely send things from one computer to another
     format: tar.gz
     overrides:
@@ -6411,6 +6411,14 @@ packages:
       netbsd: NetBSD
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
+    version_constraint: semver("!= 9.6.0")
+    version_overrides:
+      - version_constraint: 'true'
+        rosetta2: true
+        supported_envs:
+          - linux
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: sclevine
     repo_name: yj


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/4693

* https://github.com/schollz/croc/releases/tag/v9.6.0
* https://github.com/schollz/croc/releases/tag/v9.5.6

The following assets aren't found.

* croc_9.6.0_macOS-ARM64.tar.gz
* croc_9.6.0_Windows-ARM64.zip