### PR TITLE
feat: add grafana/xk6

### DIFF
--- a/pkgs/grafana/xk6/pkg.yaml
+++ b/pkgs/grafana/xk6/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grafana/xk6@v0.7.0

--- a/pkgs/grafana/xk6/registry.yaml
+++ b/pkgs/grafana/xk6/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: xk6
+    asset: xk6_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Build k6 with extensions
+    replacements:
+      darwin: mac
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: xk6_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/grafana/xk6/registry.yaml
+++ b/pkgs/grafana/xk6/registry.yaml
@@ -18,7 +18,7 @@ packages:
       type: github_release
       asset: xk6_{{trimV .Version}}_checksums.txt
       file_format: regexp
-      algorithm: sha256
+      algorithm: sha512
       pattern:
-        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6857,6 +6857,29 @@ packages:
       - version_constraint: "true"
         rosetta2: true
   - type: github_release
+    repo_owner: grafana
+    repo_name: xk6
+    asset: xk6_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Build k6 with extensions
+    replacements:
+      darwin: mac
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: xk6_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: greymd
     repo_name: teip
     asset: teip-{{trimV .Version}}.{{.Arch}}-{{.OS}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -6875,10 +6875,10 @@ packages:
       type: github_release
       asset: xk6_{{trimV .Version}}_checksums.txt
       file_format: regexp
-      algorithm: sha256
+      algorithm: sha512
       pattern:
-        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: greymd
     repo_name: teip


### PR DESCRIPTION
[grafana/xk6](https://github.com/grafana/xk6): Build k6 with extensions

```console
$ aqua g -i grafana/xk6
```

## How to confirm if this package works well

xk6 builds custom versions of [grafana/k6](https://k6.io) that include specified extensions.  To verify that the binary is working, one can run `xk6 build` which will fetch k6 sources and build a `k6` binary at the latest version.  A go 1.17+ installation is required.

```console
21:52 $ xk6 build
2022/09/27 21:57:07 [INFO] Temporary folder: /tmp/buildenv_2022-09-27-2157.167526117
2022/09/27 21:57:07 [INFO] Initializing Go module
2022/09/27 21:57:07 [INFO] exec (timeout=10s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod init k6
go: creating new go.mod: module k6
2022/09/27 21:57:07 [INFO] Pinning versions
2022/09/27 21:57:07 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod tidy -compat=1.17
go: warning: "all" matched no packages
2022/09/27 21:57:07 [INFO] Writing main module: /tmp/buildenv_2022-09-27-2157.167526117/main.go
2022/09/27 21:57:07 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod edit -require go.k6.io/k6@v0.40.0

2022/09/27 21:57:07 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod tidy -compat=1.17
go: downloading golang.org/x/net v0.0.0-20220630215102-69896b714898
go: downloading golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
go: downloading google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08
go: downloading github.com/rogpeppe/go-internal v1.6.1
2022/09/27 21:57:09 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod tidy -compat=1.17
2022/09/27 21:57:09 [INFO] Build environment ready
2022/09/27 21:57:09 [INFO] Building k6
2022/09/27 21:57:09 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go mod tidy -compat=1.17
2022/09/27 21:57:09 [INFO] exec (timeout=0s): /home/jklipp/.local/share/aquaproj-aqua/bin/go build -o /home/jklipp/aqua-registry/k6 -ldflags -w -s -trimpath
2022/09/27 21:57:19 [INFO] Build complete: ./k6
2022/09/27 21:57:19 [INFO] Cleaning up temporary folder: /tmp/buildenv_2022-09-27-2157.167526117

xk6 has now produced a new k6 binary which may be different than the command on your system path!
Be sure to run './k6 run <SCRIPT_NAME>' from the '/home/jklipp/aqua-registry' directory.
```

Reference

- [grafana/k6](https://k6.io)