### PR TITLE
fix(zellij-org/zellij): disable checksum

### DIFF
--- a/pkgs/zellij-org/zellij/registry.yaml
+++ b/pkgs/zellij-org/zellij/registry.yaml
@@ -13,10 +13,4 @@ packages:
       amd64: x86_64
       arm64: aarch64
     checksum:
-      type: github_release
-      asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776

--- a/registry.yaml
+++ b/registry.yaml
@@ -16238,13 +16238,7 @@ packages:
       amd64: x86_64
       arm64: aarch64
     checksum:
-      type: github_release
-      asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776
   - type: http
     name: ziglang/zig
     description: General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software


### PR DESCRIPTION
The checksum in the checksum file is not the checksum of tarball but the checksum of the executable binary in tarball. aqua doesn't support such a case at the moment.

https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776

```console
$ cat zellij-aarch64-apple-darwin.sha256sum 
97acef95ea7d9af2d605adf7947e47aa1130205a4d7b9f61e0c066076fb84a62  zellij

$ sha256sum zellij-aarch64-apple-darwin.tar.gz
620d754f96c40f0227ddff69ef212068a9a5ce62868bc79cdb6d671f6d519fa0  zellij-aarch64-apple-darwin.tar.gz

$ tar xvzf zellij-aarch64-apple-darwin.tar.gz 
x zellij

$ sha256sum zellij
97acef95ea7d9af2d605adf7947e47aa1130205a4d7b9f61e0c066076fb84a62  zellij
```