### PR TITLE
feat: add aws/amazon-genomics-cli

### DIFF
--- a/pkgs/aws/amazon-genomics-cli/pkg.yaml
+++ b/pkgs/aws/amazon-genomics-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aws/amazon-genomics-cli@v1.5.0

--- a/pkgs/aws/amazon-genomics-cli/registry.yaml
+++ b/pkgs/aws/amazon-genomics-cli/registry.yaml
@@ -5,6 +5,7 @@ packages:
     description: Amazon Genomics CLI is an open source tool for genomics and life science customers that simplifies and automates the deployment of cloud infrastructure
     supported_envs:
       - amd64
+      - darwin
     asset: amazon-genomics-cli-{{trimV .Version}}.zip
     files:
       - name: agc

--- a/pkgs/aws/amazon-genomics-cli/registry.yaml
+++ b/pkgs/aws/amazon-genomics-cli/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: aws
+    repo_name: amazon-genomics-cli
+    description: Amazon Genomics CLI is an open source tool for genomics and life science customers that simplifies and automates the deployment of cloud infrastructure
+    supported_envs:
+      - amd64
+    asset: amazon-genomics-cli-{{trimV .Version}}.zip
+    files:
+      - name: agc
+        src: amazon-genomics-cli/agc
+    overrides:
+      - goos: windows
+        files:
+          - name: agc
+            src: amazon-genomics-cli/agc.exe
+      - goos: linux
+        files:
+          - name: agc
+            src: amazon-genomics-cli/agc-amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -2277,6 +2277,25 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: aws
+    repo_name: amazon-genomics-cli
+    description: Amazon Genomics CLI is an open source tool for genomics and life science customers that simplifies and automates the deployment of cloud infrastructure
+    supported_envs:
+      - amd64
+    asset: amazon-genomics-cli-{{trimV .Version}}.zip
+    files:
+      - name: agc
+        src: amazon-genomics-cli/agc
+    overrides:
+      - goos: windows
+        files:
+          - name: agc
+            src: amazon-genomics-cli/agc.exe
+      - goos: linux
+        files:
+          - name: agc
+            src: amazon-genomics-cli/agc-amd64
   - type: http
     repo_owner: aws
     repo_name: aws-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -2283,6 +2283,7 @@ packages:
     description: Amazon Genomics CLI is an open source tool for genomics and life science customers that simplifies and automates the deployment of cloud infrastructure
     supported_envs:
       - amd64
+      - darwin
     asset: amazon-genomics-cli-{{trimV .Version}}.zip
     files:
       - name: agc


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6345 [aws/amazon-genomics-cli](https://github.com/aws/amazon-genomics-cli): Amazon Genomics CLI is an open source tool for genomics and life science customers that simplifies and automates the deployment of cloud infrastructure

```console
$ aqua g -i aws/amazon-genomics-cli
```