### PR TITLE
fix(dolthub/dolt): set version_constraints

### DIFF
--- a/pkgs/dolthub/dolt/pkg.yaml
+++ b/pkgs/dolthub/dolt/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: dolthub/dolt@v0.40.28
+  - name: dolthub/dolt@v0.40.29
+  - name: dolthub/dolt
+    version: v0.40.15
+  - name: dolthub/dolt
+    version: v0.40.13

--- a/pkgs/dolthub/dolt/registry.yaml
+++ b/pkgs/dolthub/dolt/registry.yaml
@@ -10,11 +10,29 @@ packages:
         format: zip
     supported_envs:
       - darwin
+      - linux
       - amd64
+    version_constraint: semver(">= 0.40.29")
     files:
       - name: dolt
         src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
-      - name: git-dolt
-        src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
-      - name: git-dolt-smudge
-        src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge
+    version_overrides:
+      - version_constraint: semver(">= 0.40.15")
+        files:
+          - name: dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
+          - name: git-dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
+          - name: git-dolt-smudge
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - amd64
+        files:
+          - name: dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
+          - name: git-dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
+          - name: git-dolt-smudge
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge

--- a/registry.yaml
+++ b/registry.yaml
@@ -4359,14 +4359,32 @@ packages:
         format: zip
     supported_envs:
       - darwin
+      - linux
       - amd64
+    version_constraint: semver(">= 0.40.29")
     files:
       - name: dolt
         src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
-      - name: git-dolt
-        src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
-      - name: git-dolt-smudge
-        src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge
+    version_overrides:
+      - version_constraint: semver(">= 0.40.15")
+        files:
+          - name: dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
+          - name: git-dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
+          - name: git-dolt-smudge
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - amd64
+        files:
+          - name: dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/dolt
+          - name: git-dolt
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt
+          - name: git-dolt-smudge
+            src: dolt-{{.OS}}-{{.Arch}}/bin/git-dolt-smudge
   - name: dominikh/go-tools/staticcheck
     type: github_release
     repo_owner: dominikh


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5747

* Remove git-dolt and git-dolt-smudge from v0.40.29 https://github.com/dolthub/dolt/releases/tag/v0.40.29
* Support `linux/arm64` from v0.40.15 https://github.com/dolthub/dolt/releases/tag/v0.40.15