### PR TITLE
fix(pivotal-cf/om): support 7.8.0

### DIFF
--- a/pkgs/pivotal-cf/om/pkg.yaml
+++ b/pkgs/pivotal-cf/om/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: pivotal-cf/om@7.7.0
+  - name: pivotal-cf/om@7.8.0
+  - name: pivotal-cf/om
+    version: 7.7.0

--- a/pkgs/pivotal-cf/om/registry.yaml
+++ b/pkgs/pivotal-cf/om/registry.yaml
@@ -2,12 +2,6 @@ packages:
   - type: github_release
     repo_owner: pivotal-cf
     repo_name: om
-    asset: om-{{.OS}}-{{trimV .Version}}.{{.Format}}
-    supported_envs:
-      - windows
-      - darwin
-      - linux/amd64
-    rosetta2: true
     description: General command line utility for working with VMware Tanzu Operations Manager
     format: tar.gz
     overrides:
@@ -21,3 +15,16 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 7.8.0")
+    supported_envs:
+      - amd64
+      - darwin
+      - linux
+    asset: om-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - amd64
+          - darwin
+        asset: om-{{.OS}}-{{trimV .Version}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -12226,12 +12226,6 @@ packages:
   - type: github_release
     repo_owner: pivotal-cf
     repo_name: om
-    asset: om-{{.OS}}-{{trimV .Version}}.{{.Format}}
-    supported_envs:
-      - windows
-      - darwin
-      - linux/amd64
-    rosetta2: true
     description: General command line utility for working with VMware Tanzu Operations Manager
     format: tar.gz
     overrides:
@@ -12245,6 +12239,19 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 7.8.0")
+    supported_envs:
+      - amd64
+      - darwin
+      - linux
+    asset: om-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - amd64
+          - darwin
+        asset: om-{{.OS}}-{{trimV .Version}}.{{.Format}}
   - type: github_release
     repo_owner: pivotal-cf
     repo_name: pivnet-cli


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6989

https://github.com/pivotal-cf/om

Asset name was changed.

- https://github.com/pivotal-cf/om/releases/tag/7.8.0 : [om-darwin-amd64-7.8.0.tar.gz](https://github.com/pivotal-cf/om/releases/download/7.8.0/om-darwin-amd64-7.8.0.tar.gz)
- https://github.com/pivotal-cf/om/releases/tag/7.7.0 : [om-darwin-7.7.0.tar.gz](https://github.com/pivotal-cf/om/releases/download/7.7.0/om-darwin-7.7.0.tar.gz)