### PR TITLE
feat: add juicedata/juicefs

### DIFF
--- a/pkgs/juicedata/juicefs/pkg.yaml
+++ b/pkgs/juicedata/juicefs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: juicedata/juicefs@v1.0.0

--- a/pkgs/juicedata/juicefs/registry.yaml
+++ b/pkgs/juicedata/juicefs/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: juicedata
+    repo_name: juicefs
+    asset: juicefs-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: JuiceFS is a distributed POSIX file system built on top of Redis and S3
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8301,6 +8301,23 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: juicedata
+    repo_name: juicefs
+    asset: juicefs-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: JuiceFS is a distributed POSIX file system built on top of Redis and S3
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: juliosueiras
     repo_name: terraform-lsp
     asset: terraform-lsp_{{trimV .Version}}_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6185 [juicedata/juicefs](https://github.com/juicedata/juicefs): JuiceFS is a distributed POSIX file system built on top of Redis and S3

```console
$ aqua g -i juicedata/juicefs
```
