### PR TITLE
feat: add stoplightio/spectral

### DIFF
--- a/pkgs/stoplightio/spectral/pkg.yaml
+++ b/pkgs/stoplightio/spectral/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: stoplightio/spectral@v6.4.1

--- a/pkgs/stoplightio/spectral/registry.yaml
+++ b/pkgs/stoplightio/spectral/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: stoplightio
+    repo_name: spectral
+    asset: spectral-{{.OS}}
+    format: raw
+    description: A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI v2 & v3
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: windows
+        asset: spectral
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -7225,6 +7225,21 @@ packages:
           - name: stern
             src: "stern_{{trimV .Version}}_{{.OS}}_{{.Arch}}/stern"
   - type: github_release
+    repo_owner: stoplightio
+    repo_name: spectral
+    asset: spectral-{{.OS}}
+    format: raw
+    description: A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI v2 & v3
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: windows
+        asset: spectral
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: sumneko
     repo_name: lua-language-server
     description: Lua Language Server coded by Lua


### PR DESCRIPTION
#4885 [stoplightio/spectral](https://github.com/stoplightio/spectral): A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI v2 & v3

```console
$ aqua g -i stoplightio/spectral
```
