### PR TITLE
feat: add MichaelMure/git-bug

### DIFF
--- a/pkgs/MichaelMure/git-bug/pkg.yaml
+++ b/pkgs/MichaelMure/git-bug/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: MichaelMure/git-bug@v0.7.2

--- a/pkgs/MichaelMure/git-bug/registry.yaml
+++ b/pkgs/MichaelMure/git-bug/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: MichaelMure
+    repo_name: git-bug
+    asset: git-bug_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Distributed, offline-first bug tracker embedded in git, with bridges
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -588,6 +588,16 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: MichaelMure
+    repo_name: git-bug
+    asset: git-bug_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Distributed, offline-first bug tracker embedded in git, with bridges
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: MusicDin
     repo_name: kubitect
     description: Kubitect provides a simple way to set up a highly available Kubernetes cluster across multiple hosts


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5750 [MichaelMure/git-bug](https://github.com/MichaelMure/git-bug): Distributed, offline-first bug tracker embedded in git, with bridges

```console
$ aqua g -i MichaelMure/git-bug
```
