### PR TITLE
feat: add google/yamlfmt

### DIFF
--- a/pkgs/google/yamlfmt/pkg.yaml
+++ b/pkgs/google/yamlfmt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/yamlfmt@v0.1.0

--- a/pkgs/google/yamlfmt/registry.yaml
+++ b/pkgs/google/yamlfmt/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: yamlfmt
+    asset: yamlfmt_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: An extensible command line tool or library to format yaml files
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5864,6 +5864,24 @@ packages:
     description: Compile-time Dependency Injection for Go
     path: github.com/google/wire/cmd/wire
   - type: github_release
+    repo_owner: google
+    repo_name: yamlfmt
+    asset: yamlfmt_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: An extensible command line tool or library to format yaml files
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: gopasspw
     repo_name: gopass
     description: The slightly more awesome standard unix password manager for teams


### PR DESCRIPTION
#5691 [google/yamlfmt](https://github.com/google/yamlfmt): An extensible command line tool or library to format yaml files

```console
$ aqua g -i google/yamlfmt
```
