### PR TITLE
feat: add linkerd/linkerd2

### DIFF
--- a/pkgs/linkerd/linkerd2/pkg.yaml
+++ b/pkgs/linkerd/linkerd2/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: linkerd/linkerd2@stable-2.12.0

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -10,12 +10,16 @@ packages:
         goarch: amd64
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
+          type: github_release
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          file_format: raw
           algorithm: sha256
       - goos: windows
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
+          type: github_release
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          file_format: raw
           algorithm: sha256
     supported_envs:
       - darwin

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -22,8 +22,5 @@ packages:
     checksum:
       type: github_release
       asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
-      file_format: regexp
+      file_format: raw
       algorithm: sha256
-      pattern:
-        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -2,26 +2,26 @@ packages:
   - type: github_release
     repo_owner: linkerd
     repo_name: linkerd2
-    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+    asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}
     format: raw
     description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
     overrides:
       - goos: darwin
         goarch: amd64
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.sha256
       - goos: windows
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.exe.sha256
     supported_envs:
       - darwin
       - linux
       - amd64
     checksum:
       type: github_release
-      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
       file_format: regexp
       algorithm: sha256
       pattern:

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -25,6 +25,8 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: linkerd
     checksum:
       type: github_release
       asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -1,0 +1,29 @@
+packages:
+  - type: github_release
+    repo_owner: linkerd
+    repo_name: linkerd2
+    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        checksum:
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+      - goos: windows
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        checksum:
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -11,10 +11,12 @@ packages:
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          algorithm: sha256
       - goos: windows
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          algorithm: sha256
     supported_envs:
       - darwin
       - linux

--- a/pkgs/linkerd/linkerd2/registry.yaml
+++ b/pkgs/linkerd/linkerd2/registry.yaml
@@ -2,26 +2,26 @@ packages:
   - type: github_release
     repo_owner: linkerd
     repo_name: linkerd2
-    asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}
+    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
     format: raw
     description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
     overrides:
       - goos: darwin
         goarch: amd64
-        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.sha256
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
       - goos: windows
-        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.exe.sha256
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
     supported_envs:
       - darwin
       - linux
       - amd64
     checksum:
       type: github_release
-      asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
       file_format: regexp
       algorithm: sha256
       pattern:

--- a/registry.yaml
+++ b/registry.yaml
@@ -8941,10 +8941,12 @@ packages:
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          algorithm: sha256
       - goos: windows
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          algorithm: sha256
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -8952,11 +8952,8 @@ packages:
     checksum:
       type: github_release
       asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
-      file_format: regexp
+      file_format: raw
       algorithm: sha256
-      pattern:
-        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: livebud
     repo_name: bud

--- a/registry.yaml
+++ b/registry.yaml
@@ -8932,26 +8932,26 @@ packages:
   - type: github_release
     repo_owner: linkerd
     repo_name: linkerd2
-    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+    asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}
     format: raw
     description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
     overrides:
       - goos: darwin
         goarch: amd64
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.sha256
       - goos: windows
-        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.exe.sha256
     supported_envs:
       - darwin
       - linux
       - amd64
     checksum:
       type: github_release
-      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
       file_format: regexp
       algorithm: sha256
       pattern:

--- a/registry.yaml
+++ b/registry.yaml
@@ -8955,6 +8955,8 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: linkerd
     checksum:
       type: github_release
       asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -8940,12 +8940,16 @@ packages:
         goarch: amd64
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
+          type: github_release
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+          file_format: raw
           algorithm: sha256
       - goos: windows
         asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
+          type: github_release
           asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+          file_format: raw
           algorithm: sha256
     supported_envs:
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -8930,6 +8930,34 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: linkerd
+    repo_name: linkerd2
+    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        checksum:
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
+      - goos: windows
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
+        checksum:
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: livebud
     repo_name: bud
     description: The Full-Stack Web Framework for Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -8932,26 +8932,26 @@ packages:
   - type: github_release
     repo_owner: linkerd
     repo_name: linkerd2
-    asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}
+    asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}
     format: raw
     description: Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x
     overrides:
       - goos: darwin
         goarch: amd64
-        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.sha256
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.sha256
       - goos: windows
-        asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}
+        asset: linkerd2-cli-{{.Version}}-{{.OS}}
         checksum:
-          asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}.exe.sha256
+          asset: linkerd2-cli-{{.Version}}-{{.OS}}.exe.sha256
     supported_envs:
       - darwin
       - linux
       - amd64
     checksum:
       type: github_release
-      asset: linkerd2-cli-stable-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+      asset: linkerd2-cli-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
       file_format: regexp
       algorithm: sha256
       pattern:


### PR DESCRIPTION
#1085 #5843 [linkerd/linkerd2](https://github.com/linkerd/linkerd2): Ultralight, security-first service mesh for Kubernetes. Main repo for Linkerd 2.x

```console
$ aqua g -i linkerd/linkerd2
```

---
issue: https://github.com/aquaproj/aqua-registry/issues/1085