### PR TITLE
feat: add kcp-dev/kcp

### DIFF
--- a/pkgs/kcp-dev/kcp/kubectl-kcp/pkg.yaml
+++ b/pkgs/kcp-dev/kcp/kubectl-kcp/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kcp-dev/kcp/kubectl-kcp@v0.8.2

--- a/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
+++ b/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
@@ -13,12 +13,3 @@ packages:
         src: bin/kubectl-workspaces
     format: tar.gz
     description: kubectl plugins for kcp
-    overrides:
-      - goos: windows
-        files:
-          - name: kubectl-kcp.exe
-            src: bin/kubectl-kcp.exe
-          - name: kubectl-ws.exe
-            src: bin/kubectl-ws.exe
-          - name: kubectl-workspaces.exe
-            src: bin/kubectl-workspaces.exe

--- a/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
+++ b/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - name: kcp-dev/kcp/kubectl-kcp
+    type: github_release
+    repo_owner: kcp-dev
+    repo_name: kcp
+    asset: kubectl-kcp-plugin_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: kubectl-kcp
+        src: bin/kubectl-kcp
+      - name: kubectl-ws
+        src: bin/kubectl-ws
+      - name: kubectl-workspaces
+        src: bin/kubectl-workspaces
+    format: tar.gz
+    description: kubectl plugins for kcp
+    overrides:
+      - goos: windows
+        files:
+          - name: kubectl-kcp.exe
+            src: bin/kubectl-kcp.exe
+          - name: kubectl-ws.exe
+            src: bin/kubectl-ws.exe
+          - name: kubectl-workspaces.exe
+            src: bin/kubectl-workspaces.exe
+    supported_envs:
+      - darwin
+      - linux
+      - windows

--- a/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
+++ b/pkgs/kcp-dev/kcp/kubectl-kcp/registry.yaml
@@ -22,7 +22,3 @@ packages:
             src: bin/kubectl-ws.exe
           - name: kubectl-workspaces.exe
             src: bin/kubectl-workspaces.exe
-    supported_envs:
-      - darwin
-      - linux
-      - windows

--- a/pkgs/kcp-dev/kcp/pkg.yaml
+++ b/pkgs/kcp-dev/kcp/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kcp-dev/kcp@v0.8.2

--- a/pkgs/kcp-dev/kcp/registry.yaml
+++ b/pkgs/kcp-dev/kcp/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: kcp-dev
+    repo_name: kcp
+    asset: kcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: kcp
+        src: bin/kcp
+    format: tar.gz
+    description: kcp is a Kubernetes-like control plane for workloads on many clusters
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: github_release
+      asset: kcp_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -8973,6 +8973,26 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: kcp-dev
+    repo_name: kcp
+    asset: kcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: kcp
+        src: /bin/kcp
+    format: tar.gz
+    description: kcp is a Kubernetes-like control plane for workloads on many clusters
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: github_release
+      asset: kcp_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_content
     repo_owner: kdabir
     repo_name: has

--- a/registry.yaml
+++ b/registry.yaml
@@ -9007,15 +9007,6 @@ packages:
         src: bin/kubectl-workspaces
     format: tar.gz
     description: kubectl plugins for kcp
-    overrides:
-      - goos: windows
-        files:
-          - name: kubectl-kcp.exe
-            src: bin/kubectl-kcp.exe
-          - name: kubectl-ws.exe
-            src: bin/kubectl-ws.exe
-          - name: kubectl-workspaces.exe
-            src: bin/kubectl-workspaces.exe
   - type: github_content
     repo_owner: kdabir
     repo_name: has

--- a/registry.yaml
+++ b/registry.yaml
@@ -9016,10 +9016,6 @@ packages:
             src: bin/kubectl-ws.exe
           - name: kubectl-workspaces.exe
             src: bin/kubectl-workspaces.exe
-    supported_envs:
-      - darwin
-      - linux
-      - windows
   - type: github_content
     repo_owner: kdabir
     repo_name: has

