### PR TITLE
feat: add kevincobain2000/gobrew

### DIFF
--- a/pkgs/kevincobain2000/gobrew/pkg.yaml
+++ b/pkgs/kevincobain2000/gobrew/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kevincobain2000/gobrew@v1.7.1

--- a/pkgs/kevincobain2000/gobrew/registry.yaml
+++ b/pkgs/kevincobain2000/gobrew/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: kevincobain2000
+    repo_name: gobrew
+    asset: gobrew-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Go version manager. Super simple tool to install and manage Go versions. Install go without root. Gobrew doesn't require shell rehash
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: gobrew_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -9001,6 +9001,24 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: kevincobain2000
+    repo_name: gobrew
+    asset: gobrew-{{.OS}}-{{.Arch}}
+    format: raw
+    description: Go version manager. Super simple tool to install and manage Go versions. Install go without root. Gobrew doesn't require shell rehash
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: gobrew_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kevwan
     repo_name: depu
     asset: depu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[kevincobain2000/gobrew](https://github.com/kevincobain2000/gobrew): Go version manager. Super simple tool to install and manage Go versions. Install go without root. Gobrew doesn't require shell rehash

```console
$ aqua g -i kevincobain2000/gobrew
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ 
```

If files such as configuration file are needed, please share them.

```
```

Reference

-
