### PR TITLE
feat: add fastly/terrctl

### DIFF
--- a/pkgs/fastly/terrctl/pkg.yaml
+++ b/pkgs/fastly/terrctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fastly/terrctl@1.0.2

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: fastly
+    repo_name: terrctl
+    asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
+    format: tar.gz
+    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
+    replacements:
+      amd64: x86_64
+      darwin: macos
+      windows: win
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+      - goos: windows
+        format: zip
+        asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+    files:
+      - name: terrctl
+        src: "{{.OS}}/terrctl"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -13,16 +13,19 @@ packages:
       - goos: darwin
         goarch: amd64
         asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}/terrctl"
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}32/terrctl.exe"
       - goos: linux
         files:
           - name: terrctl
-            src: "{{.OS}}-{{.Arch}}"
-    files:
-      - name: terrctl
-        src: "{{.OS}}/terrctl"
+            src: "{{.OS}}-{{.Arch}}/terrctl"
     supported_envs:
       - darwin
       - linux

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -16,6 +16,12 @@ packages:
         files:
           - name: terrctl
             src: "{{.OS}}/terrctl"
+      - goos: darwin
+        goarch: arm64
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}-{{.Arch}}/terrctl"
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -16,6 +16,10 @@ packages:
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+      - goos: linux
+        files:
+          - name: terrctl
+            src: "{{.OS}}-{{.Arch}}"
     files:
       - name: terrctl
         src: "{{.OS}}/terrctl"

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -2,13 +2,16 @@ packages:
   - type: github_release
     repo_owner: fastly
     repo_name: terrctl
+    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
     asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
     format: tar.gz
-    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
     replacements:
       amd64: x86_64
       darwin: macos
-      windows: win
+      windows: win64
+    files:
+      - name: terrctl
+        src: "{{.OS}}-{{.Arch}}/terrctl"
     overrides:
       - goos: darwin
         goarch: amd64
@@ -16,22 +19,12 @@ packages:
         files:
           - name: terrctl
             src: "{{.OS}}/terrctl"
-      - goos: darwin
-        goarch: arm64
-        asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
-        files:
-          - name: terrctl
-            src: "{{.OS}}-{{.Arch}}/terrctl"
       - goos: windows
         format: zip
-        asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
         files:
           - name: terrctl
-            src: "{{.OS}}32/terrctl.exe"
-      - goos: linux
-        files:
-          - name: terrctl
-            src: "{{.OS}}-{{.Arch}}/terrctl"
+            src: "{{.OS}}/terrctl.exe"
     supported_envs:
       - darwin
       - linux

--- a/pkgs/fastly/terrctl/registry.yaml
+++ b/pkgs/fastly/terrctl/registry.yaml
@@ -18,7 +18,7 @@ packages:
             src: "{{.OS}}/terrctl"
       - goos: darwin
         goarch: arm64
-        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
         files:
           - name: terrctl
             src: "{{.OS}}-{{.Arch}}/terrctl"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3491,6 +3491,30 @@ packages:
     files:
       - name: fastly
   - type: github_release
+    repo_owner: fastly
+    repo_name: terrctl
+    asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
+    format: tar.gz
+    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
+    replacements:
+      amd64: x86_64
+      darwin: macos
+      windows: win
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+      - goos: windows
+        format: zip
+        asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+    files:
+      - name: terrctl
+        src: "{{.OS}}/terrctl"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: fatedier
     repo_name: frp
     description: A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet

--- a/registry.yaml
+++ b/registry.yaml
@@ -3493,13 +3493,16 @@ packages:
   - type: github_release
     repo_owner: fastly
     repo_name: terrctl
+    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
     asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
     format: tar.gz
-    description: A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com
     replacements:
       amd64: x86_64
       darwin: macos
-      windows: win
+      windows: win64
+    files:
+      - name: terrctl
+        src: "{{.OS}}-{{.Arch}}/terrctl"
     overrides:
       - goos: darwin
         goarch: amd64
@@ -3507,22 +3510,12 @@ packages:
         files:
           - name: terrctl
             src: "{{.OS}}/terrctl"
-      - goos: darwin
-        goarch: arm64
-        asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
-        files:
-          - name: terrctl
-            src: "{{.OS}}-{{.Arch}}/terrctl"
       - goos: windows
         format: zip
-        asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
         files:
           - name: terrctl
-            src: "{{.OS}}32/terrctl.exe"
-      - goos: linux
-        files:
-          - name: terrctl
-            src: "{{.OS}}-{{.Arch}}/terrctl"
+            src: "{{.OS}}/terrctl.exe"
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -3509,7 +3509,7 @@ packages:
             src: "{{.OS}}/terrctl"
       - goos: darwin
         goarch: arm64
-        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        asset: terrctl-{{.OS}}_{{.Arch}}-{{.Version}}.{{.Format}}
         files:
           - name: terrctl
             src: "{{.OS}}-{{.Arch}}/terrctl"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3504,16 +3504,19 @@ packages:
       - goos: darwin
         goarch: amd64
         asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}/terrctl"
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}32/terrctl.exe"
       - goos: linux
         files:
           - name: terrctl
-            src: "{{.OS}}-{{.Arch}}"
-    files:
-      - name: terrctl
-        src: "{{.OS}}/terrctl"
+            src: "{{.OS}}-{{.Arch}}/terrctl"
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -3507,6 +3507,10 @@ packages:
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}
+      - goos: linux
+        files:
+          - name: terrctl
+            src: "{{.OS}}-{{.Arch}}"
     files:
       - name: terrctl
         src: "{{.OS}}/terrctl"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3507,6 +3507,12 @@ packages:
         files:
           - name: terrctl
             src: "{{.OS}}/terrctl"
+      - goos: darwin
+        goarch: arm64
+        asset: terrctl-{{.OS}}-{{.Version}}.{{.Format}}
+        files:
+          - name: terrctl
+            src: "{{.OS}}-{{.Arch}}/terrctl"
       - goos: windows
         format: zip
         asset: terrctl-{{.OS}}32-{{.Version}}.{{.Format}}


### PR DESCRIPTION
#5389 [fastly/terrctl](https://github.com/fastly/terrctl): A command-line client for Fastly Terrarium. https://wasm.fastlylabs.com

```console
$ aqua g -i fastly/terrctl
```
