### PR TITLE
feat: add hashicorp/packer-plugin-sdk/packer-sdc

### DIFF
--- a/pkgs/hashicorp/packer-plugin-sdk/packer-sdc/pkg.yaml
+++ b/pkgs/hashicorp/packer-plugin-sdk/packer-sdc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hashicorp/packer-plugin-sdk/packer-sdc@v0.3.2

--- a/pkgs/hashicorp/packer-plugin-sdk/packer-sdc/registry.yaml
+++ b/pkgs/hashicorp/packer-plugin-sdk/packer-sdc/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: hashicorp/packer-plugin-sdk/packer-sdc
+    type: go_install
+    path: github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc
+    repo_owner: hashicorp
+    repo_name: packer-plugin-sdk
+    description: The packer software development command is meant for plugin maintainers and Packer maintainers, it helps generate docs and code
+    files:
+      - name: packer-sdc

--- a/registry.yaml
+++ b/registry.yaml
@@ -7278,6 +7278,14 @@ packages:
       - darwin
       - linux
       - amd64
+  - name: hashicorp/packer-plugin-sdk/packer-sdc
+    type: go_install
+    path: github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc
+    repo_owner: hashicorp
+    repo_name: packer-plugin-sdk
+    description: The packer software development command is meant for plugin maintainers and Packer maintainers, it helps generate docs and code
+    files:
+      - name: packer-sdc
   - type: http
     repo_owner: hashicorp
     repo_name: terraform


### PR DESCRIPTION
[hashicorp/packer-plugin-sdk/packer-sdc](https://github.com/hashicorp/packer-plugin-sdk): The packer software development command is meant for plugin maintainers and Packer maintainers, it helps generate docs and code

```console
$ aqua g -i hashicorp/packer-plugin-sdk/packer-sdc
```
