### PR TITLE
fix(int128/kubelogin) krew index compatible symlink

### DIFF
--- a/pkgs/int128/kubelogin/registry.yaml
+++ b/pkgs/int128/kubelogin/registry.yaml
@@ -5,8 +5,9 @@ packages:
     asset: kubelogin_{{.OS}}_{{.Arch}}.zip
     description: kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
     files:
-      - name: kubectl-oidc_login
+      - name: kubectl-oidc-login
         src: kubelogin
+      - name: kubelogin
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -9231,8 +9231,9 @@ packages:
     asset: kubelogin_{{.OS}}_{{.Arch}}.zip
     description: kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)
     files:
-      - name: kubectl-oidc_login
+      - name: kubectl-oidc-login
         src: kubelogin
+      - name: kubelogin
     supported_envs:
       - darwin
       - linux


### PR DESCRIPTION
rename symlink of kubectl plugin to conform to krew index: https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/oidc-login.yaml