### PR TITLE
fix(goodwithtech/dockle): exclude windows if dockle >= v0.4.6

### DIFF
--- a/pkgs/goodwithtech/dockle/pkg.yaml
+++ b/pkgs/goodwithtech/dockle/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: goodwithtech/dockle@v0.4.5
+  - name: goodwithtech/dockle@v0.4.6
+  - name: goodwithtech/dockle
+    version: v0.4.5

--- a/pkgs/goodwithtech/dockle/registry.yaml
+++ b/pkgs/goodwithtech/dockle/registry.yaml
@@ -3,10 +3,6 @@ packages:
     repo_owner: goodwithtech
     repo_name: dockle
     description: Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     asset: dockle_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
@@ -24,3 +20,13 @@ packages:
       netbsd: NetBSD
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
+    version_constraint: semver(">= 0.4.6")
+    supported_envs:
+      - darwin
+      - linux
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3921,10 +3921,6 @@ packages:
     repo_owner: goodwithtech
     repo_name: dockle
     description: Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     asset: dockle_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
@@ -3942,6 +3938,16 @@ packages:
       netbsd: NetBSD
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
+    version_constraint: semver(">= 0.4.6")
+    supported_envs:
+      - darwin
+      - linux
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
   - type: github_release
     repo_owner: google
     repo_name: go-containerregistry


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5045#issuecomment-1193199570

Windows was removed.
https://github.com/goodwithtech/dockle/releases/tag/v0.4.6
https://github.com/goodwithtech/dockle/commit/43736af84d3b621827a7f4043f604cf7e70a1b46 remove windows build from goreleaser
https://github.com/goodwithtech/dockle/issues/191#issuecomment-1186106916