### PR TITLE
fix(kurehajime/dajarep): support kurehajime/dajarep >= v1.9.8

### DIFF
--- a/pkgs/kurehajime/dajarep/pkg.yaml
+++ b/pkgs/kurehajime/dajarep/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: kurehajime/dajarep@v1.9.5
+  - name: kurehajime/dajarep@v1.9.8
+  - name: kurehajime/dajarep
+    version: v1.9.5

--- a/pkgs/kurehajime/dajarep/registry.yaml
+++ b/pkgs/kurehajime/dajarep/registry.yaml
@@ -2,17 +2,21 @@ packages:
   - type: github_release
     repo_owner: kurehajime
     repo_name: dajarep
-    asset: dajarep_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: ダジャレを検索するコマンド
-    replacements:
-      amd64: x86_64
-      darwin: macos
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
+    version_constraint: semver(">= 1.9.8")
+    asset: dajarep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        asset: dajarep_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5947,20 +5947,24 @@ packages:
   - type: github_release
     repo_owner: kurehajime
     repo_name: dajarep
-    asset: dajarep_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: ダジャレを検索するコマンド
-    replacements:
-      amd64: x86_64
-      darwin: macos
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
+    version_constraint: semver(">= 1.9.8")
+    asset: dajarep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        asset: dajarep_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
   - type: github_release
     repo_owner: kurehajime
     repo_name: kuzusi


### PR DESCRIPTION
asset name format was changed

https://github.com/kurehajime/dajarep/releases/tag/v1.9.8