### PR TITLE
feat: add yinheli/sshw

### DIFF
--- a/pkgs/yinheli/sshw/pkg.yaml
+++ b/pkgs/yinheli/sshw/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: yinheli/sshw@v1.1.1
+  - name: yinheli/sshw
+    version: v1.0.8
+  - name: yinheli/sshw
+    version: v1.0.7

--- a/pkgs/yinheli/sshw/registry.yaml
+++ b/pkgs/yinheli/sshw/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: yinheli
+    repo_name: sshw
+    asset: sshw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: ssh client wrapper for automatic login
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: sshw_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.1.1")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.8")
+        # asset name was changed
+        asset: sshw-{{.OS}}-{{.Arch}}-{{.Version}}.tar.gz
+        files:
+          - name: sshw
+            src: sshw-{{.OS}}-{{.Arch}}-{{.Version}}/sshw
+        overrides: []
+        # arm64 wasn't supported
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          # SHA1 is used for algorithm of checksum
+          enabled: false
+      - version_constraint: "true"
+        # asset name was changed
+        asset: sshw-{{.OS}}-{{.Arch}}.tar.gz
+        overrides: []
+        rosetta2: true
+        # windows wasn't supported
+        supported_envs:
+          - darwin
+          - linux/amd64
+        checksum:
+          # checksum file not provided
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -17376,6 +17376,53 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: yinheli
+    repo_name: sshw
+    asset: sshw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: ssh client wrapper for automatic login
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: sshw_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.1.1")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.8")
+        # asset name was changed
+        asset: sshw-{{.OS}}-{{.Arch}}-{{.Version}}.tar.gz
+        files:
+          - name: sshw
+            src: sshw-{{.OS}}-{{.Arch}}-{{.Version}}/sshw
+        overrides: []
+        # arm64 wasn't supported
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          # SHA1 is used for algorithm of checksum
+          enabled: false
+      - version_constraint: "true"
+        # asset name was changed
+        asset: sshw-{{.OS}}-{{.Arch}}.tar.gz
+        overrides: []
+        rosetta2: true
+        # windows wasn't supported
+        supported_envs:
+          - darwin
+          - linux/amd64
+        checksum:
+          # checksum file not provided
+          enabled: false
+  - type: github_release
     repo_owner: yohamta
     repo_name: dagu
     description: A No-code workflow executor with built-in web UI


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7631 [yinheli/sshw](https://github.com/yinheli/sshw): ssh client wrapper for automatic login

```console
$ aqua g -i yinheli/sshw
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ sshw --help
Usage of /Users/username/.local/share/aquaproj-aqua/pkgs/github_release/github.com/yinheli/sshw/v1.1.1/sshw_v1.1.1_darwin_amd64.tar.gz/sshw:
  -help
        show help
  -s    use local ssh config '~/.ssh/config'
  -version
        show version
```

If files such as configuration file are needed, please share them.

```
$ cat .sshw.yaml
- name: foo server
  user: foo
  host: hoge.fuga.ssh.com
  port: 22
  keypath: /path/to/key.pem

$ sshw
Use the arrow keys to navigate: ↓ ↑ → ←  and / toggles search
✨ select host
  ➤ foo server foo@hoge.fuga.ssh.com
```

Reference

- README
	- https://github.com/yinheli/sshw/blob/master/README.md