### PR TITLE
feat: add sonatype-nexus-community/nancy

### DIFF
--- a/pkgs/sonatype-nexus-community/nancy/pkg.yaml
+++ b/pkgs/sonatype-nexus-community/nancy/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
   - name: sonatype-nexus-community/nancy@v1.0.41
+  - name: sonatype-nexus-community/nancy
+    version: v1.0.19
+  - name: sonatype-nexus-community/nancy
+    version: v1.0.6
+  - name: sonatype-nexus-community/nancy
+    version: v0.1.4
+  - name: sonatype-nexus-community/nancy
+    version: v0.1.0
+  - name: sonatype-nexus-community/nancy
+    version: 0.0.1

--- a/pkgs/sonatype-nexus-community/nancy/pkg.yaml
+++ b/pkgs/sonatype-nexus-community/nancy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sonatype-nexus-community/nancy@v1.0.41

--- a/pkgs/sonatype-nexus-community/nancy/registry.yaml
+++ b/pkgs/sonatype-nexus-community/nancy/registry.yaml
@@ -20,3 +20,42 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.0.20")
+    # support darwin/arm64
+    version_overrides:
+      - version_constraint: semver(">= 1.0.19")
+        rosetta2: true
+        # support linux/arm64
+      - version_constraint: semver(">= 1.0.6")
+        # change release filename templates to allow matching by selfupdate.
+        # see: https://github.com/rhysd/go-github-selfupdate/blob/master/selfupdate/detect.go#L95
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.4")
+        # Publish the archives for Nancy, for homebrew
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}.{{.Format}}
+      - version_constraint: semver(">= 0.1.0")
+        rosetta2: true
+        format: raw
+        overrides: []
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}
+        # provide checksum file
+      - version_constraint: "true"
+        rosetta2: true
+        format: raw
+        overrides: []
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}
+        checksum:
+          enabled: false

--- a/pkgs/sonatype-nexus-community/nancy/registry.yaml
+++ b/pkgs/sonatype-nexus-community/nancy/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: sonatype-nexus-community
+    repo_name: nancy
+    asset: nancy-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: nancychecksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -15111,6 +15111,45 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.0.20")
+    # support darwin/arm64
+    version_overrides:
+      - version_constraint: semver(">= 1.0.19")
+        rosetta2: true
+        # support linux/arm64
+      - version_constraint: semver(">= 1.0.6")
+        # change release filename templates to allow matching by selfupdate.
+        # see: https://github.com/rhysd/go-github-selfupdate/blob/master/selfupdate/detect.go#L95
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.4")
+        # Publish the archives for Nancy, for homebrew
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}.{{.Format}}
+      - version_constraint: semver(">= 0.1.0")
+        rosetta2: true
+        format: raw
+        overrides: []
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}
+        # provide checksum file
+      - version_constraint: "true"
+        rosetta2: true
+        format: raw
+        overrides: []
+        supported_envs:
+          - darwin
+          - amd64
+        asset: nancy-{{.OS}}.{{.Arch}}-{{.Version}}
+        checksum:
+          enabled: false
   - type: github_release
     repo_owner: soywod
     repo_name: himalaya

--- a/registry.yaml
+++ b/registry.yaml
@@ -15091,6 +15091,27 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: sonatype-nexus-community
+    repo_name: nancy
+    asset: nancy-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: nancychecksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: soywod
     repo_name: himalaya
     asset: himalaya-{{.OS}}.tar.gz


### PR DESCRIPTION
[sonatype-nexus-community/nancy](https://github.com/sonatype-nexus-community/nancy): A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index

```console
$ aqua g -i sonatype-nexus-community/nancy
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ nancy help
nancy is a tool to check for vulnerabilities in your Golang dependencies,
powered by the 'Sonatype OSS Index', and as well, works with Nexus IQ Server, allowing you
a smooth experience as a Golang developer, using the best tools in the market!

Usage:
  nancy [flags]
  nancy [command]

Examples:
  Typical usage will pipe the output of 'go list -json -deps' to 'nancy':
  go list -json -deps ./... | nancy sleuth [flags]
  go list -json -deps ./... | nancy iq [flags]

  If using dep typical usage is as follows :
  nancy sleuth -p Gopkg.lock [flags]
  nancy iq -p Gopkg.lock [flags]


Available Commands:
  config      Setup credentials to use when connecting to services
  help        Help about any command
  iq          Check for vulnerabilities in your Golang dependencies using 'Sonatype's Nexus IQ IQServer'
  sleuth      Check for vulnerabilities in your Golang dependencies using Sonatype's OSS Index
  update      Check if there are any updates available

Flags:
  -v, -- count                 Set log level, multiple v's is more verbose
  -c, --clean-cache            Deletes local cache directory
  -d, --db-cache-path string   Specify an alternate path for caching responses from OSS Inde, example: /tmp
  -h, --help                   help for nancy
      --loud                   indicate output should include non-vulnerable packages
  -p, --path string            Specify a path to a dep Gopkg.lock file for scanning
  -q, --quiet                  indicate output should contain only packages with vulnerabilities (default true)
      --skip-update-check      Skip the check for updates.
  -t, --token string           Specify OSS Index API token for request
  -u, --username string        Specify OSS Index username for request
  -V, --version                Get the version

Use "nancy [command] --help" for more information about a command.
```