### PR TITLE
feat: add mmarkdown/mmark

### DIFF
--- a/pkgs/mmarkdown/mmark/pkg.yaml
+++ b/pkgs/mmarkdown/mmark/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mmarkdown/mmark@v2.2.28

--- a/pkgs/mmarkdown/mmark/registry.yaml
+++ b/pkgs/mmarkdown/mmark/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: mmarkdown
+    repo_name: mmark
+    asset: mmark_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+    description: A powerful markdown processor in Go geared towards the IETF
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -9980,6 +9980,15 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: mmarkdown
+    repo_name: mmark
+    asset: mmark_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+    description: A powerful markdown processor in Go geared towards the IETF
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: momaek
     repo_name: authy
     description: TOTP Alfred Workflow, Authy Aflred Workflow, Authy command line tool


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6035 [mmarkdown/mmark](https://github.com/mmarkdown/mmark): A powerful markdown processor in Go geared towards the IETF

```console
$ aqua g -i mmarkdown/mmark
```
