### PR TITLE
feat: add mathew-fleisch/bashbot

### DIFF
--- a/pkgs/mathew-fleisch/bashbot/pkg.yaml
+++ b/pkgs/mathew-fleisch/bashbot/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mathew-fleisch/bashbot@v1.8.29

--- a/pkgs/mathew-fleisch/bashbot/registry.yaml
+++ b/pkgs/mathew-fleisch/bashbot/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: mathew-fleisch
+    repo_name: bashbot
+    asset: bashbot-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A slack-bot written in golang for infrastructure/devops teams
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -9127,6 +9127,15 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: mathew-fleisch
+    repo_name: bashbot
+    asset: bashbot-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A slack-bot written in golang for infrastructure/devops teams
+    supported_envs:
+      - linux
+      - darwin
+  - type: github_release
     repo_owner: mattn
     repo_name: cho
     asset: cho_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
#916 #5860 [mathew-fleisch/bashbot](https://github.com/mathew-fleisch/bashbot): A slack-bot written in golang for infrastructure/devops teams

```console
$ aqua g -i mathew-fleisch/bashbot
```
---
issue: https://github.com/aquaproj/aqua-registry/issues/916