### PR TITLE
feat: add mumoshu/conflint

### DIFF
--- a/pkgs/mumoshu/conflint/pkg.yaml
+++ b/pkgs/mumoshu/conflint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mumoshu/conflint@v0.2.0

--- a/pkgs/mumoshu/conflint/registry.yaml
+++ b/pkgs/mumoshu/conflint/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: mumoshu
+    repo_name: conflint
+    asset: conflint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Unified lint runners for various configuration files
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: conflint_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -10136,6 +10136,23 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: mumoshu
+    repo_name: conflint
+    asset: conflint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Unified lint runners for various configuration files
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: conflint_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: mumoshu
     repo_name: variant
     description: Wrap up your bash scripts into a modern CLI today. Graduate to a full-blown golang app tomorrow
     rosetta2: true


### PR DESCRIPTION
#5991 [mumoshu/conflint](https://github.com/mumoshu/conflint): Unified lint runners for various configuration files

```console
$ aqua g -i mumoshu/conflint
```
