### PR TITLE
feat: add k1LoW/tbls

### DIFF
--- a/pkgs/k1LoW/tbls/pkg.yaml
+++ b/pkgs/k1LoW/tbls/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/tbls@v1.56.1

--- a/pkgs/k1LoW/tbls/registry.yaml
+++ b/pkgs/k1LoW/tbls/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: tbls
+    asset: tbls_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: tbls is a CI-Friendly tool for document a database, written in Go
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    checksum:
+      type: github_release
+      asset: "checksums-${{.OS}}.txt"
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"

--- a/pkgs/k1LoW/tbls/registry.yaml
+++ b/pkgs/k1LoW/tbls/registry.yaml
@@ -17,5 +17,5 @@ packages:
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(.{64})
-        file: "^.{64}\\s+(\\S+)$"
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/k1LoW/tbls/registry.yaml
+++ b/pkgs/k1LoW/tbls/registry.yaml
@@ -13,7 +13,7 @@ packages:
       - amd64
     checksum:
       type: github_release
-      asset: "checksums-${{.OS}}.txt"
+      asset: "checksums-{{.OS}}.txt"
       file_format: regexp
       algorithm: sha256
       pattern:

--- a/registry.yaml
+++ b/registry.yaml
@@ -7327,8 +7327,8 @@ packages:
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(.{64})
-        file: "^.{64}\\s+(\\S+)$"
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: kanisterio
     repo_name: kanister

--- a/registry.yaml
+++ b/registry.yaml
@@ -7310,6 +7310,26 @@ packages:
         checksum: ^(.{64})
         file: "^.{64}\\s+\\*(\\S+)$"
   - type: github_release
+    repo_owner: k1LoW
+    repo_name: tbls
+    asset: tbls_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: tbls is a CI-Friendly tool for document a database, written in Go
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    checksum:
+      type: github_release
+      asset: "checksums-${{.OS}}.txt"
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kanisterio
     repo_name: kanister
     description: An extensible framework for application-level data management on Kubernetes

--- a/registry.yaml
+++ b/registry.yaml
@@ -7323,7 +7323,7 @@ packages:
       - amd64
     checksum:
       type: github_release
-      asset: "checksums-${{.OS}}.txt"
+      asset: "checksums-{{.OS}}.txt"
       file_format: regexp
       algorithm: sha256
       pattern:


### PR DESCRIPTION
#5545 [k1LoW/tbls](https://github.com/k1LoW/tbls): tbls is a CI-Friendly tool for document a database, written in Go

```console
$ aqua g -i k1LoW/tbls
```
