### PR TITLE
feat: add cloudflare/gokey

### DIFF
--- a/pkgs/cloudflare/gokey/pkg.yaml
+++ b/pkgs/cloudflare/gokey/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudflare/gokey@a7a2ab980535f783b88740e46b9281fc2f08e629

--- a/pkgs/cloudflare/gokey/registry.yaml
+++ b/pkgs/cloudflare/gokey/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: go_install
+    repo_owner: cloudflare
+    repo_name: gokey
+    description: A simple vaultless password manager in Go
+    path: github.com/cloudflare/gokey/cmd/gokey

--- a/registry.yaml
+++ b/registry.yaml
@@ -1944,6 +1944,11 @@ packages:
     overrides:
       - goos: darwin
         asset: "cloudflared-{{.OS}}-{{.Arch}}.tgz"
+  - type: go_install
+    repo_owner: cloudflare
+    repo_name: gokey
+    description: A simple vaultless password manager in Go
+    path: github.com/cloudflare/gokey/cmd/gokey
   - type: github_release
     repo_owner: cloudfoundry
     repo_name: bosh-cli


### PR DESCRIPTION
#4761 [cloudflare/gokey](https://github.com/cloudflare/gokey): A simple vaultless password manager in Go