### PR TITLE
feat: add Songmu/maltmill

### DIFF
--- a/pkgs/Songmu/maltmill/pkg.yaml
+++ b/pkgs/Songmu/maltmill/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Songmu/maltmill@v1.0.1

--- a/pkgs/Songmu/maltmill/registry.yaml
+++ b/pkgs/Songmu/maltmill/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: Songmu
+    repo_name: maltmill
+    asset: maltmill_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: create and update Homebrew thrid party Formulae
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: maltmill
+        src: maltmill_{{.Version}}_{{.OS}}_{{.Arch}}/maltmill
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1052,6 +1052,26 @@ packages:
         format: tar.gz
   - type: github_release
     repo_owner: Songmu
+    repo_name: maltmill
+    asset: maltmill_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: create and update Homebrew thrid party Formulae
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: maltmill
+        src: maltmill_{{.Version}}_{{.OS}}_{{.Arch}}/maltmill
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: Songmu
     repo_name: tagpr
     description: The tagpr automatically creates and updates a pull request for unreleased items, tag them when they are merged, and create releases
     asset: tagpr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6515 [Songmu/maltmill](https://github.com/Songmu/maltmill): create and update Homebrew thrid party Formulae

```console
$ aqua g -i Songmu/maltmill
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ maltmill --help
maltmill - Update or create homebrew third party formulae

Version: 1.0.1 (rev: 9622920/go1.19)

Synopsis:
    % maltmill -w [formula-files.rb]

Options:
  -token string
        github `token
  -w    write result to (source) file instead of stdout

Commands:
    new            create new formula
```

If files such as configuration file are needed, please share them.

```console
$ maltmill new -w aquaproj/registry-tool
[maltmill] created "registry-tool.rb"

$ cat registry-tool.rb
class RegistryTool < Formula
  version '0.1.4'
  homepage 'https://github.com/aquaproj/registry-tool'

  on_macos do
    if Hardware::CPU.arm?
      url 'https://github.com/aquaproj/registry-tool/releases/download/v0.1.4/registry-tool_darwin_arm64.tar.gz'
      sha256 '44e74fc2e7cf7d0ee9eaea860ddb40638002baaa1d43074d619d3119b3c23b10'
    end
    if Hardware::CPU.intel?
      url 'https://github.com/aquaproj/registry-tool/releases/download/v0.1.4/registry-tool_darwin_amd64.tar.gz'
      sha256 '202ea257c22f525ae1c9d0c16c6606b6f8a28407e2c6d2776e2265ceb6622df9'
    end
  end

  on_linux do
    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
      url 'https://github.com/aquaproj/registry-tool/releases/download/v0.1.4/registry-tool_linux_arm64.tar.gz'
      sha256 '71530aabd832faead521ff48ab48cdabf49ab9ec3dccef017ae513ad503e9fb0'
    end
    if Hardware::CPU.intel?
      url 'https://github.com/aquaproj/registry-tool/releases/download/v0.1.4/registry-tool_linux_amd64.tar.gz'
      sha256 '532673490deb9459481e25e22c8e2a3143e802b1f51a18981bed8c5ab12a8198'
    end
  end

  head do
    url 'https://github.com/aquaproj/registry-tool.git'
    depends_on 'go' => :build
  end

  def install
    if build.head?
      system 'make', 'build'
    end
    bin.install 'registry-tool'
  end
end
```

Reference

- README.md
	- https://github.com/Songmu/maltmill/blob/main/README.md
