### PR TITLE
feat: add cloud-hypervisor/cloud-hypervisor

### DIFF
--- a/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/pkg.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloud-hypervisor/cloud-hypervisor/ch-remote@v25.0

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
@@ -1,7 +1,5 @@
 packages:
   - name: cloud-hypervisor/cloud-hypervisor/ch-remote
-    aliases:
-    - name: cloud-hypervisor/ch-remote
     type: github_release
     repo_owner: cloud-hypervisor
     repo_name: cloud-hypervisor

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
@@ -14,3 +14,5 @@ packages:
       arm64: aarch64
     supported_envs:
       - linux
+    files:
+      - name: ch-remote

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - name: cloud-hypervisor/cloud-hypervisor/ch-remote
+    aliases:
+    - name: cloud-hypervisor/ch-remote
+    type: github_release
+    repo_owner: cloud-hypervisor
+    repo_name: cloud-hypervisor
+    description: Remotely control a cloud-hypervisor VMM
+    format: raw
+    asset: ch-remote-static
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: ch-remote-static-{{.Arch}}
+    replacements:
+      arm64: aarch64
+    supported_envs:
+      - linux

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/ch-remote/registry.yaml
@@ -5,14 +5,11 @@ packages:
     repo_name: cloud-hypervisor
     description: Remotely control a cloud-hypervisor VMM
     format: raw
-    asset: ch-remote-static
-    overrides:
-      - goos: linux
-        goarch: arm64
-        asset: ch-remote-static-{{.Arch}}
-    replacements:
-      arm64: aarch64
     supported_envs:
       - linux
     files:
       - name: ch-remote
+    asset: ch-remote-static
+    overrides:
+      - goarch: arm64
+        asset: ch-remote-static-aarch64

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/pkg.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloud-hypervisor/cloud-hypervisor@v25.0

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/registry.yaml
@@ -4,12 +4,9 @@ packages:
     repo_name: cloud-hypervisor
     description: Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM hypervisor and Microsoft Hypervisor (MSHV)
     format: raw
-    asset: cloud-hypervisor-static
-    overrides:
-      - goos: linux
-        goarch: arm64
-        asset: cloud-hypervisor-static-{{.Arch}}
-    replacements:
-      arm64: aarch64
     supported_envs:
       - linux
+    asset: cloud-hypervisor-static
+    overrides:
+      - goarch: arm64
+        asset: cloud-hypervisor-static-aarch64

--- a/pkgs/cloud-hypervisor/cloud-hypervisor/registry.yaml
+++ b/pkgs/cloud-hypervisor/cloud-hypervisor/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: cloud-hypervisor
+    repo_name: cloud-hypervisor
+    description: Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM hypervisor and Microsoft Hypervisor (MSHV)
+    format: raw
+    asset: cloud-hypervisor-static
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: cloud-hypervisor-static-{{.Arch}}
+    replacements:
+      arm64: aarch64
+    supported_envs:
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -1953,17 +1953,14 @@ packages:
     repo_name: cloud-hypervisor
     description: Remotely control a cloud-hypervisor VMM
     format: raw
-    asset: ch-remote-static
-    overrides:
-      - goos: linux
-        goarch: arm64
-        asset: ch-remote-static-{{.Arch}}
-    replacements:
-      arm64: aarch64
     supported_envs:
       - linux
     files:
       - name: ch-remote
+    asset: ch-remote-static
+    overrides:
+      - goarch: arm64
+        asset: ch-remote-static-aarch64
   - type: github_release
     repo_owner: cloudflare
     repo_name: cfssl

--- a/registry.yaml
+++ b/registry.yaml
@@ -1938,15 +1938,12 @@ packages:
     repo_name: cloud-hypervisor
     description: Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM hypervisor and Microsoft Hypervisor (MSHV)
     format: raw
-    asset: cloud-hypervisor-static
-    overrides:
-      - goos: linux
-        goarch: arm64
-        asset: cloud-hypervisor-static-{{.Arch}}
-    replacements:
-      arm64: aarch64
     supported_envs:
       - linux
+    asset: cloud-hypervisor-static
+    overrides:
+      - goarch: arm64
+        asset: cloud-hypervisor-static-aarch64
   - name: cloud-hypervisor/cloud-hypervisor/ch-remote
     type: github_release
     repo_owner: cloud-hypervisor

--- a/registry.yaml
+++ b/registry.yaml
@@ -1962,6 +1962,8 @@ packages:
       arm64: aarch64
     supported_envs:
       - linux
+    files:
+      - name: ch-remote
   - type: github_release
     repo_owner: cloudflare
     repo_name: cfssl

--- a/registry.yaml
+++ b/registry.yaml
@@ -1934,6 +1934,37 @@ packages:
     files:
       - name: clog
   - type: github_release
+    repo_owner: cloud-hypervisor
+    repo_name: cloud-hypervisor
+    description: Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM hypervisor and Microsoft Hypervisor (MSHV)
+    format: raw
+    asset: cloud-hypervisor-static
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: cloud-hypervisor-static-{{.Arch}}
+    replacements:
+      arm64: aarch64
+    supported_envs:
+      - linux
+  - name: cloud-hypervisor/cloud-hypervisor/ch-remote
+    aliases:
+    - name: cloud-hypervisor/ch-remote
+    type: github_release
+    repo_owner: cloud-hypervisor
+    repo_name: cloud-hypervisor
+    description: Remotely control a cloud-hypervisor VMM
+    format: raw
+    asset: ch-remote-static
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: ch-remote-static-{{.Arch}}
+    replacements:
+      arm64: aarch64
+    supported_envs:
+      - linux
+  - type: github_release
     repo_owner: cloudflare
     repo_name: cfssl
     description: "CFSSL: Cloudflare's PKI and TLS toolkit"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1948,8 +1948,6 @@ packages:
     supported_envs:
       - linux
   - name: cloud-hypervisor/cloud-hypervisor/ch-remote
-    aliases:
-    - name: cloud-hypervisor/ch-remote
     type: github_release
     repo_owner: cloud-hypervisor
     repo_name: cloud-hypervisor


### PR DESCRIPTION
#4821 [cloud-hypervisor/cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor): Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of KVM hypervisor and Microsoft Hypervisor (MSHV)
#4821 [cloud-hypervisor/cloud-hypervisor/ch-remote](https://github.com/cloud-hypervisor/cloud-hypervisor): Remotely control a cloud-hypervisor VMM

```console
$ aqua g -i cloud-hypervisor/cloud-hypervisor cloud-hypervisor/cloud-hypervisor/ch-remote
```
