### PR TITLE
feat: add mr-karan/doggo

### DIFF
--- a/pkgs/mr-karan/doggo/pkg.yaml
+++ b/pkgs/mr-karan/doggo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mr-karan/doggo@v0.5.4

--- a/pkgs/mr-karan/doggo/registry.yaml
+++ b/pkgs/mr-karan/doggo/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: mr-karan
     repo_name: doggo
     asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: ":dog: Command-line DNS Client for Humans. Written in Golang"
+    description: Command-line DNS Client for Humans. Written in Golang
     checksum:
       type: github_release
       asset: doggo_{{trimV .Version}}_checksums.txt

--- a/pkgs/mr-karan/doggo/registry.yaml
+++ b/pkgs/mr-karan/doggo/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: mr-karan
+    repo_name: doggo
+    asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: ":dog: Command-line DNS Client for Humans. Written in Golang"
+    checksum:
+      type: github_release
+      asset: doggo_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13062,7 +13062,7 @@ packages:
     repo_owner: mr-karan
     repo_name: doggo
     asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: ":dog: Command-line DNS Client for Humans. Written in Golang"
+    description: Command-line DNS Client for Humans. Written in Golang
     checksum:
       type: github_release
       asset: doggo_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13047,6 +13047,19 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: mr-karan
+    repo_name: doggo
+    asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: ":dog: Command-line DNS Client for Humans. Written in Golang"
+    checksum:
+      type: github_release
+      asset: doggo_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: mrtazz
     repo_name: checkmake
     asset: checkmake-{{.Version}}.{{.OS}}.{{.Arch}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8743 [mr-karan/doggo](https://github.com/mr-karan/doggo): :dog: Command-line DNS Client for Humans. Written in Golang

```console
$ aqua g -i mr-karan/doggo
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ doggo --help
NAME:
  doggo 🐶 DNS Client for Humans

USAGE:
  doggo [--] [query options] [arguments...]

VERSION:
  v0.5.4 (2cf9e7b 2022-07-13T11:37:54Z) - unknown

EXAMPLES:
  doggo mrkaran.dev                             Query a domain using defaults.
  doggo mrkaran.dev CNAME                       Looks up for a CNAME record.
  doggo mrkaran.dev MX @9.9.9.9                 Uses a custom DNS resolver.
  doggo -q mrkaran.dev -t MX -n 1.1.1.1         Using named arguments.

Free Form Arguments:
  Supply hostnames, query types, classes without any flag. For eg:
  doggo mrkaran.dev A @1.1.1.1

Transport Options:
  Based on the URL scheme the correct resolver is chosen.
  Fallbacks to UDP resolver if no scheme is present.

  @udp://        eg: @1.1.1.1 initiates a UDP resolver for 1.1.1.1:53.
  @tcp://        eg: @tcp://1.1.1.1 initiates a TCP resolver for 1.1.1.1:53.
  @https://      eg: @https://cloudflare-dns.com/dns-query initiates a DOH resolver for Cloudflare DoH server.
  @tls://        eg: @tls://1.1.1.1 initiates a DoT resolver for 1.1.1.1:853.
  @sdns://       initiates a DNSCrypt or DoH resolver using its DNS stamp.
  @quic://       initiates a DOQ resolver.

Query Options:
  -q, --query=HOSTNAME        Hostname to query the DNS records for (eg mrkaran.dev).
  -t, --type=TYPE             Type of the DNS Record (A, MX, NS etc).
  -n, --nameserver=ADDR       Address of a specific nameserver to send queries to (9.9.9.9, 8.8.8.8 etc).
  -c, --class=CLASS           Network class of the DNS record (IN, CH, HS etc).
  -x, --reverse               Performs a DNS Lookup for an IPv4 or IPv6 address. Sets the query type and class to PTR and IN respectively.

Resolver Options:
  --strategy=STRATEGY          Specify strategy to query nameserver listed in etc/resolv.conf. (all, random, first).
  --ndots=INT                  Specify ndots parameter. Takes value from /etc/resolv.conf if using the system namesever or 1 otherwise.
  --search                     Use the search list defined in resolv.conf. Defaults to true. Set --search=false to disable search list.
  --timeout                    Specify timeout (in seconds) for the resolver to return a response.
  -4 --ipv4                    Use IPv4 only.
  -6 --ipv6                    Use IPv6 only.
  --ndots=INT                  Specify ndots parameter. Takes value from /etc/resolv.conf if using the system namesever or 1 otherwise.
  --tls-hostname=HOSTNAME      Provide a hostname for doing verification of the certificate if the provided DoT nameserver is an IP.
  --skip-hostname-verification Skip TLS Hostname Verification in case of DOT Lookups.

Output Options:
  -J, --json                  Format the output as JSON.
  --short                     Short output format. Shows only the response section.
  --color                     Defaults to true. Set --color=false to disable colored output.
  --debug                     Enable debug logging.
  --time                      Shows how long the response took from the server.
```

Reference

- README.md
	- https://github.com/mr-karan/doggo/blob/main/README.md
