### PR TITLE
feat: add aws/aws-cli

### DIFF
--- a/pkgs/aws/aws-cli/pkg.yaml
+++ b/pkgs/aws/aws-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aws/aws-cli@2.7.15

--- a/pkgs/aws/aws-cli/registry.yaml
+++ b/pkgs/aws/aws-cli/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: http
+    repo_owner: aws
+    repo_name: aws-cli
+    version_source: github_tag
+    url: "https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip"
+    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
+    files:
+      - name: aws
+        src: aws/dist/aws
+      - name: aws_completer
+        src: aws/dist/aws_completer
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux

--- a/pkgs/aws/aws-cli/registry.yaml
+++ b/pkgs/aws/aws-cli/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: aws
     repo_name: aws-cli
     version_source: github_tag
-    url: "https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip"
+    url: https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip
     description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
     files:
       - name: aws

--- a/registry.yaml
+++ b/registry.yaml
@@ -1245,7 +1245,7 @@ packages:
     repo_owner: aws
     repo_name: aws-cli
     version_source: github_tag
-    url: "https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip"
+    url: https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip
     description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
     files:
       - name: aws

--- a/registry.yaml
+++ b/registry.yaml
@@ -1241,6 +1241,22 @@ packages:
     supported_envs: ["darwin", "linux", "windows/amd64"]
     files:
       - name: ec2-instance-selector
+  - type: http
+    repo_owner: aws
+    repo_name: aws-cli
+    version_source: github_tag
+    url: "https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip"
+    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
+    files:
+      - name: aws
+        src: aws/dist/aws
+      - name: aws_completer
+        src: aws/dist/aws_completer
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
   - type: github_release
     repo_owner: aws
     repo_name: copilot-cli


### PR DESCRIPTION
#4807 [aws/aws-cli](https://github.com/aws/aws-cli): The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services

```console
$ aqua g -i aws/aws-cli
```
