### PR TITLE
feat: add kubernetes-sigs/aws-iam-authenticator

### DIFF
--- a/pkgs/kubernetes-sigs/aws-iam-authenticator/pkg.yaml
+++ b/pkgs/kubernetes-sigs/aws-iam-authenticator/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubernetes-sigs/aws-iam-authenticator@v0.5.9

--- a/pkgs/kubernetes-sigs/aws-iam-authenticator/registry.yaml
+++ b/pkgs/kubernetes-sigs/aws-iam-authenticator/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: aws-iam-authenticator
+    asset: aws-iam-authenticator_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: authenticator_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8386,6 +8386,24 @@ packages:
         asset: kubemqctl.exe
   - type: github_release
     repo_owner: kubernetes-sigs
+    repo_name: aws-iam-authenticator
+    asset: aws-iam-authenticator_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: authenticator_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: kubernetes-sigs
     repo_name: cluster-api
     asset: clusterctl-{{.OS}}-{{.Arch}}
     format: raw


### PR DESCRIPTION
#5861 [kubernetes-sigs/aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator): A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster

```console
$ aqua g -i kubernetes-sigs/aws-iam-authenticator
```

---
issue: https://github.com/aquaproj/aqua-registry/issues/909