### PR TITLE
feat: add docker/compose-cli

### DIFF
--- a/pkgs/docker/compose-cli/pkg.yaml
+++ b/pkgs/docker/compose-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: docker/compose-cli@v1.0.29

--- a/pkgs/docker/compose-cli/registry.yaml
+++ b/pkgs/docker/compose-cli/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: docker
+    repo_name: compose-cli
+    description: Easily run your Compose application to the cloud with compose-cli
+    format: raw
+    asset: docker-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -4244,6 +4244,15 @@ packages:
             checksum: ^(\b[A-Fa-f0-9]{64}\b)
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
   - type: github_release
+    repo_owner: docker
+    repo_name: compose-cli
+    description: Easily run your Compose application to the cloud with compose-cli
+    format: raw
+    asset: docker-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux
+  - type: github_release
     repo_owner: doitintl
     repo_name: kube-no-trouble
     description: Easily check your clusters for use of deprecated APIs


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5652 [docker/compose-cli](https://github.com/docker/compose-cli): Easily run your Compose application to the cloud with compose-cli

```console
$ aqua g -i docker/compose-cli
```
