### PR TITLE
feat: add mashiike/stefunny

### DIFF
--- a/pkgs/mashiike/stefunny/pkg.yaml
+++ b/pkgs/mashiike/stefunny/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mashiike/stefunny@v0.4.3

--- a/pkgs/mashiike/stefunny/registry.yaml
+++ b/pkgs/mashiike/stefunny/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: mashiike
     repo_name: stefunny
+    description: stefunny is a deployment tool for AWS StepFunctions state machine and the accompanying AWS EventBridge rule
     asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     checksum:
       type: github_release

--- a/pkgs/mashiike/stefunny/registry.yaml
+++ b/pkgs/mashiike/stefunny/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: mashiike
+    repo_name: stefunny
+    asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -10245,6 +10245,18 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: mashiike
+    repo_name: stefunny
+    asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: mathew-fleisch
     repo_name: bashbot
     asset: bashbot-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -10247,6 +10247,7 @@ packages:
   - type: github_release
     repo_owner: mashiike
     repo_name: stefunny
+    description: stefunny is a deployment tool for AWS StepFunctions state machine and the accompanying AWS EventBridge rule
     asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     checksum:
       type: github_release


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6673 [mashiike/stefunny](https://github.com/mashiike/stefunny): stefunny is a deployment tool for AWS StepFunctions state machine and the accompanying AWS EventBridge rule

```console
$ aqua g -i mashiike/stefunny
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ stefunny --help
NAME:
   stefunny - A command line tool for deployment StepFunctions and EventBridge

USAGE:
   stefunny [global options] command [command options] [arguments...]

VERSION:
   v0.4.3

COMMANDS:
   create    create StepFunctions StateMachine.
   delete    delete StepFunctions StateMachine.
   deploy    deploy StepFunctions StateMachine and Event Bridge Rule.
   execute   execute state machine
   init      Initialize stefunny from an existing StateMachine
   render    render state machine definition(the Amazon States Language) as a dot file
   schedule  schedule Bridge Rule without deploy StepFunctions StateMachine.
   version   show version info.
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config FILE, -c FILE  Load configuration from FILE (default: config.yaml) [$STEFUNNY_CONFIG]
   --ext-code value        external code values for Jsonnet
   --ext-str value         external string values for Jsonnet
   --log-level value       Set log level (debug, info, notice, warn, error) (default: info) [$STEFUNNY_LOG_LEVEL]
   --tfstate value         URL to terraform.tfstate referenced in config [$STEFUNNY_TFSTATE]
   --help, -h              show help (default: false)
   --version, -v           print the version (default: false)
```

If files such as configuration file are needed, please share them.

```
$ stefunny init --config config.yml --state-machine hoge-hoge
2022/09/30 17:02:28 [notice] StateMachine/hoge-hoge save state machine definition to definition.jsonnet
2022/09/30 17:02:28 [notice] StateMachine/hoge-hoge save config to config.yml

$ cat config.yml
required_version: '>=v0.4.3'
state_machine:
    name: hoge-hoge
    type: STANDARD
...
```

Reference

- README.md
	- https://github.com/mashiike/stefunny/blob/main/README.md