### PR TITLE
fix(docker/compose): fix checksum config

### DIFF
--- a/pkgs/docker/compose/pkg.yaml
+++ b/pkgs/docker/compose/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: docker/compose@v2.9.0
+  - name: docker/compose@v2.10.0
+  - name: docker/compose
+    version: v2.9.0

--- a/pkgs/docker/compose/registry.yaml
+++ b/pkgs/docker/compose/registry.yaml
@@ -21,4 +21,15 @@ packages:
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 2.10.0")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -4164,7 +4164,18 @@ packages:
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 2.10.0")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
   - type: github_release
     repo_owner: doitintl
     repo_name: kube-no-trouble


### PR DESCRIPTION
support `docker/compose` >= v2.10.0

https://github.com/docker/compose/pull/9750
https://github.com/aquaproj/aqua-registry/pull/5625