### PR TITLE
feat: add mvisonneau/approuvez

### DIFF
--- a/pkgs/mvisonneau/approuvez/pkg.yaml
+++ b/pkgs/mvisonneau/approuvez/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: mvisonneau/approuvez@v0.1.1
+  - name: mvisonneau/approuvez
+    version: v0.1.0

--- a/pkgs/mvisonneau/approuvez/pkg.yaml
+++ b/pkgs/mvisonneau/approuvez/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mvisonneau/approuvez@v0.1.1

--- a/pkgs/mvisonneau/approuvez/registry.yaml
+++ b/pkgs/mvisonneau/approuvez/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: mvisonneau
+    repo_name: approuvez
+    asset: approuvez_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: command line helper to obtain live confirmation from relevant people
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: approuvez_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"

--- a/pkgs/mvisonneau/approuvez/registry.yaml
+++ b/pkgs/mvisonneau/approuvez/registry.yaml
@@ -20,3 +20,7 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -12802,6 +12802,27 @@ packages:
       - name: shfmt
   - type: github_release
     repo_owner: mvisonneau
+    repo_name: approuvez
+    asset: approuvez_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: command line helper to obtain live confirmation from relevant people
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: approuvez_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: mvisonneau
     repo_name: gpcd
     asset: gpcd_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -12904,6 +12904,10 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
         file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
   - type: github_release
     repo_owner: mvisonneau
     repo_name: gpcd


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8167 [mvisonneau/approuvez](https://github.com/mvisonneau/approuvez): command line helper to obtain live confirmation from relevant people

```console
$ aqua g -i mvisonneau/approuvez
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ approuvez --help
NAME:
   approuvez - Command line helper to obtain live confirmation from people in a blocking fashion

USAGE:
   approuvez [global options] command [command options] [arguments...]

VERSION:
   0.1.1

COMMANDS:
   ask      send a message to someone and wait for a response
   serve    run the server thing
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --log-level level    log level (debug,info,warn,fatal,panic) (default: "info") [$APPROUVEZ_LOG_LEVEL]
   --log-format format  log format (json,text) (default: "text") [$APPROUVEZ_LOG_FORMAT]
   --tls-disable        disable mutual tls for gRPC transmissions (use with care!) (default: true) [$APPROUVEZ_TLS_DISABLE]
   --tls-ca-cert path   TLS CA certificate path [$APPROUVEZ_TLS_CA_CERT]
   --tls-cert path      TLS certificate path [$APPROUVEZ_TLS_CERT]
   --tls-key path       TLS key path [$APPROUVEZ_TLS_KEY]
   --help, -h           show help (default: false)
   --version, -v        print the version (default: false)
```

If files such as configuration file are needed, please share them.

There are a few things you need to prepare in advance.

- Slack App & API Token
	- Permission: `chat:write` / `users:read` / `users:read.email`
- `approuvez serve`
	- Must be accesible via the Internet

Reference

- quickstart.md
	- https://github.com/mvisonneau/approuvez/blob/main/examples/quickstart.md
