### PR TITLE
chore: rename google/ko to ko-build/ko

### DIFF
--- a/pkgs/google/ko/pkg.yaml
+++ b/pkgs/google/ko/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: google/ko@v0.12.0

--- a/pkgs/ko-build/ko/pkg.yaml
+++ b/pkgs/ko-build/ko/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ko-build/ko@v0.12.0

--- a/pkgs/ko-build/ko/registry.yaml
+++ b/pkgs/ko-build/ko/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: google
+    repo_owner: ko-build
     repo_name: ko
+    aliases:
+      - name: google/ko
     asset: ko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Build and deploy Go applications on Kubernetes
     replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -6633,25 +6633,6 @@ packages:
       - name: jsonnetfmt
   - type: github_release
     repo_owner: google
-    repo_name: ko
-    asset: ko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: Build and deploy Go applications on Kubernetes
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-  - type: github_release
-    repo_owner: google
     repo_name: mtail
     asset: mtail_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: extract internal monitoring data from application logs for collection in a timeseries database
@@ -9123,6 +9104,27 @@ packages:
     checksum:
       type: github_release
       asset: utern_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: ko-build
+    repo_name: ko
+    aliases:
+      - name: google/ko
+    asset: ko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Build and deploy Go applications on Kubernetes
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6674 Rename the package `google/ko` to `ko-build/ko`

The repository [google/ko](https://github.com/google/ko) has been transferred to [ko-build/ko](https://github.com/ko-build/ko).