### PR TITLE
fix(mattn/gof): Support arm64

### DIFF
--- a/pkgs/mattn/gof/pkg.yaml
+++ b/pkgs/mattn/gof/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: mattn/gof@v0.0.12
+  - name: mattn/gof
+    version: v0.0.10

--- a/pkgs/mattn/gof/registry.yaml
+++ b/pkgs/mattn/gof/registry.yaml
@@ -14,5 +14,7 @@ packages:
     version_constraint: semver(">= 0.0.12")
     version_overrides:
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
+          - darwin
           - amd64

--- a/pkgs/mattn/gof/registry.yaml
+++ b/pkgs/mattn/gof/registry.yaml
@@ -2,12 +2,17 @@ packages:
   - type: github_release
     repo_owner: mattn
     repo_name: gof
-    asset: gof_{{.Version}}_{{.OS}}_amd64.{{.Format}}
+    asset: gof_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     description: Go Fuzzy
-    files:
-      - name: gof
-        src: gof_{{.Version}}_{{.OS}}_amd64/gof
     format: zip
     overrides:
       - goos: linux
         format: tar.gz
+    files:
+      - name: gof
+        src: gof_{{.Version}}_{{.OS}}_{{.Arch}}/gof
+    version_constraint: semver(">= 0.0.12")
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs:
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6314,7 +6314,9 @@ packages:
     version_constraint: semver(">= 0.0.12")
     version_overrides:
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
+          - darwin
           - amd64
   - type: github_release
     repo_owner: mattn

--- a/registry.yaml
+++ b/registry.yaml
@@ -6302,15 +6302,20 @@ packages:
   - type: github_release
     repo_owner: mattn
     repo_name: gof
-    asset: gof_{{.Version}}_{{.OS}}_amd64.{{.Format}}
+    asset: gof_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     description: Go Fuzzy
-    files:
-      - name: gof
-        src: gof_{{.Version}}_{{.OS}}_amd64/gof
     format: zip
     overrides:
       - goos: linux
         format: tar.gz
+    files:
+      - name: gof
+        src: gof_{{.Version}}_{{.OS}}_{{.Arch}}/gof
+    version_constraint: semver(">= 0.0.12")
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs:
+          - amd64
   - type: github_release
     repo_owner: mattn
     repo_name: goreman


### PR DESCRIPTION
From [v0.0.12](https://github.com/mattn/gof/releases/tag/v0.0.12), `mattn/gof` supports `arm64`. I added `version_overrides`.
