### PR TITLE
fix(stackrox/kube-linter): support kube-linter >= v0.5.0

### DIFF
--- a/pkgs/stackrox/kube-linter/pkg.yaml
+++ b/pkgs/stackrox/kube-linter/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: stackrox/kube-linter@0.4.0
+  - name: stackrox/kube-linter@0.5.0
   - name: stackrox/kube-linter
-    version: 0.2.6
+    version: 0.4.0

--- a/pkgs/stackrox/kube-linter/registry.yaml
+++ b/pkgs/stackrox/kube-linter/registry.yaml
@@ -7,4 +7,12 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    asset: kube-linter-{{.OS}}.tar.gz
+    version_constraint: semver(">= 0.5.0")
+    asset: kube-linter-{{.OS}}
+    overrides:
+      - goos: windows
+        asset: kube-linter.exe
+    version_overrides:
+      - version_constraint: "true"
+        asset: kube-linter-{{.OS}}.tar.gz
+        overrides: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -13562,7 +13562,15 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    asset: kube-linter-{{.OS}}.tar.gz
+    version_constraint: semver(">= 0.5.0")
+    asset: kube-linter-{{.OS}}
+    overrides:
+      - goos: windows
+        asset: kube-linter.exe
+    version_overrides:
+      - version_constraint: "true"
+        asset: kube-linter-{{.OS}}.tar.gz
+        overrides: []
   - type: github_release
     repo_owner: starship
     repo_name: starship


### PR DESCRIPTION
https://github.com/stackrox/kube-linter/releases/tag/0.5.0

> Release changes
> For the assets available for each release, there's been a change starting with this release:
> Instead of adding tar.gz / zip archives for specific platforms containing the kube-linter binary,
> the binary have been now added unarchived as replacement.
> The kube-linter-linux.tar.gz archive has been kept for backwards compatability with kube-linter-action,
> but is deprecated and will be removed with the next release.
> Hence, there's also no cosign signature available for it.