### PR TITLE
feat: add metalbear-co/mirrord

### DIFF
--- a/pkgs/metalbear-co/mirrord/pkg.yaml
+++ b/pkgs/metalbear-co/mirrord/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: metalbear-co/mirrord@2.6.0

--- a/pkgs/metalbear-co/mirrord/registry.yaml
+++ b/pkgs/metalbear-co/mirrord/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: metalbear-co
+    repo_name: mirrord
+    description: By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment
+    supported_envs:
+      - linux/amd64
+      - darwin
+    format: raw
+    asset: mirrord_linux_x86_64
+    overrides:
+      - goos: darwin
+        asset: mirrord_mac_universal

--- a/registry.yaml
+++ b/registry.yaml
@@ -6349,6 +6349,18 @@ packages:
     replacements:
       darwin: macos
   - type: github_release
+    repo_owner: metalbear-co
+    repo_name: mirrord
+    description: By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment
+    supported_envs:
+      - linux/amd64
+      - darwin
+    format: raw
+    asset: mirrord_linux_x86_64
+    overrides:
+      - goos: darwin
+        asset: mirrord_mac_universal
+  - type: github_release
     repo_owner: mgdm
     repo_name: htmlq
     asset: htmlq-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
#5381 [metalbear-co/mirrord](https://github.com/metalbear-co/mirrord): By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment

```console
$ aqua g -i metalbear-co/mirrord
```
