### PR TITLE
feat: add awslabs/yesiscan

### DIFF
--- a/pkgs/awslabs/yesiscan/pkg.yaml
+++ b/pkgs/awslabs/yesiscan/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: awslabs/yesiscan@v0.0.8

--- a/pkgs/awslabs/yesiscan/registry.yaml
+++ b/pkgs/awslabs/yesiscan/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: awslabs
+    repo_name: yesiscan
+    asset: yesiscan_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Automatic license scanning and reports
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2301,6 +2301,23 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: awslabs
+    repo_name: yesiscan
+    asset: yesiscan_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Automatic license scanning and reports
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_archive
     repo_owner: b3nj5m1n
     repo_name: xdg-ninja


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6188 [awslabs/yesiscan](https://github.com/awslabs/yesiscan): Automatic license scanning and reports

```console
$ aqua g -i awslabs/yesiscan
```
