### PR TITLE
fix(Aloxaf/silicon): support v0.5.1 in windows

### DIFF
--- a/pkgs/Aloxaf/silicon/pkg.yaml
+++ b/pkgs/Aloxaf/silicon/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: Aloxaf/silicon@v0.4.3
+  - name: Aloxaf/silicon@v0.5.1
+  - name: Aloxaf/silicon
+    version: v0.5.0
+  - name: Aloxaf/silicon
+    version: v0.4.3

--- a/pkgs/Aloxaf/silicon/registry.yaml
+++ b/pkgs/Aloxaf/silicon/registry.yaml
@@ -7,7 +7,7 @@ packages:
     rosetta2: true
     replacements:
       darwin: apple-darwin
-      windows: pc-windows-gnu
+      windows: pc-windows-msvc
       linux: unknown-linux-gnu
       amd64: x86_64
     version_constraint: semver("> 0.5.0")
@@ -20,3 +20,8 @@ packages:
           - darwin
           - linux/amd64
       - version_constraint: "true"
+        replacements:
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+          linux: unknown-linux-gnu
+          amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -35,7 +35,7 @@ packages:
     rosetta2: true
     replacements:
       darwin: apple-darwin
-      windows: pc-windows-gnu
+      windows: pc-windows-msvc
       linux: unknown-linux-gnu
       amd64: x86_64
     version_constraint: semver("> 0.5.0")
@@ -48,6 +48,11 @@ packages:
           - darwin
           - linux/amd64
       - version_constraint: "true"
+        replacements:
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+          linux: unknown-linux-gnu
+          amd64: x86_64
   - type: github_release
     repo_owner: Arriven
     repo_name: db1000n


### PR DESCRIPTION
windows asset was renamed.

* https://github.com/Aloxaf/silicon/releases/tag/v0.5.1
* https://github.com/Aloxaf/silicon/releases/tag/v0.4.3