### PR TITLE
feat: add golang/tools/gomvpkg

### DIFF
--- a/pkgs/golang/tools/gomvpkg/pkg.yaml
+++ b/pkgs/golang/tools/gomvpkg/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang/tools/gomvpkg@v0.1.12

--- a/pkgs/golang/tools/gomvpkg/registry.yaml
+++ b/pkgs/golang/tools/gomvpkg/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: go_install
+    name: golang/tools/gomvpkg
+    path: golang.org/x/tools/cmd/gomvpkg
+    repo_owner: golang
+    repo_name: tools
+    description: The gomvpkg command moves go packages, updating import declarations
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/gomvpkg
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: gomvpkg

--- a/registry.yaml
+++ b/registry.yaml
@@ -6004,6 +6004,17 @@ packages:
     files:
       - name: goimports
   - type: go_install
+    name: golang/tools/gomvpkg
+    path: golang.org/x/tools/cmd/gomvpkg
+    repo_owner: golang
+    repo_name: tools
+    description: The gomvpkg command moves go packages, updating import declarations
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/gomvpkg
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: gomvpkg
+  - type: go_install
     name: golang/tools/gorename
     path: golang.org/x/tools/cmd/gorename
     repo_owner: golang


### PR DESCRIPTION
#5976 [golang/tools/gomvpkg](https://pkg.go.dev/golang.org/x/tools/cmd/gomvpkg): The gomvpkg command moves go packages, updating import declarations

```console
$ aqua g -i golang/tools/gomvpkg
```
