### PR TITLE
feat: Add rhysd/vim-startuptime

### DIFF
--- a/pkgs/rhysd/vim-startuptime/pkg.yaml
+++ b/pkgs/rhysd/vim-startuptime/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rhysd/vim-startuptime@v1.3.0

--- a/pkgs/rhysd/vim-startuptime/registry.yaml
+++ b/pkgs/rhysd/vim-startuptime/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: rhysd
+    repo_name: vim-startuptime
+    asset: vim-startuptime_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A small Go program for better `vim --startuptime` alternative
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -7490,6 +7490,15 @@ packages:
           - amd64
         overrides: []
   - type: github_release
+    repo_owner: rhysd
+    repo_name: vim-startuptime
+    asset: vim-startuptime_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A small Go program for better `vim --startuptime` alternative
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: rikatz
     repo_name: kubepug
     description: Kubernetes PreUpGrade (Checker)


### PR DESCRIPTION
#5250 [rhysd/vim-startuptime](https://github.com/rhysd/vim-startuptime): A small Go program for better `vim --startuptime` alternative
