### PR TITLE
feat: add bep/s3deploy

### DIFF
--- a/pkgs/bep/s3deploy/pkg.yaml
+++ b/pkgs/bep/s3deploy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bep/s3deploy@v2.7.0

--- a/pkgs/bep/s3deploy/registry.yaml
+++ b/pkgs/bep/s3deploy/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: bep
+    repo_name: s3deploy
+    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A simple tool to deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. "Cache-Control")
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: s3deploy_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2469,6 +2469,29 @@ packages:
       - name: pewpew
         src: pewpew/pewpew
   - type: github_release
+    repo_owner: bep
+    repo_name: s3deploy
+    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A simple tool to deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. "Cache-Control")
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: s3deploy_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: bitnami-labs
     repo_name: sealed-secrets
     asset: kubeseal-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5645 [bep/s3deploy](https://github.com/bep/s3deploy): A simple tool to deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. "Cache-Control")

```console
$ aqua g -i bep/s3deploy
```
