### PR TITLE
feat: add chenjiandongx/kubectl-images

### DIFF
--- a/pkgs/chenjiandongx/kubectl-images/pkg.yaml
+++ b/pkgs/chenjiandongx/kubectl-images/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chenjiandongx/kubectl-images@v0.5.2

--- a/pkgs/chenjiandongx/kubectl-images/registry.yaml
+++ b/pkgs/chenjiandongx/kubectl-images/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_name: kubectl-images
     asset: kubectl-images_{{.OS}}_{{.Arch}}.tar.gz
     description: Show container images used in the cluster
+    version_constraint: semver(">= 0.3.6")
     supported_envs:
       - darwin
       - linux
@@ -16,3 +17,22 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver(">= 0.3.4")
+        # linux/arm64 is supported
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.3.3")
+        # darwin/arm64 is supported
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        checksum:
+          enabled: false
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/chenjiandongx/kubectl-images/registry.yaml
+++ b/pkgs/chenjiandongx/kubectl-images/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: chenjiandongx
+    repo_name: kubectl-images
+    asset: kubectl-images_{{.OS}}_{{.Arch}}.tar.gz
+    description: Show container images used in the cluster
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-images_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3750,6 +3750,7 @@ packages:
     repo_name: kubectl-images
     asset: kubectl-images_{{.OS}}_{{.Arch}}.tar.gz
     description: Show container images used in the cluster
+    version_constraint: semver(">= 0.3.6")
     supported_envs:
       - darwin
       - linux
@@ -3762,6 +3763,25 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver(">= 0.3.4")
+        # linux/arm64 is supported
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.3.3")
+        # darwin/arm64 is supported
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        checksum:
+          enabled: false
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: chmln
     repo_name: sd

--- a/registry.yaml
+++ b/registry.yaml
@@ -3749,7 +3749,7 @@ packages:
     repo_owner: chenjiandongx
     repo_name: kubectl-images
     asset: kubectl-images_{{.OS}}_{{.Arch}}.tar.gz
-    description: 🕸  Show container images used in the cluster
+    description: Show container images used in the cluster
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -3746,6 +3746,23 @@ packages:
               - name: cheat
                 src: dist/cheat-windows-amd64.exe
   - type: github_release
+    repo_owner: chenjiandongx
+    repo_name: kubectl-images
+    asset: kubectl-images_{{.OS}}_{{.Arch}}.tar.gz
+    description: 🕸  Show container images used in the cluster
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-images_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: chmln
     repo_name: sd
     asset: sd-{{.Version}}-{{.Arch}}-{{.OS}}


### PR DESCRIPTION
[chenjiandongx/kubectl-images](https://github.com/chenjiandongx/kubectl-images): Show container images used in the cluster

```console
$ aqua g -i chenjiandongx/kubectl-images
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl images
```

