### PR TITLE
feat: add purpleclay/dns53

### DIFF
--- a/pkgs/purpleclay/dns53/pkg.yaml
+++ b/pkgs/purpleclay/dns53/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: purpleclay/dns53@v0.9.0

--- a/pkgs/purpleclay/dns53/registry.yaml
+++ b/pkgs/purpleclay/dns53/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: purpleclay
+    repo_name: dns53
+    asset: dns53_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Dynamic DNS within Amazon Route53. Expose your EC2 quickly, easily and privately
+    replacements:
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      enabled: false

--- a/pkgs/purpleclay/dns53/registry.yaml
+++ b/pkgs/purpleclay/dns53/registry.yaml
@@ -11,4 +11,10 @@ packages:
       - goos: windows
         format: zip
     checksum:
-      enabled: false
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13354,7 +13354,13 @@ packages:
       - goos: windows
         format: zip
     checksum:
-      enabled: false
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: quarkslab
     repo_name: kdigger

--- a/registry.yaml
+++ b/registry.yaml
@@ -13343,6 +13343,19 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: purpleclay
+    repo_name: dns53
+    asset: dns53_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Dynamic DNS within Amazon Route53. Expose your EC2 quickly, easily and privately
+    replacements:
+      amd64: x86_64
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      enabled: false
+  - type: github_release
     repo_owner: quarkslab
     repo_name: kdigger
     description: Kubernetes focused container assessment tool for penetration testing


### PR DESCRIPTION
[purpleclay/dns53](https://github.com/purpleclay/dns53): Dynamic DNS within Amazon Route53. Expose your EC2 quickly, easily and privately

```console
$ aqua g -i purpleclay/dns53
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ dns53 --help
Dynamic DNS within Amazon Route 53. Expose your EC2 quickly, easily, and privately within a Route
53 Private Hosted Zone (PHZ).

Your EC2 will be exposed through a dynamically generated resource record that will automatically
be deleted when dns53 exits. Let dns53 name your resource record for you, or customise it to your needs.

Built using Bubbletea 🧋

Usage:
  dns53 [flags]
  dns53 [command]

Examples:
  # Launch the TUI and use the wizard to select a PHZ
  dns53

  # Launch the TUI using a chosen PHZ, effectively skipping the wizard
  dns53 --phz-id Z000000000ABCDEFGHIJK

  # Launch the TUI, automatically creating and attaching to a default
  # PHZ. This will also skip the wizard
  dns53 --auto-attach

  # Launch the TUI with a given domain name
  dns53 --domain-name custom.domain

  # Launch the TUI with a templated domain name
  dns53 --domain-name "{{.IPv4}}.{{.Region}}"

Available Commands:
  completion  Generate completion script for your target shell
  help        Help about any command
  imds        Toggle EC2 IMDS features
  tags        Lists all available EC2 instance tags and how to use them with Go templating
  version     Prints the build time version information

Flags:
      --auto-attach          automatically create and attach a record set to a default private hosted zone
      --domain-name string   assign a custom domain name when generating a record set
  -h, --help                 help for dns53
      --phz-id string        an ID of a Route53 private hosted zone to use when generating a record set
      --profile string       the AWS named profile to use when loading credentials
      --region string        the AWS region to use when querying AWS

Use "dns53 [command] --help" for more information about a command.
```