### PR TITLE
feat: add k1LoW/awsdo

### DIFF
--- a/pkgs/k1LoW/awsdo/pkg.yaml
+++ b/pkgs/k1LoW/awsdo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/awsdo@v0.10.0

--- a/pkgs/k1LoW/awsdo/registry.yaml
+++ b/pkgs/k1LoW/awsdo/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: awsdo
+    asset: awsdo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: awsdo is a tool to do anything using AWS temporary credentials
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -9233,6 +9233,26 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\*(\\S+)$"
   - type: github_release
     repo_owner: k1LoW
+    repo_name: awsdo
+    asset: awsdo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: awsdo is a tool to do anything using AWS temporary credentials
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: ndiag
     asset: ndiag_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7208 [k1LoW/awsdo](https://github.com/k1LoW/awsdo): awsdo is a tool to do anything using AWS temporary credentials

```console
$ aqua g -i k1LoW/awsdo
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ awsdo --help
awsdo is a tool to do anything using AWS temporary credentials.

Usage:
  awsdo [flags]

Flags:
      --disable-cache           disable the credentials cache
  -d, --duration string         the duration that the credentials should remain valid (default "1hour")
  -h, --help                    help for awsdo
      --login                   generate login link for the AWS management console
  -p, --profile string          AWS named profile
  -r, --role-arn string         IAM Role ARN to be assumed
  -n, --serial-number string    the identification number of the MFA device
  -s, --source-profile string   AWS named profile that assume role
  -c, --token-code string       the value provided by the MFA device
  -v, --version                 version for awsdo
```

If files such as configuration file are needed, please share them.

```
$ awsdo
export AWS_REGION=ap-northeast-1
export AWS_ACCESS_KEY_ID=ASIA....
export AWS_SECRET_ACCESS_KEY=hogehoge
export AWS_SESSION_TOKNE=tokenexamplehoge
```

Reference

- README.md
	- https://github.com/k1LoW/awsdo/blob/main/README.md