### PR TITLE
feat: add mattn/twty

### DIFF
--- a/pkgs/mattn/twty/pkg.yaml
+++ b/pkgs/mattn/twty/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mattn/twty@v0.0.13

--- a/pkgs/mattn/twty/pkg.yaml
+++ b/pkgs/mattn/twty/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: mattn/twty@v0.0.13
+  - name: mattn/twty
+    version: v0.0.11
+  - name: mattn/twty
+    version: v0.0.4

--- a/pkgs/mattn/twty/registry.yaml
+++ b/pkgs/mattn/twty/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: mattn
+    repo_name: twty
+    asset: twty_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: command-line twitter client written in golang
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: twty
+        src: twty_{{.Version}}_{{.OS}}_{{.Arch}}/twty

--- a/pkgs/mattn/twty/registry.yaml
+++ b/pkgs/mattn/twty/registry.yaml
@@ -11,3 +11,10 @@ packages:
     files:
       - name: twty
         src: twty_{{.Version}}_{{.OS}}_{{.Arch}}/twty
+    version_constraint: semver(">= 0.0.13")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -11318,6 +11318,13 @@ packages:
     files:
       - name: twty
         src: twty_{{.Version}}_{{.OS}}_{{.Arch}}/twty
+    version_constraint: semver(">= 0.0.13")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: maxpert
     repo_name: marmot

--- a/registry.yaml
+++ b/registry.yaml
@@ -11307,6 +11307,18 @@ packages:
       - goos: linux
         format: tar.gz
   - type: github_release
+    repo_owner: mattn
+    repo_name: twty
+    asset: twty_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: command-line twitter client written in golang
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: twty
+        src: twty_{{.Version}}_{{.OS}}_{{.Arch}}/twty
+  - type: github_release
     repo_owner: maxpert
     repo_name: marmot
     description: A distributed SQLite replicator


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7412 [mattn/twty](https://github.com/mattn/twty): command-line twitter client written in golang

```console
$ aqua g -i mattn/twty
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ twty --help
Usage of twty:
  -a PROFILE: switch profile to load configuration file.
  -f ID: specify favorite ID
  -i ID: specify in-reply ID, if not specify text, it will be RT.
  -l USER/LIST: show list's timeline (ex: mattn_jp/subtech)
  -m FILE: upload media
  -u USER: show user's timeline
  -s WORD: search timeline
  -S DELAY tweets after DELAY
  -json: as JSON
  -r: show replies
  -v: detail display
  -ff FILENAME: post utf-8 string from a file("-" means STDIN)
  -count NUMBER: show NUMBER tweets at timeline.
  -since DATE: show tweets created after the DATE (ex. 2017-05-01)
  -until DATE: show tweets created before the DATE (ex. 2017-05-31)
  -since_id NUMBER: show tweets that have ids greater than NUMBER.
  -max_id NUMBER: show tweets that have ids lower than NUMBER.
```

If files such as configuration file are needed, please share them.

```console
$ twty -u szkdash
szkdash: 200⭐
https://t.co/ond8eQzeLt
szkdash: GitHub Actions: Deprecating save-state and set-output commands https://t.co/lN2dtZTvEp
szkdash: Released aqua-registry v3.74.0 🎉
New:
protocolbuffers/protobuf/protoc: Protocol Buffers - Google's data interchange format

Thanks, mikutas
https://t.co/xwN0xCaXWP
#aquaclivm
szkdash: Released aqua-registry v3.75.0 🎉

New:
tridentctl
containerd
crun
fuse-overlayfs
bigquery-emulator
kubeadm
kubectl-convert
runc
rootlesskit
slirp4netns

Thanks ponkio-o and takumin
https://t.co/GfrzCjqstf
#aquaclivm
szkdash: GitHub, `Copy permalink` から revision 固定して Link 取得できるんだ https://t.co/Gz7iLbTaLK
szkdash: GITHUB_STEP_SUMMARY の bug, https://t.co/Qd0dYTA5WC から報告したら修正された
https://t.co/yc11hnzq52
szkdash: reply にも書いておこう
https://t.co/uzRt719muL
szkdash: Released tfaction v0.5.19 🎉

- Use GITHUB_OUTPUT instead of deprecated set-output command
- Use GITHUB_SERVER_URL for GitHub Enterprise

https://t.co/o5om97ZXtr
szkdash: Released aqua-registry v3.76.0 🎉

New:
GoogleCloudPlatform/cloud-sql-proxy
containerd/fuse-overlayfs-snapshotter
hashicorp/boundary

Thanks ponkio-o and takumin
https://t.co/7Lhz4gGWeg
#aquaclivm
szkdash: https://t.co/AbZkJl7nht
szkdash: Renovate's github-actions manager supports digest pinning while following the action version tag.
https://t.co/HpWqoMb78i
szkdash: Renovate "helpers:pinGitHubActionDigests" preset is very useful...
https://t.co/HpWqoMb78i
szkdash: aqua-registry has supported over 900 packages 🎉
Thank you, all contributors!
#aquaclivm https://t.co/AjsYtyRmkp
szkdash: Released aqua-registry v3.78.0 🎉

New:
k1LoW/awsdo
kyverno/kyverno
folbricht/desync
dbrgn/tealdeer

Thanks, ponkio-o, sheldonhull, and takumin
https://t.co/u5YfseXEU8
#aquaclivm
szkdash: @dbrgn had tealdeer added to aqua project. Thanks for this tool. I finally groked how to use tar😆 https://t.co/KBrjWi3gzo 🎉
szkdash: The Platform Values of Earthly
https://t.co/Trddxbn9Ni
szkdash: @ibuildthecloud Aqua! Best solution I’ve found and I’ve done asdf, brew, go-updater scripts and more.  My entire dev setup 90% is now done in seconds through aqua!
szkdash: Released aqua-registry v3.81.0 🎉

New:
bitwarden/clients
handlename/ssmwrap
kyoshidajp/ghkw
wakatime/wakatime-cli

Thanks,  ponkio-o and CrystalMethod
https://t.co/hbVuTEyFAq
#aquaclivm
szkdash: tfaction の導入事例だ。ありがとうございます！ https://t.co/1GZuNO4Ee3
szkdash: Released aqua-registry v3.82.0 🎉

New:
drud/ddev: Local web development environment system for PHP
librespeed/speedtest-cli: CLI for LibreSpeed
making/rsc: curl for RSocket
ysugimoto/falco: VCL parser and linter optimized for Fastly

https://t.co/S4cqTVx4e6
#aquaclivm
```

Reference

- help command
	- `twty --help`