### PR TITLE
feat: add anchore/quill

### DIFF
--- a/pkgs/anchore/quill/pkg.yaml
+++ b/pkgs/anchore/quill/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: anchore/quill@v0.2.0

--- a/pkgs/anchore/quill/registry.yaml
+++ b/pkgs/anchore/quill/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: anchore
+    repo_name: quill
+    asset: quill_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Simple mac binary signing from any platform
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: quill_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1869,6 +1869,27 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: anchore
+    repo_name: quill
+    asset: quill_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Simple mac binary signing from any platform
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: quill_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: anchore
     repo_name: syft
     description: CLI tool and library for generating a Software Bill of Materials from container images and filesystems
     supported_envs:


### PR DESCRIPTION
[anchore/quill](https://github.com/anchore/quill): Simple mac binary signing from any platform

```console
aqua g -i anchore/quill
```

## How to confirm if this package works well

Should return help output.

Command and output

```console
quill -h
```


Reference

- https://github.com/anchore/quill/