### PR TITLE
feat: add golang/tools/godoc

### DIFF
--- a/pkgs/golang/tools/godoc/pkg.yaml
+++ b/pkgs/golang/tools/godoc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang/tools/godoc@v0.1.12

--- a/pkgs/golang/tools/godoc/registry.yaml
+++ b/pkgs/golang/tools/godoc/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: go_install
+    name: golang/tools/godoc
+    path: golang.org/x/tools/cmd/godoc
+    repo_owner: golang
+    repo_name: tools
+    description: Godoc extracts and generates documentation for Go programs
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/godoc
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: godoc

--- a/registry.yaml
+++ b/registry.yaml
@@ -5991,6 +5991,17 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: go_install
+    name: golang/tools/godoc
+    path: golang.org/x/tools/cmd/godoc
+    repo_owner: golang
+    repo_name: tools
+    description: Godoc extracts and generates documentation for Go programs
+    link: https://pkg.go.dev/golang.org/x/tools/cmd/godoc
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: godoc
+  - type: go_install
     name: golang/tools/goimports
     aliases: # Set aliases to keep the compatibility
       - name: golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
#5977 [golang/tools/godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc): Godoc extracts and generates documentation for Go programs

```console
$ aqua g -i golang/tools/godoc
```
