### PR TITLE
feat: add aws/amazon-ec2-spot-interrupter

### DIFF
--- a/pkgs/aws/amazon-ec2-spot-interrupter/pkg.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aws/amazon-ec2-spot-interrupter@v0.0.8

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -8,8 +8,13 @@ packages:
       darwin: Darwin
       linux: Linux
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          arm64: armv6
     files:
       - name: ec2-spot-interrupter
         src: ec2-spot-interrupter

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -8,7 +8,7 @@ packages:
       darwin: Darwin
       linux: Linux
     supported_envs:
-      - linux
+      - linux/amd64
       - darwin
     files:
       - name: ec2-spot-interrupter

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: aws
+    repo_name: amazon-ec2-spot-interrupter
+    asset: ec2-spot-interrupter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: The ec2-spot-interrupter is a simple CLI tool that triggers Amazon EC2 Spot Interruption Notifications and Rebalance Recommendations
+    replacements:
+      darwin: Darwin
+      linux: Linux
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: ec2-spot-interrupter
+        src: ec2-spot-interrupter

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -10,10 +10,5 @@ packages:
     supported_envs:
       - linux
       - darwin
-    overrides:
-      - goos: linux
-        goarch: arm64
-        replacements:
-          arm64: armv6
     files:
       - name: ec2-spot-interrupter

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -17,4 +17,3 @@ packages:
           arm64: armv6
     files:
       - name: ec2-spot-interrupter
-        src: ec2-spot-interrupter

--- a/registry.yaml
+++ b/registry.yaml
@@ -1485,6 +1485,20 @@ packages:
       - amd64
     files:
       - name: ec2-instance-selector
+  - type: github_release
+    repo_owner: aws
+    repo_name: amazon-ec2-spot-interrupter
+    asset: ec2-spot-interrupter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: The ec2-spot-interrupter is a simple CLI tool that triggers Amazon EC2 Spot Interruption Notifications and Rebalance Recommendations
+    replacements:
+      darwin: Darwin
+      linux: Linux
+    supported_envs:
+      - linux/amd64
+      - darwin
+    files:
+      - name: ec2-spot-interrupter
+        src: ec2-spot-interrupter
   - type: http
     repo_owner: aws
     repo_name: aws-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -1496,11 +1496,6 @@ packages:
     supported_envs:
       - linux/amd64
       - darwin
-    overrides:
-      - goos: linux
-        goarch: arm64
-        replacements:
-          arm64: armv6
     files:
       - name: ec2-spot-interrupter
   - type: http

--- a/registry.yaml
+++ b/registry.yaml
@@ -1494,7 +1494,7 @@ packages:
       darwin: Darwin
       linux: Linux
     supported_envs:
-      - linux
+      - linux/amd64
       - darwin
     overrides:
       - goos: linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -1494,8 +1494,13 @@ packages:
       darwin: Darwin
       linux: Linux
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          arm64: armv6
     files:
       - name: ec2-spot-interrupter
         src: ec2-spot-interrupter

--- a/registry.yaml
+++ b/registry.yaml
@@ -1503,7 +1503,6 @@ packages:
           arm64: armv6
     files:
       - name: ec2-spot-interrupter
-        src: ec2-spot-interrupter
   - type: http
     repo_owner: aws
     repo_name: aws-cli


### PR DESCRIPTION
#5485 [aws/amazon-ec2-spot-interrupter](https://github.com/aws/amazon-ec2-spot-interrupter): The ec2-spot-interrupter is a simple CLI tool that triggers Amazon EC2 Spot Interruption Notifications and Rebalance Recommendations

```console
$ aqua g -i aws/amazon-ec2-spot-interrupter
```
