### PR TITLE
feat: add golang/tools/gorename

### DIFF
--- a/pkgs/golang/tools/gorename/pkg.yaml
+++ b/pkgs/golang/tools/gorename/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang/tools/gorename@v0.1.12

--- a/pkgs/golang/tools/gorename/registry.yaml
+++ b/pkgs/golang/tools/gorename/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: go_install
+    name: golang/tools/gorename
+    path: golang.org/x/tools/cmd/gorename
+    repo_owner: golang
+    repo_name: tools
+    description: The gorename command performs precise type-safe renaming of identifiers in Go source code
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/gorename
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: gorename

--- a/registry.yaml
+++ b/registry.yaml
@@ -6004,6 +6004,17 @@ packages:
     files:
       - name: goimports
   - type: go_install
+    name: golang/tools/gorename
+    path: golang.org/x/tools/cmd/gorename
+    repo_owner: golang
+    repo_name: tools
+    description: The gorename command performs precise type-safe renaming of identifiers in Go source code
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/gorename
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: gorename
+  - type: go_install
     name: golang/tools/stringer
     path: golang.org/x/tools/cmd/stringer
     repo_owner: golang


### PR DESCRIPTION
#5974 [golang/tools/gorename](https://pkg.go.dev/golang.org/x/tools/cmd/gorename): The gorename command performs precise type-safe renaming of identifiers in Go source code

```console
$ aqua g -i golang/tools/gorename
```
