### PR TITLE
feat: add GoogleCloudPlatform/cloud-sql-proxy

### DIFF
--- a/pkgs/GoogleCloudPlatform/cloud-sql-proxy/pkg.yaml
+++ b/pkgs/GoogleCloudPlatform/cloud-sql-proxy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: GoogleCloudPlatform/cloud-sql-proxy@v1.32.0

--- a/pkgs/GoogleCloudPlatform/cloud-sql-proxy/registry.yaml
+++ b/pkgs/GoogleCloudPlatform/cloud-sql-proxy/registry.yaml
@@ -11,6 +11,4 @@ packages:
       - windows/amd64
     overrides:
       - goos: windows
-        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_{{.Arch}}.exe
-        replacements:
-          amd64: x64
+        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_x64.exe

--- a/pkgs/GoogleCloudPlatform/cloud-sql-proxy/registry.yaml
+++ b/pkgs/GoogleCloudPlatform/cloud-sql-proxy/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: http
+    repo_owner: GoogleCloudPlatform
+    repo_name: cloud-sql-proxy
+    description: A utility for connecting securely to your Cloud SQL instances
+    url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy.{{.OS}}.{{.Arch}}
+    format: raw
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    overrides:
+      - goos: windows
+        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_{{.Arch}}.exe
+        replacements:
+          amd64: x64

--- a/registry.yaml
+++ b/registry.yaml
@@ -460,9 +460,7 @@ packages:
       - windows/amd64
     overrides:
       - goos: windows
-        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_{{.Arch}}.exe
-        replacements:
-          amd64: x64
+        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_x64.exe
   - type: github_release
     repo_owner: GoogleCloudPlatform
     repo_name: terraformer

--- a/registry.yaml
+++ b/registry.yaml
@@ -448,6 +448,21 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+  - type: http
+    repo_owner: GoogleCloudPlatform
+    repo_name: cloud-sql-proxy
+    description: A utility for connecting securely to your Cloud SQL instances
+    url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy.{{.OS}}.{{.Arch}}
+    format: raw
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    overrides:
+      - goos: windows
+        url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_{{.Arch}}.exe
+        replacements:
+          amd64: x64
   - type: github_release
     repo_owner: GoogleCloudPlatform
     repo_name: terraformer


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7096 [GoogleCloudPlatform/cloud-sql-proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy): A utility for connecting securely to your Cloud SQL instances

