### PR TITLE
feat: Add rust-lang/rust-analyzer

### DIFF
--- a/pkgs/rust-lang/rust-analyzer/pkg.yaml
+++ b/pkgs/rust-lang/rust-analyzer/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: rust-lang/rust-analyzer@2022-07-04
+  - name: rust-lang/rust-analyzer@2022-07-18

--- a/pkgs/rust-lang/rust-analyzer/pkg.yaml
+++ b/pkgs/rust-lang/rust-analyzer/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rust-lang/rust-analyzer@2022-07-04

--- a/pkgs/rust-lang/rust-analyzer/registry.yaml
+++ b/pkgs/rust-lang/rust-analyzer/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: rust-lang
+    repo_name: rust-analyzer
+    asset: "rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}"
+    format: gz
+    description: A Rust compiler front-end for IDEs
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+    files:
+      - name: rust-analyzer
+        src: "rust-analyzer-{{.Arch}}-{{.OS}}"

--- a/pkgs/rust-lang/rust-analyzer/registry.yaml
+++ b/pkgs/rust-lang/rust-analyzer/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: rust-lang
     repo_name: rust-analyzer
-    asset: "rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}"
+    asset: rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}
     format: gz
     description: A Rust compiler front-end for IDEs
     replacements:
@@ -18,4 +18,4 @@ packages:
           linux: unknown-linux-gnu
     files:
       - name: rust-analyzer
-        src: "rust-analyzer-{{.Arch}}-{{.OS}}"
+        src: rust-analyzer-{{.Arch}}-{{.OS}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -6524,6 +6524,26 @@ packages:
     files:
       - name: mdbook
   - type: github_release
+    repo_owner: rust-lang
+    repo_name: rust-analyzer
+    asset: "rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}"
+    format: gz
+    description: A Rust compiler front-end for IDEs
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+    files:
+      - name: rust-analyzer
+        src: "rust-analyzer-{{.Arch}}-{{.OS}}"
+  - type: github_release
     repo_owner: ryane
     repo_name: kfilt
     format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -6526,7 +6526,7 @@ packages:
   - type: github_release
     repo_owner: rust-lang
     repo_name: rust-analyzer
-    asset: "rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}"
+    asset: rust-analyzer-{{.Arch}}-{{.OS}}.{{.Format}}
     format: gz
     description: A Rust compiler front-end for IDEs
     replacements:
@@ -6542,7 +6542,7 @@ packages:
           linux: unknown-linux-gnu
     files:
       - name: rust-analyzer
-        src: "rust-analyzer-{{.Arch}}-{{.OS}}"
+        src: rust-analyzer-{{.Arch}}-{{.OS}}
   - type: github_release
     repo_owner: ryane
     repo_name: kfilt


### PR DESCRIPTION
#4875 [rust-lang/rust-analyzer](https://github.com/rust-lang/rust-analyzer): A Rust compiler front-end for IDEs

---

Added packages:

- [`rust-lang/rust-analyzer`](https://github.com/rust-lang/rust-analyzer)