### PR TITLE
feat: add hirosassa/ksnotify

### DIFF
--- a/pkgs/hirosassa/ksnotify/pkg.yaml
+++ b/pkgs/hirosassa/ksnotify/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hirosassa/ksnotify@v0.1.6

--- a/pkgs/hirosassa/ksnotify/registry.yaml
+++ b/pkgs/hirosassa/ksnotify/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: hirosassa
+    repo_name: ksnotify
+    asset: ksnotify-{{.Arch}}-{{.OS}}
+    format: raw
+    description: A CLI command to parse kustomize build result and notify it to GitLab
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -8155,6 +8155,20 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: hirosassa
+    repo_name: ksnotify
+    asset: ksnotify-{{.Arch}}-{{.OS}}
+    format: raw
+    description: A CLI command to parse kustomize build result and notify it to GitLab
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+  - type: github_release
+    repo_owner: hirosassa
     repo_name: tfcmt-gitlab
     asset: tfcmt-gitlab_{{.OS}}_{{.Arch}}.tar.gz
     description: tfcmt-gitlab is a CLI command to parse and notify Terraform execution results. This command supports GitLab as a CI and notification platform


### PR DESCRIPTION
[hirosassa/ksnotify](https://github.com/hirosassa/ksnotify): A CLI command to parse kustomize build result and notify it to GitLab

```console
$ aqua g -i hirosassa/ksnotify
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ksnotify --version
ksnotify x.x.x
```

Reference

- [GitHub repo](https://github.com/hirosassa/ksnotify)