### PR TITLE
feat: add yoheimuta/protolint

### DIFF
--- a/pkgs/yoheimuta/protolint/pkg.yaml
+++ b/pkgs/yoheimuta/protolint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yoheimuta/protolint@v0.39.0

--- a/pkgs/yoheimuta/protolint/registry.yaml
+++ b/pkgs/yoheimuta/protolint/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: yoheimuta
+    repo_name: protolint
+    asset: protolint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A pluggable linter and fixer to enforce Protocol Buffer style and conventions
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    files:
+      - name: protolint
+      - name: protoc-gen-protolint
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13498,6 +13498,27 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: yoheimuta
+    repo_name: protolint
+    asset: protolint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A pluggable linter and fixer to enforce Protocol Buffer style and conventions
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    files:
+      - name: protolint
+      - name: protoc-gen-protolint
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: zaquestion
     repo_name: lab
     rosetta2: true


### PR DESCRIPTION
#5594 [yoheimuta/protolint](https://github.com/yoheimuta/protolint): A pluggable linter and fixer to enforce Protocol Buffer style and conventions

```console
$ aqua g -i yoheimuta/protolint
```
