### PR TITLE
feat: add x-motemen/blogsync

### DIFF
--- a/pkgs/x-motemen/blogsync/pkg.yaml
+++ b/pkgs/x-motemen/blogsync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: x-motemen/blogsync@v0.12.1

--- a/pkgs/x-motemen/blogsync/registry.yaml
+++ b/pkgs/x-motemen/blogsync/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: x-motemen
+    repo_name: blogsync
+    asset: blogsync_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Push and pull blog entries from/to local filesystem
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: blogsync
+        src: blogsync_{{.Version}}_{{.OS}}_{{.Arch}}/blogsync

--- a/registry.yaml
+++ b/registry.yaml
@@ -13894,6 +13894,22 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: x-motemen
+    repo_name: blogsync
+    asset: blogsync_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Push and pull blog entries from/to local filesystem
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: blogsync
+        src: blogsync_{{.Version}}_{{.OS}}_{{.Arch}}/blogsync
+  - type: github_release
+    repo_owner: x-motemen
     repo_name: ghq
     asset: ghq_{{.OS}}_{{.Arch}}.zip
     description: Remote repository management made easy


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5692 [x-motemen/blogsync](https://github.com/x-motemen/blogsync): Push and pull blog entries from/to local filesystem

```console
$ aqua g -i x-motemen/blogsync
```
