### PR TITLE
feat: add orlangure/gocovsh

### DIFF
--- a/pkgs/orlangure/gocovsh/pkg.yaml
+++ b/pkgs/orlangure/gocovsh/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: orlangure/gocovsh@v0.6.1

--- a/pkgs/orlangure/gocovsh/registry.yaml
+++ b/pkgs/orlangure/gocovsh/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: orlangure
+    repo_name: gocovsh
+    asset: gocovsh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line 💻"
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/orlangure/gocovsh/registry.yaml
+++ b/pkgs/orlangure/gocovsh/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: orlangure
     repo_name: gocovsh
     asset: gocovsh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line 💻"
+    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line"
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13276,7 +13276,7 @@ packages:
     repo_owner: orlangure
     repo_name: gocovsh
     asset: gocovsh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line 💻"
+    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line"
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13273,6 +13273,19 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: orlangure
+    repo_name: gocovsh
+    asset: gocovsh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: "Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line 💻"
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: ory
     repo_name: hydra
     asset: hydra_{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[orlangure/gocovsh](https://github.com/orlangure/gocovsh): Go Coverage in your terminal: a tool for exploring Go Coverage reports from the command line 💻

```console
$ aqua g -i orlangure/gocovsh
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gocovsh --help
gocovsh: Go Coverage in your terminal

Usage: /Users/lars/.local/share/aqua/pkgs/github_release/github.com/orlangure/gocovsh/v0.6.1/gocovsh_0.6.1_darwin_amd64.tar.gz/gocovsh [options]

If provided, stdin is expected to be a list of files to be processed, for example:

        git diff --name-only | /Users/lars/.local/share/aqua/pkgs/github_release/github.com/orlangure/gocovsh/v0.6.1/gocovsh_0.6.1_darwin_amd64.tar.gz/gocovsh

Supported options:

  -profile string
        File name of coverage profile generated by go test -coverprofile coverage.out (default "coverage.out")
  -sort-by-coverage
        sort files by coverage instead of alphabetically
  -version
        show version
```

If files such as configuration file are needed, please share them.

```
```
