### PR TITLE
feat: add lima-vm/sshocker

### DIFF
--- a/pkgs/lima-vm/sshocker/pkg.yaml
+++ b/pkgs/lima-vm/sshocker/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: lima-vm/sshocker@v0.3.0

--- a/pkgs/lima-vm/sshocker/registry.yaml
+++ b/pkgs/lima-vm/sshocker/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: lima-vm
+    repo_name: sshocker
+    asset: sshocker-{{.OS}}-{{.Arch}}
+    format: raw
+    description: ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: Darwin
+      linux: Linux
+    supported_envs:
+      - linux
+      - darwin

--- a/pkgs/lima-vm/sshocker/registry.yaml
+++ b/pkgs/lima-vm/sshocker/registry.yaml
@@ -5,11 +5,14 @@ packages:
     asset: sshocker-{{.OS}}-{{.Arch}}
     format: raw
     description: ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: Darwin
-      linux: Linux
     supported_envs:
       - linux
       - darwin
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+    overrides:
+      - goos: linux
+        replacements:
+          arm64: aarch64
+          linux: Linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -6083,14 +6083,17 @@ packages:
     asset: sshocker-{{.OS}}-{{.Arch}}
     format: raw
     description: ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: Darwin
-      linux: Linux
     supported_envs:
       - linux
       - darwin
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+    overrides:
+      - goos: linux
+        replacements:
+          arm64: aarch64
+          linux: Linux
   - type: github_release
     repo_owner: livebud
     repo_name: bud

--- a/registry.yaml
+++ b/registry.yaml
@@ -6078,6 +6078,20 @@ packages:
         supported_envs:
           - darwin
   - type: github_release
+    repo_owner: lima-vm
+    repo_name: sshocker
+    asset: sshocker-{{.OS}}-{{.Arch}}
+    format: raw
+    description: ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: Darwin
+      linux: Linux
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
     repo_owner: livebud
     repo_name: bud
     description: The Full-Stack Web Framework for Go


### PR DESCRIPTION
#5350 [lima-vm/sshocker](https://github.com/lima-vm/sshocker): ssh + reverse sshfs + port forwarder, in Docker-like CLI (predecessor of Lima)

```console
$ aqua g -i lima-vm/sshocker
```
