### PR TITLE
chore: rename SpectralOps/teller to tellerops/teller

### DIFF
--- a/pkgs/SpectralOps/teller/pkg.yaml
+++ b/pkgs/SpectralOps/teller/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: SpectralOps/teller@v1.5.5

--- a/pkgs/tellerops/teller/pkg.yaml
+++ b/pkgs/tellerops/teller/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tellerops/teller@v1.5.5

--- a/pkgs/tellerops/teller/registry.yaml
+++ b/pkgs/tellerops/teller/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: SpectralOps
+    repo_owner: tellerops
     repo_name: teller
+    aliases:
+      - name: SpectralOps/teller
     description: A secrets management tool for developers built in Go - never leave your command line for secrets
     replacements:
       darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -1080,25 +1080,6 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
-    repo_owner: SpectralOps
-    repo_name: teller
-    description: A secrets management tool for developers built in Go - never leave your command line for secrets
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    asset: teller_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-  - type: github_release
     repo_owner: TaKO8Ki
     repo_name: frum
     asset: frum-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
@@ -14622,6 +14603,27 @@ packages:
         url: https://app.getambassador.io/download/tel2/{{.OS}}/{{.Arch}}/{{trimV .Version}}/telepresence.zip
     files:
       - name: telepresence
+  - type: github_release
+    repo_owner: tellerops
+    repo_name: teller
+    aliases:
+      - name: SpectralOps/teller
+    description: A secrets management tool for developers built in Go - never leave your command line for secrets
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    asset: teller_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: temporalio
     repo_name: tctl


### PR DESCRIPTION
#6638 Rename the package `SpectralOps/teller` to `tellerops/teller`

The repository [SpectralOps/teller](https://github.com/SpectralOps/teller) has been transferred to [tellerops/teller](https://github.com/tellerops/teller).

---

The Organization name had been changed.
https://github.com/SpectralOps/teller to https://github.com/tellerops/teller