### PR TITLE
feat: add ekzhang/bore

### DIFF
--- a/pkgs/ekzhang/bore/pkg.yaml
+++ b/pkgs/ekzhang/bore/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ekzhang/bore@v0.4.0

--- a/pkgs/ekzhang/bore/registry.yaml
+++ b/pkgs/ekzhang/bore/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: ekzhang
+    repo_name: bore
+    asset: bore-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: bore is a simple CLI tool for making tunnels to localhost
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3254,6 +3254,24 @@ packages:
     files:
       - name: gh-md-toc
   - type: github_release
+    repo_owner: ekzhang
+    repo_name: bore
+    asset: bore-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: bore is a simple CLI tool for making tunnels to localhost
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+  - type: github_release
     repo_owner: emirozer
     repo_name: kubectl-doctor
     description: kubectl cluster triage plugin for k8s - (brew doctor equivalent)


### PR DESCRIPTION
#5059 [ekzhang/bore](https://github.com/ekzhang/bore): bore is a simple CLI tool for making tunnels to localhost

```console
$ aqua g -i ekzhang/bore
```
