### PR TITLE
feat: add google/osv-scanner

### DIFF
--- a/pkgs/google/osv-scanner/pkg.yaml
+++ b/pkgs/google/osv-scanner/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: google/osv-scanner@v1.0.1
+  - name: google/osv-scanner
+    version: v1.0.0

--- a/pkgs/google/osv-scanner/registry.yaml
+++ b/pkgs/google/osv-scanner/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: osv-scanner
+    asset: osv-scanner_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
+    checksum:
+      type: github_release
+      asset: osv-scanner_{{trimV .Version}}_SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.0.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7691,6 +7691,27 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: google
+    repo_name: osv-scanner
+    asset: osv-scanner_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    description: Vulnerability scanner written in Go which uses the data provided by https://osv.dev
+    checksum:
+      type: github_release
+      asset: osv-scanner_{{trimV .Version}}_SHA256SUMS
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.0.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
   - type: go_install
     repo_owner: google
     repo_name: pprof


### PR DESCRIPTION
[google/osv-scanner](https://github.com/google/osv-scanner): Vulnerability scanner written in Go which uses the data provided by https://osv.dev

```console
$ aqua g -i google/osv-scanner
```