### PR TITLE
feat: add ivaaaan/smug

### DIFF
--- a/pkgs/ivaaaan/smug/pkg.yaml
+++ b/pkgs/ivaaaan/smug/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ivaaaan/smug@v0.3.3

--- a/pkgs/ivaaaan/smug/pkg.yaml
+++ b/pkgs/ivaaaan/smug/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: ivaaaan/smug@v0.3.3
+  - name: ivaaaan/smug
+    version: v0.2.3
+  - name: ivaaaan/smug
+    version: v0.2.2

--- a/pkgs/ivaaaan/smug/registry.yaml
+++ b/pkgs/ivaaaan/smug/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: ivaaaan
+    repo_name: smug
+    asset: smug_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Session manager and task runner for tmux. Start your development environment within one command
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/ivaaaan/smug/registry.yaml
+++ b/pkgs/ivaaaan/smug/registry.yaml
@@ -23,10 +23,11 @@ packages:
       - version_constraint: semver(">=0.2.3")
         supported_envs:
           - amd64
-          - linux/arm64
+          - linux
         rosetta2: true
       # only supported amd64
       - version_constraint: "true"
         supported_envs:
+          - darwin
           - amd64
         rosetta2: true

--- a/pkgs/ivaaaan/smug/registry.yaml
+++ b/pkgs/ivaaaan/smug/registry.yaml
@@ -17,3 +17,16 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.2.5")
+    version_overrides:
+      # added support for linux/arm64
+      - version_constraint: semver(">=0.2.3")
+        supported_envs:
+          - amd64
+          - linux/arm64
+        rosetta2: true
+      # only supported amd64
+      - version_constraint: "true"
+        supported_envs:
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -9679,6 +9679,19 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.2.5")
+    version_overrides:
+      # added support for linux/arm64
+      - version_constraint: semver(">=0.2.3")
+        supported_envs:
+          - amd64
+          - linux/arm64
+        rosetta2: true
+      # only supported amd64
+      - version_constraint: "true"
+        supported_envs:
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: ivanilves
     repo_name: lstags

--- a/registry.yaml
+++ b/registry.yaml
@@ -9685,11 +9685,12 @@ packages:
       - version_constraint: semver(">=0.2.3")
         supported_envs:
           - amd64
-          - linux/arm64
+          - linux
         rosetta2: true
       # only supported amd64
       - version_constraint: "true"
         supported_envs:
+          - darwin
           - amd64
         rosetta2: true
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -9662,6 +9662,24 @@ packages:
       - name: mmv
         src: mmv_{{.Version}}_{{.OS}}_{{.Arch}}/mmv
   - type: github_release
+    repo_owner: ivaaaan
+    repo_name: smug
+    asset: smug_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Session manager and task runner for tmux. Start your development environment within one command
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: ivanilves
     repo_name: lstags
     description: Explore Docker registries and manipulate Docker images


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8804 [ivaaaan/smug](https://github.com/ivaaaan/smug): Session manager and task runner for tmux. Start your development environment within one command

```console
$ aqua g -i ivaaaan/smug
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ smug --help
Smug - tmux session manager. Version v0.3.3


Usage:
        smug <command> [<project>] [-f, --file <file>] [-w, --windows <window>]... [-a, --attach] [-d, --debug] [--detach] [-i, --inside-current-session] [<key>=<value>]...

Options:
        -f, --file A custom path to a config file
        -w, --windows List of windows to start. If session exists, those windows will be attached to current session
        -a, --attach Force switch client for a session
        -i, --inside-current-session Create all windows inside current session
        -d, --debug Print all commands to ~/.config/smug/smug.log
        --detach Detach tmux session. The same as -d flag in the tmux

Commands:
        list    list available project configurations
        edit    edit project configuration
        new     new project configuration
        start   start project session
        stop    stop project session
        print   session configuration to stdout

Examples:
        $ smug list
        $ smug edit blog
        $ smug new blog
        $ smug start blog
        $ smug start blog:win1
        $ smug start blog -w win1
        $ smug start blog:win1,win2
        $ smug stop blog
        $ smug start blog --attach
        $ smug print > ~/.config/smug/blog.yml
```

If files such as configuration file are needed, please share them.

```console
$ cat blog.yml
session: blog

root: ~/Code/blog

before_start:
  - docker-compose up -d

stop:
  - docker-compose stop

windows:
  - name: code
    layout: main-horizontal
    commands:
      - $EDITOR app/dependencies.php
    panes:
      - type: horizontal
        commands:
          - make run-tests
  - name: ssh
    commands:
      - ssh -i ~/keys/blog.pem ubuntu@127.0.0.1
```

Reference

- README.md
	- https://github.com/ivaaaan/smug/blob/master/README.md