### PR TITLE
feat: add google/mtail

### DIFF
--- a/pkgs/google/mtail/pkg.yaml
+++ b/pkgs/google/mtail/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/mtail@v3.0.0-rc50

--- a/pkgs/google/mtail/registry.yaml
+++ b/pkgs/google/mtail/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: mtail
+    asset: mtail_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: extract internal monitoring data from application logs for collection in a timeseries database
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5871,6 +5871,24 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: google
+    repo_name: mtail
+    asset: mtail_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: extract internal monitoring data from application logs for collection in a timeseries database
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: go_install
     repo_owner: google
     repo_name: pprof


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5744 [google/mtail](https://github.com/google/mtail): extract internal monitoring data from application logs for collection in a timeseries database

```console
$ aqua g -i google/mtail
```
