### PR TITLE
feat: add rapiz1/catp

### DIFF
--- a/pkgs/rapiz1/catp/pkg.yaml
+++ b/pkgs/rapiz1/catp/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rapiz1/catp@v0.2.0

--- a/pkgs/rapiz1/catp/registry.yaml
+++ b/pkgs/rapiz1/catp/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: rapiz1
+    repo_name: catp
+    asset: catp-{{.Arch}}-{{.OS}}.zip
+    description: Print the output of a running process
+    replacements:
+      amd64: x86_64
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7227,6 +7227,16 @@ packages:
     format: raw
     description: Rancher Kubernetes Engine (RKE), an extremely simple, lightning fast Kubernetes distribution that runs entirely within containers
   - type: github_release
+    repo_owner: rapiz1
+    repo_name: catp
+    asset: catp-{{.Arch}}-{{.OS}}.zip
+    description: Print the output of a running process
+    replacements:
+      amd64: x86_64
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+  - type: github_release
     repo_owner: rclone
     repo_name: rclone
     asset: rclone-{{.Version}}-{{.OS}}-{{.Arch}}.zip


### PR DESCRIPTION
#5107 [rapiz1/catp](https://github.com/rapiz1/catp): Print the output of a running process

```console
$ aqua g -i rapiz1/catp
```
