### PR TITLE
feat: add fullstorydev/grpcui

### DIFF
--- a/pkgs/fullstorydev/grpcui/pkg.yaml
+++ b/pkgs/fullstorydev/grpcui/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fullstorydev/grpcui@v1.3.1

--- a/pkgs/fullstorydev/grpcui/registry.yaml
+++ b/pkgs/fullstorydev/grpcui/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: fullstorydev
+    repo_name: grpcui
+    asset: grpcui_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: An interactive web UI for gRPC, along the lines of postman
+    replacements:
+      amd64: x86_64
+      darwin: osx
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: grpcui_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5800,6 +5800,30 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: fullstorydev
+    repo_name: grpcui
+    asset: grpcui_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: An interactive web UI for gRPC, along the lines of postman
+    replacements:
+      amd64: x86_64
+      darwin: osx
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: grpcui_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: fullstorydev
     repo_name: grpcurl
     description: "Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers"
     supported_envs:


### PR DESCRIPTION
[fullstorydev/grpcui](https://github.com/fullstorydev/grpcui): An interactive web UI for gRPC, along the lines of postman

```console
$ aqua g -i fullstorydev/grpcui
```

## How to confirm if this package works well

gRPC UI can be tested by retrieving a Hello World proto and having grpcui connect to a test service at `grpcb.in:9001`:

```console
$ wget -q https://raw.githubusercontent.com/moul/pb/master/hello/hello.proto
$ grpcui -proto hello.proto grpcb.in:9001
gRPC Web UI available at http://127.0.0.1:35405/
```

Browsing to grpcui at the given address will let you interact with the program and send grpc requests based on the proto to the test host.

Reference

- 
