### PR TITLE
feat: add k1LoW/octocov

### DIFF
--- a/pkgs/k1LoW/octocov/pkg.yaml
+++ b/pkgs/k1LoW/octocov/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/octocov@v0.40.1

--- a/pkgs/k1LoW/octocov/registry.yaml
+++ b/pkgs/k1LoW/octocov/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: octocov
+    asset: octocov_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: octocov is a toolkit for collecting code metrics (code coverage, code to test ratio and test execution time)
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -7328,6 +7328,26 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
   - type: github_release
     repo_owner: k1LoW
+    repo_name: octocov
+    asset: octocov_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: octocov is a toolkit for collecting code metrics (code coverage, code to test ratio and test execution time)
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: tbls
     asset: tbls_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip


### PR DESCRIPTION
#5565 [k1LoW/octocov](https://github.com/k1LoW/octocov): octocov is a toolkit for collecting code metrics (code coverage, code to test ratio and test execution time)

```console
$ aqua g -i k1LoW/octocov
```
