### PR TITLE
feat: add FairwindsOps/gonogo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: aquaproj/aqua-installer@a39f721a15ed34ccbc85706e6e8ae8572c9ca9c6 # v1.2.0
         with:
           aqua_version: v1.25.0
-      - uses: suzuki-shunsuke/ci-info-action/store@c6a3abba5a3280cf36469931689b8d0dd03544c3 # tag=v0.1.0
+      - uses: suzuki-shunsuke/ci-info-action/store@main
       - run: echo "https://github.com/aquaproj/aqua-registry/pull/$CI_INFO_PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
 
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: aquaproj/aqua-installer@a39f721a15ed34ccbc85706e6e8ae8572c9ca9c6 # v1.2.0
         with:
           aqua_version: v1.25.0
-      - uses: suzuki-shunsuke/ci-info-action/store@main
+      - uses: suzuki-shunsuke/ci-info-action/store@v0.1.1
       - run: echo "https://github.com/aquaproj/aqua-registry/pull/$CI_INFO_PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
 
   test:

--- a/pkgs/FairwindsOps/gonogo/pkg.yaml
+++ b/pkgs/FairwindsOps/gonogo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: FairwindsOps/gonogo@v0.2.5

--- a/pkgs/FairwindsOps/gonogo/registry.yaml
+++ b/pkgs/FairwindsOps/gonogo/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: FairwindsOps
+    repo_name: gonogo
+    description: Tool to evaluate upgrade confidence for Kubernetes cluster addons
+    asset: gonogo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -355,6 +355,19 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: FairwindsOps
+    repo_name: gonogo
+    description: Tool to evaluate upgrade confidence for Kubernetes cluster addons
+    asset: gonogo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: FairwindsOps
     repo_name: nova
     asset: nova_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Find outdated or deprecated Helm charts running in your cluster


### PR DESCRIPTION
#8718 [FairwindsOps/gonogo](https://github.com/FairwindsOps/gonogo): Tool to evaluate upgrade confidence for Kubernetes cluster addons

```console
$ aqua g -i FairwindsOps/gonogo
```