### PR TITLE
feat: add yitsushi/totp-cli

### DIFF
--- a/pkgs/yitsushi/totp-cli/pkg.yaml
+++ b/pkgs/yitsushi/totp-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yitsushi/totp-cli@v1.2.4

--- a/pkgs/yitsushi/totp-cli/registry.yaml
+++ b/pkgs/yitsushi/totp-cli/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: yitsushi
+    repo_name: totp-cli
+    asset: totp-cli-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Authy/Google Authenticator like TOTP CLI tool written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -18636,6 +18636,19 @@ packages:
           # checksum file not provided
           enabled: false
   - type: github_release
+    repo_owner: yitsushi
+    repo_name: totp-cli
+    asset: totp-cli-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Authy/Google Authenticator like TOTP CLI tool written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: yohamta
     repo_name: dagu
     description: A No-code workflow executor with built-in web UI


### PR DESCRIPTION
[yitsushi/totp-cli](https://github.com/yitsushi/totp-cli): Authy/Google Authenticator like TOTP CLI tool written in Go

```console
$ aqua g -i yitsushi/totp-cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ totp-cli
change-password                             Change password
delete <namespace> [account]                Delete an account or a whole namespace
generate <namespace> <account>              Generate a specific OTP
instant                                     Generate an OTP from TOTP_TOKEN or stdin without the Storage backend
set-prefix [namespace] [account] [prefix]   Set prefix for a token
version                                     Print current version of this application
add-token [namespace] [account]             Add new token
dump                                        Dump all available namespaces or accounts under a namespace
import <input-file>                         Import tokens from a yaml file.
list [namespace]                            List all available namespaces or accounts under a namespace
update                                      Check and update totp-cli itself
help [command]                              Display this help or a command specific help
```
