### PR TITLE
feat: add Songmu/timeout

### DIFF
--- a/pkgs/Songmu/timeout/pkg.yaml
+++ b/pkgs/Songmu/timeout/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Songmu/timeout@v0.4.0

--- a/pkgs/Songmu/timeout/registry.yaml
+++ b/pkgs/Songmu/timeout/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: Songmu
+    repo_name: timeout
+    asset: timeout_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Timeout invocation. Go porting of GNU timeout and able to use as Go package
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: go-timeout
+        src: timeout_{{.Version}}_{{.OS}}_{{.Arch}}/go-timeout

--- a/registry.yaml
+++ b/registry.yaml
@@ -1267,6 +1267,22 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: Songmu
+    repo_name: timeout
+    asset: timeout_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Timeout invocation. Go porting of GNU timeout and able to use as Go package
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: go-timeout
+        src: timeout_{{.Version}}_{{.OS}}_{{.Arch}}/go-timeout
+  - type: github_release
     repo_owner: TaKO8Ki
     repo_name: frum
     asset: frum-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz


### PR DESCRIPTION
#8693 [Songmu/timeout](https://github.com/Songmu/timeout): Timeout invocation. Go porting of GNU timeout and able to use as Go package

```console
$ aqua g -i Songmu/timeout
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ go-timeout --help
```
