### PR TITLE
feat: add concourse/concourse

### DIFF
--- a/pkgs/concourse/concourse/concourse/pkg.yaml
+++ b/pkgs/concourse/concourse/concourse/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: concourse/concourse/concourse@v7.9.0

--- a/pkgs/concourse/concourse/concourse/registry.yaml
+++ b/pkgs/concourse/concourse/concourse/registry.yaml
@@ -13,6 +13,8 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    # TODO checksum: support sha1
+    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: concourse
         src: concourse/bin/concourse

--- a/pkgs/concourse/concourse/concourse/registry.yaml
+++ b/pkgs/concourse/concourse/concourse/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - name: concourse/concourse/concourse
+    type: github_release
+    repo_owner: concourse
+    repo_name: concourse
+    asset: concourse-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    description: Concourse is a container-based continuous thing-doer written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - windows/amd64
+    rosetta2: true
+    files:
+      - name: concourse
+        src: concourse/bin/concourse

--- a/pkgs/concourse/concourse/concourse/registry.yaml
+++ b/pkgs/concourse/concourse/concourse/registry.yaml
@@ -10,10 +10,8 @@ packages:
       - goos: windows
         format: zip
     supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - windows/amd64
+      - darwin
+      - amd64
     rosetta2: true
     files:
       - name: concourse

--- a/pkgs/concourse/concourse/fly/pkg.yaml
+++ b/pkgs/concourse/concourse/fly/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: concourse/concourse/fly@v7.9.0

--- a/pkgs/concourse/concourse/fly/registry.yaml
+++ b/pkgs/concourse/concourse/fly/registry.yaml
@@ -13,5 +13,7 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    # TODO checksum: support sha1
+    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: fly

--- a/pkgs/concourse/concourse/fly/registry.yaml
+++ b/pkgs/concourse/concourse/fly/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - name: concourse/concourse/fly
+    type: github_release
+    repo_owner: concourse
+    repo_name: concourse
+    asset: fly-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    description: Concourse is a container-based continuous thing-doer written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - windows/amd64
+    rosetta2: true
+    files:
+      - name: fly

--- a/pkgs/concourse/concourse/fly/registry.yaml
+++ b/pkgs/concourse/concourse/fly/registry.yaml
@@ -10,10 +10,8 @@ packages:
       - goos: windows
         format: zip
     supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - windows/amd64
+      - darwin
+      - amd64
     rosetta2: true
     files:
       - name: fly

--- a/registry.yaml
+++ b/registry.yaml
@@ -4558,6 +4558,25 @@ packages:
     supported_envs:
       - darwin
       - amd64
+  - name: concourse/concourse/concourse
+    type: github_release
+    repo_owner: concourse
+    repo_name: concourse
+    asset: concourse-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    description: Concourse is a container-based continuous thing-doer written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - windows/amd64
+    rosetta2: true
+    files:
+      - name: concourse
+        src: concourse/bin/concourse
   - name: concourse/concourse/fly
     type: github_release
     repo_owner: concourse

--- a/registry.yaml
+++ b/registry.yaml
@@ -4572,6 +4572,8 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    # TODO checksum: support sha1
+    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: concourse
         src: concourse/bin/concourse

--- a/registry.yaml
+++ b/registry.yaml
@@ -4591,6 +4591,8 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    # TODO checksum: support sha1
+    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: fly
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -4569,10 +4569,8 @@ packages:
       - goos: windows
         format: zip
     supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - windows/amd64
+      - darwin
+      - amd64
     rosetta2: true
     files:
       - name: concourse

--- a/registry.yaml
+++ b/registry.yaml
@@ -4558,6 +4558,24 @@ packages:
     supported_envs:
       - darwin
       - amd64
+  - name: concourse/concourse/fly
+    type: github_release
+    repo_owner: concourse
+    repo_name: concourse
+    asset: fly-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    description: Concourse is a container-based continuous thing-doer written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - windows/amd64
+    rosetta2: true
+    files:
+      - name: fly
   - type: github_release
     repo_owner: container-tools
     repo_name: spectrum

--- a/registry.yaml
+++ b/registry.yaml
@@ -4588,10 +4588,8 @@ packages:
       - goos: windows
         format: zip
     supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - windows/amd64
+      - darwin
+      - amd64
     rosetta2: true
     files:
       - name: fly


### PR DESCRIPTION
Concourse is a container-based continuous thing-doer written in Go.
* Official site: https://concourse-ci.org
* GitHub: https://github.com/concourse/concourse


