### PR TITLE
feat: add stateful/rdme

### DIFF
--- a/pkgs/stateful/rdme/pkg.yaml
+++ b/pkgs/stateful/rdme/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: stateful/rdme@v0.1.7

--- a/pkgs/stateful/rdme/registry.yaml
+++ b/pkgs/stateful/rdme/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: stateful
+    repo_name: rdme
+    asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Execute commands directly from a README
+    replacements:
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11959,6 +11959,25 @@ packages:
       file_format: raw
       algorithm: sha256
   - type: github_release
+    repo_owner: stateful
+    repo_name: rdme
+    asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Execute commands directly from a README
+    replacements:
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: stedolan
     repo_name: jq
     asset: jq-{{.OS}}


### PR DESCRIPTION
#5634 [stateful/rdme](https://github.com/stateful/rdme): Execute commands directly from a README

```console
$ aqua g -i stateful/rdme
```
