### PR TITLE
feat: add fujiwara/riex

### DIFF
--- a/pkgs/fujiwara/riex/pkg.yaml
+++ b/pkgs/fujiwara/riex/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiwara/riex@v0.0.2

--- a/pkgs/fujiwara/riex/registry.yaml
+++ b/pkgs/fujiwara/riex/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: fujiwara
+    repo_name: riex
+    asset: riex_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: AWS RI expiration detector
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6612,6 +6612,22 @@ packages:
         format: zip
   - type: github_release
     repo_owner: fujiwara
+    repo_name: riex
+    asset: riex_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: AWS RI expiration detector
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: fujiwara
     repo_name: tfstate-lookup
     description: Lookup resource attributes in tfstate
     asset: tfstate-lookup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8179 [fujiwara/riex](https://github.com/fujiwara/riex): AWS RI expiration detector

```console
$ aqua g -i fujiwara/riex
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ riex --help
Usage: riex <days>

Arguments:
  <days>    Show reserved instances that will be expired within specified days.

Flags:
  -h, --help           Show context-sensitive help.
      --active         Show active reserved instances.
      --expired=INT    Show reserved instances expired in the last specified days.
```

If files such as configuration file are needed, please share them.

```console
$ riex 30
...
```

Reference

- README.md
	- https://github.com/fujiwara/riex/blob/main/README.md
