### PR TITLE
feat: add corrupt952/closest

### DIFF
--- a/pkgs/corrupt952/closest/pkg.yaml
+++ b/pkgs/corrupt952/closest/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: corrupt952/closest@v0.0.3

--- a/pkgs/corrupt952/closest/registry.yaml
+++ b/pkgs/corrupt952/closest/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: corrupt952
+    repo_name: closest
+    asset: closest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: The command that searches the current directory or parent directories for a specific file and returns the closest path
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: closest_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -4625,6 +4625,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+out/(\\S+)$"
   - type: github_release
+    repo_owner: corrupt952
+    repo_name: closest
+    asset: closest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: The command that searches the current directory or parent directories for a specific file and returns the closest path
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: closest_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: cortesi
     repo_name: modd
     description: A flexible developer tool that runs processes and responds to filesystem changes


### PR DESCRIPTION
[corrupt952/closest](https://github.com/corrupt952/closest): The command that searches the current directory or parent directories for a specific file and returns the closest path

```console
$ aqua g -i corrupt952/closest
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ closest .ssh
/home/john/.ssh

$ closest usr
/usr
```