### PR TITLE
chore: rename armosec/kubescape

### DIFF
--- a/pkgs/armosec/kubescape/pkg.yaml
+++ b/pkgs/armosec/kubescape/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: armosec/kubescape@v2.0.170

--- a/pkgs/kubescape/kubescape/pkg.yaml
+++ b/pkgs/kubescape/kubescape/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubescape/kubescape@v2.0.170

--- a/pkgs/kubescape/kubescape/registry.yaml
+++ b/pkgs/kubescape/kubescape/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: armosec
+    repo_owner: kubescape
     repo_name: kubescape
+    aliases:
+      - name: armosec/kubescape
     description: kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA
     rosetta2: true
     complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -2101,24 +2101,6 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
-    repo_owner: armosec
-    repo_name: kubescape
-    description: kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA
-    rosetta2: true
-    complete_windows_ext: false
-    supported_envs:
-      - darwin
-      - amd64
-    asset: kubescape-{{.OS}}-latest
-    replacements:
-      linux: ubuntu
-      darwin: macos
-    checksum:
-      type: github_release
-      asset: kubescape-{{.OS}}-latest-sha256
-      file_format: raw
-      algorithm: sha256
-  - type: github_release
     repo_owner: arrow2nd
     repo_name: nekome
     asset: nekome_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
@@ -9333,6 +9315,26 @@ packages:
       - linux
       - amd64
     url: https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}
+  - type: github_release
+    repo_owner: kubescape
+    repo_name: kubescape
+    aliases:
+      - name: armosec/kubescape
+    description: kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA
+    rosetta2: true
+    complete_windows_ext: false
+    supported_envs:
+      - darwin
+      - amd64
+    asset: kubescape-{{.OS}}-latest
+    replacements:
+      linux: ubuntu
+      darwin: macos
+    checksum:
+      type: github_release
+      asset: kubescape-{{.OS}}-latest-sha256
+      file_format: raw
+      algorithm: sha256
   - type: github_release
     repo_owner: kubesphere
     repo_name: kubeeye


### PR DESCRIPTION
The Organization name had been changed.
https://github.com/kubescape/kubescape