### PR TITLE
chore: rename erroneousboat/slack-term to jpbruinsslot/slack-term

### DIFF
--- a/pkgs/erroneousboat/slack-term/pkg.yaml
+++ b/pkgs/erroneousboat/slack-term/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: erroneousboat/slack-term@v0.5.0

--- a/pkgs/jpbruinsslot/slack-term/pkg.yaml
+++ b/pkgs/jpbruinsslot/slack-term/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jpbruinsslot/slack-term@v0.5.0

--- a/pkgs/jpbruinsslot/slack-term/registry.yaml
+++ b/pkgs/jpbruinsslot/slack-term/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: erroneousboat
+    repo_owner: jpbruinsslot
     repo_name: slack-term
+    aliases:
+      - name: erroneousboat/slack-term
     asset: slack-term-{{.OS}}-amd64
     rosetta2: true
     description: Slack client for your terminal

--- a/registry.yaml
+++ b/registry.yaml
@@ -5298,15 +5298,6 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
-    repo_owner: erroneousboat
-    repo_name: slack-term
-    asset: slack-term-{{.OS}}-amd64
-    rosetta2: true
-    description: Slack client for your terminal
-    supported_envs:
-      - darwin
-      - linux/amd64
-  - type: github_release
     repo_owner: estesp
     repo_name: manifest-tool
     description: Command line tool to create and query container image manifest list/indexes
@@ -8537,6 +8528,17 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: jpbruinsslot
+    repo_name: slack-term
+    aliases:
+      - name: erroneousboat/slack-term
+    asset: slack-term-{{.OS}}-amd64
+    rosetta2: true
+    description: Slack client for your terminal
+    supported_envs:
+      - darwin
+      - linux/amd64
   - type: github_release
     repo_owner: jpillora
     repo_name: chisel


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6639 Rename the package `erroneousboat/slack-term` to `jpbruinsslot/slack-term`

The repository [erroneousboat/slack-term](https://github.com/erroneousboat/slack-term) has been transferred to [jpbruinsslot/slack-term](https://github.com/jpbruinsslot/slack-term).