### PR TITLE
feat: add Songmu/gitsemvers

### DIFF
--- a/pkgs/Songmu/gitsemvers/pkg.yaml
+++ b/pkgs/Songmu/gitsemvers/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Songmu/gitsemvers@v0.0.3

--- a/pkgs/Songmu/gitsemvers/registry.yaml
+++ b/pkgs/Songmu/gitsemvers/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: github_release
+    repo_owner: Songmu
+    repo_name: gitsemvers
+    asset: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: git-semvers
+        src: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}/git-semvers

--- a/pkgs/Songmu/gitsemvers/registry.yaml
+++ b/pkgs/Songmu/gitsemvers/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: Songmu
     repo_name: gitsemvers
+    description: Retrieve semvers from git tags
     asset: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -1162,6 +1162,17 @@ packages:
         format: tar.gz
   - type: github_release
     repo_owner: Songmu
+    repo_name: gitsemvers
+    asset: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: git-semvers
+        src: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}/git-semvers
+  - type: github_release
+    repo_owner: Songmu
     repo_name: gocredits
     description: creates CREDITS file from LICENSE files of dependencies
     rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -1163,6 +1163,7 @@ packages:
   - type: github_release
     repo_owner: Songmu
     repo_name: gitsemvers
+    description: Retrieve semvers from git tags
     asset: gitsemvers_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
     overrides:


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8742 [Songmu/gitsemvers](https://github.com/Songmu/gitsemvers): Retrieve semvers from git tags



```console
$ aqua g -i Songmu/gitsemvers
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ git-semvers --help
Usage:
  git-semvers [OPTIONS]

Version: 0.0.3

Application Options:
  -r, --repo=                git repository path (default: .)
  -g, --git=                 git path (default: git)
  -P, --with-pre-release     display pre-release versions
  -B, --with-build-metadata  display build-metadata versions

Help Options:
  -h, --help                 Show this help message
```

Reference

- README.md
	- https://github.com/Songmu/gitsemvers/blob/main/README.md