### PR TITLE
fix(omrikiei/ktunnel) symlink kubectl-ktunnel

### DIFF
--- a/pkgs/omrikiei/ktunnel/registry.yaml
+++ b/pkgs/omrikiei/ktunnel/registry.yaml
@@ -9,6 +9,18 @@ packages:
       darwin: Darwin
       linux: Linux
       windows: Windows
+    files:
+      - name: kubectl-tunnel
+        src: ktunnel
+      - name: ktunnel
+        src: ktunnel
+    overrides:
+      - goos: windows
+        files:
+          - name: kubectl-tunnel.exe
+            src: ktunnel.exe
+          - name: ktunnel.exe
+            src: ktunnel.exe
     checksum:
       type: github_release
       asset: checksums.txt

--- a/pkgs/omrikiei/ktunnel/registry.yaml
+++ b/pkgs/omrikiei/ktunnel/registry.yaml
@@ -14,13 +14,6 @@ packages:
         src: ktunnel
       - name: ktunnel
         src: ktunnel
-    overrides:
-      - goos: windows
-        files:
-          - name: kubectl-tunnel.exe
-            src: ktunnel.exe
-          - name: ktunnel.exe
-            src: ktunnel.exe
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13617,13 +13617,6 @@ packages:
         src: ktunnel
       - name: ktunnel
         src: ktunnel
-    overrides:
-      - goos: windows
-        files:
-          - name: kubectl-tunnel.exe
-            src: ktunnel.exe
-          - name: ktunnel.exe
-            src: ktunnel.exe
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13612,6 +13612,18 @@ packages:
       darwin: Darwin
       linux: Linux
       windows: Windows
+    files:
+      - name: kubectl-tunnel
+        src: ktunnel
+      - name: ktunnel
+        src: ktunnel
+    overrides:
+      - goos: windows
+        files:
+          - name: kubectl-tunnel.exe
+            src: ktunnel.exe
+          - name: ktunnel.exe
+            src: ktunnel.exe
     checksum:
       type: github_release
       asset: checksums.txt


### PR DESCRIPTION
With this additional link the binary can be used as kubectl plugin `kubectl tunnel ...` as defined here: https://github.com/omrikiei/ktunnel/blob/master/krew/tunnel.yaml . Had to re-add the original ktunnel binary. 