### PR TITLE
feat: add svenstaro/miniserve

### DIFF
--- a/pkgs/svenstaro/miniserve/pkg.yaml
+++ b/pkgs/svenstaro/miniserve/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: svenstaro/miniserve@v0.22.0
+  - name: svenstaro/miniserve
+    version: v0.10.4
+  - name: svenstaro/miniserve
+    version: v0.7.0

--- a/pkgs/svenstaro/miniserve/pkg.yaml
+++ b/pkgs/svenstaro/miniserve/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: svenstaro/miniserve@v0.22.0

--- a/pkgs/svenstaro/miniserve/registry.yaml
+++ b/pkgs/svenstaro/miniserve/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_name: miniserve
     asset: miniserve-{{trimV .Version}}-{{.Arch}}-{{.OS}}
     format: raw
-    description: 🌟 For when you really just want to serve some files over HTTP right now
+    description: For when you really just want to serve some files over HTTP right now
     replacements:
       amd64: x86_64
       arm64: aarch64

--- a/pkgs/svenstaro/miniserve/registry.yaml
+++ b/pkgs/svenstaro/miniserve/registry.yaml
@@ -16,3 +16,21 @@ packages:
       - linux
       - amd64
     rosetta2: true
+    version_constraint: semver(">= 0.11.0")
+    version_overrides:
+      # asset name was changed
+      - version_constraint: semver(">= 0.8.0")
+        asset: miniserve-{{.Version}}-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: "true"
+        asset: miniserve-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/svenstaro/miniserve/registry.yaml
+++ b/pkgs/svenstaro/miniserve/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: svenstaro
+    repo_name: miniserve
+    asset: miniserve-{{trimV .Version}}-{{.Arch}}-{{.OS}}
+    format: raw
+    description: 🌟 For when you really just want to serve some files over HTTP right now
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -16733,6 +16733,23 @@ packages:
           arm64: aarch64
           darwin: macos
   - type: github_release
+    repo_owner: svenstaro
+    repo_name: miniserve
+    asset: miniserve-{{trimV .Version}}-{{.Arch}}-{{.OS}}
+    format: raw
+    description: 🌟 For when you really just want to serve some files over HTTP right now
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: swaggo
     repo_name: swag
     description: Automatically generate RESTful API documentation with Swagger 2.0 for Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -16749,6 +16749,24 @@ packages:
       - linux
       - amd64
     rosetta2: true
+    version_constraint: semver(">= 0.11.0")
+    version_overrides:
+      # asset name was changed
+      - version_constraint: semver(">= 0.8.0")
+        asset: miniserve-{{.Version}}-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: "true"
+        asset: miniserve-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: swaggo
     repo_name: swag

--- a/registry.yaml
+++ b/registry.yaml
@@ -16737,7 +16737,7 @@ packages:
     repo_name: miniserve
     asset: miniserve-{{trimV .Version}}-{{.Arch}}-{{.OS}}
     format: raw
-    description: 🌟 For when you really just want to serve some files over HTTP right now
+    description: For when you really just want to serve some files over HTTP right now
     replacements:
       amd64: x86_64
       arm64: aarch64


### PR DESCRIPTION
[svenstaro/miniserve](https://github.com/svenstaro/miniserve): For when you really just want to serve some files over HTTP right now

```console
$ aqua g -i svenstaro/miniserve
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ miniserve
miniserve v0.22.0
05:39:35 [WARN] miniserve has been invoked without an explicit path so it will serve the current directory after a short delay.
05:39:35 [WARN] Invoke with -h|--help to see options or invoke as `miniserve .` to hide this advice.
Starting server in 3… 2… 1…
Bound to [::]:8080, 0.0.0.0:8080
Serving path /Users/lars/repos/personal/CrystalMethod/aqua-registry
Available at (non-exhaustive list):
    http://10.54.9.8:8080
    http://127.0.0.1:8080
    http://[::1]:8080

Quit by pressing CTRL-C
```