### PR TITLE
chore: rename goimports

### DIFF
--- a/pkgs/golang.org/x/tools/cmd/goimports/pkg.yaml
+++ b/pkgs/golang.org/x/tools/cmd/goimports/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: golang.org/x/tools/cmd/goimports@v0.1.12
+  - name: golang/tools/goimports@v0.1.12

--- a/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
+++ b/pkgs/golang.org/x/tools/cmd/goimports/registry.yaml
@@ -1,6 +1,8 @@
 packages:
   - type: go_install
-    name: golang.org/x/tools/cmd/goimports
+    name: golang/tools/goimports
+    aliases: # Set aliases to keep the compatibility
+      - name: golang.org/x/tools/cmd/goimports
     path: golang.org/x/tools/cmd/goimports
     repo_owner: golang
     repo_name: tools

--- a/registry.yaml
+++ b/registry.yaml
@@ -4040,7 +4040,9 @@ packages:
     description: Benchstat computes and compares statistics about benchmarks
     link: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
   - type: go_install
-    name: golang.org/x/tools/cmd/goimports
+    name: golang/tools/goimports
+    aliases: # Set aliases to keep the compatibility
+      - name: golang.org/x/tools/cmd/goimports
     path: golang.org/x/tools/cmd/goimports
     repo_owner: golang
     repo_name: tools


### PR DESCRIPTION
Rename `goimports` as per discussion in https://github.com/aquaproj/aqua-renovate-config/issues/191

Signed-off-by: Noel Georgi <git@frezbo.dev>