### PR TITLE
feat: add mattermost/mmctl

### DIFF
--- a/pkgs/mattermost/mmctl/pkg.yaml
+++ b/pkgs/mattermost/mmctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mattermost/mmctl@v7.1.3

--- a/pkgs/mattermost/mmctl/registry.yaml
+++ b/pkgs/mattermost/mmctl/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: mattermost
+    repo_name: mmctl
+    asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: tar
+    description: A remote CLI tool for Mattermost
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -9719,6 +9719,19 @@ packages:
       - linux
       - darwin
   - type: github_release
+    repo_owner: mattermost
+    repo_name: mmctl
+    asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: tar
+    description: A remote CLI tool for Mattermost
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: mattn
     repo_name: cho
     asset: cho_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6158 [mattermost/mmctl](https://github.com/mattermost/mmctl): A remote CLI tool for Mattermost

```console
$ aqua g -i mattermost/mmctl
```
