### PR TITLE
feat: add mitchellh/gon

### DIFF
--- a/pkgs/mitchellh/gon/pkg.yaml
+++ b/pkgs/mitchellh/gon/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mitchellh/gon@v0.2.5

--- a/pkgs/mitchellh/gon/registry.yaml
+++ b/pkgs/mitchellh/gon/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: mitchellh
+    repo_name: gon
+    asset: gon_{{.OS}}.zip
+    description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -11659,6 +11659,16 @@ packages:
       asset: "{{.Asset}}.sha256"
       file_format: raw
       algorithm: sha256
+  - type: github_release
+    repo_owner: mitchellh
+    repo_name: gon
+    asset: gon_{{.OS}}.zip
+    description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+    rosetta2: true
   - type: go_install
     repo_owner: mitchellh
     repo_name: gox


### PR DESCRIPTION
#7488 [mitchellh/gon](https://github.com/mitchellh/gon): Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library

```console
$ aqua g -i mitchellh/gon
```