### PR TITLE
feat: add superbrothers/ksort

### DIFF
--- a/pkgs/superbrothers/ksort/pkg.yaml
+++ b/pkgs/superbrothers/ksort/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: superbrothers/ksort@v0.4.3

--- a/pkgs/superbrothers/ksort/registry.yaml
+++ b/pkgs/superbrothers/ksort/registry.yaml
@@ -4,3 +4,7 @@ packages:
     repo_name: ksort
     asset: ksort-{{.OS}}-{{.Arch}}.zip
     description: Sort manfest files in a proper order by Kind
+    files:
+      - name: ksort
+      - name: kubectl-sort_manifests
+        src: ksort

--- a/pkgs/superbrothers/ksort/registry.yaml
+++ b/pkgs/superbrothers/ksort/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: github_release
+    repo_owner: superbrothers
+    repo_name: ksort
+    asset: ksort-{{.OS}}-{{.Arch}}.zip
+    description: Sort manfest files in a proper order by Kind

--- a/registry.yaml
+++ b/registry.yaml
@@ -8602,6 +8602,10 @@ packages:
     repo_name: ksort
     asset: ksort-{{.OS}}-{{.Arch}}.zip
     description: Sort manfest files in a proper order by Kind
+    files:
+      - name: ksort
+      - name: kubectl-sort_manifests
+        src: ksort
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: akoi

--- a/registry.yaml
+++ b/registry.yaml
@@ -8598,6 +8598,11 @@ packages:
       - name: lua-language-server
         src: bin/lua-language-server
   - type: github_release
+    repo_owner: superbrothers
+    repo_name: ksort
+    asset: ksort-{{.OS}}-{{.Arch}}.zip
+    description: Sort manfest files in a proper order by Kind
+  - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: akoi
     asset: akoi_{{trimV .Version}}_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
#5360 [superbrothers/ksort](https://github.com/superbrothers/ksort): Sort manfest files in a proper order by Kind

```console
$ aqua g -i superbrothers/ksort
```
