### PR TITLE
feat: add k1LoW/runn

### DIFF
--- a/pkgs/k1LoW/runn/pkg.yaml
+++ b/pkgs/k1LoW/runn/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/runn@v0.35.0

--- a/pkgs/k1LoW/runn/registry.yaml
+++ b/pkgs/k1LoW/runn/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: runn
+    asset: runn_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: runn is a package/tool for running operations following a scenario
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8701,6 +8701,26 @@ packages:
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: k1LoW
+    repo_name: runn
+    asset: runn_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: runn is a package/tool for running operations following a scenario
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: tbls
     asset: tbls_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6415 [k1LoW/runn](https://github.com/k1LoW/runn): runn is a package/tool for running operations following a scenario

```console
$ aqua g -i k1LoW/runn
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ runn --help
runn is a tool for running operations following a scenario.

Usage:
  runn [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list        list books
  run         run books

Flags:
  -h, --help      help for runn
  -v, --version   version for runn

Use "runn [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

1. Create `scenario.yml`
```yaml
$ cat scenario.yml
desc: Test httpbin
runners:
  req: https://httpbin.org
steps:
  -
    req:
      /get:
        get:
          body:
    test: steps[0].res.status == 200
```

2. Run `runn run`
```console
$ runn run scenario.yml
Test httpbin ... ok

1 scenario, 0 skipped, 0 failures
```

Reference

- README
	- https://github.com/k1LoW/runn#runbook--runn-scenario-file-
