### PR TITLE
feat: add pseudomuto/protoc-gen-doc

### DIFF
--- a/pkgs/pseudomuto/protoc-gen-doc/pkg.yaml
+++ b/pkgs/pseudomuto/protoc-gen-doc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pseudomuto/protoc-gen-doc@v1.5.1

--- a/pkgs/pseudomuto/protoc-gen-doc/registry.yaml
+++ b/pkgs/pseudomuto/protoc-gen-doc/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: pseudomuto
+    repo_name: protoc-gen-doc
+    asset: protoc-gen-doc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Documentation generator plugin for Google Protocol Buffers
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11950,6 +11950,19 @@ packages:
       - goos: windows
         format: zip
   - type: github_release
+    repo_owner: pseudomuto
+    repo_name: protoc-gen-doc
+    asset: protoc-gen-doc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Documentation generator plugin for Google Protocol Buffers
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: pulumi
     repo_name: kubespy
     description: Tools for observing Kubernetes resources in real time, powered by Pulumi


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6372 [pseudomuto/protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc): Documentation generator plugin for Google Protocol Buffers

```console
$ aqua g -i pseudomuto/protoc-gen-doc
```
