### PR TITLE
feat: add Shopify/toxiproxy

### DIFF
--- a/pkgs/Shopify/toxiproxy/pkg.yaml
+++ b/pkgs/Shopify/toxiproxy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Shopify/toxiproxy@v2.4.0

--- a/pkgs/Shopify/toxiproxy/registry.yaml
+++ b/pkgs/Shopify/toxiproxy/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: Shopify
+    repo_name: toxiproxy
+    asset: toxiproxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "A TCP proxy to simulate network and system conditions for chaos and resiliency testing"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: toxiproxy-cli
+      - name: toxiproxy-server
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/Shopify/toxiproxy/registry.yaml
+++ b/pkgs/Shopify/toxiproxy/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: Shopify
     repo_name: toxiproxy
     asset: toxiproxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "A TCP proxy to simulate network and system conditions for chaos and resiliency testing"
+    description: A TCP proxy to simulate network and system conditions for chaos and resiliency testing
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -790,7 +790,7 @@ packages:
     repo_owner: Shopify
     repo_name: toxiproxy
     asset: toxiproxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "A TCP proxy to simulate network and system conditions for chaos and resiliency testing"
+    description: A TCP proxy to simulate network and system conditions for chaos and resiliency testing
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -787,6 +787,26 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: Shopify
+    repo_name: toxiproxy
+    asset: toxiproxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "A TCP proxy to simulate network and system conditions for chaos and resiliency testing"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: toxiproxy-cli
+      - name: toxiproxy-server
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: Songmu
     repo_name: ecschedule
     asset: ecschedule_{{.Version}}_{{.OS}}_amd64.{{.Format}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/5990 [Shopify/toxiproxy](https://github.com/Shopify/toxiproxy): A TCP proxy to simulate network and system conditions for chaos and resiliency testing

```console
$ aqua g -i Shopify/toxiproxy
```
