### PR TITLE
feat: add docker/hub-tool

### DIFF
--- a/pkgs/docker/hub-tool/pkg.yaml
+++ b/pkgs/docker/hub-tool/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: docker/hub-tool@v0.4.5

--- a/pkgs/docker/hub-tool/pkg.yaml
+++ b/pkgs/docker/hub-tool/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: docker/hub-tool@v0.4.5
+  - name: docker/hub-tool
+    version: v0.3.1
+  - name: docker/hub-tool
+    version: v0.1.0

--- a/pkgs/docker/hub-tool/registry.yaml
+++ b/pkgs/docker/hub-tool/registry.yaml
@@ -18,3 +18,17 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.4.1")
+    # darwin/arm64 was supported
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        # linux/arm64 was supported
+        # asset name and format were changed
+        rosetta2: true
+      - version_constraint: "true"
+        asset: hub-tool_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/docker/hub-tool/registry.yaml
+++ b/pkgs/docker/hub-tool/registry.yaml
@@ -27,6 +27,7 @@ packages:
         rosetta2: true
       - version_constraint: "true"
         asset: hub-tool_{{.OS}}_{{.Arch}}
+        overrides: []
         format: raw
         rosetta2: true
         supported_envs:

--- a/pkgs/docker/hub-tool/registry.yaml
+++ b/pkgs/docker/hub-tool/registry.yaml
@@ -11,6 +11,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: hub-tool
+            src: hub-tool.exe
     supported_envs:
       - darwin
       - linux

--- a/pkgs/docker/hub-tool/registry.yaml
+++ b/pkgs/docker/hub-tool/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: docker
+    repo_name: hub-tool
+    asset: hub-tool-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Docker Hub experimental CLI tool
+    files:
+      - name: hub-tool
+        src: hub-tool/hub-tool
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5518,6 +5518,7 @@ packages:
         rosetta2: true
       - version_constraint: "true"
         asset: hub-tool_{{.OS}}_{{.Arch}}
+        overrides: []
         format: raw
         rosetta2: true
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -5509,6 +5509,20 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.4.1")
+    # darwin/arm64 was supported
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        # linux/arm64 was supported
+        # asset name and format were changed
+        rosetta2: true
+      - version_constraint: "true"
+        asset: hub-tool_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: doitintl
     repo_name: kube-no-trouble

--- a/registry.yaml
+++ b/registry.yaml
@@ -5491,6 +5491,22 @@ packages:
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
       - version_constraint: "true"
   - type: github_release
+    repo_owner: docker
+    repo_name: hub-tool
+    asset: hub-tool-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Docker Hub experimental CLI tool
+    files:
+      - name: hub-tool
+        src: hub-tool/hub-tool
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: doitintl
     repo_name: kube-no-trouble
     description: Easily check your clusters for use of deprecated APIs

--- a/registry.yaml
+++ b/registry.yaml
@@ -5502,6 +5502,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: hub-tool
+            src: hub-tool.exe
     supported_envs:
       - darwin
       - linux


### PR DESCRIPTION
[docker/hub-tool](https://github.com/docker/hub-tool): Docker Hub experimental CLI tool

```console
$ aqua g -i docker/hub-tool
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ hub-tool --help
A tool to manage your Docker Hub images

Usage:
  /Users/lars/.local/share/aqua/pkgs/github_release/github.com/docker/hub-tool/v0.4.5/hub-tool-darwin-amd64.tar.gz/hub-tool/hub-tool
  /Users/lars/.local/share/aqua/pkgs/github_release/github.com/docker/hub-tool/v0.4.5/hub-tool-darwin-amd64.tar.gz/hub-tool/hub-tool [command]

Available Commands:
  account     Manage your account
  help        Help about any command
  login       Login to the Hub
  logout      Logout of the Hub
  org         Manage organizations
  repo        Manage repositories
  tag         Manage tags
  token       Manage Personal Access Tokens
  version     Version information about this tool

Flags:
  -h, --help      help for /Users/lars/.local/share/aqua/pkgs/github_release/github.com/docker/hub-tool/v0.4.5/hub-tool-darwin-amd64.tar.gz/hub-tool/hub-tool
      --verbose   Print logs
      --version   Display the version of this tool

Use "/Users/lars/.local/share/aqua/pkgs/github_release/github.com/docker/hub-tool/v0.4.5/hub-tool-darwin-amd64.tar.gz/hub-tool/hub-tool [command] --help" for more information about a command.
```
