### PR TITLE
feat: add kevwan/depu

### DIFF
--- a/pkgs/kevwan/depu/pkg.yaml
+++ b/pkgs/kevwan/depu/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kevwan/depu@v1.0.5

--- a/pkgs/kevwan/depu/registry.yaml
+++ b/pkgs/kevwan/depu/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: kevwan
+    repo_name: depu
+    asset: depu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A tool to check  available updates of packages in go.mod
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -5242,6 +5242,14 @@ packages:
     description: checks presence of various command line tools and their versions on the path
   - type: github_release
     repo_owner: kevwan
+    repo_name: depu
+    asset: depu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A tool to check  available updates of packages in go.mod
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
+    repo_owner: kevwan
     repo_name: tproxy
     asset: tproxy-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
#4992 [kevwan/depu](https://github.com/kevwan/depu): A tool to check  available updates of packages in go.mod

```console
$ aqua g -i kevwan/depu
```
