### PR TITLE
feat: add prometheus/alertmanager

### DIFF
--- a/pkgs/prometheus/alertmanager/pkg.yaml
+++ b/pkgs/prometheus/alertmanager/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: prometheus/alertmanager@v0.25.0

--- a/pkgs/prometheus/alertmanager/registry.yaml
+++ b/pkgs/prometheus/alertmanager/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: prometheus
+    repo_name: alertmanager
+    asset: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: Prometheus Alertmanager
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: alertmanager
+        src: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}/alertmanager
+      - name: amtool
+        src: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}/amtool

--- a/registry.yaml
+++ b/registry.yaml
@@ -14908,6 +14908,24 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: prometheus
+    repo_name: alertmanager
+    asset: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: Prometheus Alertmanager
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: alertmanager
+        src: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}/alertmanager
+      - name: amtool
+        src: alertmanager-{{trimV .Version}}.{{.OS}}-{{.Arch}}/amtool
+  - type: github_release
+    repo_owner: prometheus
     repo_name: promlens
     asset: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
     description: PromLens – The query builder, analyzer, and explainer for PromQL


### PR DESCRIPTION
[Alertmanager](https://github.com/prometheus/alertmanager) handles alerts sent by client applications such as the Prometheus server.

included commands
* alertmanager: server binary
* [amtool](https://github.com/prometheus/alertmanager#amtool): CLI tool for interacting with the Alertmanager API

```console
$ aqua g -i prometheus/alertmanager
```

## How to confirm if this package works well

Command and output

```console
$ alertmanager --help
usage: alertmanager [<flags>]

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --config.file="alertmanager.yml"  
                                 Alertmanager configuration file name.
      --storage.path="data/"     Base path for data storage.
      --data.retention=120h      How long to keep data for.
      --alerts.gc-interval=30m   Interval between alert GC.
      --web.config.file=""       [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
      --web.external-url=WEB.EXTERNAL-URL  
                                 The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative
                                 and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager.
                                 If omitted, relevant URL components will be derived automatically.
      --web.route-prefix=WEB.ROUTE-PREFIX  
                                 Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.
      --web.listen-address=":9093"  
                                 Address to listen on for the web interface and API.
      --web.get-concurrency=0    Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger.
      --web.timeout=0            Timeout for HTTP requests. If negative or zero, no timeout is set.
      --cluster.listen-address="0.0.0.0:9094"  
                                 Listen address for cluster. Set to empty string to disable HA mode.
      --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 Explicit address to advertise in cluster.
      --cluster.peer=CLUSTER.PEER ...  
                                 Initial peers (may be repeated).
      --cluster.peer-timeout=15s  
                                 Time to wait between peers to send notifications.
      --cluster.gossip-interval=200ms  
                                 Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at
                                 the expense of increased bandwidth.
      --cluster.pushpull-interval=1m0s  
                                 Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense
                                 of increased bandwidth usage.
      --cluster.tcp-timeout=10s  Timeout for establishing a stream connection with a remote node for a full state sync, and for stream read and write operations.
      --cluster.probe-timeout=500ms  
                                 Timeout to wait for an ack from a probed node before assuming it is unhealthy. This should be set to 99-percentile of RTT (round-trip time) on your
                                 network.
      --cluster.probe-interval=1s  
                                 Interval between random node probes. Setting this lower (more frequent) will cause the cluster to detect failed nodes more quickly at the expense of
                                 increased bandwidth usage.
      --cluster.settle-timeout=1m0s  
                                 Maximum time to wait for cluster connections to settle before evaluating notifications.
      --cluster.reconnect-interval=10s  
                                 Interval between attempting to reconnect to lost peers.
      --cluster.reconnect-timeout=6h0m0s  
                                 Length of time to attempt to reconnect to a lost peer.
      --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
      --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
      --version                  Show application version.
```

```console
$ amtool --help
usage: amtool [<flags>] <command> [<args> ...]

View and modify the current Alertmanager state.

Config File: The alertmanager tool will read a config file in YAML format from one of two default config locations: $HOME/.config/amtool/config.yml or /etc/amtool/config.yml

All flags can be given in the config file, but the following are the suited for static configuration:

  alertmanager.url
        Set a default alertmanager url for each request

  author
        Set a default author value for new silences. If this argument is not
        specified then the username will be used

  require-comment
        Bool, whether to require a comment on silence creation. Defaults to true

  output
        Set a default output type. Options are (simple, extended, json)

  date.format
        Sets the output format for dates. Defaults to "2006-01-02 15:04:05 MST"

  tls.insecure.skip.verify
        Skips TLS certificate verification for all HTTPS requests.
        Defaults to false.

Flags:
  -h, --help           Show context-sensitive help (also try --help-long and --help-man).
      --date.format="2006-01-02 15:04:05 MST"  
                       Format of date output
  -v, --verbose        Verbose running information
      --alertmanager.url=ALERTMANAGER.URL  
                       Alertmanager to talk to
  -o, --output=simple  Output formatter (simple, extended, json)
      --timeout=30s    Timeout for the executed command
      --tls.insecure.skip.verify  
                       Skip TLS certificate verification
      --version-check  Check alertmanager version. Use --no-version-check to disable.
      --version        Show application version.

Commands:
  help [<command>...]
  alert
    query* [<flags>] [<matcher-groups>...]
    add [<flags>] [<labels>...]
  silence
    add [<flags>] [<matcher-groups>...]
    expire [<silence-ids>...]
    import [<flags>] [<input-file>]
    query* [<flags>] [<matcher-groups>...]
    update [<flags>] [<update-ids>...]
  check-config [<check-files>...]
  cluster
    show*
  config
    show*
    routes [<flags>]
      show*
      test [<flags>] [<labels>...]
  template
    render --template.glob=TEMPLATE.GLOB --template.text=TEMPLATE.TEXT [<flags>]
```

Reference

- amtool: https://github.com/prometheus/alertmanager#amtool