### PR TITLE
feat: add livesense-inc/go-aws-s3get

### DIFF
--- a/pkgs/livesense-inc/go-aws-s3get/pkg.yaml
+++ b/pkgs/livesense-inc/go-aws-s3get/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: livesense-inc/go-aws-s3get@v0.1.0

--- a/pkgs/livesense-inc/go-aws-s3get/registry.yaml
+++ b/pkgs/livesense-inc/go-aws-s3get/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: livesense-inc
+    repo_name: go-aws-s3get
+    asset: s3get-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A stupid simple S3 downloader CLI tool with supporting AWS Access Key
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: s3get
+    checksum:
+      type: github_release
+      asset: s3get_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11809,6 +11809,27 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: livesense-inc
+    repo_name: go-aws-s3get
+    asset: s3get-{{.OS}}-{{.Arch}}
+    format: raw
+    description: A stupid simple S3 downloader CLI tool with supporting AWS Access Key
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: s3get
+    checksum:
+      type: github_release
+      asset: s3get_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: liweiyi88
     repo_name: gosnakego
     asset: gosnakego_{{.OS}}_{{.Arch}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8212 [livesense-inc/go-aws-s3get](https://github.com/livesense-inc/go-aws-s3get): A stupid simple S3 downloader CLI tool with supporting AWS Access Key

```console
$ aqua g -i livesense-inc/go-aws-s3get
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ s3get --help
NAME:
   s3get - A stupid simple downloader for AWS S3

USAGE:
   s3get-darwin-x86_64 [global options] s3://bucket-name/path/to/file output-file

VERSION:
   0.1.0 (rev:912ebd3)

GLOBAL OPTIONS:
   --region value, -r value   AWS region name [$AWS_DEFAULT_REGION, $AWS_REGION]
   --profile value, -p value  AWS_PROFILE, profile name to use (default: "default") [$AWS_PROFILE]
   --id value, -i value       AWS_ACCESS_KEY_ID, recommend to use env (default: secret) [$AWS_ACCESS_KEY_ID]
   --secret value, -s value   AWS_SECRET_ACCESS_KEY, recommend to use env (default: secret) [$AWS_SECRET_ACCESS_KEY]
   --help, -h                 show help (default: false)
   --version, -v              print the version (default: false)
```

Reference

- README.md
	- https://github.com/livesense-inc/go-aws-s3get#run
