### PR TITLE
feat: add mvisonneau/s5

### DIFF
--- a/pkgs/mvisonneau/s5/pkg.yaml
+++ b/pkgs/mvisonneau/s5/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: mvisonneau/s5@v0.1.12
+  - name: mvisonneau/s5
+    version: v0.1.10
+  - name: mvisonneau/s5
+    version: 0.1.9
+  - name: mvisonneau/s5
+    version: 0.1.4
+  - name: mvisonneau/s5
+    version: 0.1.3

--- a/pkgs/mvisonneau/s5/pkg.yaml
+++ b/pkgs/mvisonneau/s5/pkg.yaml
@@ -8,3 +8,5 @@ packages:
     version: 0.1.4
   - name: mvisonneau/s5
     version: 0.1.3
+  - name: mvisonneau/s5
+    version: 0.1.1

--- a/pkgs/mvisonneau/s5/registry.yaml
+++ b/pkgs/mvisonneau/s5/registry.yaml
@@ -1,0 +1,61 @@
+packages:
+  - type: github_release
+    repo_owner: mvisonneau
+    repo_name: s5
+    asset: s5_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Safely Store Super Sensitive Stuff
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: s5_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.11")
+    version_overrides:
+        # arm64 wasn't supported
+      - version_constraint: semver("= 0.1.10")
+        rosetta2: true
+        # checksum file was changed
+      - version_constraint: semver("= 0.1.9")
+        asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: s5_{{trimV .Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        # checksum file was changed
+      - version_constraint: semver(">= 0.1.4")
+        asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        # assets was changed
+      - version_constraint: "true"
+        asset: s5_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        overrides:
+          - goos: windows
+            asset: s5_{{.OS}}_{{.Arch}}.exe
+        checksum:
+          enabled: false

--- a/pkgs/mvisonneau/s5/registry.yaml
+++ b/pkgs/mvisonneau/s5/registry.yaml
@@ -2,9 +2,9 @@ packages:
   - type: github_release
     repo_owner: mvisonneau
     repo_name: s5
+    description: Safely Store Super Sensitive Stuff
     asset: s5_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: Safely Store Super Sensitive Stuff
     overrides:
       - goos: windows
         format: zip
@@ -21,12 +21,13 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.1.11")
+    # darwin/arm64 was supported
     version_overrides:
-        # arm64 wasn't supported
       - version_constraint: semver("= 0.1.10")
+        # checksum file and asset were changed
         rosetta2: true
-        # checksum file was changed
       - version_constraint: semver("= 0.1.9")
+        # checksum file was changed
         asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         rosetta2: true
         checksum:
@@ -37,8 +38,8 @@ packages:
           pattern:
             checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-        # checksum file was changed
       - version_constraint: semver(">= 0.1.4")
+        # assets and checksum were changed
         asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         rosetta2: true
         checksum:
@@ -49,13 +50,25 @@ packages:
           pattern:
             checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-        # assets was changed
-      - version_constraint: "true"
-        asset: s5_{{.OS}}_{{.Arch}}
+      - version_constraint: semver("= 0.1.3")
+        # linux/arm64 was supported
         format: raw
         rosetta2: true
+        asset: s5_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             asset: s5_{{.OS}}_{{.Arch}}.exe
+        checksum:
+          enabled: false
+      - version_constraint: "true"
+        format: raw
+        rosetta2: true
+        asset: s5_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            asset: s5_{{.OS}}_{{.Arch}}.exe
+        supported_envs:
+          - darwin
+          - amd64
         checksum:
           enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -12209,6 +12209,66 @@ packages:
       - name: shfmt
   - type: github_release
     repo_owner: mvisonneau
+    repo_name: s5
+    asset: s5_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Safely Store Super Sensitive Stuff
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: s5_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.11")
+    version_overrides:
+        # arm64 wasn't supported
+      - version_constraint: semver("= 0.1.10")
+        rosetta2: true
+        # checksum file was changed
+      - version_constraint: semver("= 0.1.9")
+        asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: s5_{{trimV .Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        # checksum file was changed
+      - version_constraint: semver(">= 0.1.4")
+        asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+        # assets was changed
+      - version_constraint: "true"
+        asset: s5_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        overrides:
+          - goos: windows
+            asset: s5_{{.OS}}_{{.Arch}}.exe
+        checksum:
+          enabled: false
+  - type: github_release
+    repo_owner: mvisonneau
     repo_name: tfcw
     description: Terraform Cloud Wrapper
     format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -12210,9 +12210,9 @@ packages:
   - type: github_release
     repo_owner: mvisonneau
     repo_name: s5
+    description: Safely Store Super Sensitive Stuff
     asset: s5_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: Safely Store Super Sensitive Stuff
     overrides:
       - goos: windows
         format: zip
@@ -12229,12 +12229,13 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.1.11")
+    # darwin/arm64 was supported
     version_overrides:
-        # arm64 wasn't supported
       - version_constraint: semver("= 0.1.10")
+        # checksum file and asset were changed
         rosetta2: true
-        # checksum file was changed
       - version_constraint: semver("= 0.1.9")
+        # checksum file was changed
         asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         rosetta2: true
         checksum:
@@ -12245,8 +12246,8 @@ packages:
           pattern:
             checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-        # checksum file was changed
       - version_constraint: semver(">= 0.1.4")
+        # assets and checksum were changed
         asset: s5_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         rosetta2: true
         checksum:
@@ -12257,14 +12258,26 @@ packages:
           pattern:
             checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-        # assets was changed
-      - version_constraint: "true"
-        asset: s5_{{.OS}}_{{.Arch}}
+      - version_constraint: semver("= 0.1.3")
+        # linux/arm64 was supported
         format: raw
         rosetta2: true
+        asset: s5_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             asset: s5_{{.OS}}_{{.Arch}}.exe
+        checksum:
+          enabled: false
+      - version_constraint: "true"
+        format: raw
+        rosetta2: true
+        asset: s5_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            asset: s5_{{.OS}}_{{.Arch}}.exe
+        supported_envs:
+          - darwin
+          - amd64
         checksum:
           enabled: false
   - type: github_release


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/7787 [mvisonneau/s5](https://github.com/mvisonneau/s5): Safely Store Super Sensitive Stuff

```console
$ aqua g -i mvisonneau/s5
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ s5 --help
NAME:
   s5 - cipher/decipher text within a file

USAGE:
   s5 [global options] command [command options] [arguments...]

VERSION:
   0.1.12

COMMANDS:
   cipher    return an encrypted s5 pattern that can be included in any file
   decipher  return an unencrypted s5 value from a given pattern
   render    render a file that (may) contain s5 encrypted patterns
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --log-level level    log level (debug,info,warn,fatal,panic) (default: "info") [$S5_LOG_LEVEL]
   --log-format format  log format (json,text) (default: "text") [$S5_LOG_FORMAT]
   --help, -h           show help (default: false)
   --version, -v        print the version (default: false)
```

Example:

```console
# cipher
$ s5 cipher aws --kms-key-arn <<arn>> hoge
{{s5:AQICAHja0AZHyrwbQH/DjRMQss+3ZnSo2ru3FOSiHz302RnHbwG+wth3ouXXfxE88WD+6sJqAAAAYjBgBgkqhkiG9w0BBwagUzBRAgEAMEwGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPhdtDy0hC7MZ3j1hAgEQgB8se82H2jwVM3snDkaMRfTyK8JB2Q72AjCldNJIX4+d}}

# decipher
$ s5 aws decipher aws {{s5:AQICAHja0AZHyrwbQH/DjRMQss+3ZnSo2ru3FOSiHz302RnHbwG+wth3ouXXfxE88WD+6sJqAAAAYjBgBgkqhkiG9w0BBwagUzBRAgEAMEwGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPhdtDy0hC7MZ3j1hAgEQgB8se82H2jwVM3snDkaMRfTyK8JB2Q72AjCldNJIX4+d}}
hoge
```

Reference

- README.md
	- https://github.com/mvisonneau/s5/blob/main/README.md
