### PR TITLE
feat: add k0kubun/sqldef/mssqldef

### DIFF
--- a/pkgs/k0kubun/sqldef/mssqldef/pkg.yaml
+++ b/pkgs/k0kubun/sqldef/mssqldef/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k0kubun/sqldef/mssqldef@v0.14.1

--- a/pkgs/k0kubun/sqldef/mssqldef/registry.yaml
+++ b/pkgs/k0kubun/sqldef/mssqldef/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - name: k0kubun/sqldef/mssqldef
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: sqldef
+    description: Idempotent schema management for Microsoft SQL Server
+    asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: mssqldef
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    version_constraint: semver(">= 0.10.2")
+    # darwin/arm64 is supported
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs: []

--- a/registry.yaml
+++ b/registry.yaml
@@ -9766,6 +9766,27 @@ packages:
       - name: fzf-tmux
     checksum:
       enabled: false
+  - name: k0kubun/sqldef/mssqldef
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: sqldef
+    description: Idempotent schema management for Microsoft SQL Server
+    asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+    files:
+      - name: mssqldef
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    version_constraint: semver(">= 0.10.2")
+    # darwin/arm64 is supported
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    version_overrides:
+      - version_constraint: "true"
+        supported_envs: []
   - name: k0kubun/sqldef/mysqldef
     type: github_release
     repo_owner: k0kubun


### PR DESCRIPTION
[k0kubun/sqldef/mssqldef](https://github.com/k0kubun/sqldef): Idempotent schema management for Microsoft SQL Server

```console
$ aqua g -i k0kubun/sqldef/mssqldef
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mssqldef --help
Usage:
  mssqldef [options] db_name

Application Options:
  -U, --user=user_name       MSSQL user name (default: sa)
  -P, --password=password    MSSQL user password, overridden by $MSSQL_PWD
  -h, --host=host_name       Host to connect to the MSSQL server (default: 127.0.0.1)
  -p, --port=port_num        Port used for the connection (default: 1433)
      --password-prompt      Force MSSQL user password prompt
      --file=sql_file        Read schema SQL from the file, rather than stdin (default: -)
      --dry-run              Don't run DDLs but just show them
      --export               Just dump the current schema to stdout
      --skip-drop            Skip destructive changes such as DROP
      --help                 Show this help
      --version              Show this version
```

Reference

- https://github.com/k0kubun/sqldef#mssqldef
