### PR TITLE
feat: add goccy/bigquery-emulator

### DIFF
--- a/pkgs/goccy/bigquery-emulator/pkg.yaml
+++ b/pkgs/goccy/bigquery-emulator/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: goccy/bigquery-emulator@v0.1.16

--- a/pkgs/goccy/bigquery-emulator/registry.yaml
+++ b/pkgs/goccy/bigquery-emulator/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: goccy
+    repo_name: bigquery-emulator
+    asset: bigquery-emulator-{{.OS}}-{{.Arch}}
+    format: raw
+    description: BigQuery emulator server implemented in Go
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6404,6 +6404,16 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: goccy
+    repo_name: bigquery-emulator
+    asset: bigquery-emulator-{{.OS}}-{{.Arch}}
+    format: raw
+    description: BigQuery emulator server implemented in Go
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
   - type: go_install
     repo_owner: goccy
     repo_name: kubetest


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7092 [goccy/bigquery-emulator](https://github.com/goccy/bigquery-emulator): BigQuery emulator server implemented in Go

```console
$ aqua g -i goccy/bigquery-emulator
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ bigquery-emulator --help
Usage:
  bigquery-emulator-darwin-amd64 [OPTIONS]

Application Options:
      --project=        specify the project name
      --dataset=        specify the dataset name
      --port=           specify the port number (default: 9050)
      --log-level=      specify the log level (debug/info/warn/error) (default: error)
      --log-format=     sepcify the log format (console/json) (default: console)
      --database=       specify the database file if required. if not specified, it will be on memory
      --data-from-yaml= specify the path to the YAML file that contains the initial data
  -v, --version         print version

Help Options:
  -h, --help            Show this help message
```

If files such as configuration file are needed, please share them.

```console
$ cat test.yaml
projects:
- id: test
  datasets:
    - id: dataset1
      tables:
        - id: table_a
          columns:
            - name: id
              type: INTEGER
            - name: name
              type: STRING
          data:
            - id: 1
              name: alice
            - id: 2
              name: bob
        - id: table_b
          columns:
            - name: num
              type: NUMERIC
            - name: bignum
              type: BIGNUMERIC
            - name: interval
              type: INTERVAL
          data:
            - num: 1.2345
              bignum: 1.234567891234
              interval: 1-6 15 0:0:0
```

```
$ bigquery-emulator --project=test --data-from-yaml=./test.yaml
[bigquery-emulator] listening at 0.0.0.0:9050
```

Reference

- README.md
	- https://github.com/goccy/bigquery-emulator/blob/main/README.md#how-to-use-from-bq-client