### PR TITLE
fix(gohugoio/hugo): darwin universal binary

### DIFF
--- a/pkgs/gohugoio/hugo/pkg.yaml
+++ b/pkgs/gohugoio/hugo/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: gohugoio/hugo@v0.101.0
+  - name: gohugoio/hugo@v0.102.0
+  - name: gohugoio/hugo
+    version: v0.101.0

--- a/pkgs/gohugoio/hugo/registry.yaml
+++ b/pkgs/gohugoio/hugo/registry.yaml
@@ -19,9 +19,6 @@ packages:
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
     format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
     checksum:
       type: github_release
       asset: hugo_{{trimV .Version}}_checksums.txt
@@ -30,3 +27,14 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.102.0")
+    overrides:
+      - goos: windows
+        format: zip
+      - goos: darwin
+        asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -5632,9 +5632,6 @@ packages:
       freebsd: FreeBSD
       dragonfly: DragonFlyBSD
     format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
     checksum:
       type: github_release
       asset: hugo_{{trimV .Version}}_checksums.txt
@@ -5643,6 +5640,17 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.102.0")
+    overrides:
+      - goos: windows
+        format: zip
+      - goos: darwin
+        asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: gojuno
     repo_name: minimock


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5817

https://github.com/gohugoio/hugo/releases/tag/v0.102.0

> The MacOS archives have been replaced with universal/fat binaries that works on all MacOS platforms, named *macOS-universal.tar.gz.