### PR TITLE
feat: add mvisonneau/gpcd

### DIFF
--- a/pkgs/mvisonneau/gpcd/pkg.yaml
+++ b/pkgs/mvisonneau/gpcd/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mvisonneau/gpcd@v0.0.1

--- a/pkgs/mvisonneau/gpcd/registry.yaml
+++ b/pkgs/mvisonneau/gpcd/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: mvisonneau
+    repo_name: gpcd
+    asset: gpcd_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: GoPro Cloud Downloader
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: gpcd_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12209,6 +12209,27 @@ packages:
       - name: shfmt
   - type: github_release
     repo_owner: mvisonneau
+    repo_name: gpcd
+    asset: gpcd_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: GoPro Cloud Downloader
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: gpcd_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: mvisonneau
     repo_name: tfcw
     description: Terraform Cloud Wrapper
     format: tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7786 [mvisonneau/gpcd](https://github.com/mvisonneau/gpcd): GoPro Cloud Downloader

```console
$ aqua g -i mvisonneau/gpcd
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gpcd --help
NAME:
   gpcd - download bulk medias from GoPro Cloud

USAGE:
   gpcd [global options] command [command options] [arguments...]

VERSION:
   0.0.1

COMMANDS:
   list      list available medias
   download  download medias
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --api-endpoint value              Go Pro Cloud API endpoint (default: "https://api.gopro.com/media/") [$GPCD_API_ENDPOINT]
   --local-path value                where the medias should be downloaded (default: "./medias") [$GPCD_LOCAL_PATH]
   --bearer-token value              Used to authenticate over your account [$GPCD_BEARER_TOKEN]
   --user-agent value                (default: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:106.0) Gecko/20100101 Firefox/106.0") [$GPCD_USER_AGENT]
   --from value                      filter for medias captured after this date
   --to value                        filter for medias captured before this date
   --max-concurrent-downloads value  (default: 16)
   --help, -h                        show help (default: false)
   --version, -v                     print the version (default: false)
```

Reference

- README.md
	- https://github.com/mvisonneau/gpcd/blob/main/README.md