### PR TITLE
feat: add handlename/ssmwrap

### DIFF
--- a/pkgs/handlename/ssmwrap/pkg.yaml
+++ b/pkgs/handlename/ssmwrap/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: handlename/ssmwrap@v1.2.1

--- a/pkgs/handlename/ssmwrap/registry.yaml
+++ b/pkgs/handlename/ssmwrap/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: handlename
+    repo_name: ssmwrap
+    asset: ssmwrap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Exec command with environment variables loaded from AWS SSM
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: ssmwrap
+        src: ssmwrap_{{.Version}}_{{.OS}}_{{.Arch}}/ssmwrap

--- a/registry.yaml
+++ b/registry.yaml
@@ -7584,6 +7584,18 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+bin/(\\S+)$"
   - type: github_release
+    repo_owner: handlename
+    repo_name: ssmwrap
+    asset: ssmwrap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Exec command with environment variables loaded from AWS SSM
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: ssmwrap
+        src: ssmwrap_{{.Version}}_{{.OS}}_{{.Arch}}/ssmwrap
+  - type: github_release
     repo_owner: harelba
     repo_name: q
     description: q - Run SQL directly on CSV or TSV files


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7320 [handlename/ssmwrap](https://github.com/handlename/ssmwrap): Exec command with environment variables loaded from AWS SSM

```console
$ aqua g -i handlename/ssmwrap
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ssmwrap --help
Usage of /Users/username/.local/share/aquaproj-aqua/pkgs/github_release/github.com/handlename/ssmwrap/v1.2.1/ssmwrap_v1.2.1_darwin_amd64.zip/ssmwrap_v1.2.1_darwin_amd64/ssmwrap:
  -env
        export values as environment variables (default true)
  -env-entire-path
        use entire parameter path for name of environment variables
        disabled: /path/to/value -> VALUE
        enabled: /path/to/value -> PATH_TO_VALUE
  -env-prefix string
        prefix for environment variables
  -file value
        write values as file
        format:  Name=VALUE_NAME,Path=FILE_PATH,Mode=FILE_MODE,Gid=FILE_GROUP_ID,Uid=FILE_USER_ID
        example: Name=/foo/bar,Path=/etc/bar,Mode=600,Gid=123,Uid=456
  -names string
        comma separated parameter names
  -no-env
        disable export to environment variables
  -no-recursive
        retrieve values just under -paths only
  -paths string
        comma separated parameter paths
  -prefix string
        alias for -env-prefix
  -recursive
        retrieve values recursively (default true)
  -retries int
        number of times of retry
  -version
        display version
```

If files such as configuration file are needed, please share them.

Setup aws cli profile.
```console
export AWS_PROFILE=<your profile>
```

Run `ssmwrap`
```console
ssmwrap -paths /prod -- env
```

Reference

- README.md
	- https://github.com/handlename/ssmwrap/blob/master/README.md