### PR TITLE
Add docker-credential-gcloud binary in twistedpair/google-cloud-sdk

### DIFF
--- a/pkgs/twistedpair/google-cloud-sdk/registry.yaml
+++ b/pkgs/twistedpair/google-cloud-sdk/registry.yaml
@@ -10,6 +10,8 @@ packages:
         src: google-cloud-sdk/bin/gcloud
       - name: gsutil
         src: google-cloud-sdk/bin/gsutil
+      - name: docker-credential-gcloud
+        src: google-cloud-sdk/bin/docker-credential-gcloud
     replacements:
       amd64: x86_64
       arm64: arm

--- a/registry.yaml
+++ b/registry.yaml
@@ -14629,6 +14629,8 @@ packages:
         src: google-cloud-sdk/bin/gcloud
       - name: gsutil
         src: google-cloud-sdk/bin/gsutil
+      - name: docker-credential-gcloud
+        src: google-cloud-sdk/bin/docker-credential-gcloud
     replacements:
       amd64: x86_64
       arm64: arm


### PR DESCRIPTION
When I used twistedpair/google-cloud-sdk, I found that docker-credential-gcloud binary is not linked.

```
$ gcloud auth configure-docker
WARNING: `docker-credential-gcloud` not in system PATH. 
gcloud's Docker credential helper can be configured but it will not work until this is corrected.      
```

This PR create the link for docker-credential-gcloud.