### PR TITLE
fix(updatecli/updatecli): support v0.40.2

### DIFF
--- a/pkgs/updatecli/updatecli/pkg.yaml
+++ b/pkgs/updatecli/updatecli/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: updatecli/updatecli@v0.40.1
+  - name: updatecli/updatecli@v0.40.2
+  - name: updatecli/updatecli
+    version: v0.40.1

--- a/pkgs/updatecli/updatecli/registry.yaml
+++ b/pkgs/updatecli/updatecli/registry.yaml
@@ -13,11 +13,24 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    # TODO support signature verification with Cosign
+    # https://github.com/updatecli/updatecli/releases/tag/v0.40.2
     checksum:
       type: github_release
-      asset: updatecli_{{trimV .Version}}_checksums.txt
+      asset: checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.40.2")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: updatecli_{{trimV .Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -17805,14 +17805,27 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    # TODO support signature verification with Cosign
+    # https://github.com/updatecli/updatecli/releases/tag/v0.40.2
     checksum:
       type: github_release
-      asset: updatecli_{{trimV .Version}}_checksums.txt
+      asset: checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.40.2")
+    version_overrides:
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: updatecli_{{trimV .Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: uptrace
     repo_name: uptrace


### PR DESCRIPTION
The checksum file name was changed.

https://github.com/updatecli/updatecli/releases/tag/v0.40.2

> Use Cosign to sign Updatecli release assets
> https://github.com/updatecli/updatecli/pull/1041