### PR TITLE
feat: add gotify/cli

### DIFF
--- a/pkgs/gotify/cli/pkg.yaml
+++ b/pkgs/gotify/cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: gotify/cli@v2.2.2

--- a/pkgs/gotify/cli/registry.yaml
+++ b/pkgs/gotify/cli/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: gotify
+    repo_name: cli
+    asset: gotify-cli-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A command line interface for pushing messages to gotify/server
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: gotify

--- a/registry.yaml
+++ b/registry.yaml
@@ -6513,6 +6513,18 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: gotify
+    repo_name: cli
+    asset: gotify-cli-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A command line interface for pushing messages to gotify/server
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: gotify
+  - type: github_release
     repo_owner: grafana
     repo_name: grafana-kiosk
     description: Kiosk Utility for Grafana


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6186 [gotify/cli](https://github.com/gotify/cli): A command line interface for pushing messages to gotify/server

```console
$ aqua g -i gotify/cli
```
