### PR TITLE
feat: add hmarr/codeowners

### DIFF
--- a/pkgs/hmarr/codeowners/pkg.yaml
+++ b/pkgs/hmarr/codeowners/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hmarr/codeowners@v0.4.0

--- a/pkgs/hmarr/codeowners/registry.yaml
+++ b/pkgs/hmarr/codeowners/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: hmarr
+    repo_name: codeowners
+    asset: codeowners_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "\U0001F512 CLI and Go library for CODEOWNERS files"
+    supported_envs:
+      - linux
+      - darwin

--- a/pkgs/hmarr/codeowners/registry.yaml
+++ b/pkgs/hmarr/codeowners/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: hmarr
     repo_name: codeowners
     asset: codeowners_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "\U0001F512 CLI and Go library for CODEOWNERS files"
+    description: CLI and Go library for CODEOWNERS files
     supported_envs:
       - linux
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -3882,7 +3882,7 @@ packages:
     repo_owner: hmarr
     repo_name: codeowners
     asset: codeowners_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "\U0001F512 CLI and Go library for CODEOWNERS files"
+    description: CLI and Go library for CODEOWNERS files
     supported_envs:
       - linux
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -3879,6 +3879,14 @@ packages:
         format: zip
     description: Predict next English words
   - type: github_release
+    repo_owner: hmarr
+    repo_name: codeowners
+    asset: codeowners_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "\U0001F512 CLI and Go library for CODEOWNERS files"
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
     repo_owner: homeport
     repo_name: dyff
     description: A diff tool for YAML files, and sometimes JSON


### PR DESCRIPTION
#4764 [hmarr/codeowners](https://github.com/hmarr/codeowners): CLI and Go library for CODEOWNERS files

```console
$ aqua g -i hmarr/codeowners
```