### PR TITLE
feat: add slsa-framework/slsa-github-generator/slsa-builder-go

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@v1.1.2
         with:
-          aqua_version: v1.20.2
+          aqua_version: v1.20.3-0
 
       - uses: aquaproj/registry-action/test@v0.1.4
         with:

--- a/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/pkg.yaml
+++ b/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: slsa-framework/slsa-github-generator/slsa-builder-go@v1.2.0

--- a/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/registry.yaml
+++ b/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/registry.yaml
@@ -3,6 +3,7 @@ packages:
     repo_owner: slsa-framework
     repo_name: slsa-github-generator
     description: Language-agnostic SLSA provenance generation for Github Actions
+    link: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/go
     # Officially only an asset for linux/amd64 is released.
     # So we support other platforms by `go_install` package.
     type: go_install

--- a/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/registry.yaml
+++ b/pkgs/slsa-framework/slsa-github-generator/slsa-builder-go/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - name: slsa-framework/slsa-github-generator/slsa-builder-go
+    repo_owner: slsa-framework
+    repo_name: slsa-github-generator
+    description: Language-agnostic SLSA provenance generation for Github Actions
+    # Officially only an asset for linux/amd64 is released.
+    # So we support other platforms by `go_install` package.
+    type: go_install
+    path: github.com/slsa-framework/slsa-github-generator/internal/builders/go
+    files:
+      - name: slsa-builder-go
+    overrides:
+      - goos: linux
+        goarch: amd64
+        type: github_release
+        asset: slsa-builder-go-{{.OS}}-{{.Arch}}
+        format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -14582,6 +14582,7 @@ packages:
     repo_owner: slsa-framework
     repo_name: slsa-github-generator
     description: Language-agnostic SLSA provenance generation for Github Actions
+    link: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/go
     # Officially only an asset for linux/amd64 is released.
     # So we support other platforms by `go_install` package.
     type: go_install

--- a/registry.yaml
+++ b/registry.yaml
@@ -14578,6 +14578,22 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - name: slsa-framework/slsa-github-generator/slsa-builder-go
+    repo_owner: slsa-framework
+    repo_name: slsa-github-generator
+    description: Language-agnostic SLSA provenance generation for Github Actions
+    # Officially only an asset for linux/amd64 is released.
+    # So we support other platforms by `go_install` package.
+    type: go_install
+    path: github.com/slsa-framework/slsa-github-generator/internal/builders/go
+    files:
+      - name: slsa-builder-go
+    overrides:
+      - goos: linux
+        goarch: amd64
+        type: github_release
+        asset: slsa-builder-go-{{.OS}}-{{.Arch}}
+        format: raw
   - type: github_release
     repo_owner: slsa-framework
     repo_name: slsa-verifier


### PR DESCRIPTION
#7158 [slsa-framework/slsa-github-generator/slsa-builder-go](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/go): Language-agnostic SLSA provenance generation for Github Actions

```console
$ aqua g -i slsa-framework/slsa-github-generator/slsa-builder-go
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ slsa-builder-go build --help
Usage of build:
  -dry
    	dry run of the build without invoking compiler
```

If files such as configuration file are needed, please share them.

```
```

Reference

-
