### PR TITLE
feat: add rootless-containers/slirp4netns

### DIFF
--- a/pkgs/rootless-containers/slirp4netns/pkg.yaml
+++ b/pkgs/rootless-containers/slirp4netns/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rootless-containers/slirp4netns@v1.2.0

--- a/pkgs/rootless-containers/slirp4netns/registry.yaml
+++ b/pkgs/rootless-containers/slirp4netns/registry.yaml
@@ -5,11 +5,10 @@ packages:
     description: User-mode networking for unprivileged network namespaces
     asset: slirp4netns-{{.Arch}}
     format: raw
-    overrides:
-      - goos: linux
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
     checksum:
       type: github_release
       asset: SHA256SUMS

--- a/pkgs/rootless-containers/slirp4netns/registry.yaml
+++ b/pkgs/rootless-containers/slirp4netns/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: rootless-containers
+    repo_name: slirp4netns
+    description: User-mode networking for unprivileged network namespaces
+    asset: slirp4netns-{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -13090,11 +13090,10 @@ packages:
     description: User-mode networking for unprivileged network namespaces
     asset: slirp4netns-{{.Arch}}
     format: raw
-    overrides:
-      - goos: linux
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
     checksum:
       type: github_release
       asset: SHA256SUMS

--- a/registry.yaml
+++ b/registry.yaml
@@ -13085,6 +13085,27 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: rootless-containers
+    repo_name: slirp4netns
+    description: User-mode networking for unprivileged network namespaces
+    asset: slirp4netns-{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux
+  - type: github_release
     repo_owner: ropnop
     repo_name: kerbrute
     description: A tool to perform Kerberos pre-auth bruteforcing


### PR DESCRIPTION
[rootless-containers/slirp4netns](https://github.com/rootless-containers/slirp4netns): User-mode networking for unprivileged network namespaces

```console
$ aqua g -i rootless-containers/slirp4netns
```
