### PR TITLE
feat: add grpc-ecosystem/grpc-health-probe

### DIFF
--- a/pkgs/grpc-ecosystem/grpc-health-probe/pkg.yaml
+++ b/pkgs/grpc-ecosystem/grpc-health-probe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grpc-ecosystem/grpc-health-probe@v0.4.13

--- a/pkgs/grpc-ecosystem/grpc-health-probe/registry.yaml
+++ b/pkgs/grpc-ecosystem/grpc-health-probe/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: grpc-ecosystem
+    repo_name: grpc-health-probe
+    asset: grpc_health_probe-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A command-line tool to perform health-checks for gRPC applications in Kubernetes etc
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: grpc_health_probe
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -7016,6 +7016,25 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: grpc-ecosystem
+    repo_name: grpc-health-probe
+    asset: grpc_health_probe-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A command-line tool to perform health-checks for gRPC applications in Kubernetes etc
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: grpc_health_probe
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - name: grpc/grpc-go/protoc-gen-go-grpc
     type: github_release
     repo_owner: grpc


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6846 [grpc-ecosystem/grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe): A command-line tool to perform health-checks for gRPC applications in Kubernetes etc

```console
$ aqua g -i grpc-ecosystem/grpc-health-probe
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ grpc_health_probe -help
Usage:
  -addr string
        (required) tcp host:port to connect
  -alts
        use ALTS (default: false, INSECURE plaintext transport)
  -connect-timeout duration
        timeout for establishing connection (default 1s)
  -gzip
        use GZIPCompressor for requests and GZIPDecompressor for response (default: false)
  -rpc-header value
        additional RPC headers in 'name: value' format. May specify more than one via multiple flags.
  -rpc-timeout duration
        timeout for health check rpc (default 1s)
  -service string
        service name to check (default: "")
  -spiffe
        use SPIFFE to obtain mTLS credentials
  -tls
        use TLS (default: false, INSECURE plaintext transport)
  -tls-ca-cert string
        (with -tls, optional) file containing trusted certificates for verifying server
  -tls-client-cert string
        (with -tls, optional) client certificate for authenticating to the server (requires -tls-client-key)
  -tls-client-key string
        (with -tls) client private key for authenticating to the server (requires -tls-client-cert)
  -tls-no-verify
        (with -tls) don't verify the certificate (INSECURE) presented by the server (default: false)
  -tls-server-name string
        (with -tls) override the hostname used to verify the server certificate
  -user-agent string
        user-agent header value of health check requests (default "grpc_health_probe")
  -v    verbose logs
```

If files such as configuration file are needed, please share them.

```
$ grpc_health_probe -addr=localhost:5000
healthy: SERVING
```

Reference

- README.md
	- https://github.com/grpc-ecosystem/grpc-health-probe/blob/master/README.md

---

close: https://github.com/aquaproj/aqua-registry/issues/1017