### PR TITLE
feat: add ryodocx/kube-credential-cache

### DIFF
--- a/pkgs/ryodocx/kube-credential-cache/pkg.yaml
+++ b/pkgs/ryodocx/kube-credential-cache/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ryodocx/kube-credential-cache@v0.5.0

--- a/pkgs/ryodocx/kube-credential-cache/registry.yaml
+++ b/pkgs/ryodocx/kube-credential-cache/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+  - type: github_release
+    repo_owner: ryodocx
+    repo_name: kube-credential-cache
+    asset: kube-credential-cache_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Accelerator cache for kubernetes access
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: kcc-cache
+      - name: kcc-injector
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12650,6 +12650,31 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: ryodocx
+    repo_name: kube-credential-cache
+    asset: kube-credential-cache_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Accelerator cache for kubernetes access
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: kcc-cache
+      - name: kcc-injector
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: s0md3v
     repo_name: Smap
     description: a drop-in replacement for Nmap powered by shodan.io


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6418 [ryodocx/kube-credential-cache](https://github.com/ryodocx/kube-credential-cache): Accelerator cache for kubernetes access

```console
$ aqua g -i ryodocx/kube-credential-cache
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

kcc-injector
```console
$ kcc-injector --help
Usage: kcc-injector [flags] <kubeconfig-filepath>
  -c string
        injection command (default "kcc-cache")
  -i    edit file in-place
  -r    restore kubeconfig to original
```

kcc-cache (Called from `kubectl`)
```console
$ kcc-cache --help
kcc-cache: read command output failed: exec: "--help": executable file not found in $PATH
error occurred at: https://github.com/ryodocx/kube-credential-cache/blob/0571d68ea98e04f8d5726d47627bbfeecb7a7853/cmd/kcc-cache/main.go#L151
```

If files such as configuration file are needed, please share them.

Inject `kcc-cache` command to kubectl config. (or [manual setup](https://github.com/ryodocx/kube-credential-cache#usageedit-kubeconfig))
```console
$ kcc-injector -i ~/.kube/config
```

Run `kubectl`
```console
$ kubectl get pod
```

Reference

- README - Usage
	- https://github.com/ryodocx/kube-credential-cache#usageedit-kubeconfig
