### PR TITLE
feat: add clamoriniere/crd-to-markdown

### DIFF
--- a/pkgs/clamoriniere/crd-to-markdown/pkg.yaml
+++ b/pkgs/clamoriniere/crd-to-markdown/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: clamoriniere/crd-to-markdown@v0.0.3

--- a/pkgs/clamoriniere/crd-to-markdown/registry.yaml
+++ b/pkgs/clamoriniere/crd-to-markdown/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: clamoriniere
+    repo_name: crd-to-markdown
+    asset: crd-to-markdown_{{.OS}}_{{.Arch}}
+    format: raw
+    description: util to generate a markdown file from a Kubernetes CRD go struct definition
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3426,6 +3426,30 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: clamoriniere
+    repo_name: crd-to-markdown
+    asset: crd-to-markdown_{{.OS}}_{{.Arch}}
+    format: raw
+    description: util to generate a markdown file from a Kubernetes CRD go struct definition
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: cli
     repo_name: cli
     description: GitHub’s official command line tool


### PR DESCRIPTION
#6234 [clamoriniere/crd-to-markdown](https://github.com/clamoriniere/crd-to-markdown): util to generate a markdown file from a Kubernetes CRD go struct definition

```console
$ aqua g -i clamoriniere/crd-to-markdown
```
