### PR TITLE
feat: add jmattheis/goverter

### DIFF
--- a/pkgs/jmattheis/goverter/pkg.yaml
+++ b/pkgs/jmattheis/goverter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jmattheis/goverter@v0.11.0

--- a/pkgs/jmattheis/goverter/registry.yaml
+++ b/pkgs/jmattheis/goverter/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: go_install
+    repo_owner: jmattheis
+    repo_name: goverter
+    description: Generate type-safe Go converters by simply defining an interface
+    path: github.com/jmattheis/goverter/cmd/goverter

--- a/registry.yaml
+++ b/registry.yaml
@@ -9961,6 +9961,11 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+  - type: go_install
+    repo_owner: jmattheis
+    repo_name: goverter
+    description: Generate type-safe Go converters by simply defining an interface
+    path: github.com/jmattheis/goverter/cmd/goverter
   - type: github_release
     repo_owner: joehillen
     repo_name: sysz


### PR DESCRIPTION
[jmattheis/goverter](https://github.com/jmattheis/goverter): Generate type-safe Go converters by simply defining an interface

```console
$ aqua g -i jmattheis/goverter
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

Require Go

```console
$ go mod init example
$ goverter example
```

Confirm output file `./generated/generated.go`

```go
// Code generated by github.com/jmattheis/goverter, DO NOT EDIT.

package generated

import example "example"

type ConverterImpl struct{}

func (c *ConverterImpl) Convert(source []example.Input) []example.Output {
	exampleOutputList := make([]example.Output, len(source))
	for i := 0; i < len(source); i++ {
		exampleOutputList[i] = c.exampleInputToExampleOutput(source[i])
	}
	return exampleOutputList
}
func (c *ConverterImpl) exampleInputToExampleOutput(source example.Input) example.Output {
	var exampleOutput example.Output
	exampleOutput.Name = source.Name
	exampleOutput.Age = source.Age
	return exampleOutput
}

```

If files such as configuration file are needed, please share them.

`input.go`

```go
package example

// goverter:converter
type Converter interface {
	Convert(source []Input) []Output
}

type Input struct {
	Name string
	Age  int
}
type Output struct {
	Name string
	Age  int
}

```

Reference

- There aren't any executable files in [GitHub Releases](https://github.com/jmattheis/goverter/releases)