### PR TITLE
feat: add prometheus/promlens

### DIFF
--- a/pkgs/prometheus/promlens/pkg.yaml
+++ b/pkgs/prometheus/promlens/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: prometheus/promlens@v0.3.0

--- a/pkgs/prometheus/promlens/registry.yaml
+++ b/pkgs/prometheus/promlens/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: prometheus
+    repo_name: promlens
+    asset: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: PromLens – The query builder, analyzer, and explainer for PromQL
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: promlens
+        src: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}/promlens

--- a/registry.yaml
+++ b/registry.yaml
@@ -14459,6 +14459,22 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: prometheus
+    repo_name: promlens
+    asset: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: PromLens – The query builder, analyzer, and explainer for PromQL
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: promlens
+        src: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}/promlens
   - name: protocolbuffers/protobuf-go/protoc-gen-go
     type: github_release
     repo_owner: protocolbuffers


### PR DESCRIPTION
[prometheus/promlens](https://github.com/prometheus/promlens): PromLens – The query builder, analyzer, and explainer for PromQL

```console
$ aqua g -i prometheus/promlens
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$  promlens
ts=2022-12-15T09:17:20.998Z caller=main.go:202 level=info msg="No link sharing backends are enabled - disabling link sharing functionality."
ts=2022-12-15T09:17:20.999Z caller=main.go:216 level=info msg="No Grafana backend enabled - disabling Grafana datasource integration."
ts=2022-12-15T09:17:20.999Z caller=tls_config.go:232 level=info msg="Listening on" address=[::]:8080
ts=2022-12-15T09:17:20.999Z caller=tls_config.go:235 level=info msg="TLS is disabled." http2=false address=[::]:8080
```

You can access promlens from your browser at `http://localhost:8080`.