### PR TITLE
feat: add dtan4/ghrls

### DIFF
--- a/pkgs/dtan4/ghrls/pkg.yaml
+++ b/pkgs/dtan4/ghrls/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dtan4/ghrls@v0.2.1

--- a/pkgs/dtan4/ghrls/pkg.yaml
+++ b/pkgs/dtan4/ghrls/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: dtan4/ghrls@v0.2.1
+  - name: dtan4/ghrls
+    version: v0.1.0

--- a/pkgs/dtan4/ghrls/registry.yaml
+++ b/pkgs/dtan4/ghrls/registry.yaml
@@ -2,14 +2,8 @@ packages:
   - type: github_release
     repo_owner: dtan4
     repo_name: ghrls
-    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: List & Describe GitHub Releases
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
+    format: tar.gz
     overrides:
       - goos: windows
         format: zip
@@ -17,6 +11,13 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver("> 0.1.0")
+    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
     checksum:
       type: github_release
       asset: checksums.txt
@@ -25,3 +26,13 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        asset: ghrls-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements: {}
+        checksum:
+          enabled: false
+        files:
+          - name: ghrls
+            src: "{{.OS}}-{{.Arch}}/ghrls"

--- a/pkgs/dtan4/ghrls/registry.yaml
+++ b/pkgs/dtan4/ghrls/registry.yaml
@@ -7,10 +7,6 @@ packages:
     overrides:
       - goos: windows
         format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     version_constraint: semver("> 0.1.0")
     asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
     replacements:
@@ -18,6 +14,10 @@ packages:
       darwin: Darwin
       linux: Linux
       windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     checksum:
       type: github_release
       asset: checksums.txt
@@ -31,8 +31,11 @@ packages:
         rosetta2: true
         asset: ghrls-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements: {}
-        checksum:
-          enabled: false
         files:
           - name: ghrls
             src: "{{.OS}}-{{.Arch}}/ghrls"
+        supported_envs:
+          - darwin
+          - amd64
+        checksum:
+          enabled: false

--- a/pkgs/dtan4/ghrls/registry.yaml
+++ b/pkgs/dtan4/ghrls/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - type: github_release
+    repo_owner: dtan4
+    repo_name: ghrls
+    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: List & Describe GitHub Releases
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5374,10 +5374,6 @@ packages:
     overrides:
       - goos: windows
         format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     version_constraint: semver("> 0.1.0")
     asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
     replacements:
@@ -5385,6 +5381,10 @@ packages:
       darwin: Darwin
       linux: Linux
       windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     checksum:
       type: github_release
       asset: checksums.txt
@@ -5398,11 +5398,14 @@ packages:
         rosetta2: true
         asset: ghrls-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements: {}
-        checksum:
-          enabled: false
         files:
           - name: ghrls
             src: "{{.OS}}-{{.Arch}}/ghrls"
+        supported_envs:
+          - darwin
+          - amd64
+        checksum:
+          enabled: false
   - type: github_release
     repo_owner: dtan4
     repo_name: k8sec

--- a/registry.yaml
+++ b/registry.yaml
@@ -5369,14 +5369,8 @@ packages:
   - type: github_release
     repo_owner: dtan4
     repo_name: ghrls
-    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: List & Describe GitHub Releases
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
+    format: tar.gz
     overrides:
       - goos: windows
         format: zip
@@ -5384,6 +5378,13 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver("> 0.1.0")
+    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
     checksum:
       type: github_release
       asset: checksums.txt
@@ -5392,6 +5393,16 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        asset: ghrls-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements: {}
+        checksum:
+          enabled: false
+        files:
+          - name: ghrls
+            src: "{{.OS}}-{{.Arch}}/ghrls"
   - type: github_release
     repo_owner: dtan4
     repo_name: k8sec

--- a/registry.yaml
+++ b/registry.yaml
@@ -5368,6 +5368,32 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: dtan4
+    repo_name: ghrls
+    asset: ghrls_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: List & Describe GitHub Releases
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: dtan4
     repo_name: k8sec
     asset: k8sec_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7630 [dtan4/ghrls](https://github.com/dtan4/ghrls): List & Describe GitHub Releases

```console
$ aqua g -i dtan4/ghrls
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ghrls --help
List & Describe GitHub Releases

Usage:
  ghrls [command]

Available Commands:
  get         Describe release information
  help        Help about any command
  list        List releases
  version     Print the version number

Flags:
  -h, --help   help for ghrls

Use "ghrls [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

```console
$ ghrls list aquaproj/aqua
TAG                   TYPE           CREATEDAT                        NAME
v1.22.0               TAG+RELEASE    2022-11-04 19:33:40 +0900 JST    v1.22.0
v1.22.0-pr-1336-2     TAG+RELEASE    2022-11-04 12:35:15 +0900 JST    v1.22.0-pr-1336-2
v1.22.0-2             TAG+RELEASE    2022-11-04 10:30:27 +0900 JST    v1.22.0-2
v1.22.0-1             TAG+RELEASE    2022-10-29 08:44:11 +0900 JST    v1.22.0-1
v1.22.0-0             TAG+RELEASE    2022-10-23 20:42:12 +0900 JST    v1.22.0-0
v1.21.0               TAG+RELEASE    2022-10-18 23:11:20 +0900 JST    v1.21.0
v1.20.3-0             TAG+RELEASE    2022-10-18 15:05:20 +0900 JST    v1.20.3-0
v1.20.2               TAG+RELEASE    2022-10-11 11:33:00 +0900 JST    v1.20.2
v1.20.2-0             TAG+RELEASE    2022-10-11 10:03:21 +0900 JST    v1.20.2-0
v1.20.1               TAG+RELEASE    2022-10-10 16:15:16 +0900 JST    v1.20.1
v1.20.0               TAG+RELEASE    2022-10-10 10:09:36 +0900 JST    v1.20.0
v1.20.0-8-checksum    TAG+RELEASE    2022-09-28 19:35:08 +0900 JST    v1.20.0-8-checksum
v1.20.0-7-checksum    TAG+RELEASE    2022-09-28 15:57:38 +0900 JST    v1.20.0-7-checksum
v1.20.0-6-checksum    TAG+RELEASE    2022-09-25 17:27:22 +0900 JST    v1.20.0-6-checksum
v1.20.0-5             TAG+RELEASE    2022-10-10 08:52:50 +0900 JST    v1.20.0-5
v1.20.0-5-checksum    TAG+RELEASE    2022-09-12 17:57:12 +0900 JST    v1.20.0-5-checksum
v1.20.0-4             TAG+RELEASE    2022-10-09 21:57:14 +0900 JST    v1.20.0-4
v1.20.0-4-checksum    TAG+RELEASE    2022-08-17 13:24:06 +0900 JST    v1.20.0-4-checksum
```

Reference

- README
	- https://github.com/dtan4/ghrls/blob/master/README.md