### PR TITLE
feat: add fujiwara/ecrm

### DIFF
--- a/pkgs/fujiwara/ecrm/pkg.yaml
+++ b/pkgs/fujiwara/ecrm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiwara/ecrm@v0.2.0

--- a/pkgs/fujiwara/ecrm/registry.yaml
+++ b/pkgs/fujiwara/ecrm/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: fujiwara
+    repo_name: ecrm
+    asset: ecrm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A command line tool for managing ECR repositories
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5247,6 +5247,22 @@ packages:
       - name: semver
   - type: github_release
     repo_owner: fujiwara
+    repo_name: ecrm
+    asset: ecrm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A command line tool for managing ECR repositories
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: fujiwara
     repo_name: lambroll
     description: lambroll is a minimal deployment tool for AWS Lambda
     asset: lambroll_{{.Version}}_{{.OS}}_amd64.{{.Format}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5864 [fujiwara/ecrm](https://github.com/fujiwara/ecrm): A command line tool for managing ECR repositories

```console
$ aqua g -i fujiwara/ecrm
```
