### PR TITLE
fix(oam-dev): rename oam-dev/kubevela and oam-dev/kubevela/kubectl-plugin

### DIFF
--- a/pkgs/kubevela/kubevela/kubectl-plugin/pkg.yaml
+++ b/pkgs/kubevela/kubevela/kubectl-plugin/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: kubevela/kubevela/kubectl-plugin@v1.5.6
+  - name: kubevela/kubevela/kubectl-plugin
+    version: v1.1.13

--- a/pkgs/kubevela/kubevela/kubectl-plugin/registry.yaml
+++ b/pkgs/kubevela/kubevela/kubectl-plugin/registry.yaml
@@ -1,8 +1,10 @@
 packages:
-  - name: oam-dev/kubevela/kubectl-plugin
+  - name: kubevela/kubevela/kubectl-plugin
     type: github_release
-    repo_owner: oam-dev
+    repo_owner: kubevela
     repo_name: kubevela
+    aliases:
+      - name: oam-dev/kubevela/kubectl-plugin
     description: The Modern Application Deployment System Based on OAM
     complete_windows_ext: false
     supported_envs:

--- a/pkgs/kubevela/kubevela/kubectl-plugin/registry.yaml
+++ b/pkgs/kubevela/kubevela/kubectl-plugin/registry.yaml
@@ -25,10 +25,5 @@ packages:
           - darwin
           - amd64
     checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # https://github.com/kubevela/kubevela/issues/4822
+      enabled: false

--- a/pkgs/kubevela/kubevela/pkg.yaml
+++ b/pkgs/kubevela/kubevela/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: kubevela/kubevela@v1.5.6
+  - name: kubevela/kubevela
+    version: v1.1.13

--- a/pkgs/kubevela/kubevela/registry.yaml
+++ b/pkgs/kubevela/kubevela/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: oam-dev
+    repo_owner: kubevela
     repo_name: kubevela
+    aliases:
+      - name: oam-dev/kubevela
     description: The Modern Application Deployment System Based on OAM
     complete_windows_ext: false
     supported_envs:

--- a/pkgs/kubevela/kubevela/registry.yaml
+++ b/pkgs/kubevela/kubevela/registry.yaml
@@ -24,10 +24,5 @@ packages:
           - darwin
           - amd64
     checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # https://github.com/kubevela/kubevela/issues/4822
+      enabled: false

--- a/pkgs/oam-dev/kubevela/kubectl-plugin/pkg.yaml
+++ b/pkgs/oam-dev/kubevela/kubectl-plugin/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: oam-dev/kubevela/kubectl-plugin@v1.5.6
-  - name: oam-dev/kubevela/kubectl-plugin
-    version: v1.1.13

--- a/pkgs/oam-dev/kubevela/pkg.yaml
+++ b/pkgs/oam-dev/kubevela/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: oam-dev/kubevela@v1.5.6
-  - name: oam-dev/kubevela
-    version: v1.1.13

--- a/registry.yaml
+++ b/registry.yaml
@@ -9811,13 +9811,8 @@ packages:
           - darwin
           - amd64
     checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # https://github.com/kubevela/kubevela/issues/4822
+      enabled: false
   - name: kubevela/kubevela/kubectl-plugin
     type: github_release
     repo_owner: kubevela
@@ -9844,13 +9839,8 @@ packages:
           - darwin
           - amd64
     checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # https://github.com/kubevela/kubevela/issues/4822
+      enabled: false
   - type: github_release
     repo_owner: kudobuilder
     repo_name: kuttl

--- a/registry.yaml
+++ b/registry.yaml
@@ -9787,6 +9787,71 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: kubevela
+    repo_name: kubevela
+    aliases:
+      - name: oam-dev/kubevela
+    description: The Modern Application Deployment System Based on OAM
+    complete_windows_ext: false
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    files:
+      - name: vela
+        src: "{{.OS}}-{{.Arch}}/vela"
+    version_constraint: semver(">= 1.2.0")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        complete_windows_ext: true
+        asset: vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - name: kubevela/kubevela/kubectl-plugin
+    type: github_release
+    repo_owner: kubevela
+    repo_name: kubevela
+    aliases:
+      - name: oam-dev/kubevela/kubectl-plugin
+    description: The Modern Application Deployment System Based on OAM
+    complete_windows_ext: false
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: kubectl-vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    files:
+      - name: kubectl-vela
+        src: "{{.OS}}-{{.Arch}}/kubectl-vela"
+    version_constraint: semver(">= 1.2.0")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        complete_windows_ext: true
+        asset: kubectl-vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kudobuilder
     repo_name: kuttl
     description: KUbernetes Test TooL (kuttl)
@@ -11478,67 +11543,6 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-  - type: github_release
-    repo_owner: oam-dev
-    repo_name: kubevela
-    description: The Modern Application Deployment System Based on OAM
-    complete_windows_ext: false
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-    files:
-      - name: vela
-        src: "{{.OS}}-{{.Arch}}/vela"
-    version_constraint: semver(">= 1.2.0")
-    version_overrides:
-      - version_constraint: "true"
-        rosetta2: true
-        complete_windows_ext: true
-        asset: vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-        supported_envs:
-          - darwin
-          - amd64
-    checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-  - name: oam-dev/kubevela/kubectl-plugin
-    type: github_release
-    repo_owner: oam-dev
-    repo_name: kubevela
-    description: The Modern Application Deployment System Based on OAM
-    complete_windows_ext: false
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: kubectl-vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-    files:
-      - name: kubectl-vela
-        src: "{{.OS}}-{{.Arch}}/kubectl-vela"
-    version_constraint: semver(">= 1.2.0")
-    version_overrides:
-      - version_constraint: "true"
-        rosetta2: true
-        complete_windows_ext: true
-        asset: kubectl-vela-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
-        supported_envs:
-          - darwin
-          - amd64
-    checksum:
-      type: github_release
-      asset: sha256sums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: ogham
     repo_name: dog


### PR DESCRIPTION
The repository oam-dev/kubevela was transferred to kubevela/kubevela.

fix(kubevela/kubevela): disable checksum 

https://github.com/kubevela/kubevela/issues/4822