### PR TITLE
fix(k1LoW/octocov): fix checksum file name

### DIFF
--- a/pkgs/k1LoW/octocov/pkg.yaml
+++ b/pkgs/k1LoW/octocov/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: k1LoW/octocov@v0.40.1
+  - name: k1LoW/octocov@v0.41.0
+  - name: k1LoW/octocov
+    version: v0.40.1

--- a/pkgs/k1LoW/octocov/registry.yaml
+++ b/pkgs/k1LoW/octocov/registry.yaml
@@ -13,9 +13,20 @@ packages:
       - darwin
     checksum:
       type: github_release
-      asset: checksums.txt
+      asset: checksums-{{.OS}}.txt
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.41.0")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8009,12 +8009,23 @@ packages:
       - darwin
     checksum:
       type: github_release
-      asset: checksums.txt
+      asset: checksums-{{.OS}}.txt
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.41.0")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: k1LoW
     repo_name: tbls


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5907

checksum file was renamed.

* TO BE: https://github.com/k1LoW/octocov/releases/tag/v0.41.0
* AS IS: https://github.com/k1LoW/octocov/releases/tag/v0.40.1