### PR TITLE
feat: add lotabout/rargs

### DIFF
--- a/pkgs/lotabout/rargs/pkg.yaml
+++ b/pkgs/lotabout/rargs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: lotabout/rargs@v0.3.0

--- a/pkgs/lotabout/rargs/registry.yaml
+++ b/pkgs/lotabout/rargs/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: lotabout
+    repo_name: rargs
+    asset: rargs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    description: "xargs + awk with pattern matching support. `ls *.bak | rargs -p '(.*)\\.bak' mv {0} {1}`"
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -8818,6 +8818,19 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: lotabout
+    repo_name: rargs
+    asset: rargs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    description: "xargs + awk with pattern matching support. `ls *.bak | rargs -p '(.*)\\.bak' mv {0} {1}`"
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+  - type: github_release
+    repo_owner: lotabout
     repo_name: skim
     asset: skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
     description: Fuzzy Finder in rust


### PR DESCRIPTION
#5694 [lotabout/rargs](https://github.com/lotabout/rargs): xargs + awk with pattern matching support. `ls *.bak | rargs -p '(.*)\.bak' mv {0} {1}`

```console
$ aqua g -i lotabout/rargs
```
