### PR TITLE
feat: add containers/fuse-overlayfs

### DIFF
--- a/pkgs/containers/fuse-overlayfs/pkg.yaml
+++ b/pkgs/containers/fuse-overlayfs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: containers/fuse-overlayfs@v1.9

--- a/pkgs/containers/fuse-overlayfs/registry.yaml
+++ b/pkgs/containers/fuse-overlayfs/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: containers
+    repo_name: fuse-overlayfs
+    description: An implementation of overlay+shiftfs in FUSE for rootless containers
+    asset: fuse-overlayfs-{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -3961,6 +3961,26 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: containers
+    repo_name: fuse-overlayfs
+    description: An implementation of overlay+shiftfs in FUSE for rootless containers
+    asset: fuse-overlayfs-{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+      arm: armv7l
+      arm64: aarch64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    supported_envs:
+      - linux
+  - type: github_release
     repo_owner: controlplaneio
     repo_name: kubesec
     asset: kubesec_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[containers/fuse-overlayfs](https://github.com/containers/fuse-overlayfs): An implementation of overlay+shiftfs in FUSE for rootless containers

```console
$ aqua g -i containers/fuse-overlayfs
```