--- a/registry.yaml
+++ b/registry.yaml
@@ -8979,7 +8979,7 @@ packages:
     asset: kcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     files:
       - name: kcp
-        src: /bin/kcp
+        src: bin/kcp
     format: tar.gz
     description: kcp is a Kubernetes-like control plane for workloads on many clusters
     supported_envs:
@@ -8993,6 +8993,33 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - name: kcp-dev/kcp/kubectl-kcp
+    type: github_release
+    repo_owner: kcp-dev
+    repo_name: kcp
+    asset: kubectl-kcp-plugin_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: kubectl-kcp
+        src: bin/kubectl-kcp
+      - name: kubectl-ws
+        src: bin/kubectl-ws
+      - name: kubectl-workspaces
+        src: bin/kubectl-workspaces
+    format: tar.gz
+    description: kubectl plugins for kcp
+    overrides:
+      - goos: windows
+        files:
+          - name: kubectl-kcp.exe
+            src: bin/kubectl-kcp.exe
+          - name: kubectl-ws.exe
+            src: bin/kubectl-ws.exe
+          - name: kubectl-workspaces.exe
+            src: bin/kubectl-workspaces.exe
+    supported_envs:
+      - darwin
+      - linux
+      - windows
   - type: github_content
     repo_owner: kdabir
     repo_name: has


### PR DESCRIPTION
[kcp-dev/kcp](https://github.com/kcp-dev/kcp): kcp is a Kubernetes-like control plane for workloads on many clusters

```console
$ aqua g -i kcp-dev/kcp
$ aqua g -i kcp-dev/kcp/kubectl-kcp
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kcp -h
KCP is the easiest way to manage Kubernetes applications against one or more clusters, by giving you a personal control plane that schedules your workloads onto one or many clusters, and making it simple to pick up and move. Advanced use cases
including spreading your apps across clusters for resiliency, scheduling batch workloads onto clusters with free capacity, and enabling collaboration for individual teams without having access to the underlying clusters.

To get started, launch a new cluster with 'kcp start', which will initialize your personal control plane and write an admin kubeconfig file to disk.

Usage:
  kcp [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  start       Start the control plane process

Flags:
      --add-dir-header                   If true, adds the file directory to the header of the log messages (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-
klog-specific-flags-in-k8s-components)
      --alsologtostderr                  log to standard error as well as files (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-
components)
  -h, --help                             help for kcp
      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0) (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-
specific-flags-in-k8s-components)
      --log-dir string                   If non-empty, write log files in this directory (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-
k8s-components)
      --log-file string                  If non-empty, use this log file (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components)
      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800) (DEPRECATED: will be removed in a future release, see
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components)
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --logtostderr                      log to standard error instead of files (default true) (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-
flags-in-k8s-components)
      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level) (DEPRECATED: will be removed in a future release, see
https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components)
      --skip-headers                     If true, avoid header prefixes in the log messages (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-
in-k8s-components)
      --skip-log-headers                 If true, avoid headers when opening log files (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-
components)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2) (DEPRECATED: will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-
specific-flags-in-k8s-components)
  -v, --v Level                          number for the log level verbosity
      --version                          version for kcp
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "kcp [command] --help" for more information about a command.
```

```console
$ kubectl kcp -h
KCP is the easiest way to manage Kubernetes applications against one or more clusters, by giving you a personal control plane that schedules your workloads onto one or many clusters, and making it simple to pick up and move. Advanced use cases including spreading your apps across clusters for resiliency, scheduling batch workloads onto clusters with free capacity, and enabling collaboration for individual teams without having access to the underlying clusters.

This command provides KCP specific sub-command for kubectl.

Usage:
  kcp [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  crd         CRD related operations
  help        Help about any command
  workload    Manages KCP sync targets
  workspace   Manages KCP workspaces

Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for kcp
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity
      --version                          version for kcp
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "kcp [command] --help" for more information about a command.
```
