### PR TITLE
feat: add caddyserver/caddy

### DIFF
--- a/pkgs/caddyserver/caddy/pkg.yaml
+++ b/pkgs/caddyserver/caddy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: caddyserver/caddy@v2.5.2

--- a/pkgs/caddyserver/caddy/registry.yaml
+++ b/pkgs/caddyserver/caddy/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: caddyserver
+    repo_name: caddy
+    asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Fast, multi-platform web server with automatic HTTPS
+    replacements:
+      darwin: mac
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: caddy_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"

--- a/pkgs/caddyserver/caddy/registry.yaml
+++ b/pkgs/caddyserver/caddy/registry.yaml
@@ -14,7 +14,7 @@ packages:
       type: github_release
       asset: caddy_{{trimV .Version}}_checksums.txt
       file_format: regexp
-      algorithm: sha256
+      algorithm: sha512
       pattern:
-        checksum: ^(.{64})
-        file: "^.{64}\\s+(\\S+)$"
+        checksum: ^(.{128})
+        file: "^.{128}\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2742,6 +2742,25 @@ packages:
         checksum: ^(.{64})
         file: "^.{64}\\s+(\\S+)$"
   - type: github_release
+    repo_owner: caddyserver
+    repo_name: caddy
+    asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Fast, multi-platform web server with automatic HTTPS
+    replacements:
+      darwin: mac
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: caddy_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"
+  - type: github_release
     repo_owner: cantino
     repo_name: mcfly
     asset: mcfly-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -2756,10 +2756,10 @@ packages:
       type: github_release
       asset: caddy_{{trimV .Version}}_checksums.txt
       file_format: regexp
-      algorithm: sha256
+      algorithm: sha512
       pattern:
-        checksum: ^(.{64})
-        file: "^.{64}\\s+(\\S+)$"
+        checksum: ^(.{128})
+        file: "^.{128}\\s+(\\S+)$"
   - type: github_release
     repo_owner: cantino
     repo_name: mcfly


### PR DESCRIPTION
#5501 [caddyserver/caddy](https://github.com/caddyserver/caddy): Fast, multi-platform web server with automatic HTTPS

```console
$ aqua g -i caddyserver/caddy
```
