### PR TITLE
feat: Add nametake/golangci-lint-langserver

### DIFF
--- a/pkgs/nametake/golangci-lint-langserver/pkg.yaml
+++ b/pkgs/nametake/golangci-lint-langserver/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: nametake/golangci-lint-langserver@v0.0.6

--- a/pkgs/nametake/golangci-lint-langserver/registry.yaml
+++ b/pkgs/nametake/golangci-lint-langserver/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: nametake
+    repo_name: golangci-lint-langserver
+    asset: "golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz"
+    description: golangci-lint language server
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    rosetta2: true

--- a/pkgs/nametake/golangci-lint-langserver/registry.yaml
+++ b/pkgs/nametake/golangci-lint-langserver/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: nametake
     repo_name: golangci-lint-langserver
-    asset: "golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz"
+    asset: golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz
     description: golangci-lint language server
     replacements:
       amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5604,7 +5604,7 @@ packages:
   - type: github_release
     repo_owner: nametake
     repo_name: golangci-lint-langserver
-    asset: "golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz"
+    asset: golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz
     description: golangci-lint language server
     replacements:
       amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5602,6 +5602,17 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: nametake
+    repo_name: golangci-lint-langserver
+    asset: "golangci-lint-langserver_{{.OS}}_{{.Arch}}.tar.gz"
+    description: golangci-lint language server
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    rosetta2: true
+  - type: github_release
     repo_owner: nektos
     repo_name: act
     description: Run your GitHub Actions locally


### PR DESCRIPTION
#4876 [nametake/golangci-lint-langserver](https://github.com/nametake/golangci-lint-langserver): golangci-lint language server

---

Added packages:

- [`nametake/golangci-lint-langserver`](https://github.com/nametake/golangci-lint-langserver)