### PR TITLE
feat: add google/gke-policy-automation

### DIFF
--- a/pkgs/google/gke-policy-automation/pkg.yaml
+++ b/pkgs/google/gke-policy-automation/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/gke-policy-automation@v1.2.0

--- a/pkgs/google/gke-policy-automation/registry.yaml
+++ b/pkgs/google/gke-policy-automation/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: gke-policy-automation
+    asset: gke-policy-automation_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    files:
+      - name: gke-policy
+        src: gke-policy
+    description: Tool and policy library for reviewing Google Kubernetes Engine clusters against best practices

--- a/registry.yaml
+++ b/registry.yaml
@@ -4101,6 +4101,14 @@ packages:
           - amd64
   - type: github_release
     repo_owner: google
+    repo_name: gke-policy-automation
+    asset: gke-policy-automation_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    files:
+      - name: gke-policy
+        src: gke-policy
+    description: Tool and policy library for reviewing Google Kubernetes Engine clusters against best practices
+  - type: github_release
+    repo_owner: google
     repo_name: go-containerregistry
     asset: go-containerregistry_{{.OS}}_{{.Arch}}.tar.gz
     description: CLIs for working with container registries


### PR DESCRIPTION
#5354 [google/gke-policy-automation](https://github.com/google/gke-policy-automation): Tool and policy library for reviewing Google Kubernetes Engine clusters against best practices

```console
$ aqua g -i google/gke-policy-automation
```
