### PR TITLE
feat: add dylanaraps/neofetch

### DIFF
--- a/pkgs/dylanaraps/neofetch/pkg.yaml
+++ b/pkgs/dylanaraps/neofetch/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dylanaraps/neofetch@7.1.0

--- a/pkgs/dylanaraps/neofetch/registry.yaml
+++ b/pkgs/dylanaraps/neofetch/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_content
+    repo_owner: dylanaraps
+    repo_name: neofetch
+    path: neofetch
+    description: A command-line system information tool written in bash 3.2+
+    supported_envs:
+      - darwin
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -5400,6 +5400,14 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_content
+    repo_owner: dylanaraps
+    repo_name: neofetch
+    path: neofetch
+    description: A command-line system information tool written in bash 3.2+
+    supported_envs:
+      - darwin
+      - linux
   - type: github_release
     repo_owner: earthly
     repo_name: earthly


### PR DESCRIPTION
[dylanaraps/neofetch](https://github.com/dylanaraps/neofetch): A command-line system information tool written in bash 3.2+

```console
$ aqua g -i dylanaraps/neofetch
```

## How to confirm if this package works well

Command and output

```console
$ neofetch
```

Note: This is a single shell script, so I added `supported_envs` as `linux` and `darwin`.