### PR TITLE
feat: add prometheus/prom2json

### DIFF
--- a/pkgs/prometheus/prom2json/pkg.yaml
+++ b/pkgs/prometheus/prom2json/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: prometheus/prom2json@v1.3.2

--- a/pkgs/prometheus/prom2json/pkg.yaml
+++ b/pkgs/prometheus/prom2json/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: prometheus/prom2json@v1.3.2
+  - name: prometheus/prom2json
+    version: v1.3.0

--- a/pkgs/prometheus/prom2json/registry.yaml
+++ b/pkgs/prometheus/prom2json/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: prometheus
+    repo_name: prom2json
+    asset: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: A tool to scrape a Prometheus client and dump the result as JSON
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: prom2json
+        src: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}/prom2json

--- a/pkgs/prometheus/prom2json/registry.yaml
+++ b/pkgs/prometheus/prom2json/registry.yaml
@@ -15,3 +15,11 @@ packages:
     files:
       - name: prom2json
         src: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}/prom2json
+    version_constraint: semver(">= 1.3.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -14922,6 +14922,14 @@ packages:
     files:
       - name: prom2json
         src: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}/prom2json
+    version_constraint: semver(">= 1.3.1")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
   - type: github_release
     repo_owner: prometheus
     repo_name: promlens

--- a/registry.yaml
+++ b/registry.yaml
@@ -14908,6 +14908,22 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: prometheus
+    repo_name: prom2json
+    asset: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
+    description: A tool to scrape a Prometheus client and dump the result as JSON
+    checksum:
+      type: github_release
+      asset: sha256sums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: prom2json
+        src: prom2json-{{trimV .Version}}.{{.OS}}-{{.Arch}}/prom2json
+  - type: github_release
+    repo_owner: prometheus
     repo_name: promlens
     asset: promlens-{{trimV .Version}}.{{.OS}}-{{.Arch}}.tar.gz
     description: PromLens – The query builder, analyzer, and explainer for PromQL


### PR DESCRIPTION
[prom2json](https://github.com/prometheus/prom2json) is a tool to scrape a Prometheus client and dump the result as JSON.

```console
$ aqua g -i prometheus/prom2json
```

## How to confirm if this package works well

Command and output

```console
$ prom2json --help
Usage of prom2json:
  -accept-invalid-cert
        Accept any certificate during TLS handshake. Insecure, use only for testing.
  -cert string
        client certificate file
  -key string
        client certificate's key file
```