### PR TITLE
feat: add Pluralith/pluralith-cli

### DIFF
--- a/pkgs/Pluralith/pluralith-cli/pkg.yaml
+++ b/pkgs/Pluralith/pluralith-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Pluralith/pluralith-cli@v0.1.12

--- a/pkgs/Pluralith/pluralith-cli/registry.yaml
+++ b/pkgs/Pluralith/pluralith-cli/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: Pluralith
+    repo_name: pluralith-cli
+    asset: pluralith_cli_tap_{{.OS}}_{{.Arch}}_{{.Version}}.{{.Format}}
+    format: tar.gz
+    description: A tool for Terraform state visualisation and automated generation of infrastructure documentation
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: pluralith
+        src: "{{.OS}}/pluralith"
+    checksum:
+      type: github_release
+      asset: pluralith_checksums_{{.Version}}.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -760,6 +760,30 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: Pluralith
+    repo_name: pluralith-cli
+    asset: pluralith_cli_tap_{{.OS}}_{{.Arch}}_{{.Version}}.{{.Format}}
+    format: tar.gz
+    description: A tool for Terraform state visualisation and automated generation of infrastructure documentation
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: pluralith
+        src: "{{.OS}}/pluralith"
+    checksum:
+      type: github_release
+      asset: pluralith_checksums_{{.Version}}.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: Praqma
     repo_name: helmsman
     rosetta2: true


### PR DESCRIPTION
#6223 [Pluralith/pluralith-cli](https://github.com/Pluralith/pluralith-cli): A tool for Terraform state visualisation and automated generation of infrastructure documentation

```console
$ aqua g -i Pluralith/pluralith-cli
```
