### PR TITLE
feat: add fortio/fortio

### DIFF
--- a/pkgs/fortio/fortio/pkg.yaml
+++ b/pkgs/fortio/fortio/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fortio/fortio@v1.34.1

--- a/pkgs/fortio/fortio/registry.yaml
+++ b/pkgs/fortio/fortio/registry.yaml
@@ -11,6 +11,9 @@ packages:
       - goos: windows
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+    files:
+      - name: fortio
+        src: usr/bin/fortio
     supported_envs:
       - linux
       - windows/amd64

--- a/pkgs/fortio/fortio/registry.yaml
+++ b/pkgs/fortio/fortio/registry.yaml
@@ -11,6 +11,8 @@ packages:
       - goos: windows
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+        files:
+          - name: fortio.exe
     files:
       - name: fortio
         src: usr/bin/fortio

--- a/pkgs/fortio/fortio/registry.yaml
+++ b/pkgs/fortio/fortio/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: fortio
+    repo_name: fortio
+    asset: fortio-{{.OS}}_{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    format: tgz
+    description: Fortio load testing library, command line tool, advanced echo server and web UI in go (golang). Allows to specify a set query-per-second load and record latency histograms and other useful stats
+    replacements:
+      windows: win
+    overrides:
+      - goos: windows
+        format: zip
+        asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+    supported_envs:
+      - linux
+      - windows/amd64

--- a/pkgs/fortio/fortio/registry.yaml
+++ b/pkgs/fortio/fortio/registry.yaml
@@ -12,7 +12,7 @@ packages:
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
         files:
-          - name: fortio.exe
+          - name: fortio
     files:
       - name: fortio
         src: usr/bin/fortio

--- a/registry.yaml
+++ b/registry.yaml
@@ -4809,6 +4809,9 @@ packages:
       - goos: windows
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+    files:
+      - name: fortio
+        src: usr/bin/fortio
     supported_envs:
       - linux
       - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4797,6 +4797,21 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: fortio
+    repo_name: fortio
+    asset: fortio-{{.OS}}_{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    format: tgz
+    description: Fortio load testing library, command line tool, advanced echo server and web UI in go (golang). Allows to specify a set query-per-second load and record latency histograms and other useful stats
+    replacements:
+      windows: win
+    overrides:
+      - goos: windows
+        format: zip
+        asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+    supported_envs:
+      - linux
+      - windows/amd64
   - type: github_content
     repo_owner: fsaintjacques
     repo_name: semver-tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -4809,6 +4809,8 @@ packages:
       - goos: windows
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
+        files:
+          - name: fortio.exe
     files:
       - name: fortio
         src: usr/bin/fortio

--- a/registry.yaml
+++ b/registry.yaml
@@ -4810,7 +4810,7 @@ packages:
         format: zip
         asset: fortio_{{.OS}}_{{trimV .Version}}.{{.Format}}
         files:
-          - name: fortio.exe
+          - name: fortio
     files:
       - name: fortio
         src: usr/bin/fortio


### PR DESCRIPTION
#5564 [fortio/fortio](https://github.com/fortio/fortio): Fortio load testing library, command line tool, advanced echo server and web UI in go (golang). Allows to specify a set query-per-second load and record latency histograms and other useful stats

```console
$ aqua g -i fortio/fortio
```