```console
$ aqua g -i GoogleCloudPlatform/cloud-sql-proxy
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cloud-sql-proxy --help

The Cloud SQL Auth proxy allows simple, secure connectivity to Google Cloud SQL. It
is a long-running process that opens local sockets (either TCP or Unix sockets)
according to the parameters passed to it. A local application connects to a
Cloud SQL instance by using the corresponding socket.


Authorization:
  * On Google Compute Engine, the default service account is used.
    The Cloud SQL API must be enabled for the VM.

  * When the gcloud command-line tool is installed on the local machine, the
    "active account" is used for authentication. Run 'gcloud auth list' to see
    which accounts are installed on your local machine and
    'gcloud config list account' to view the active account.

  * To configure the proxy using a service account, pass the -credential_file
    parameter or set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
    This will override gcloud or GCE (Google Compute Engine) credentials,
    if they exist.

  * To configure the proxy using IAM authentication, pass the -enable_iam_login
    flag. This will cause the proxy to use IAM account credentials for
    database user authentication.

General:
  -quiet
    Disable log messages (e.g. when new connections are established).
    WARNING: this option disables ALL logging output (including connection
    errors), which will likely make debugging difficult. The -quiet flag takes
    precedence over the -verbose flag.

  -log_debug_stdout
    When explicitly set to true, verbose and info log messages will be directed
    to stdout as opposed to the default stderr.

  -verbose
    When explicitly set to false, disable log messages that are not errors nor
    first-time startup messages (e.g. when new connections are established).

  -structured_logs
    When set to true, all log messages are written out as JSON.

  -term_timeout
        How long to wait for connections to close after receiving a SIGTERM before
        shutting down the proxy. Defaults to 0. If all connections close before the
        duration, the proxy will shutdown early.

Connection:
  -instances
    To connect to a specific list of instances, set the instances parameter
    to a comma-separated list of instance connection strings. For example:

        -instances=my-project:my-region:my-instance

    For convenience, this flag may be specified multiple times.

    For connectivity over TCP, you must specify a tcp port as part of the
    instance string. For example, the following example opens a loopback TCP
    socket on port 3306, which will be proxied to connect to the instance
    'my-instance' in project 'my-project'. To listen on other interfaces than
    localhost, a custom bind address (e.g., 0.0.0.0) may be provided. For
    example:

        -instances=my-project:my-region:my-instance=tcp:3306
    or
        -instances=my-project:my-region:my-instance=tcp:0.0.0.0:3306

    When connecting over TCP, the -instances parameter is required.

    To set a custom socket name, you can specify it as part of the instance
    string.  The following example opens a unix socket in the directory
    specified by -dir, which will be proxied to connect to the instance
    'my-instance' in project 'my-project':

        -instances=my-project:my-region:my-instance=unix:custom-socket-name

    Note: The directory specified by -dir must exist and the socket file path
    (i.e., dir plus INSTANCE_CONNECTION_NAME) must be under your platform's
    limit (typically 108 characters on many Unix systems, but varies by platform).

    To override the -dir parameter, specify an absolute path as shown in the
    following example:

        -instances=my-project:my-region:my-instance=unix:/my/custom/sql-socket

     Supplying INSTANCES environment variable achieves the same effect.  One can
     use that to keep k8s manifest files constant across multiple environments

  -instances_metadata
     When running on GCE (Google Compute Engine) you can avoid the need to
     specify the list of instances on the command line by using the Metadata
     server. This parameter specifies a path to a metadata value which is then
     interpreted as a list of instances in the exact same way as the -instances
     parameter. Updates to the metadata value will be observed and acted on by
     the Proxy.

  -projects
    To direct the proxy to allow connections to all instances in specific
    projects, set the projects parameter:

        -projects=my-project

  -fuse
    If your local environment has FUSE installed, you can specify the -fuse
    flag to avoid the requirement to specify instances in advance. With FUSE,
    any attempts to open a Unix socket in the directory specified by -dir
    automatically creates that socket and connects to the corresponding
    instance.

  -dir
    When using Unix sockets (the default for systems which support them), the
    Proxy places the sockets in the directory specified by the -dir parameter.

Automatic instance discovery:
   If the Google Cloud SQL is installed on the local machine and no instance
   connection flags are specified, the proxy connects to all instances in the
   gcloud tool's active project. Run 'gcloud config list project' to
   display the active project.


Information for all flags:
  -check_region
    If specified, the 'region' portion of the connection string is required for
    Unix socket-based connections.

  -credential_file
    If provided, this json file will be used to retrieve Service Account
    credentials.  You may set the GOOGLE_APPLICATION_CREDENTIALS environment
    variable for the same effect.

  -dir
    Directory to use for placing Unix sockets representing database instances

  -enable_iam_login
    Enables database user authentication using Cloud SQL's IAM DB Authentication (Postgres only).

  -fd_rlimit
    Sets the rlimit on the number of open file descriptors for the proxy to
    the provided value. If set to zero, disables attempts to set the rlimit.
    Defaults to a value which can support 4K connections to one instance

  -fuse
    Mount a directory at 'dir' using FUSE for accessing instances. Note that the
    directory at 'dir' must be empty before this program is started.

  -fuse_tmp
    Used as a temporary directory if -fuse is set. Note that files in this directory
    can be removed automatically by this program.

  -health_check_port
    When applicable, health checks take place on this port number. Defaults to 8090.

  -host
    When set, the proxy uses this host as the base API path. Example:
    https://sqladmin.googleapis.com

  -instances
    Comma-separated list of fully qualified instances (project:region:name)
    to connect to. If the name has the suffix '=tcp:port', a TCP server is opened
    on the specified port on localhost to proxy to that instance. It is also possible
    to listen on a custom address by providing a host, e.g., '=tcp:0.0.0.0:port'. If
    no value is provided for 'tcp', one socket file per instance is opened in 'dir'.
    For convenience, this flag may be specified multiple times.
    You may use the INSTANCES environment variable for the same effect. Using both will
    use the value from the flag, Not compatible with -fuse.

  -instances_metadata
    If provided, it is treated as a path to a metadata value which
    is polled for a comma-separated list of instances to connect to. For example,
    to use the instance metadata value named 'cloud-sql-instances' you would
    provide 'instance/attributes/cloud-sql-instances'. Not compatible with -fuse

  -ip_address_types
    Default to be 'PUBLIC,PRIVATE'. Options: a list of strings separated by
    ',', e.g. 'PUBLIC,PRIVATE'

  -log_debug_stdout
    If true, log messages that are not errors will output to stdout instead of stderr

  -max_connections
    If provided, the maximum number of connections to establish before refusing
    new connections. Defaults to 0 (no limit)

  -projects
    Open sockets for each Cloud SQL Instance in the projects specified
    (comma-separated list)

  -quiet
    Disable log messages

  -quota_project
    Specifies the project to use for Cloud SQL Admin API quota tracking.

  -refresh_config_throttle
    If set, this flag specifies the amount of forced sleep between successive
    API calls in order to protect client API quota. Minimum allowed value is
        1s

  -skip_failed_instance_config
    Setting this flag will allow you to prevent the proxy from terminating
    when some instance configurations could not be parsed and/or are
    unavailable.

  -structured_logs
    Configures all log messages to be emitted as JSON.

  -term_timeout
    When set, the proxy will wait for existing connections to close before
    terminating. Any connections that haven't closed after the timeout will be
    dropped

  -token
    When set, the proxy uses this Bearer token for authorization.

  -use_http_health_check
    When set, creates an HTTP server that checks and communicates the health of the proxy client.

  -verbose
    If false, verbose output such as information about when connections are
    created/closed without error are suppressed

  -version
    Print the version of the proxy and exit
```

If files such as configuration file are needed, please share them.

```
$ cloud-sql-proxy --port 6000 <INSTANCE_CONNECTION_NAME>
```

Reference

- README.md (Usage)
    - https://github.com/GoogleCloudPlatform/cloud-sql-proxy#usage