### PR TITLE
fix: remove console prefix from markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -34,7 +34,7 @@ aqua -v
 > Please remove unneeded configuration to reproduce the issue.
 
 ```yaml
-aqua.yaml
+# aqua.yaml
 ```
 
 ```console

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -14,7 +14,7 @@ e.g. `suzuki-shunsuke/github-comment`
 Please use the latest version.
 
 ```console
-$ aqua -v
+aqua -v
 
 ```
 
@@ -34,11 +34,11 @@ $ aqua -v
 > Please remove unneeded configuration to reproduce the issue.
 
 ```yaml
-# aqua.yaml
+aqua.yaml
 ```
 
 ```console
-$
+
 ```
 
 ## Debug Output
@@ -46,7 +46,7 @@ $
 Please set the environment variable `AQUA_LOG_LEVEL=debug` and run aqua and tell us the debug output.
 
 ```console
-$
+
 ```
 
 ## Expected Behaviour


### PR DESCRIPTION
Based on discussion earlier, this cleans up the extra `$` prefix.

- https://github.com/aquaproj/aqua/issues/1274