### PR TITLE
docs: fix git command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ you have to create an Issue and describe what is changed and why the change is n
 Checkout the repository and install [aqua-registry CLI](https://github.com/aquaproj/registry-tool).
 
 ```console
-$ git checkout https://github.com/aquaproj/aqua-registry
+$ git clone https://github.com/aquaproj/aqua-registry
 $ cd aqua-registry
 $ aqua i -l # Install aqua-registry CLI
 ```


### PR DESCRIPTION
If run `git checkout`  an error occurs.

```shell
$ git checkout https://github.com/aquaproj/aqua-registry
error: pathspec 'https://github.com/aquaproj/aqua-registry' did not match any file(s) known to git
```