### PR TITLE
fix(dominikh/go-tools/staticcheck): fix versioning

### DIFF
--- a/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: dominikh/go-tools/staticcheck@v0.3.3
+  - name: dominikh/go-tools/staticcheck
+    version: "2022.1.2"
+  - name: dominikh/go-tools/staticcheck
+    version: "2022.1"

--- a/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
@@ -1,3 +1,3 @@
 packages:
-  - name: dominikh/go-tools/staticcheck
-    version: 2022.1
+  - name: dominikh/go-tools/staticcheck@v0.3.3
+  - name: dominikh/go-tools/staticcheck@2022.1.2

--- a/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/pkg.yaml
@@ -1,3 +1,2 @@
 packages:
   - name: dominikh/go-tools/staticcheck@v0.3.3
-  - name: dominikh/go-tools/staticcheck@2022.1.2

--- a/pkgs/dominikh/go-tools/staticcheck/registry.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/registry.yaml
@@ -4,19 +4,21 @@ packages:
     repo_owner: dominikh
     repo_name: go-tools
     description: Go static analysis, detecting bugs, performance issues, and much more
-    asset: staticcheck_{{.OS}}_{{.Arch}}.tar.gz
+    asset: staticcheck_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    rosetta2: true
     files:
       - name: staticcheck
         src: staticcheck/staticcheck
     supported_envs:
-      - darwin
+      - darwin/amd64
       - linux
-      - amd64
+      - windows/amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        checksum: "^(\b[A-Fa-f0-9]{64}\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/dominikh/go-tools/staticcheck/registry.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/registry.yaml
@@ -4,14 +4,13 @@ packages:
     repo_owner: dominikh
     repo_name: go-tools
     description: Go static analysis, detecting bugs, performance issues, and much more
-    asset: staticcheck_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
+    asset: staticcheck_{{.OS}}_{{.Arch}}.tar.gz
     rosetta2: true
     files:
       - name: staticcheck
         src: staticcheck/staticcheck
     supported_envs:
-      - darwin/amd64
+      - darwin
       - linux
       - windows/amd64
     checksum:

--- a/pkgs/dominikh/go-tools/staticcheck/registry.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/registry.yaml
@@ -12,7 +12,7 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - windows/amd64
+      - amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"

--- a/pkgs/dominikh/go-tools/staticcheck/registry.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/registry.yaml
@@ -20,5 +20,5 @@ packages:
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: "^(\b[A-Fa-f0-9]{64}\b)"
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/dominikh/go-tools/staticcheck/registry.yaml
+++ b/pkgs/dominikh/go-tools/staticcheck/registry.yaml
@@ -21,3 +21,10 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver("< 2000.0.0")
+    # versioning was changed from v0.3.3
+    # https://github.com/dominikh/go-tools/releases/tag/v0.3.3
+    # https://github.com/dominikh/go-tools/releases/tag/2022.1.2
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -5001,21 +5001,23 @@ packages:
     repo_owner: dominikh
     repo_name: go-tools
     description: Go static analysis, detecting bugs, performance issues, and much more
-    asset: staticcheck_{{.OS}}_{{.Arch}}.tar.gz
+    asset: staticcheck_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    rosetta2: true
     files:
       - name: staticcheck
         src: staticcheck/staticcheck
     supported_envs:
-      - darwin
+      - darwin/amd64
       - linux
-      - amd64
+      - windows/amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        checksum: "^(\b[A-Fa-f0-9]{64}\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: dotenv-linter

--- a/registry.yaml
+++ b/registry.yaml
@@ -5001,14 +5001,13 @@ packages:
     repo_owner: dominikh
     repo_name: go-tools
     description: Go static analysis, detecting bugs, performance issues, and much more
-    asset: staticcheck_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
+    asset: staticcheck_{{.OS}}_{{.Arch}}.tar.gz
     rosetta2: true
     files:
       - name: staticcheck
         src: staticcheck/staticcheck
     supported_envs:
-      - darwin/amd64
+      - darwin
       - linux
       - windows/amd64
     checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -5009,7 +5009,7 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - windows/amd64
+      - amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5017,7 +5017,7 @@ packages:
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: "^(\b[A-Fa-f0-9]{64}\b)"
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: dotenv-linter

--- a/registry.yaml
+++ b/registry.yaml
@@ -5018,6 +5018,13 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver("< 2000.0.0")
+    # versioning was changed from v0.3.3
+    # https://github.com/dominikh/go-tools/releases/tag/v0.3.3
+    # https://github.com/dominikh/go-tools/releases/tag/2022.1.2
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: false
   - type: github_release
     repo_owner: dotenv-linter
     repo_name: dotenv-linter


### PR DESCRIPTION
- GitHub release versioning changed
  - newer: https://github.com/dominikh/go-tools/releases/tag/v0.3.3
  - older: https://github.com/dominikh/go-tools/releases/tag/2022.1.2