### PR TITLE
fix(aws/aws-cli): add a warning "Linux Only"

### DIFF
--- a/pkgs/aws/aws-cli/registry.yaml
+++ b/pkgs/aws/aws-cli/registry.yaml
@@ -2,9 +2,11 @@ packages:
   - type: http
     repo_owner: aws
     repo_name: aws-cli
+    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
+    search_words:
+      - Linux Only
     version_source: github_tag
     url: https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip
-    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
     files:
       - name: aws
         src: aws/dist/aws

--- a/registry.yaml
+++ b/registry.yaml
@@ -1244,9 +1244,11 @@ packages:
   - type: http
     repo_owner: aws
     repo_name: aws-cli
+    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
+    search_words:
+      - Linux Only
     version_source: github_tag
     url: https://awscli.amazonaws.com/awscli-exe-{{.OS}}-{{.Arch}}-{{.Version}}.zip
-    description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
     files:
       - name: aws
         src: aws/dist/aws


### PR DESCRIPTION
Follow up #4807

aws/aws-cli supports only Linux, but it will be confusing for Windows and macOS users.
So I add a warning "Linux Only" with `search_words`.

```console
$ aqua g
```

<img width="391" alt="image" src="https://user-images.githubusercontent.com/13323303/179017235-f375feb5-c009-49bd-a7ec-0df84d29983e.png">

```
> aws/aws-cli [aws, aws_completer]: Linux Only
  1/668
> aws/aws
```