### PR TITLE
feat: support sha1

### DIFF
--- a/pkgs/concourse/concourse/concourse/registry.yaml
+++ b/pkgs/concourse/concourse/concourse/registry.yaml
@@ -13,8 +13,14 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: concourse
         src: concourse/bin/concourse
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      file_format: regexp
+      algorithm: sha1
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{40}\b)
+        file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"

--- a/pkgs/x-motemen/ghq/registry.yaml
+++ b/pkgs/x-motemen/ghq/registry.yaml
@@ -14,3 +14,11 @@ packages:
           - amd64
           - darwin
         rosetta2: true
+    checksum:
+      type: github_release
+      asset: SHASUMS
+      file_format: regexp
+      algorithm: sha1
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{40}\b)
+        file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"

--- a/pkgs/yinheli/sshw/registry.yaml
+++ b/pkgs/yinheli/sshw/registry.yaml
@@ -33,7 +33,13 @@ packages:
           - amd64
         checksum:
           # SHA1 is used for algorithm of checksum
-          enabled: false
+          type: github_release
+          asset: checksum.txt
+          file_format: regexp
+          algorithm: sha1
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{40}\b)
+            file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"
       - version_constraint: "true"
         # asset name was changed
         asset: sshw-{{.OS}}-{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -4572,11 +4572,17 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: concourse
         src: concourse/bin/concourse
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      file_format: regexp
+      algorithm: sha1
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{40}\b)
+        file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"
   - name: concourse/concourse/fly
     type: github_release
     repo_owner: concourse
@@ -19050,6 +19056,14 @@ packages:
           - amd64
           - darwin
         rosetta2: true
+    checksum:
+      type: github_release
+      asset: SHASUMS
+      file_format: regexp
+      algorithm: sha1
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{40}\b)
+        file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: x-motemen
     repo_name: gobump
@@ -19226,7 +19240,13 @@ packages:
           - amd64
         checksum:
           # SHA1 is used for algorithm of checksum
-          enabled: false
+          type: github_release
+          asset: checksum.txt
+          file_format: regexp
+          algorithm: sha1
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{40}\b)
+            file: "^\\b[A-Fa-f0-9]{40}\\b\\s+(\\S+)$"
       - version_constraint: "true"
         # asset name was changed
         asset: sshw-{{.OS}}-{{.Arch}}.tar.gz


### PR DESCRIPTION
## ⚠️ Breaking Changes

aqua >= v1.29.0 is requred. https://github.com/aquaproj/aqua/issues/1216

### How to migrate

Upgrade aqua to v1.29.0 or later.