### PR TITLE
feat: add marp-team/marp-cli

### DIFF
--- a/pkgs/marp-team/marp-cli/pkg.yaml
+++ b/pkgs/marp-team/marp-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: marp-team/marp-cli@v2.0.4

--- a/pkgs/marp-team/marp-cli/registry.yaml
+++ b/pkgs/marp-team/marp-cli/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: marp-team
+    repo_name: marp-cli
+    asset: marp-cli-{{.Version}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A CLI interface for Marp and Marpit based converters
+    files:
+      - name: marp
+    replacements:
+      darwin: mac
+      windows: win
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -5084,6 +5084,24 @@ packages:
       386: i386
       amd64: x86_64
   - type: github_release
+    repo_owner: marp-team
+    repo_name: marp-cli
+    asset: marp-cli-{{.Version}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A CLI interface for Marp and Marpit based converters
+    files:
+      - name: marp
+    replacements:
+      darwin: mac
+      windows: win
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: mattn
     repo_name: gof
     asset: "gof_{{.Version}}_{{.OS}}_amd64.{{.Format}}"


### PR DESCRIPTION
#4810 [marp-team/marp-cli](https://github.com/marp-team/marp-cli): A CLI interface for Marp and Marpit based converters

```console
$ aqua g -i marp-team/marp-cli
```
