### PR TITLE
feat: add CycloneDX/cyclonedx-cli

### DIFF
--- a/pkgs/CycloneDX/cyclonedx-cli/pkg.yaml
+++ b/pkgs/CycloneDX/cyclonedx-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: CycloneDX/cyclonedx-cli@v0.24.2

--- a/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
+++ b/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
@@ -9,3 +9,5 @@ packages:
       amd64: x64
       darwin: osx
       windows: win
+    files:
+      - name: cyclonedx

--- a/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
+++ b/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: CycloneDX
+    repo_name: cyclonedx-cli
+    asset: cyclonedx-{{.OS}}-{{.Arch}}
+    format: raw
+    description: CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions
+    replacements:
+      amd64: x64
+      darwin: osx
+      windows: win

--- a/registry.yaml
+++ b/registry.yaml
@@ -277,6 +277,8 @@ packages:
       amd64: x64
       darwin: osx
       windows: win
+    files:
+      - name: cyclonedx
   - type: github_release
     repo_owner: DelineaXPM
     repo_name: dsv-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -268,6 +268,16 @@ packages:
     files:
       - name: btm
   - type: github_release
+    repo_owner: CycloneDX
+    repo_name: cyclonedx-cli
+    asset: cyclonedx-{{.OS}}-{{.Arch}}
+    format: raw
+    description: CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions
+    replacements:
+      amd64: x64
+      darwin: osx
+      windows: win
+  - type: github_release
     repo_owner: DelineaXPM
     repo_name: dsv-cli
     aliases:


### PR DESCRIPTION
[CycloneDX/cyclonedx-cli](https://github.com/CycloneDX/cyclonedx-cli): CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions

```console
$ aqua g -i CycloneDX/cyclonedx-cli
```

## How to confirm if this package works well

Command and output

```console
$ cyclonedx-cli --help
cyclonedx-osx-arm64

Usage:
  cyclonedx-osx-arm64 [options] [command]

Options:
  --version       Show version information
  -?, -h, --help  Show help and usage information

Commands:
  add                         Add information to a BOM (currently supports files)
  analyze                     Analyze a BOM file
  convert                     Convert between different BOM formats
  diff <from-file> <to-file>  Generate a BOM diff
  keygen                      Generates an RSA public/private key pair for BOM signing
  merge                       Merge two or more BOMs
  sign                        Sign a BOM or file
  validate                    Validate a BOM
  verify                      Verify signatures for BOMs and files
```

Reference

- https://github.com/CycloneDX/cyclonedx-cli/blob/main/README.md
