### PR TITLE
fix(inlets/inletsctl): disable checksum

### DIFF
--- a/pkgs/inlets/inletsctl/registry.yaml
+++ b/pkgs/inlets/inletsctl/registry.yaml
@@ -16,10 +16,6 @@ packages:
           - name: inletsctl
             src: inletsctl-arm64
     checksum:
-      type: github_release
-      asset: inletsctl.sha256
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # The checksum in the checksum file is not the checksum of tarball but the checksum of the executable binary in tarball.
+      # aqua doesn't support such a case at the moment.
+      enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -7887,13 +7887,9 @@ packages:
           - name: inletsctl
             src: inletsctl-arm64
     checksum:
-      type: github_release
-      asset: inletsctl.sha256
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      # The checksum in the checksum file is not the checksum of tarball but the checksum of the executable binary in tarball.
+      # aqua doesn't support such a case at the moment.
+      enabled: false
   - type: github_release
     repo_owner: inlets
     repo_name: mixctl


### PR DESCRIPTION
The checksum in the checksum file is not the checksum of tarball but the checksum of the executable binary in tarball. aqua doesn't support such a case at the moment.

```console
$ cat inletsctl-darwin-arm64.sha256 
58375245c4683a8ec33013ed105353204241a14a94cd997d50570e27b3eb7227  inletsctl-darwin-arm64

$ sha256sum inletsctl-darwin-arm64.tgz
6b07b8af34a2286d0a2b42b717e66226627524392f3feea4bc1c320b4f53f921  inletsctl-darwin-arm64.tgz

$ tar xvzf inletsctl-darwin-arm64.tgz 
x inletsctl-darwin-arm64

$ sha256sum inletsctl-darwin-arm64
58375245c4683a8ec33013ed105353204241a14a94cd997d50570e27b3eb7227  inletsctl-darwin-arm64
```