### PR TITLE
fix(buildkite/cli): support v2 in Windows

### DIFF
--- a/pkgs/buildkite/cli/pkg.yaml
+++ b/pkgs/buildkite/cli/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: buildkite/cli@v1.2.0
+  - name: buildkite/cli@v2.0.0
+  - name: buildkite/cli
+    version: v1.2.0
   - name: buildkite/cli
     version: v1.1.0

--- a/pkgs/buildkite/cli/registry.yaml
+++ b/pkgs/buildkite/cli/registry.yaml
@@ -12,9 +12,13 @@ packages:
     files:
       - name: bk
         src: cli
-    version_constraint: semver(">= 1.2.0")
+    version_constraint: semver(">= 2.0.0")
+    complete_windows_ext: false
     version_overrides:
+      - version_constraint: semver(">= 1.2.0")
+        complete_windows_ext: true
       - version_constraint: "true"
+        complete_windows_ext: true
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1941,9 +1941,13 @@ packages:
     files:
       - name: bk
         src: cli
-    version_constraint: semver(">= 1.2.0")
+    version_constraint: semver(">= 2.0.0")
+    complete_windows_ext: false
     version_overrides:
+      - version_constraint: semver(">= 1.2.0")
+        complete_windows_ext: true
       - version_constraint: "true"
+        complete_windows_ext: true
         supported_envs:
           - darwin
           - amd64


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5084

`.exe` was removed from v2.0.0.

https://github.com/buildkite/cli/releases/tag/v2.0.0

https://github.com/buildkite/cli/releases/tag/v1.2.0