### PR TITLE
feat: add sigstore/sget

### DIFF
--- a/pkgs/sigstore/sget/pkg.yaml
+++ b/pkgs/sigstore/sget/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: sigstore/sget
+    version: d625ec53ce53d8654ab9d61ba00f6c2d05726e7a

--- a/pkgs/sigstore/sget/registry.yaml
+++ b/pkgs/sigstore/sget/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: sigstore
+    repo_name: sget
+    description: sget is command for safer, automatic verification of signatures and integration with Sigstore's binary transparency log, Rekor

--- a/registry.yaml
+++ b/registry.yaml
@@ -14999,6 +14999,10 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: go_install
+    repo_owner: sigstore
+    repo_name: sget
+    description: sget is command for safer, automatic verification of signatures and integration with Sigstore's binary transparency log, Rekor
   - type: github_release
     repo_owner: simeji
     repo_name: jid


### PR DESCRIPTION
#7705 [sigstore/sget](https://github.com/sigstore/sget): sget is command for safer, automatic verification of signatures and integration with Sigstore's binary transparency log, Rekor

```console
$ aqua g -i sigstore/sget
```