### PR TITLE
chore: replace shell scripts to Go

### DIFF
--- a/.cmdx.yaml
+++ b/.cmdx.yaml
@@ -55,3 +55,8 @@ tasks:
     args:
       - name: pkg
         required: true
+  - name: lint
+    short: l
+    description: lint the go code
+    usage: lint the go code
+    script: golangci-lint run

--- a/.cmdx.yaml
+++ b/.cmdx.yaml
@@ -46,12 +46,12 @@ tasks:
     short: gr
     description: Merge registry.yaml
     usage: Merge registry.yaml
-    script: bash generate-registry.sh
+    script: go run ./cmd/generate-registry
   - name: scaffold
     short: s
     description: scaffold
     usage: scaffold
-    script: bash scaffold.sh "{{.pkg}}"
+    script: go run ./cmd/scaffold "{{.pkg}}"
     args:
       - name: pkg
         required: true

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,0 +1,28 @@
+---
+name: test Go
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - .golangci.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - .golangci.yml
+env:
+  AQUA_LOG_COLOR: always
+  AQUA_CONFIG: aqua-all.yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aquaproj/aqua-installer@v1.0.0
+        with:
+          aqua_version: v1.17.0
+      - uses: suzuki-shunsuke/github-action-golangci-lint@v0.1.3
+      # - run: go test -v ./... -race -covermode=atomic

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - maligned # WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
+    - interfacer # WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
+    - scopelint # WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
+    - wsl
+    - goerr113
+    - lll
+    - godot
+    - nlreturn
+    - godox
+    - golint
+    - tagliatelle
+    - exhaustivestruct # https://github.com/mbilski/exhaustivestruct
+    - ireturn
+    - varnamelen
+    - exhaustive
+    - exhaustruct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ And please run `bash generate-registry.sh` to update [registry.yaml](registry.ya
 $ bash generate-registry.sh
 ```
 
+Instead of `generate-registry.sh`, you can also use Go.
+
+```console
+$ go run ./cmd/generate-registry
+```
+
 ## Run generate-registry.sh to update reigstry.yaml
 
 [registry.yaml on the repository root directory](registry.yaml) is generated with [generate-registry.sh](generate-registry.sh).
@@ -24,6 +30,12 @@ Don't edit it manually, and if you update `registry.yaml` in [pkgs](pkgs) direct
 
 ```console
 $ bash generate-registry.sh
+```
+
+Instead of `generate-registry.sh`, you can also use Go.
+
+```console
+$ go run ./cmd/generate-registry
 ```
 
 ## Scaffold configuration
@@ -38,6 +50,12 @@ e.g.
 
 ```console
 $ bash scaffold.sh cli/cli
+```
+
+Instead of `scaffold.sh`, you can also use Go.
+
+```console
+$ go run ./cmd/scaffold cli/cli
 ```
 
 Then please update generated files.

--- a/cmd/generate-registry/main.go
+++ b/cmd/generate-registry/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/aquaproj/aqua-registry/internal/api"
+)
+
+func main() {
+	if err := api.GenerateRegistry(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/scaffold/main.go
+++ b/cmd/scaffold/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aquaproj/aqua-registry/internal/api"
+)
+
+func main() {
+	if err := core(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+const dirPermission os.FileMode = 0o775
+
+func core() error {
+	ctx := context.Background()
+	if len(os.Args) != 2 {
+		return errors.New(`usage: $ bash scaffold.sh <pkgname>
+e.g. $ bash scaffold.sh cli/cli`)
+	}
+	pkgName := os.Args[1]
+	pkgDir := filepath.Join(append([]string{"pkgs"}, strings.Split(pkgName, "/")...)...)
+	pkgFile := filepath.Join(pkgDir, "pkg.yaml")
+	rgFile := filepath.Join(pkgDir, "registry.yaml")
+	if err := os.MkdirAll(pkgDir, dirPermission); err != nil {
+		return fmt.Errorf("create directories: %w", err)
+	}
+	if err := aquaGR(ctx, pkgName, rgFile); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "Update registry.yaml")
+	if err := api.GenerateRegistry(); err != nil {
+		return err
+	}
+	if err := createAquaYAML(); err != nil {
+		return err
+	}
+	if err := aquaG(ctx, pkgName); err != nil {
+		return err
+	}
+	if err := createPkgFile(ctx, pkgName, pkgFile); err != nil {
+		return err
+	}
+	if err := aquaI(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func aquaGR(ctx context.Context, pkgName, rgFilePath string) error {
+	outFile, err := os.Create(rgFilePath)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+	fmt.Fprintf(os.Stderr, "+ aqua gr %s\n", pkgName)
+	cmd := exec.CommandContext(ctx, "aqua", "gr", pkgName)
+	cmd.Stdout = outFile
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createAquaYAML() error {
+	if _, err := os.Stat("aqua.yaml"); err == nil {
+		return nil
+	}
+	outFile, err := os.Create("aqua.yaml")
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+	srcFile, err := os.Open("aqua.yaml.tmpl")
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	if _, err := io.Copy(outFile, srcFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+func aquaG(ctx context.Context, pkgName string) error {
+	fmt.Fprintf(os.Stderr, "+ aqua g -i %s\n", pkgName)
+	cmd := exec.CommandContext(ctx, "aqua", "g", "-i", pkgName)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func aquaI(ctx context.Context) error {
+	fmt.Fprintln(os.Stderr, "+ aqua i")
+	cmd := exec.CommandContext(ctx, "aqua", "i")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createPkgFile(ctx context.Context, pkgName, pkgFilePath string) error {
+	outFile, err := os.Create(pkgFilePath)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+	if _, err := outFile.WriteString("packages:\n"); err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(os.Stderr, "+ aqua g %s\n", pkgName)
+	cmd := exec.CommandContext(ctx, "aqua", "g", pkgName)
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	txt := ""
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		txt += fmt.Sprintf("  %s\n", line)
+	}
+	if _, err := outFile.WriteString(txt); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/scaffold/main.go
+++ b/cmd/scaffold/main.go
@@ -25,7 +25,7 @@ const dirPermission os.FileMode = 0o775
 
 func core() error {
 	ctx := context.Background()
-	if len(os.Args) != 2 {
+	if len(os.Args) != 2 { //nolint:gomnd
 		return errors.New(`usage: $ bash scaffold.sh <pkgname>
 e.g. $ bash scaffold.sh cli/cli`)
 	}
@@ -41,7 +41,7 @@ e.g. $ bash scaffold.sh cli/cli`)
 	}
 	fmt.Fprintln(os.Stderr, "Update registry.yaml")
 	if err := api.GenerateRegistry(); err != nil {
-		return err
+		return fmt.Errorf("update registry.yaml: %w", err)
 	}
 	if err := createAquaYAML(); err != nil {
 		return err
@@ -61,7 +61,7 @@ e.g. $ bash scaffold.sh cli/cli`)
 func aquaGR(ctx context.Context, pkgName, rgFilePath string) error {
 	outFile, err := os.Create(rgFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("create a file %s: %w", rgFilePath, err)
 	}
 	defer outFile.Close()
 	fmt.Fprintf(os.Stderr, "+ aqua gr %s\n", pkgName)
@@ -69,7 +69,7 @@ func aquaGR(ctx context.Context, pkgName, rgFilePath string) error {
 	cmd.Stdout = outFile
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("execute a command: %w", err)
 	}
 	return nil
 }
@@ -80,16 +80,16 @@ func createAquaYAML() error {
 	}
 	outFile, err := os.Create("aqua.yaml")
 	if err != nil {
-		return err
+		return fmt.Errorf("create aqua.yaml: %w", err)
 	}
 	defer outFile.Close()
 	srcFile, err := os.Open("aqua.yaml.tmpl")
 	if err != nil {
-		return err
+		return fmt.Errorf("open aqua.yaml.tmpl: %w", err)
 	}
 	defer srcFile.Close()
 	if _, err := io.Copy(outFile, srcFile); err != nil {
-		return err
+		return fmt.Errorf("copy aqua.yaml.tmpl to aqua.yaml: %w", err)
 	}
 	return nil
 }
@@ -101,7 +101,7 @@ func aquaG(ctx context.Context, pkgName string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("execute a command: %w", err)
 	}
 	return nil
 }
@@ -113,7 +113,7 @@ func aquaI(ctx context.Context) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("execute a command: aqua i: %w", err)
 	}
 	return nil
 }
@@ -121,11 +121,11 @@ func aquaI(ctx context.Context) error {
 func createPkgFile(ctx context.Context, pkgName, pkgFilePath string) error {
 	outFile, err := os.Create(pkgFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("create a file %s: %w", pkgFilePath, err)
 	}
 	defer outFile.Close()
 	if _, err := outFile.WriteString("packages:\n"); err != nil {
-		return err
+		return fmt.Errorf("write a string to file %s: %w", pkgFilePath, err)
 	}
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(os.Stderr, "+ aqua g %s\n", pkgName)
@@ -133,14 +133,14 @@ func createPkgFile(ctx context.Context, pkgName, pkgFilePath string) error {
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("execute a command: aqua g %s: %w", pkgName, err)
 	}
 	txt := ""
 	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
 		txt += fmt.Sprintf("  %s\n", line)
 	}
 	if _, err := outFile.WriteString(txt); err != nil {
-		return err
+		return fmt.Errorf("write a string to file %s: %w", pkgFilePath, err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/aquaproj/aqua-registry
+
+go 1.18

--- a/internal/api/generate_registry.go
+++ b/internal/api/generate_registry.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bufio"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func GenerateRegistry() error {
+	tempFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return err
+	}
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+	if err := copyHeader(tempFile); err != nil {
+		return err
+	}
+	registryFilePaths, err := listRegistryFiles()
+	if err != nil {
+		return err
+	}
+	lines, err := readRegistryFiles(registryFilePaths)
+	if err != nil {
+		return err
+	}
+	if _, err := tempFile.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+		return err
+	}
+	if err := copyRegistry(tempFile.Name()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyHeader(tempFile io.Writer) error {
+	header, err := os.Open("registry-header.yaml")
+	if err != nil {
+		return err
+	}
+	defer header.Close()
+	if _, err := io.Copy(tempFile, header); err != nil {
+		return err
+	}
+	return nil
+}
+
+func listRegistryFiles() ([]string, error) {
+	registryFilePaths := []string{}
+	if err := filepath.WalkDir("pkgs", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d == nil {
+				return err
+			}
+			return nil
+		}
+		if filepath.Base(p) == "registry.yaml" {
+			registryFilePaths = append(registryFilePaths, p)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	sort.Strings(registryFilePaths)
+	return registryFilePaths, nil
+}
+
+func readRegistryFiles(registryFilePaths []string) ([]string, error) {
+	lines := []string{}
+	for _, registryFilePath := range registryFilePaths {
+		if err := func() error {
+			f, err := os.Open(registryFilePath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "packages:") {
+					continue
+				}
+				if line == "---" {
+					continue
+				}
+				lines = append(lines, line)
+			}
+			if err := scanner.Err(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+	return lines, nil
+}
+
+func copyRegistry(tempFilePath string) error {
+	rTempFile, err := os.Open(tempFilePath)
+	if err != nil {
+		return err
+	}
+	defer rTempFile.Close()
+	registryFile, err := os.Create("registry.yaml")
+	if err != nil {
+		return err
+	}
+	defer registryFile.Close()
+	if _, err := io.Copy(registryFile, rTempFile); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/api/generate_registry.go
+++ b/internal/api/generate_registry.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -13,7 +14,7 @@ import (
 func GenerateRegistry() error {
 	tempFile, err := os.CreateTemp("", "")
 	if err != nil {
-		return err
+		return fmt.Errorf("create a temporal file: %w", err)
 	}
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
@@ -29,7 +30,7 @@ func GenerateRegistry() error {
 		return err
 	}
 	if _, err := tempFile.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
-		return err
+		return fmt.Errorf("write a string to a temporal file: %w", err)
 	}
 	if err := copyRegistry(tempFile.Name()); err != nil {
 		return err
@@ -40,11 +41,11 @@ func GenerateRegistry() error {
 func copyHeader(tempFile io.Writer) error {
 	header, err := os.Open("registry-header.yaml")
 	if err != nil {
-		return err
+		return fmt.Errorf("open registry-header.yaml: %w", err)
 	}
 	defer header.Close()
 	if _, err := io.Copy(tempFile, header); err != nil {
-		return err
+		return fmt.Errorf("copy registry-header.yaml to a temporal file: %w", err)
 	}
 	return nil
 }
@@ -63,7 +64,7 @@ func listRegistryFiles() ([]string, error) {
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("find registry.yaml in the directory pkgs: %w", err)
 	}
 	sort.Strings(registryFilePaths)
 	return registryFilePaths, nil
@@ -75,7 +76,7 @@ func readRegistryFiles(registryFilePaths []string) ([]string, error) {
 		if err := func() error {
 			f, err := os.Open(registryFilePath)
 			if err != nil {
-				return err
+				return fmt.Errorf("open %s: %w", registryFilePath, err)
 			}
 			defer f.Close()
 			scanner := bufio.NewScanner(f)
@@ -90,7 +91,7 @@ func readRegistryFiles(registryFilePaths []string) ([]string, error) {
 				lines = append(lines, line)
 			}
 			if err := scanner.Err(); err != nil {
-				return err
+				return fmt.Errorf("scan a file: %w", err)
 			}
 			return nil
 		}(); err != nil {
@@ -103,16 +104,16 @@ func readRegistryFiles(registryFilePaths []string) ([]string, error) {
 func copyRegistry(tempFilePath string) error {
 	rTempFile, err := os.Open(tempFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("open a temporal file: %w", err)
 	}
 	defer rTempFile.Close()
 	registryFile, err := os.Create("registry.yaml")
 	if err != nil {
-		return err
+		return fmt.Errorf("create registry.yaml: %w", err)
 	}
 	defer registryFile.Close()
 	if _, err := io.Copy(registryFile, rTempFile); err != nil {
-		return err
+		return fmt.Errorf("copy a temporal file to registry.yaml: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
We provide some helper scirpts written in Shell Scripts.

* scaffold.sh
* generate-registry.sh

But these scripts depend on Shell and probably they don't work on Windows.

So I rewrite these scripts in Go.

```console
$ go run ./cmd/scaffold <package>
```

```console
$ go run ./cmd/generate-registry
```