### PR TITLE
feat: add gardener/docforge

### DIFF
--- a/pkgs/gardener/docforge/pkg.yaml
+++ b/pkgs/gardener/docforge/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: gardener/docforge@v0.32.0

--- a/pkgs/gardener/docforge/registry.yaml
+++ b/pkgs/gardener/docforge/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: gardener
+    repo_name: docforge
+    asset: docforge-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Scalable build tool for distributed documentation sources
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -5764,6 +5764,16 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: gardener
+    repo_name: docforge
+    asset: docforge-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Scalable build tool for distributed documentation sources
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+  - type: github_release
     repo_owner: gcla
     repo_name: termshark
     description: A terminal UI for tshark, inspired by Wireshark


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6346 [gardener/docforge](https://github.com/gardener/docforge): Scalable build tool for distributed documentation sources

```console
$ aqua g -i gardener/docforge
```
