### PR TITLE
feat: add electric-saw/kafta

### DIFF
--- a/pkgs/electric-saw/kafta/pkg.yaml
+++ b/pkgs/electric-saw/kafta/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: electric-saw/kafta@v0.1.2

--- a/pkgs/electric-saw/kafta/registry.yaml
+++ b/pkgs/electric-saw/kafta/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: electric-saw
+    repo_name: kafta
+    asset: kafta_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Kafta is a command line for managing Kafka clusters
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -4447,6 +4447,24 @@ packages:
       - darwin
       - amd64
   - type: github_release
+    repo_owner: electric-saw
+    repo_name: kafta
+    asset: kafta_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Kafta is a command line for managing Kafka clusters
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: emirozer
     repo_name: kubectl-doctor
     description: kubectl cluster triage plugin for k8s - (brew doctor equivalent)


### PR DESCRIPTION
#5611 [electric-saw/kafta](https://github.com/electric-saw/kafta): Kafta is a command line for managing Kafka clusters

```console
$ aqua g -i electric-saw/kafta
```
