### PR TITLE
feat: add rootless-containers/rootlesskit

### DIFF
--- a/pkgs/rootless-containers/rootlesskit/pkg.yaml
+++ b/pkgs/rootless-containers/rootlesskit/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rootless-containers/rootlesskit@v1.0.1

--- a/pkgs/rootless-containers/rootlesskit/registry.yaml
+++ b/pkgs/rootless-containers/rootlesskit/registry.yaml
@@ -5,11 +5,10 @@ packages:
     description: Linux-native fakeroot using user namespaces
     asset: rootlesskit-{{.Arch}}.{{.Format}}
     format: tar.gz
-    overrides:
-      - goos: linux
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
     checksum:
       type: github_release
       asset: SHA256SUMS

--- a/pkgs/rootless-containers/rootlesskit/registry.yaml
+++ b/pkgs/rootless-containers/rootlesskit/registry.yaml
@@ -19,3 +19,7 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     supported_envs:
       - linux
+    files:
+    - name: rootlessctl
+    - name: rootlesskit
+    - name: rootlesskit-docker-proxy

--- a/pkgs/rootless-containers/rootlesskit/registry.yaml
+++ b/pkgs/rootless-containers/rootlesskit/registry.yaml
@@ -20,6 +20,6 @@ packages:
     supported_envs:
       - linux
     files:
-    - name: rootlessctl
-    - name: rootlesskit
-    - name: rootlesskit-docker-proxy
+      - name: rootlessctl
+      - name: rootlesskit
+      - name: rootlesskit-docker-proxy

--- a/pkgs/rootless-containers/rootlesskit/registry.yaml
+++ b/pkgs/rootless-containers/rootlesskit/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: rootless-containers
+    repo_name: rootlesskit
+    description: Linux-native fakeroot using user namespaces
+    asset: rootlesskit-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -13085,6 +13085,27 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: rootless-containers
+    repo_name: rootlesskit
+    description: Linux-native fakeroot using user namespaces
+    asset: rootlesskit-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux
+  - type: github_release
     repo_owner: ropnop
     repo_name: kerbrute
     description: A tool to perform Kerberos pre-auth bruteforcing

--- a/registry.yaml
+++ b/registry.yaml
@@ -13105,9 +13105,9 @@ packages:
     supported_envs:
       - linux
     files:
-    - name: rootlessctl
-    - name: rootlesskit
-    - name: rootlesskit-docker-proxy
+      - name: rootlessctl
+      - name: rootlesskit
+      - name: rootlesskit-docker-proxy
   - type: github_release
     repo_owner: ropnop
     repo_name: kerbrute

--- a/registry.yaml
+++ b/registry.yaml
@@ -13104,6 +13104,10 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     supported_envs:
       - linux
+    files:
+    - name: rootlessctl
+    - name: rootlesskit
+    - name: rootlesskit-docker-proxy
   - type: github_release
     repo_owner: ropnop
     repo_name: kerbrute

--- a/registry.yaml
+++ b/registry.yaml
@@ -13090,11 +13090,10 @@ packages:
     description: Linux-native fakeroot using user namespaces
     asset: rootlesskit-{{.Arch}}.{{.Format}}
     format: tar.gz
-    overrides:
-      - goos: linux
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
     checksum:
       type: github_release
       asset: SHA256SUMS


### PR DESCRIPTION
[rootless-containers/rootlesskit](https://github.com/rootless-containers/rootlesskit): Linux-native fakeroot using user namespaces

```console
$ aqua g -i rootless-containers/rootlesskit
```
