### PR TITLE
feat: Add mattn/efm-langserver

### DIFF
--- a/pkgs/mattn/efm-langserver/pkg.yaml
+++ b/pkgs/mattn/efm-langserver/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mattn/efm-langserver@v0.0.44

--- a/pkgs/mattn/efm-langserver/registry.yaml
+++ b/pkgs/mattn/efm-langserver/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: mattn
+    repo_name: efm-langserver
+    asset: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: zip
+    description: General purpose Language Server
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: efm-langserver
+        src: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver"

--- a/pkgs/mattn/efm-langserver/registry.yaml
+++ b/pkgs/mattn/efm-langserver/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: mattn
     repo_name: efm-langserver
-    asset: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+    asset: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     description: General purpose Language Server
     overrides:
@@ -10,4 +10,4 @@ packages:
         format: tar.gz
     files:
       - name: efm-langserver
-        src: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver"
+        src: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver

--- a/registry.yaml
+++ b/registry.yaml
@@ -5258,7 +5258,7 @@ packages:
   - type: github_release
     repo_owner: mattn
     repo_name: efm-langserver
-    asset: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+    asset: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     description: General purpose Language Server
     overrides:
@@ -5266,7 +5266,7 @@ packages:
         format: tar.gz
     files:
       - name: efm-langserver
-        src: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver"
+        src: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver
   - type: github_release
     repo_owner: mattn
     repo_name: gof

--- a/registry.yaml
+++ b/registry.yaml
@@ -5257,6 +5257,18 @@ packages:
     rosetta2: true
   - type: github_release
     repo_owner: mattn
+    repo_name: efm-langserver
+    asset: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: zip
+    description: General purpose Language Server
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: efm-langserver
+        src: "efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver"
+  - type: github_release
+    repo_owner: mattn
     repo_name: gof
     asset: "gof_{{.Version}}_{{.OS}}_amd64.{{.Format}}"
     description: Go Fuzzy


### PR DESCRIPTION
#4878 [mattn/efm-langserver](https://github.com/mattn/efm-langserver): General purpose Language Server

---

Added packages:

- [`mattn/efm-langserver`](https://github.com/mattn/efm-langserver)