### PR TITLE
feat: add ory/hydra

### DIFF
--- a/pkgs/ory/hydra/pkg.yaml
+++ b/pkgs/ory/hydra/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ory/hydra@v1.11.10

--- a/pkgs/ory/hydra/registry.yaml
+++ b/pkgs/ory/hydra/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_name: hydra
     asset: hydra_{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: OpenID Certified™ OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
+    description: OpenID Certified OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
     replacements:
       amd64: 64bit
       darwin: macOS

--- a/pkgs/ory/hydra/registry.yaml
+++ b/pkgs/ory/hydra/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: ory
+    repo_name: hydra
+    asset: hydra_{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: OpenID Certified™ OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
+    replacements:
+      amd64: 64bit
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11264,7 +11264,7 @@ packages:
     repo_name: hydra
     asset: hydra_{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: OpenID Certified™ OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
+    description: OpenID Certified OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
     replacements:
       amd64: 64bit
       darwin: macOS

--- a/registry.yaml
+++ b/registry.yaml
@@ -11260,6 +11260,26 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: ory
+    repo_name: hydra
+    asset: hydra_{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: OpenID Certified™ OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid
+    replacements:
+      amd64: 64bit
+      darwin: macOS
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: ossf
     repo_name: scorecard
     description: Security Scorecards - Security health metrics for Open Source


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6276 [ory/hydra](https://github.com/ory/hydra): OpenID Certified™ OpenID Connect and OAuth Provider written in Go - cloud native, security-first, open source API security for your infrastructure. SDKs for any language. Works with Hardware Security Modules. Compatible with MITREid

```console
$ aqua g -i ory/hydra
```
