### PR TITLE
feat: add runatlantis/atlantis

### DIFF
--- a/pkgs/runatlantis/atlantis/pkg.yaml
+++ b/pkgs/runatlantis/atlantis/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: runatlantis/atlantis@v0.20.1

--- a/pkgs/runatlantis/atlantis/pkg.yaml
+++ b/pkgs/runatlantis/atlantis/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: runatlantis/atlantis@v0.20.1
+  - name: runatlantis/atlantis
+    version: v0.17.3
+  - name: runatlantis/atlantis
+    version: v0.15.1

--- a/pkgs/runatlantis/atlantis/registry.yaml
+++ b/pkgs/runatlantis/atlantis/registry.yaml
@@ -2,12 +2,8 @@ packages:
   - type: github_release
     repo_owner: runatlantis
     repo_name: atlantis
-    asset: atlantis_{{.OS}}_{{.Arch}}.zip
     description: Terraform Pull Request Automation
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    asset: atlantis_{{.OS}}_{{.Arch}}.zip
     checksum:
       type: github_release
       asset: checksums.txt
@@ -16,3 +12,26 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.17.4")
+    # support windows/amd64 and darwin/arm64
+    # provide a checksum file
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.16.0")
+        checksum:
+          enabled: false
+        rosetta2: true
+        # support linux/arm64
+        supported_envs:
+          - darwin
+          - linux
+      - version_constraint: "true"
+        checksum:
+          enabled: false
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64

--- a/pkgs/runatlantis/atlantis/registry.yaml
+++ b/pkgs/runatlantis/atlantis/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: runatlantis
+    repo_name: atlantis
+    asset: atlantis_{{.OS}}_{{.Arch}}.zip
+    description: Terraform Pull Request Automation
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13904,12 +13904,8 @@ packages:
   - type: github_release
     repo_owner: runatlantis
     repo_name: atlantis
-    asset: atlantis_{{.OS}}_{{.Arch}}.zip
     description: Terraform Pull Request Automation
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    asset: atlantis_{{.OS}}_{{.Arch}}.zip
     checksum:
       type: github_release
       asset: checksums.txt
@@ -13918,6 +13914,29 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.17.4")
+    # support windows/amd64 and darwin/arm64
+    # provide a checksum file
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.16.0")
+        checksum:
+          enabled: false
+        rosetta2: true
+        # support linux/arm64
+        supported_envs:
+          - darwin
+          - linux
+      - version_constraint: "true"
+        checksum:
+          enabled: false
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64
   - type: github_release
     repo_owner: rust-lang
     repo_name: mdBook

--- a/registry.yaml
+++ b/registry.yaml
@@ -13902,6 +13902,23 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: runatlantis
+    repo_name: atlantis
+    asset: atlantis_{{.OS}}_{{.Arch}}.zip
+    description: Terraform Pull Request Automation
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: rust-lang
     repo_name: mdBook
     rosetta2: true


### PR DESCRIPTION
[runatlantis/atlantis](https://github.com/runatlantis/atlantis): Terraform Pull Request Automation

```console
$ aqua g -i runatlantis/atlantis
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ atlantis --help
WARN[0000] package isn't found                           aqua_version=1.21.0 env=linux/amd64 exe_name=atlantis package_name=protocolbuffers/protobuf program=aqua registry_name=standard
Terraform Pull Request Automation

Usage:
  atlantis [command]

Available Commands:
  help        Help about any command
  server      Start the atlantis server
  testdrive   Start a guided tour of Atlantis
  version     Print the current Atlantis version

Flags:
  -h, --help   help for atlantis

Use "atlantis [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

```
```

Reference

-