### PR TITLE
fix(webdevops/go-crond): support go-crond >= 22.9.0

### DIFF
--- a/pkgs/webdevops/go-crond/pkg.yaml
+++ b/pkgs/webdevops/go-crond/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: webdevops/go-crond@21.5.0
+  - name: webdevops/go-crond@22.9.0
+  - name: webdevops/go-crond
+    version: 21.5.0

--- a/pkgs/webdevops/go-crond/registry.yaml
+++ b/pkgs/webdevops/go-crond/registry.yaml
@@ -3,12 +3,16 @@ packages:
     repo_owner: webdevops
     repo_name: go-crond
     description: Cron daemon written in golang (for eg. usage in docker images)
-    rosetta2: true
     supported_envs:
       - darwin
       - linux
     format: raw
-    asset: go-crond-{{.Arch}}-{{.OS}}
-    replacements:
-      amd64: "64"
-      darwin: osx
+    version_constraint: semver(">= 22.9.0")
+    asset: go-crond.{{.OS}}.{{.Arch}}
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-crond-{{.Arch}}-{{.OS}}
+        rosetta2: true
+        replacements:
+          amd64: "64"
+          darwin: osx

--- a/registry.yaml
+++ b/registry.yaml
@@ -15239,15 +15239,19 @@ packages:
     repo_owner: webdevops
     repo_name: go-crond
     description: Cron daemon written in golang (for eg. usage in docker images)
-    rosetta2: true
     supported_envs:
       - darwin
       - linux
     format: raw
-    asset: go-crond-{{.Arch}}-{{.OS}}
-    replacements:
-      amd64: "64"
-      darwin: osx
+    version_constraint: semver(">= 22.9.0")
+    asset: go-crond.{{.OS}}.{{.Arch}}
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-crond-{{.Arch}}-{{.OS}}
+        rosetta2: true
+        replacements:
+          amd64: "64"
+          darwin: osx
   - type: github_release
     repo_owner: whalebrew
     repo_name: whalebrew


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6342

---

[webdevops/go-crond](https://github.com/webdevops/go-crond): Support go-crond >= 22.9.0

https://github.com/webdevops/go-crond/releases/tag/22.9.0

Asset names were changed.