### PR TITLE
fix(gohugoio/hugo): support hugo >= v0.103.0

### DIFF
--- a/pkgs/gohugoio/hugo/pkg.yaml
+++ b/pkgs/gohugoio/hugo/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: gohugoio/hugo@v0.102.3
+  - name: gohugoio/hugo@v0.103.0
+  - name: gohugoio/hugo
+    version: v0.102.3
   - name: gohugoio/hugo
     version: v0.101.0

--- a/pkgs/gohugoio/hugo/registry.yaml
+++ b/pkgs/gohugoio/hugo/registry.yaml
@@ -6,18 +6,6 @@ packages:
     description: The world’s fastest framework for building websites
     files:
       - name: hugo
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
     format: tar.gz
     checksum:
       type: github_release
@@ -27,14 +15,33 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    version_constraint: semver(">= 0.102.0")
+    version_constraint: semver(">= 0.103.0")
     overrides:
       - goos: windows
         format: zip
       - goos: darwin
-        asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+        asset: hugo_{{trimV .Version}}_darwin-universal.tar.gz
     version_overrides:
+      - version_constraint: semver(">= 0.102.0")
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+        replacements: &hugo_replacements_1
+          amd64: 64bit
+          386: 32bit
+          arm: ARM
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+          openbsd: OpenBSD
+          netbsd: NetBSD
+          freebsd: FreeBSD
+          dragonfly: DragonFlyBSD
       - version_constraint: "true"
+        replacements: *hugo_replacements_1
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -6096,18 +6096,6 @@ packages:
     description: The world’s fastest framework for building websites
     files:
       - name: hugo
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
     format: tar.gz
     checksum:
       type: github_release
@@ -6117,14 +6105,33 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    version_constraint: semver(">= 0.102.0")
+    version_constraint: semver(">= 0.103.0")
     overrides:
       - goos: windows
         format: zip
       - goos: darwin
-        asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+        asset: hugo_{{trimV .Version}}_darwin-universal.tar.gz
     version_overrides:
+      - version_constraint: semver(">= 0.102.0")
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            asset: hugo_{{trimV .Version}}_macOS-universal.tar.gz
+        replacements: &hugo_replacements_1
+          amd64: 64bit
+          386: 32bit
+          arm: ARM
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+          openbsd: OpenBSD
+          netbsd: NetBSD
+          freebsd: FreeBSD
+          dragonfly: DragonFlyBSD
       - version_constraint: "true"
+        replacements: *hugo_replacements_1
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
https://github.com/gohugoio/hugo/releases/tag/v0.103.0

asset name was changed.

> We have standardised the archive names for the release archives (as you can see further below).
> Hugo has since the first version used a rather odd and non-standard mixed case naming of the archive files (e.g. hugo_0.102.3_OpenBSD-64bit.tar.gz).
> We now use the standard GOOS/GOARCH values as-is, which makes it easier for people to script against.
> To avoid breakage when running on Netlify and similar, we create aliases for the most commonly downloaded Linux-archives on the old format and will continue to do so in the foreseeable future.