### PR TITLE
feat: add `twistedpair/google-cloud-sdk`

### DIFF
--- a/pkgs/twistedpair/google-cloud-sdk/pkg.yaml
+++ b/pkgs/twistedpair/google-cloud-sdk/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: twistedpair/google-cloud-sdk@399.0.0

--- a/pkgs/twistedpair/google-cloud-sdk/registry.yaml
+++ b/pkgs/twistedpair/google-cloud-sdk/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: http
+    repo_owner: twistedpair
+    repo_name: google-cloud-sdk
+    description: CLI for interacting with Google Cloud products and services.
+    version_source: github_tag
+    url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{ .Version }}-{{.OS}}-{{.Arch}}.tar.gz"
+    files:
+      - name: gcloud
+        src: google-cloud-sdk/bin/gcloud
+      - name: gsutil
+        src: google-cloud-sdk/bin/gsutil
+    replacements:
+      amd64: x86_64
+      arm64: arm
+    supported_envs:
+      - darwin
+      - linux

--- a/pkgs/twistedpair/google-cloud-sdk/registry.yaml
+++ b/pkgs/twistedpair/google-cloud-sdk/registry.yaml
@@ -2,9 +2,9 @@ packages:
   - type: http
     repo_owner: twistedpair
     repo_name: google-cloud-sdk
-    description: CLI for interacting with Google Cloud products and services.
+    description: CLI for interacting with Google Cloud products and services
     version_source: github_tag
-    url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{ .Version }}-{{.OS}}-{{.Arch}}.tar.gz"
+    url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
     files:
       - name: gcloud
         src: google-cloud-sdk/bin/gcloud

--- a/registry.yaml
+++ b/registry.yaml
@@ -13363,9 +13363,9 @@ packages:
   - type: http
     repo_owner: twistedpair
     repo_name: google-cloud-sdk
-    description: CLI for interacting with Google Cloud products and services.
+    description: CLI for interacting with Google Cloud products and services
     version_source: github_tag
-    url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{ .Version }}-{{.OS}}-{{.Arch}}.tar.gz"
+    url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
     files:
       - name: gcloud
         src: google-cloud-sdk/bin/gcloud

--- a/registry.yaml
+++ b/registry.yaml
@@ -13360,6 +13360,23 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: http
+    repo_owner: twistedpair
+    repo_name: google-cloud-sdk
+    description: CLI for interacting with Google Cloud products and services.
+    version_source: github_tag
+    url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-{{ .Version }}-{{.OS}}-{{.Arch}}.tar.gz"
+    files:
+      - name: gcloud
+        src: google-cloud-sdk/bin/gcloud
+      - name: gsutil
+        src: google-cloud-sdk/bin/gsutil
+    replacements:
+      amd64: x86_64
+      arm64: arm
+    supported_envs:
+      - darwin
+      - linux
   - type: github_release
     repo_owner: twpayne
     repo_name: chezmoi


### PR DESCRIPTION
#5742 [twistedpair/google-cloud-sdk](https://github.com/twistedpair/google-cloud-sdk): Mirror of gcloud Google Cloud Platform SDK to track release changes

```console
$ aqua g -i twistedpair/google-cloud-sdk
```

---

Add Google cloud `gcloud` and `gsutil` cli

Google publishes the versions of the gcloud cli only extractable from a
json file, so here we are using a [git
project](https://github.com/twistedpair/google-cloud-sdk/) that mirrors
the Gcloud cli releases.

Signed-off-by: Noel Georgi <git@frezbo.dev>