### PR TITLE
feat: add gogs/gogs

### DIFF
--- a/pkgs/gogs/gogs/pkg.yaml
+++ b/pkgs/gogs/gogs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: gogs/gogs@v0.12.10

--- a/pkgs/gogs/gogs/registry.yaml
+++ b/pkgs/gogs/gogs/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: gogs
+    repo_name: gogs
+    asset: gogs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Gogs is a painless self-hosted Git service
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    files:
+      - name: gogs
+        src: gogs/gogs
+    checksum:
+      type: github_release
+      asset: checksum_sha256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5698,6 +5698,29 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: gogs
+    repo_name: gogs
+    asset: gogs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Gogs is a painless self-hosted Git service
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    files:
+      - name: gogs
+        src: gogs/gogs
+    checksum:
+      type: github_release
+      asset: checksum_sha256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: gohugoio
     repo_name: hugo
     asset: hugo_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5937 [gogs/gogs](https://github.com/gogs/gogs): Gogs is a painless self-hosted Git service

```console
$ aqua g -i gogs/gogs
```
