### PR TITLE
feat: add kvz/json2hcl

### DIFF
--- a/pkgs/kvz/json2hcl/pkg.yaml
+++ b/pkgs/kvz/json2hcl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kvz/json2hcl@v0.1.1

--- a/pkgs/kvz/json2hcl/registry.yaml
+++ b/pkgs/kvz/json2hcl/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: github_release
+    repo_owner: kvz
+    repo_name: json2hcl
+    asset: json2hcl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Convert JSON to HCL, and vice versa. We don't use json2hcl anymore ourselves, so we can't invest time into it. However, we're still welcoming PRs

--- a/registry.yaml
+++ b/registry.yaml
@@ -5020,6 +5020,11 @@ packages:
     files:
       - name: kubectl-node_shell
   - type: github_release
+    repo_owner: kvz
+    repo_name: json2hcl
+    asset: json2hcl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Convert JSON to HCL, and vice versa. We don't use json2hcl anymore ourselves, so we can't invest time into it. However, we're still welcoming PRs
+  - type: github_release
     repo_owner: kyleconroy
     repo_name: sqlc
     description: Generate type-safe code from SQL


### PR DESCRIPTION
#4872 [kvz/json2hcl](https://github.com/kvz/json2hcl): Convert JSON to HCL, and vice versa. We don't use json2hcl anymore ourselves, so we can't invest time into it. However, we're still welcoming PRs

```console
$ aqua g -i kvz/json2hcl
```
