### PR TITLE
feat: add Orange-OpenSource/hurl

### DIFF
--- a/pkgs/Orange-OpenSource/hurl/pkg.yaml
+++ b/pkgs/Orange-OpenSource/hurl/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: Orange-OpenSource/hurl@1.8.0
+  - name: Orange-OpenSource/hurl
+    version: 1.6.1
+  - name: Orange-OpenSource/hurl
+    version: 1.6.0

--- a/pkgs/Orange-OpenSource/hurl/pkg.yaml
+++ b/pkgs/Orange-OpenSource/hurl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Orange-OpenSource/hurl@1.8.0

--- a/pkgs/Orange-OpenSource/hurl/registry.yaml
+++ b/pkgs/Orange-OpenSource/hurl/registry.yaml
@@ -26,3 +26,16 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver(">= 1.7.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.6.1")
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win64
+      - version_constraint: "true"
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win64

--- a/pkgs/Orange-OpenSource/hurl/registry.yaml
+++ b/pkgs/Orange-OpenSource/hurl/registry.yaml
@@ -18,6 +18,11 @@ packages:
       - goos: windows
         format: zip
         asset: hurl-{{.Version}}-{{.OS}}.{{.Format}}
+        files:
+          - name: hurl
+            src: hurl.exe
+          - name: hurlfmt
+            src: hurlfmt.exe
     supported_envs:
       - darwin
       - amd64

--- a/pkgs/Orange-OpenSource/hurl/registry.yaml
+++ b/pkgs/Orange-OpenSource/hurl/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: Orange-OpenSource
+    repo_name: hurl
+    asset: hurl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: Hurl, run and test HTTP requests with plain text
+    files:
+      - name: hurl
+        src: hurl-{{.Version}}/hurl
+      - name: hurlfmt
+        src: hurl-{{.Version}}/hurlfmt
+    replacements:
+      amd64: x86_64
+      darwin: macos
+      windows: win64
+    overrides:
+      - goos: windows
+        format: zip
+        asset: hurl-{{.Version}}-{{.OS}}.{{.Format}}
+    supported_envs:
+      - darwin
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -786,6 +786,28 @@ packages:
           - name: tridentctl
             src: trident-installer/extras/macos/bin/tridentctl
   - type: github_release
+    repo_owner: Orange-OpenSource
+    repo_name: hurl
+    asset: hurl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: Hurl, run and test HTTP requests with plain text
+    files:
+      - name: hurl
+        src: hurl-{{.Version}}/hurl
+      - name: hurlfmt
+        src: hurl-{{.Version}}/hurlfmt
+    replacements:
+      amd64: x86_64
+      darwin: macos
+      windows: win64
+    overrides:
+      - goos: windows
+        format: zip
+        asset: hurl-{{.Version}}-{{.OS}}.{{.Format}}
+    supported_envs:
+      - darwin
+      - amd64
+  - type: github_release
     repo_owner: PaulJuliusMartinez
     repo_name: jless
     asset: jless-{{.Version}}-{{.Arch}}-{{.OS}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -812,6 +812,19 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver(">= 1.7.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.6.1")
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win64
+      - version_constraint: "true"
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win64
   - type: github_release
     repo_owner: PaulJuliusMartinez
     repo_name: jless

--- a/registry.yaml
+++ b/registry.yaml
@@ -804,6 +804,11 @@ packages:
       - goos: windows
         format: zip
         asset: hurl-{{.Version}}-{{.OS}}.{{.Format}}
+        files:
+          - name: hurl
+            src: hurl.exe
+          - name: hurlfmt
+            src: hurlfmt.exe
     supported_envs:
       - darwin
       - amd64


### PR DESCRIPTION
[Orange-OpenSource/hurl](https://github.com/Orange-OpenSource/hurl): Hurl, run and test HTTP requests with plain text

```console
$ aqua g -i Orange-OpenSource/hurl
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ hurl
Run Hurl file(s) or standard input

Usage: hurl [OPTIONS] [FILE]...

Arguments:
  [FILE]...  Sets the input file to use

Options:
      --cacert <FILE>                     CA certificate to verify peer against (PEM format)
      --color                             Colorize output
      --compressed                        Request compressed response (using deflate or gzip)
      --connect-timeout <SECONDS>         Maximum time allowed for connection [default: 300]
  -b, --cookie <FILE>                     Read cookies from FILE
  -c, --cookie-jar <FILE>                 Write cookies to FILE after running the session (only for one session)
      --fail-at-end                       Fail at end
      --file-root <DIR>                   Set root filesystem to import files (default is current directory)
  -L, --location                          Follow redirects
      --glob <GLOB>                       Specify input files that match the given GLOB. Multiple glob flags may be used
  -i, --include                           Include the HTTP headers in the output
      --ignore-asserts                    Ignore asserts defined in the Hurl file
  -k, --insecure                          Allow insecure SSL connections
      --interactive                       Turn on interactive mode
      --json                              Output each Hurl file result to JSON
      --max-redirs <NUM>                  Maximum number of redirects allowed, -1 for unlimited redirects [default: 50]
  -m, --max-time <SECONDS>                Maximum time allowed for the transfer [default: 300]
      --no-color                          Do not colorize output
      --no-output                         Suppress output. By default, Hurl outputs the body of the last response
      --noproxy <HOST(S)>                 List of hosts which do not use proxy
  -o, --output <FILE>                     Write to FILE instead of stdout
  -x, --proxy <[PROTOCOL://]HOST[:PORT]>  Use proxy on given protocol/host/port
      --report-junit <FILE>               Write a Junit XML report to FILE
      --report-html <DIR>                 Generate HTML report to DIR
      --retry                             Retry requests on errors
      --retry-interval <MILLISECONDS>     Interval in milliseconds before a retry [default: 1000]
      --retry-max-count <NUM>             Maximum number of retries, -1 for unlimited retries [default: 10]
      --test                              Activate test mode
      --to-entry <ENTRY_NUMBER>           Execute Hurl file to ENTRY_NUMBER (starting at 1)
  -u, --user <USER:PASSWORD>              Add basic Authentication header to each request
  -A, --user-agent <NAME>                 Specify the User-Agent string to send to the HTTP server
      --variable <NAME=VALUE>             Define a variable
      --variables-file <FILE>             Define a properties file in which you define your variables
  -v, --verbose                           Turn on verbose output
      --very-verbose                      Turn on verbose output, including HTTP response and libcurl logs
  -h, --help                              Print help information
  -V, --version                           Print version information
```
