### PR TITLE
feat: add wakatime/wakatime-cli

### DIFF
--- a/pkgs/wakatime/wakatime-cli/pkg.yaml
+++ b/pkgs/wakatime/wakatime-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: wakatime/wakatime-cli@v1.55.2

--- a/pkgs/wakatime/wakatime-cli/registry.yaml
+++ b/pkgs/wakatime/wakatime-cli/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: wakatime
+    repo_name: wakatime-cli
+    asset: wakatime-cli-{{.OS}}-{{.Arch}}.zip
+    description: Command line interface used by all WakaTime text editor plugins
+    files:
+    - name: wakatime-cli
+      src: wakatime-cli-{{.OS}}-{{.Arch}}
+    checksum:
+      type: github_release
+      asset: checksums_sha256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -16607,6 +16607,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: wakatime
+    repo_name: wakatime-cli
+    asset: wakatime-cli-{{.OS}}-{{.Arch}}.zip
+    description: Command line interface used by all WakaTime text editor plugins
+    files:
+    - name: wakatime-cli
+      src: wakatime-cli-{{.OS}}-{{.Arch}}
+    checksum:
+      type: github_release
+      asset: checksums_sha256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: wallix
     repo_name: awless
     description: A Mighty CLI for AWS


### PR DESCRIPTION
[wakatime/wakatime-cli](https://github.com/wakatime/wakatime-cli): Command line interface used by all WakaTime text editor plugins

```console
$ aqua g -i wakatime/wakatime-cli
```
