### PR TITLE
feat: add muesli/gitty

### DIFF
--- a/pkgs/muesli/gitty/pkg.yaml
+++ b/pkgs/muesli/gitty/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: muesli/gitty@v0.7.0

--- a/pkgs/muesli/gitty/registry.yaml
+++ b/pkgs/muesli/gitty/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: muesli
+    repo_name: gitty
+    asset: gitty_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Contextual information about your git projects, right on the command-line
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8911,6 +8911,27 @@ packages:
         checksum: ^(.{64})
         file: "^.{64}\\s+(\\S+)$"
   - type: github_release
+    repo_owner: muesli
+    repo_name: gitty
+    asset: gitty_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Contextual information about your git projects, right on the command-line
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"
+  - type: github_release
     repo_owner: mumoshu
     repo_name: config-registry
     description: Switch between kubeconfigs and avoid unintentional operation on your production clusters


### PR DESCRIPTION
#5504 [muesli/gitty](https://github.com/muesli/gitty): Contextual information about your git projects, right on the command-line

```console
$ aqua g -i muesli/gitty
```
