### PR TITLE
fix: rename golang/tools/gopls to golang.org/x/tools/gopls

### DIFF
--- a/pkgs/golang.org/x/tools/gopls/pkg.yaml
+++ b/pkgs/golang.org/x/tools/gopls/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang.org/x/tools/gopls@v0.8.4

--- a/pkgs/golang.org/x/tools/gopls/registry.yaml
+++ b/pkgs/golang.org/x/tools/gopls/registry.yaml
@@ -1,10 +1,12 @@
 packages:
   - type: go_install
-    name: golang/tools/gopls
+    name: golang.org/x/tools/gopls
+    aliases:
+      - name: golang/tools/gopls
     path: golang.org/x/tools/gopls
     repo_owner: golang
     repo_name: tools
     description: Go language server
-    version_filter: 'Version startsWith "gopls/"'
+    version_filter: Version startsWith "gopls/"
     files:
       - name: gopls

--- a/pkgs/golang/tools/gopls/pkg.yaml
+++ b/pkgs/golang/tools/gopls/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: golang/tools/gopls@v0.8.4

--- a/registry.yaml
+++ b/registry.yaml
@@ -3886,6 +3886,17 @@ packages:
     path: golang.org/x/tools/cmd/goimports
     description: updates your Go import lines, adding missing ones and removing unreferenced ones
     link: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+  - type: go_install
+    name: golang.org/x/tools/gopls
+    aliases:
+      - name: golang/tools/gopls
+    path: golang.org/x/tools/gopls
+    repo_owner: golang
+    repo_name: tools
+    description: Go language server
+    version_filter: Version startsWith "gopls/"
+    files:
+      - name: gopls
   - repo_owner: golang
     repo_name: go
     type: http
@@ -3915,15 +3926,6 @@ packages:
       - linux
       - amd64
 
-  - type: go_install
-    name: golang/tools/gopls
-    path: golang.org/x/tools/gopls
-    repo_owner: golang
-    repo_name: tools
-    description: Go language server
-    version_filter: 'Version startsWith "gopls/"'
-    files:
-      - name: gopls
   - type: github_release
     repo_owner: golangci
     repo_name: golangci-lint


### PR DESCRIPTION
[Package name of go_install should be equivalent to Go's Module path](https://aquaproj.github.io/docs/reference/registry-style-guide/#package-name-of-go_install-should-be-equivalent-to-gos-module-path)