### PR TITLE
feat: add ipinfo/cli and ipinfo/cli/{subcommand}

### DIFF
--- a/pkgs/ipinfo/cli/cidr2ip/pkg.yaml
+++ b/pkgs/ipinfo/cli/cidr2ip/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/cidr2ip@cidr2ip-1.0.0

--- a/pkgs/ipinfo/cli/cidr2ip/registry.yaml
+++ b/pkgs/ipinfo/cli/cidr2ip/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/cidr2ip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "cidr2ip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: cidr2ip
+        src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/cidr2ip/registry.yaml
+++ b/pkgs/ipinfo/cli/cidr2ip/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: cidr2ip
+            src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: cidr2ip
         src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/cidr2range/pkg.yaml
+++ b/pkgs/ipinfo/cli/cidr2range/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/cidr2range@cidr2range-1.2.0

--- a/pkgs/ipinfo/cli/cidr2range/registry.yaml
+++ b/pkgs/ipinfo/cli/cidr2range/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/cidr2range
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "cidr2range-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: cidr2range
+        src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/cidr2range/registry.yaml
+++ b/pkgs/ipinfo/cli/cidr2range/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: cidr2range
+            src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: cidr2range
         src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/grepip/pkg.yaml
+++ b/pkgs/ipinfo/cli/grepip/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/grepip@grepip-1.2.1

--- a/pkgs/ipinfo/cli/grepip/registry.yaml
+++ b/pkgs/ipinfo/cli/grepip/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/grepip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "grepip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: grepip
+        src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/grepip/registry.yaml
+++ b/pkgs/ipinfo/cli/grepip/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: grepip
+            src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: grepip
         src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/pkg.yaml
+++ b/pkgs/ipinfo/cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli@ipinfo-2.9.0

--- a/pkgs/ipinfo/cli/prips/pkg.yaml
+++ b/pkgs/ipinfo/cli/prips/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/prips@prips-1.0.0

--- a/pkgs/ipinfo/cli/prips/registry.yaml
+++ b/pkgs/ipinfo/cli/prips/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/prips
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "prips-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: prips
+        src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/prips/registry.yaml
+++ b/pkgs/ipinfo/cli/prips/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: prips
+            src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: prips
         src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/randip/pkg.yaml
+++ b/pkgs/ipinfo/cli/randip/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/randip@randip-1.1.0

--- a/pkgs/ipinfo/cli/randip/registry.yaml
+++ b/pkgs/ipinfo/cli/randip/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: randip
+            src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: randip
         src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/randip/registry.yaml
+++ b/pkgs/ipinfo/cli/randip/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/randip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "randip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: randip
+        src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/range2cidr/pkg.yaml
+++ b/pkgs/ipinfo/cli/range2cidr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/range2cidr@range2cidr-1.3.0

--- a/pkgs/ipinfo/cli/range2cidr/registry.yaml
+++ b/pkgs/ipinfo/cli/range2cidr/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/range2cidr
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "range2cidr-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: range2cidr
+        src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/range2cidr/registry.yaml
+++ b/pkgs/ipinfo/cli/range2cidr/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: range2cidr
+            src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: range2cidr
         src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/range2ip/pkg.yaml
+++ b/pkgs/ipinfo/cli/range2ip/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/range2ip@range2ip-1.0.0

--- a/pkgs/ipinfo/cli/range2ip/registry.yaml
+++ b/pkgs/ipinfo/cli/range2ip/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: range2ip
+            src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: range2ip
         src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/range2ip/registry.yaml
+++ b/pkgs/ipinfo/cli/range2ip/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/range2ip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "range2ip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: range2ip
+        src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/registry.yaml
+++ b/pkgs/ipinfo/cli/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "ipinfo-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: ipinfo
+        src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/registry.yaml
+++ b/pkgs/ipinfo/cli/registry.yaml
@@ -13,6 +13,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: ipinfo
+            src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: ipinfo
         src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/splitcidr/pkg.yaml
+++ b/pkgs/ipinfo/cli/splitcidr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ipinfo/cli/splitcidr@splitcidr-1.0.0

--- a/pkgs/ipinfo/cli/splitcidr/registry.yaml
+++ b/pkgs/ipinfo/cli/splitcidr/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: splitcidr
+            src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: splitcidr
         src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}

--- a/pkgs/ipinfo/cli/splitcidr/registry.yaml
+++ b/pkgs/ipinfo/cli/splitcidr/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    name: ipinfo/cli/splitcidr
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "splitcidr-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: splitcidr
+        src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -9278,6 +9278,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: ipinfo
+            src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: ipinfo
         src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9296,6 +9299,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: cidr2ip
+            src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: cidr2ip
         src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9314,6 +9320,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: cidr2range
+            src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: cidr2range
         src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9332,6 +9341,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: grepip
+            src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: grepip
         src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9350,6 +9362,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: prips
+            src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: prips
         src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9368,6 +9383,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: randip
+            src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: randip
         src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9386,6 +9404,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: range2cidr
+            src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: range2cidr
         src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9404,6 +9425,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: range2ip
+            src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: range2ip
         src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}
@@ -9422,6 +9446,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: splitcidr
+            src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}.exe
     files:
       - name: splitcidr
         src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -9264,6 +9264,167 @@ packages:
       algorithm: sha512
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{128}\b)
+  - type: github_release
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "ipinfo-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: ipinfo
+        src: ipinfo_{{trimPrefix "ipinfo-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/cidr2ip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "cidr2ip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: cidr2ip
+        src: cidr2ip_{{trimPrefix "cidr2ip-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/cidr2range
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "cidr2range-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: cidr2range
+        src: cidr2range_{{trimPrefix "cidr2range-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/grepip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "grepip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: grepip
+        src: grepip_{{trimPrefix "grepip-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/prips
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "prips-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: prips
+        src: prips_{{trimPrefix "prips-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/randip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "randip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: randip
+        src: randip_{{trimPrefix "randip-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/range2cidr
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "range2cidr-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: range2cidr
+        src: range2cidr_{{trimPrefix "range2cidr-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/range2ip
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "range2ip-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: range2ip
+        src: range2ip_{{trimPrefix "range2ip-" .Version}}_{{.OS}}_{{.Arch}}
+  - type: github_release
+    name: ipinfo/cli/splitcidr
+    repo_owner: ipinfo
+    repo_name: cli
+    description: Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)
+    version_filter: Version startsWith "splitcidr-"
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: splitcidr
+        src: splitcidr_{{trimPrefix "splitcidr-" .Version}}_{{.OS}}_{{.Arch}}
   - name: istio/istio/istioctl
     type: github_release
     repo_owner: istio


### PR DESCRIPTION
#8689 [ipinfo/cli](https://github.com/ipinfo/cli): Official Command Line Interface for the IPinfo API (IP geolocation and other types of IP data)

```console
$ aqua g -i ipinfo/cli ipinfo/cli/grepip ipinfo/cli/prips ipinfo/cli/cidr2range ipinfo/cli/cidr2ip ipinfo/cli/range2cidr ipinfo/cli/range2ip ipinfo/cli/splitcidr ipinfo/cli/randip
```