### PR TITLE
feat: add grafana/jsonnet-language-server

### DIFF
--- a/pkgs/grafana/jsonnet-language-server/pkg.yaml
+++ b/pkgs/grafana/jsonnet-language-server/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grafana/jsonnet-language-server@v0.9.1

--- a/pkgs/grafana/jsonnet-language-server/registry.yaml
+++ b/pkgs/grafana/jsonnet-language-server/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: jsonnet-language-server
+    asset: jsonnet-language-server_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: A Language Server Protocol (LSP) server for Jsonnet (https://jsonnet.org)
+    checksum:
+      type: github_release
+      asset: jsonnet-language-server_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6602,6 +6602,20 @@ packages:
       - name: grr
   - type: github_release
     repo_owner: grafana
+    repo_name: jsonnet-language-server
+    asset: jsonnet-language-server_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: A Language Server Protocol (LSP) server for Jsonnet (https://jsonnet.org)
+    checksum:
+      type: github_release
+      asset: jsonnet-language-server_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: grafana
     repo_name: k6
     description: A modern load testing tool, using Go and JavaScript
     supported_envs:


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6220 [grafana/jsonnet-language-server](https://github.com/grafana/jsonnet-language-server): A Language Server Protocol (LSP) server for Jsonnet (https://jsonnet.org)

```console
$ aqua g -i grafana/jsonnet-language-server
```
