### PR TITLE
feat: add aereal/jsondiff

### DIFF
--- a/pkgs/aereal/jsondiff/pkg.yaml
+++ b/pkgs/aereal/jsondiff/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aereal/jsondiff@v0.2.2

--- a/pkgs/aereal/jsondiff/registry.yaml
+++ b/pkgs/aereal/jsondiff/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: aereal
+    repo_name: jsondiff
+    asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: functions to calculate JSON objects differences with gojq filter
+    checksum:
+      type: github_release
+      asset: jsondiff_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1517,6 +1517,19 @@ packages:
     checksum:
       enabled: false
   - type: github_release
+    repo_owner: aereal
+    repo_name: jsondiff
+    asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: functions to calculate JSON objects differences with gojq filter
+    checksum:
+      type: github_release
+      asset: jsondiff_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: ahmetb
     repo_name: kubectl-tree
     asset: kubectl-tree_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7160 [aereal/jsondiff](https://github.com/aereal/jsondiff): functions to calculate JSON objects differences with gojq filter

```console
$ aqua g -i aereal/jsondiff
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ jsondiff --help
Usage of /Users/username/.local/share/aquaproj-aqua/pkgs/github_release/github.com/aereal/jsondiff/v0.2.2/jsondiff_0.2.2_darwin_amd64.tar.gz/jsondiff:
  -exit-code
        exit with 1 if there were differences and 0 means no differences
  -ignore string
        gojq query to ignore the structure to calculate differences
  -only string
        gojq query to point the structure to calculate differences

```

If files such as configuration file are needed, please share them.

```console
$ cat hoge1.json
{
    "hoge": "fuga"
}

$ cat hoge2.json
{
    "hoge": "fuga",
    "poyo": "poyo"
}
```

```console
$ jsondiff hoge1.json hoge2.json
--- hoge1.json
+++ hoge2.json
@@ -1,4 +1,5 @@
 {
-  "hoge": "fuga"
+  "hoge": "fuga",
+  "poyo": "poyo"
 }


```

Reference

- README.md
	- https://github.com/aereal/jsondiff/blob/main/README.md