### PR TITLE
fix(git-town): 🐛 package did not handle replacements for cpu type correctly

### DIFF
--- a/pkgs/git-town/git-town/pkg.yaml
+++ b/pkgs/git-town/git-town/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: git-town/git-town@v7.8.0
+  - name: git-town/git-town
+    version: v7.4.0
+  - name: git-town/git-town
+    version: v7.3.0

--- a/pkgs/git-town/git-town/registry.yaml
+++ b/pkgs/git-town/git-town/registry.yaml
@@ -15,5 +15,19 @@ packages:
         asset: git-town_{{trimV .Version}}_{{.OS}}_intel_64.{{.Format}}
     supported_envs:
       - darwin
+      - linux
       - amd64
-    rosetta2: true
+    version_constraint: semver(">= 7.7.0")
+    version_overrides:
+      - version_constraint: semver(">= 7.4.0")
+        # In v7.7.0, darwin/arm64 was supported
+        rosetta2: true
+      - version_constraint: "true"
+        # In v7.4.0, linux/arm64 was supported and asset name formats were changed
+        rosetta2: true
+        replacements: {}
+        asset: git-town-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/git-town/git-town/registry.yaml
+++ b/pkgs/git-town/git-town/registry.yaml
@@ -9,6 +9,9 @@ packages:
       darwin: macos
       amd64: intel_64
       arm64: arm_64
+    overrides:
+      - goos: windows
+        format: zip
     supported_envs:
       - darwin
       - linux
@@ -27,3 +30,4 @@ packages:
         supported_envs:
           - darwin
           - amd64
+        overrides: []

--- a/pkgs/git-town/git-town/registry.yaml
+++ b/pkgs/git-town/git-town/registry.yaml
@@ -2,11 +2,13 @@ packages:
   - type: github_release
     repo_owner: git-town
     repo_name: git-town
-    asset: git-town_{{trimV .Version}}_{{.OS}}_arm_64.{{.Format}}
+    asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     description: Generic, high-level Git workflow support
     replacements:
       darwin: macos
+      amd64: intel_64
+      arm64: arm_64
     overrides:
       - goos: windows
         format: zip

--- a/pkgs/git-town/git-town/registry.yaml
+++ b/pkgs/git-town/git-town/registry.yaml
@@ -9,10 +9,6 @@ packages:
       darwin: macos
       amd64: intel_64
       arm64: arm_64
-    overrides:
-      - goos: windows
-        format: zip
-        asset: git-town_{{trimV .Version}}_{{.OS}}_intel_64.{{.Format}}
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -6280,11 +6280,13 @@ packages:
   - type: github_release
     repo_owner: git-town
     repo_name: git-town
-    asset: git-town_{{trimV .Version}}_{{.OS}}_arm_64.{{.Format}}
+    asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     description: Generic, high-level Git workflow support
     replacements:
       darwin: macos
+      amd64: intel_64
+      arm64: arm_64
     overrides:
       - goos: windows
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -6287,10 +6287,6 @@ packages:
       darwin: macos
       amd64: intel_64
       arm64: arm_64
-    overrides:
-      - goos: windows
-        format: zip
-        asset: git-town_{{trimV .Version}}_{{.OS}}_intel_64.{{.Format}}
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -6287,6 +6287,9 @@ packages:
       darwin: macos
       amd64: intel_64
       arm64: arm_64
+    overrides:
+      - goos: windows
+        format: zip
     supported_envs:
       - darwin
       - linux
@@ -6305,6 +6308,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
+        overrides: []
   - name: github.com/zeromicro/go-zero/tools/goctl
     type: go_install
     repo_owner: zeromicro

--- a/registry.yaml
+++ b/registry.yaml
@@ -6293,8 +6293,22 @@ packages:
         asset: git-town_{{trimV .Version}}_{{.OS}}_intel_64.{{.Format}}
     supported_envs:
       - darwin
+      - linux
       - amd64
-    rosetta2: true
+    version_constraint: semver(">= 7.7.0")
+    version_overrides:
+      - version_constraint: semver(">= 7.4.0")
+        # In v7.7.0, darwin/arm64 was supported
+        rosetta2: true
+      - version_constraint: "true"
+        # In v7.4.0, linux/arm64 was supported and asset name formats were changed
+        rosetta2: true
+        replacements: {}
+        asset: git-town-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64
   - name: github.com/zeromicro/go-zero/tools/goctl
     type: go_install
     repo_owner: zeromicro


### PR DESCRIPTION
#7146 [git-town/git-town](https://github.com/git-town/git-town): Fix wrong `replacements`

---

Resolve the cpu arch type not being correctly set as a templated variable.