### PR TITLE
feat: add estesp/manifest-tool

### DIFF
--- a/pkgs/estesp/manifest-tool/pkg.yaml
+++ b/pkgs/estesp/manifest-tool/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: estesp/manifest-tool@v2.0.5

--- a/pkgs/estesp/manifest-tool/registry.yaml
+++ b/pkgs/estesp/manifest-tool/registry.yaml
@@ -11,7 +11,7 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - window/amd64
+      - windows/amd64
     checksum:
       type: github_release
       asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum

--- a/pkgs/estesp/manifest-tool/registry.yaml
+++ b/pkgs/estesp/manifest-tool/registry.yaml
@@ -8,6 +8,10 @@ packages:
     files:
       - name: manifest-tool
         src: manifest-tool-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux
+      - window/amd64
     checksum:
       type: github_release
       asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum

--- a/pkgs/estesp/manifest-tool/registry.yaml
+++ b/pkgs/estesp/manifest-tool/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: estesp
+    repo_name: manifest-tool
+    description: Command line tool to create and query container image manifest list/indexes
+    format: tar.gz
+    asset: binaries-manifest-tool-{{trimV .Version}}.{{.Format}}
+    files:
+      - name: manifest-tool
+        src: manifest-tool-{{.OS}}-{{.Arch}}
+    checksum:
+      type: github_release
+      asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -4575,6 +4575,10 @@ packages:
     files:
       - name: manifest-tool
         src: manifest-tool-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux
+      - window/amd64
     checksum:
       type: github_release
       asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum

--- a/registry.yaml
+++ b/registry.yaml
@@ -4567,6 +4567,23 @@ packages:
       - darwin
       - linux/amd64
   - type: github_release
+    repo_owner: estesp
+    repo_name: manifest-tool
+    description: Command line tool to create and query container image manifest list/indexes
+    format: tar.gz
+    asset: binaries-manifest-tool-{{trimV .Version}}.{{.Format}}
+    files:
+      - name: manifest-tool
+        src: manifest-tool-{{.OS}}-{{.Arch}}
+    checksum:
+      type: github_release
+      asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: evilmartians
     repo_name: lefthook
     description: Fast and powerful Git hooks manager for any type of projects

--- a/registry.yaml
+++ b/registry.yaml
@@ -4578,7 +4578,7 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - window/amd64
+      - windows/amd64
     checksum:
       type: github_release
       asset: binaries-manifest-tool-{{trimV .Version}}.tar.gz.sha256sum


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5626 [estesp/manifest-tool](https://github.com/estesp/manifest-tool): Command line tool to create and query container image manifest list/indexes

```console
$ aqua g -i estesp/manifest-tool
```
