### PR TITLE
feat: add sheepla/gofind

### DIFF
--- a/pkgs/sheepla/gofind/pkg.yaml
+++ b/pkgs/sheepla/gofind/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sheepla/gofind@v0.0.3

--- a/pkgs/sheepla/gofind/registry.yaml
+++ b/pkgs/sheepla/gofind/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: sheepla
+    repo_name: gofind
+    asset: gofind_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A command line pkg.go.dev searcher and `go get` helper
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11920,6 +11920,28 @@ packages:
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: sheepla
+    repo_name: gofind
+    asset: gofind_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A command line pkg.go.dev searcher and `go get` helper
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: sheepla
     repo_name: longgopher
     description: ʕ◉ϖ◉ʔ loooooooooooooooooooooong gopher
     asset: longgopher_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
#5757 [sheepla/gofind](https://github.com/sheepla/gofind): A command line pkg.go.dev searcher and `go get` helper

```console
$ aqua g -i sheepla/gofind
```
