### PR TITLE
fix(kubernetes/kubectl): enable rosetta2 in case of kubectl < v1.21.0

### DIFF
--- a/pkgs/kubernetes-sigs/kustomize/registry.yaml
+++ b/pkgs/kubernetes-sigs/kustomize/registry.yaml
@@ -4,6 +4,14 @@ packages:
     repo_name: kustomize
     description: Customization of kubernetes YAML configurations
     asset: kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_filter: Version startsWith "kustomize/"
     version_constraint: semverWithVersion(">= 4.5.4", trimPrefix(Version, "kustomize/"))
     version_overrides:

--- a/pkgs/kubernetes/kubectl/pkg.yaml
+++ b/pkgs/kubernetes/kubectl/pkg.yaml
@@ -2,3 +2,5 @@ packages:
   - name: kubernetes/kubectl@v1.25.2
   - name: kubernetes/kubectl
     version: v1.22.15
+  - name: kubernetes/kubectl
+    version: v1.20.15

--- a/pkgs/kubernetes/kubectl/registry.yaml
+++ b/pkgs/kubernetes/kubectl/registry.yaml
@@ -23,7 +23,13 @@ packages:
           file_format: raw
     version_constraint: semver(">= 1.23.0")
     version_overrides:
+      - version_constraint: semver(">= 1.21.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
           - darwin
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -9430,6 +9430,14 @@ packages:
     repo_name: kustomize
     description: Customization of kubernetes YAML configurations
     asset: kustomize_{{trimPrefix "kustomize/" .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_filter: Version startsWith "kustomize/"
     version_constraint: semverWithVersion(">= 4.5.4", trimPrefix(Version, "kustomize/"))
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -9509,7 +9509,13 @@ packages:
           file_format: raw
     version_constraint: semver(">= 1.23.0")
     version_overrides:
+      - version_constraint: semver(">= 1.21.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
           - darwin
           - linux


### PR DESCRIPTION
[kubernetes/kubectl](https://github.com/kubernetes/kubectl): Enable `rosetta2` in case of kubectl < v1.21.0
[kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize): Set checksum configuration