### PR TITLE
fix(bep/s3deploy): support v2.9.0

### DIFF
--- a/pkgs/bep/s3deploy/pkg.yaml
+++ b/pkgs/bep/s3deploy/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: bep/s3deploy@v2.8.1
+  - name: bep/s3deploy@v2.9.0
+  - name: bep/s3deploy
+    version: v2.8.1

--- a/pkgs/bep/s3deploy/registry.yaml
+++ b/pkgs/bep/s3deploy/registry.yaml
@@ -2,15 +2,9 @@ packages:
   - type: github_release
     repo_owner: bep
     repo_name: s3deploy
-    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
     description: A simple tool to deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. "Cache-Control")
-    replacements:
-      amd64: 64bit
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
+    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     overrides:
       - goos: windows
         format: zip
@@ -22,3 +16,16 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver("> 2.9.0")
+    version_overrides:
+      - version_constraint: semver("= 2.9.0")
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: "true"
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -2782,15 +2782,9 @@ packages:
   - type: github_release
     repo_owner: bep
     repo_name: s3deploy
-    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
     description: A simple tool to deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. "Cache-Control")
-    replacements:
-      amd64: 64bit
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
+    asset: s3deploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     overrides:
       - goos: windows
         format: zip
@@ -2802,6 +2796,19 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver("> 2.9.0")
+    version_overrides:
+      - version_constraint: semver("= 2.9.0")
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: "true"
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
   - type: github_release
     repo_owner: binwiederhier
     repo_name: ntfy


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/6994#issuecomment-1275977138

[bep/s3deploy](https://github.com/bep/s3deploy): Support  v2.9.0

https://github.com/bep/s3deploy/releases/tag/v2.9.0

> We have ported the release script to [Hugoreleaser](https://github.com/gohugoio/hugoreleaser). This means that the archive names have changed (standardised), but it also means that you get only one unviversal, notarized MacOS PKG archive.

And in v2.9.0 the release workflow doesn't work well.

- https://github.com/bep/s3deploy/issues/312
- https://app.circleci.com/pipelines/github/bep/s3deploy/326/workflows/b11368ca-2548-4592-89d4-3966b00f2940/jobs/160

So Some assets for v2.9.0 weren't released. Only linux/amd64 and windows/amd64 were released.

- https://github.com/bep/s3deploy/releases/tag/v2.9.0
- https://github.com/bep/s3deploy/releases/tag/v2.8.1