### PR TITLE
feat: add hirosassa/tfcmt-gitlab

### DIFF
--- a/pkgs/hirosassa/tfcmt-gitlab/pkg.yaml
+++ b/pkgs/hirosassa/tfcmt-gitlab/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: hirosassa/tfcmt-gitlab@v0.1.4
+  - name: hirosassa/tfcmt-gitlab
+    version: v0.1.2

--- a/pkgs/hirosassa/tfcmt-gitlab/pkg.yaml
+++ b/pkgs/hirosassa/tfcmt-gitlab/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: hirosassa/tfcmt-gitlab@v0.1.4
-  - name: hirosassa/tfcmt-gitlab
-    version: v0.1.2

--- a/pkgs/hirosassa/tfcmt-gitlab/registry.yaml
+++ b/pkgs/hirosassa/tfcmt-gitlab/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: hirosassa
+    repo_name: tfcmt-gitlab
+    asset: tfcmt-gitlab_{{.OS}}_{{.Arch}}.tar.gz
+    description: tfcmt-gitlab is a CLI command to parse and notify Terraform execution results. This command supports GitLab as a CI and notification platform
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: tfcmt-gitlab_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6270,6 +6270,22 @@ packages:
         checksum: ^(.{64})
         file: "^.{64}\\s+(\\S+)$"
   - type: github_release
+    repo_owner: hirosassa
+    repo_name: tfcmt-gitlab
+    asset: tfcmt-gitlab_{{.OS}}_{{.Arch}}.tar.gz
+    description: tfcmt-gitlab is a CLI command to parse and notify Terraform execution results. This command supports GitLab as a CI and notification platform
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: tfcmt-gitlab_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"
+  - type: github_release
     repo_owner: hktalent
     repo_name: scan4all
     asset: scan4all_{{.Version}}_{{.OS}}_{{.Arch}}.zip


### PR DESCRIPTION
#5493 [hirosassa/tfcmt-gitlab](https://github.com/hirosassa/tfcmt-gitlab): tfcmt-gitlab is a CLI command to parse and notify Terraform execution results. This command supports GitLab as a CI and notification platform

---

I added [hirosassa/tfcmt-gitlab](https://github.com/hirosassa/tfcmt-gitlab).