### PR TITLE
fix(ziglang/zig): Use github_tag for version_source

### DIFF
--- a/pkgs/ziglang/zig/registry.yaml
+++ b/pkgs/ziglang/zig/registry.yaml
@@ -1,6 +1,8 @@
 packages:
   - type: http
     name: ziglang/zig
+    repo_owner: ziglang
+    repo_name: zig
     description: General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software
     link: https://ziglang.org/
     url: https://ziglang.org/download/{{.Version}}/zig-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
@@ -16,3 +18,4 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    version_source: github_tag

--- a/pkgs/ziglang/zig/registry.yaml
+++ b/pkgs/ziglang/zig/registry.yaml
@@ -1,6 +1,5 @@
 packages:
   - type: http
-    name: ziglang/zig
     repo_owner: ziglang
     repo_name: zig
     description: General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software

--- a/registry.yaml
+++ b/registry.yaml
@@ -16751,7 +16751,6 @@ packages:
     checksum:
       enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776
   - type: http
-    name: ziglang/zig
     repo_owner: ziglang
     repo_name: zig
     description: General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software

--- a/registry.yaml
+++ b/registry.yaml
@@ -16752,6 +16752,8 @@ packages:
       enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776
   - type: http
     name: ziglang/zig
+    repo_owner: ziglang
+    repo_name: zig
     description: General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software
     link: https://ziglang.org/
     url: https://ziglang.org/download/{{.Version}}/zig-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
@@ -16767,6 +16769,7 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    version_source: github_tag
   - type: github_release
     repo_owner: zigtools
     repo_name: zls


### PR DESCRIPTION
#7117 [ziglang/zig](https://github.com/ziglang/zig): Set `version_source` to `github_tag`

- https://github.com/aquaproj/aqua-registry/pull/2797