### PR TITLE
feat: add in-toto/in-toto-golang

### DIFF
--- a/pkgs/in-toto/in-toto-golang/pkg.yaml
+++ b/pkgs/in-toto/in-toto-golang/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: in-toto/in-toto-golang@v0.5.0

--- a/pkgs/in-toto/in-toto-golang/registry.yaml
+++ b/pkgs/in-toto/in-toto-golang/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - type: go_install
+    repo_owner: in-toto
+    repo_name: in-toto-golang
+    description: A Go implementation of in-toto. in-toto is a framework to protect software supply chain integrity
+    files:
+      - name: in-toto

--- a/registry.yaml
+++ b/registry.yaml
@@ -8443,6 +8443,12 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: go_install
+    repo_owner: in-toto
+    repo_name: in-toto-golang
+    description: A Go implementation of in-toto. in-toto is a framework to protect software supply chain integrity
+    files:
+      - name: in-toto
   - type: github_release
     repo_owner: incu6us
     repo_name: goimports-reviser


### PR DESCRIPTION
#7764 [in-toto/in-toto-golang](https://github.com/in-toto/in-toto-golang): A Go implementation of in-toto. in-toto is a framework to protect software supply chain integrity

```console
$ aqua g -i in-toto/in-toto-golang
```