### PR TITLE
feat: add opencontainers/runc

### DIFF
--- a/pkgs/opencontainers/runc/pkg.yaml
+++ b/pkgs/opencontainers/runc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: opencontainers/runc@v1.1.4

--- a/pkgs/opencontainers/runc/registry.yaml
+++ b/pkgs/opencontainers/runc/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: opencontainers
+    repo_name: runc
+    description: CLI tool for spawning and running containers according to the OCI specification
+    asset: runc.{{.Arch}}
+    format: raw
+    supported_envs:
+      - linux
+    checksum:
+      type: github_release
+      asset: runc.sha256sum
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11805,6 +11805,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: opencontainers
+    repo_name: runc
+    description: CLI tool for spawning and running containers according to the OCI specification
+    asset: runc.{{.Arch}}
+    format: raw
+    supported_envs:
+      - linux
+    checksum:
+      type: github_release
+      asset: runc.sha256sum
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: openfaas
     repo_name: faas-cli
     format: raw


### PR DESCRIPTION
[opencontainers/runc](https://github.com/opencontainers/runc): CLI tool for spawning and running containers according to the OCI specification

```console
$ aqua g -i opencontainers/runc
```
