### PR TITLE
feat: add golang/tools/guru

### DIFF
--- a/pkgs/golang/tools/guru/pkg.yaml
+++ b/pkgs/golang/tools/guru/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang/tools/guru@v0.1.12

--- a/pkgs/golang/tools/guru/registry.yaml
+++ b/pkgs/golang/tools/guru/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: go_install
+    name: golang/tools/guru
+    path: golang.org/x/tools/cmd/guru
+    repo_owner: golang
+    repo_name: tools
+    description: A tool for answering questions about Go source code
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/guru
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: guru

--- a/registry.yaml
+++ b/registry.yaml
@@ -6015,6 +6015,17 @@ packages:
     files:
       - name: gorename
   - type: go_install
+    name: golang/tools/guru
+    path: golang.org/x/tools/cmd/guru
+    repo_owner: golang
+    repo_name: tools
+    description: A tool for answering questions about Go source code
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/guru
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: guru
+  - type: go_install
     name: golang/tools/stringer
     path: golang.org/x/tools/cmd/stringer
     repo_owner: golang


### PR DESCRIPTION
#5975 [golang/tools/guru](https://pkg.go.dev/golang.org/x/tools/cmd/guru): A tool for answering questions about Go source code

```console
$ aqua g -i golang/tools/guru
```
