### PR TITLE
feat: add kubernetes/kubectl-convert

### DIFF
--- a/pkgs/kubernetes/kubectl-convert/pkg.yaml
+++ b/pkgs/kubernetes/kubectl-convert/pkg.yaml
@@ -1,0 +1,5 @@
+packages:
+  - name: kubernetes/kubectl-convert@v1.25.3
+  - name: kubernetes/kubectl-convert@v1.24.7
+  - name: kubernetes/kubectl-convert@v1.23.13
+  - name: kubernetes/kubectl-convert@v1.22.15

--- a/pkgs/kubernetes/kubectl-convert/pkg.yaml
+++ b/pkgs/kubernetes/kubectl-convert/pkg.yaml
@@ -1,5 +1,8 @@
 packages:
   - name: kubernetes/kubectl-convert@v1.25.3
-  - name: kubernetes/kubectl-convert@v1.24.7
-  - name: kubernetes/kubectl-convert@v1.23.13
-  - name: kubernetes/kubectl-convert@v1.22.15
+  - name: kubernetes/kubectl-convert
+    version: v1.24.7
+  - name: kubernetes/kubectl-convert
+    version: v1.23.13
+  - name: kubernetes/kubectl-convert
+    version: v1.22.15

--- a/pkgs/kubernetes/kubectl-convert/registry.yaml
+++ b/pkgs/kubernetes/kubectl-convert/registry.yaml
@@ -20,7 +20,7 @@ packages:
           file_format: raw
     version_constraint: semver(">= 1.23.0")
     version_overrides:
-    - version_constraint: semver("< 1.23.0")
+    - version_constraint: "true"
       supported_envs:
         - darwin
         - linux

--- a/pkgs/kubernetes/kubectl-convert/registry.yaml
+++ b/pkgs/kubernetes/kubectl-convert/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - name: kubernetes/kubectl-convert
+    type: http
+    repo_owner: kubernetes
+    repo_name: kubernetes
+    description: A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions
+    url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert
+    format: raw
+    checksum:
+      type: http
+      url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.sha256
+      algorithm: sha256
+      file_format: raw
+    overrides:
+      - goos: windows
+        checksum:
+          type: http
+          url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.exe.sha256
+          algorithm: sha256
+          file_format: raw
+    version_constraint: semver(">= 1.23.0")
+    version_overrides:
+    - version_constraint: semver("< 1.23.0")
+      supported_envs:
+        - darwin
+        - linux
+        - windows/amd64

--- a/pkgs/kubernetes/kubectl-convert/registry.yaml
+++ b/pkgs/kubernetes/kubectl-convert/registry.yaml
@@ -6,6 +6,8 @@ packages:
     description: A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions
     url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert
     format: raw
+    files:
+      - name: kubectl-convert
     checksum:
       type: http
       url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -9897,7 +9897,7 @@ packages:
           file_format: raw
     version_constraint: semver(">= 1.23.0")
     version_overrides:
-    - version_constraint: semver("< 1.23.0")
+    - version_constraint: "true"
       supported_envs:
         - darwin
         - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -9883,6 +9883,8 @@ packages:
     description: A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions
     url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert
     format: raw
+    files:
+      - name: kubectl-convert
     checksum:
       type: http
       url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -9876,6 +9876,32 @@ packages:
           - darwin
           - linux
           - amd64
+  - name: kubernetes/kubectl-convert
+    type: http
+    repo_owner: kubernetes
+    repo_name: kubernetes
+    description: A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions
+    url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert
+    format: raw
+    checksum:
+      type: http
+      url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.sha256
+      algorithm: sha256
+      file_format: raw
+    overrides:
+      - goos: windows
+        checksum:
+          type: http
+          url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl-convert.exe.sha256
+          algorithm: sha256
+          file_format: raw
+    version_constraint: semver(">= 1.23.0")
+    version_overrides:
+    - version_constraint: semver("< 1.23.0")
+      supported_envs:
+        - darwin
+        - linux
+        - windows/amd64
   - type: http
     repo_owner: kubernetes
     repo_name: minikube


### PR DESCRIPTION
[kubernetes/kubectl-convert](https://github.com/kubernetes/kubernetes/tree/master/cmd/kubectl-convert): A plugin for Kubernetes command-line tool kubectl, which allows you to convert manifests between different API versions

```console
$ aqua g -i kubernetes/kubectl-convert
```

https://kubernetes.io/docs/tasks/tools/included/kubectl-convert-overview/