### PR TITLE
feat: add citrusframework/yaks

### DIFF
--- a/pkgs/citrusframework/yaks/pkg.yaml
+++ b/pkgs/citrusframework/yaks/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: citrusframework/yaks@v0.11.0

--- a/pkgs/citrusframework/yaks/registry.yaml
+++ b/pkgs/citrusframework/yaks/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: citrusframework
+    repo_name: yaks
+    asset: yaks-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: YAKS is a platform to enable Cloud Native BDD testing on Kubernetes
+    replacements:
+      amd64: 64bit
+      darwin: mac
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -3607,6 +3607,18 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: citrusframework
+    repo_name: yaks
+    asset: yaks-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: YAKS is a platform to enable Cloud Native BDD testing on Kubernetes
+    replacements:
+      amd64: 64bit
+      darwin: mac
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: civo
     repo_name: cli
     description: Our Command Line Interface (CLI) for interacting with your Civo resources


### PR DESCRIPTION
[citrusframework/yaks](https://github.com/citrusframework/yaks): YAKS is a platform to enable Cloud Native BDD testing on Kubernetes

```console
$ aqua g -i citrusframework/yaks
```

## How to confirm if this package works well

Command and output

```console
$ yaks version 
YAKS 0.11.0
```

Reference

- https://citrusframework.org/yaks/reference/html/index.html
- https://github.com/citrusframework/yaks
