### PR TITLE
fix(shipyard-run/shipyard): fix checksum config

### DIFF
--- a/pkgs/shipyard-run/shipyard/pkg.yaml
+++ b/pkgs/shipyard-run/shipyard/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: shipyard-run/shipyard@v0.4.10
+  - name: shipyard-run/shipyard
+    version: v0.3.18

--- a/pkgs/shipyard-run/shipyard/registry.yaml
+++ b/pkgs/shipyard-run/shipyard/registry.yaml
@@ -5,8 +5,6 @@ packages:
     asset: shipyard_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     description: Modern cloud native development environments
-    replacements:
-      amd64: x86_64
     overrides:
       - goos: linux
         format: tar.gz
@@ -14,11 +12,23 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.20")
     checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      enabled: false
+    replacements:
+      amd64: x86_64
+    version_overrides:
+      - version_constraint: "true"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/shipyard-run/shipyard/registry.yaml
+++ b/pkgs/shipyard-run/shipyard/registry.yaml
@@ -14,6 +14,9 @@ packages:
       - amd64
     version_constraint: semver(">= 0.3.20")
     checksum:
+      # In addition to https://github.com/shipyard-run/shipyard/issues/181,
+      # the checksum of shipyard_0.3.18_Darwin_arm64.zip in checksums.txt is wrong.
+      # We couldn't trust this package's checksums.txt, so we disable the checksum verification.
       enabled: false
     replacements:
       amd64: x86_64
@@ -24,11 +27,3 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          file_format: regexp
-          algorithm: sha256
-          pattern:
-            checksum: ^(\b[A-Fa-f0-9]{64}\b)
-            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13704,8 +13704,6 @@ packages:
     asset: shipyard_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     description: Modern cloud native development environments
-    replacements:
-      amd64: x86_64
     overrides:
       - goos: linux
         format: tar.gz
@@ -13713,14 +13711,26 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.20")
     checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      enabled: false
+    replacements:
+      amd64: x86_64
+    version_overrides:
+      - version_constraint: "true"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: showwin
     repo_name: speedtest-go

--- a/registry.yaml
+++ b/registry.yaml
@@ -13713,6 +13713,9 @@ packages:
       - amd64
     version_constraint: semver(">= 0.3.20")
     checksum:
+      # In addition to https://github.com/shipyard-run/shipyard/issues/181,
+      # the checksum of shipyard_0.3.18_Darwin_arm64.zip in checksums.txt is wrong.
+      # We couldn't trust this package's checksums.txt, so we disable the checksum verification.
       enabled: false
     replacements:
       amd64: x86_64
@@ -13723,14 +13726,6 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          file_format: regexp
-          algorithm: sha256
-          pattern:
-            checksum: ^(\b[A-Fa-f0-9]{64}\b)
-            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: showwin
     repo_name: speedtest-go


### PR DESCRIPTION
In addition to https://github.com/shipyard-run/shipyard/issues/181,
the checksum of shipyard_0.3.18_Darwin_arm64.zip in checksums.txt is wrong.
We can't trust this package's checksums.txt, so we disable the checksum verification.