### PR TITLE
feat: add showwin/speedtest-go

### DIFF
--- a/pkgs/showwin/speedtest-go/pkg.yaml
+++ b/pkgs/showwin/speedtest-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: showwin/speedtest-go@v1.1.5

--- a/pkgs/showwin/speedtest-go/registry.yaml
+++ b/pkgs/showwin/speedtest-go/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: showwin
+    repo_name: speedtest-go
+    asset: speedtest-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: CLI and Go API to Test Internet Speed using speedtest.net
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/showwin/speedtest-go/registry.yaml
+++ b/pkgs/showwin/speedtest-go/registry.yaml
@@ -13,6 +13,9 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: speedtest
+        src: speedtest-go
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -11686,6 +11686,9 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: speedtest
+        src: speedtest-go
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -11673,6 +11673,28 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: showwin
+    repo_name: speedtest-go
+    asset: speedtest-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: CLI and Go API to Test Internet Speed using speedtest.net
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: shyiko
     repo_name: kubesec
     asset: kubesec-{{.Version}}-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5644 [showwin/speedtest-go](https://github.com/showwin/speedtest-go): CLI and Go API to Test Internet Speed using speedtest.net

```console
$ aqua g -i showwin/speedtest-go
```
