### PR TITLE
feat: add making/rsc

### DIFF
--- a/pkgs/making/rsc/pkg.yaml
+++ b/pkgs/making/rsc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: making/rsc@0.9.1

--- a/pkgs/making/rsc/registry.yaml
+++ b/pkgs/making/rsc/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: making
+    repo_name: rsc
+    asset: rsc-{{.Arch}}-pc-{{.OS}}
+    format: raw
+    description: RSocket Client CLI (RSC) that aims to be a curl for RSocket
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+    overrides:
+      - goos: darwin
+        asset: rsc-{{.Arch}}-{{.OS}}
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -11092,6 +11092,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: making
+    repo_name: rsc
+    asset: rsc-{{.Arch}}-pc-{{.OS}}
+    format: raw
+    description: RSocket Client CLI (RSC) that aims to be a curl for RSocket
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+    overrides:
+      - goos: darwin
+        asset: rsc-{{.Arch}}-{{.OS}}
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+  - type: github_release
     repo_owner: mantil-io
     repo_name: mantil
     description: Build your AWS Lambda-based Go backends quicker than ever


### PR DESCRIPTION
[making/rsc](https://github.com/making/rsc): RSocket Client CLI (RSC) that aims to be a curl for RSocket

```console
$ aqua g -i making/rsc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ rsc
Uri is required.

usage: rsc [options] uri

Non-option arguments:
[String: uri]

Option                                Description
------                                -----------
--ab, --authBearer [String]           Enable Authentication Metadata
                                        Extension (Bearer).
--authBasic [String]                  [DEPRECATED] Enable Authentication
                                        Metadata Extension (Basic). This
                                        Metadata exists only for the
                                        backward compatibility with Spring
                                        Security 5.2
--channel                             Shortcut of --im REQUEST_CHANNEL
--completion [ShellType]              Output shell completion code for the
                                        specified shell (bash, zsh, fish,
                                        powershell)
-d, --data [String]                   Data. Use '-' to read data from
                                        standard input. (default: )
--dataMimeType, --dmt [String]        MimeType for data (default:
                                        application/json)
--debug                               Enable FrameLogger
--delayElements [Long]                Enable delayElements(delay) in milli
                                        seconds
--dumpOpts                            Dump options as a file that can be
                                        loaded by --optsFile option
--fnf                                 Shortcut of --im FIRE_AND_FORGET
-h, --help [String]                   Print help
--im, --interactionModel              InteractionModel (default:
  [InteractionModel]                    REQUEST_RESPONSE)
-l, --load [String]                   Load a file as Data. (e.g. ./foo.txt,
                                        /tmp/foo.txt, https://example.com)
--limitRate [Integer]                 Enable limitRate(rate)
--log [String]                        Enable log()
-m, --metadata [String]               Metadata (default: )
--metadataMimeType, --mmt [String]    MimeType for metadata (default:
                                        application/json)
--optsFile [String]                   Configure options from a YAML file (e.
                                        g. ./opts.yaml, /tmp/opts.yaml,
                                        https://example.com/opts.yaml)
--printB3                             Print B3 propagation info. Ignored
                                        unless --trace is set.
-q, --quiet                           Disable the output on next
-r, --route [String]                  Enable Routing Metadata Extension
--request                             Shortcut of --im REQUEST_RESPONSE
--resume [Integer]                    Enable resume. Resume session duration
                                        can be configured in seconds.
--retry [Integer]                     Enable retry. Retry every 1 second
                                        with the given max attempts.
--sd, --setupData [String]            Data for Setup payload
--setupMetadata, --sm [String]        Metadata for Setup payload
--setupMetadataMimeType, --smmt       Metadata MimeType for Setup payload
  [String]                              (default: application/json)
--showSystemProperties                Show SystemProperties for troubleshoot
--stacktrace                          Show Stacktrace when an exception
                                        happens
--stream                              Shortcut of --im REQUEST_STREAM
--take [Integer]                      Enable take(n)
--trace [TracingMetadataCodec$Flags]  Enable Tracing (Zipkin) Metadata
                                        Extension. Unless sampling state
                                        (UNDECIDED, NOT_SAMPLE, SAMPLE,
                                        DEBUG) is specified, DEBUG is used
                                        if no state is specified.
--trustCert [String]                  PEM file for a trusted certificate. (e.
                                        g. ./foo.crt, /tmp/foo.crt, https:
                                        //example.com/foo.crt)
-u, --as, --authSimple [String]       Enable Authentication Metadata
                                        Extension (Simple). The format must
                                        be 'username:password'.
-v, --version                         Print version
-w, --wiretap                         Enable wiretap
--wsHeader, --wsh [String]            Header for web socket connection
--zipkinUrl [String]                  Zipkin URL to send a span (e.g. http:
                                        //localhost:9411). Ignored unless --
                                        trace is set.
```