```console
$ aqua g -i concourse/concourse/concourse # server-side CLI
$ aqua g -i concourse/concourse/fly       # client CLI
```

## How to confirm if this package works well

Command and output

```console
$ concourse --help
Usage:
  concourse [OPTIONS] <command>

Application Options:
  -v, --version  Print the version of Concourse and exit [$CONCOURSE_VERSION]

Help Options:
  -h, --help     Show this help message

Available commands:
  generate-key   Generate RSA key for use with Concourse components.
  land-worker    Safely drain a worker's assignments for temporary downtime.
  migrate        Run database migrations.
  quickstart     Run both 'web' and 'worker' together, auto-wired. Not recommended for production.
  retire-worker  Safely remove a worker from the cluster permanently.
  web            Run the web UI and build scheduler.
  worker         Run and register a worker.
```

```console
$ fly --help
Usage:
  fly [OPTIONS] <command>

Application Options:
  -t, --target=              Concourse target name
  -v, --version              Print the version of Fly and exit
      --verbose              Print API requests and responses
      --print-table-headers  Print table headers even for redirected output

Help Options:
  -h, --help                 Show this help message

Available commands:
  abort-build               Abort a build (aliases: ab)
  active-users              List the active users since a date or for the past 2 months (aliases: au)
  archive-pipeline          Archive a pipeline (aliases: ap)
  builds                    List builds data (aliases: bs)
  check-resource            Check a resource (aliases: cr)
  check-resource-type       Check a resource-type (aliases: crt)
  checklist                 Print a Checkfile of the given pipeline (aliases: cl)
  clear-task-cache          Clears cache from a task container (aliases: ctc)
  completion                generate shell completion code
  containers                Print the active containers (aliases: cs)
  curl                      curl the api (aliases: c)
  delete-target             Delete target (aliases: dtg)
  destroy-pipeline          Destroy a pipeline (aliases: dp)
  destroy-team              Destroy a team and delete all of its data (aliases: dt)
  disable-resource-version  Disable a version of a resource (aliases: drv)
  edit-target               Edit a target (aliases: etg)
  enable-resource-version   Enable a version of a resource (aliases: erv)
  execute                   Execute a one-off build using local bits (aliases: e)
  expose-pipeline           Make a pipeline publicly viewable (aliases: ep)
  format-pipeline           Format a pipeline config (aliases: fp)
  get-pipeline              Get a pipeline's current configuration (aliases: gp)
  get-team                  Show team configuration (aliases: gt)
  help                      Print this help message
  hide-pipeline             Hide a pipeline from the public (aliases: hp)
  hijack                    Execute a command in a container (aliases: intercept, i)
  jobs                      List the jobs in the pipelines (aliases: js)
  land-worker               Land a worker (aliases: lw)
  login                     Authenticate with the target (aliases: l)
  logout                    Release authentication with the target (aliases: o)
  order-pipelines           Orders pipelines (aliases: op)
  pause-job                 Pause a job (aliases: pj)
  pause-pipeline            Pause a pipeline (aliases: pp)
  pin-resource              Pin a version to a resource (aliases: pr)
  pipelines                 List the configured pipelines (aliases: ps)
  prune-worker              Prune a stalled, landing, landed, or retiring worker (aliases: pw)
  rename-pipeline           Rename a pipeline (aliases: rp)
  rename-team               Rename a team (aliases: rt)
  rerun-build               Rerun a build (aliases: rb)
  resource-versions         List the versions of a resource (aliases: rvs)
  resources                 List the resources in the pipeline (aliases: rs)
  schedule-job              Request the scheduler to run for a job. Introduced as a recovery command for the v6.0 scheduler. (aliases: sj)
  set-pipeline              Create or update a pipeline's configuration (aliases: sp)
  set-team                  Create or modify a team to have the given credentials (aliases: st)
  status                    Login status
  sync                      Download and replace the current fly from the target (aliases: s)
  targets                   List saved targets (aliases: ts)
  teams                     List the configured teams (aliases: t)
  trigger-job               Start a job in a pipeline (aliases: tj)
  unpause-job               Unpause a job (aliases: uj)
  unpause-pipeline          Un-pause a pipeline (aliases: up)
  unpin-resource            Unpin a resource (aliases: ur)
  userinfo                  User information
  validate-pipeline         Validate a pipeline config (aliases: vp)
  volumes                   List the active volumes (aliases: vs)
  watch                     Stream a build's output (aliases: w)
  workers                   List the registered workers (aliases: ws)
```

Reference

- concouse CLI: https://concourse-ci.org/concourse-cli.html
- fly CLI: https://concourse-ci.org/fly.html