### PR TITLE
feat: add cocogitto/cocogitto

### DIFF
--- a/pkgs/cocogitto/cocogitto/pkg.yaml
+++ b/pkgs/cocogitto/cocogitto/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cocogitto/cocogitto@5.2.0

--- a/pkgs/cocogitto/cocogitto/registry.yaml
+++ b/pkgs/cocogitto/cocogitto/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: cocogitto
+    repo_name: cocogitto
+    asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    description: The Conventional Commits toolbox
+    replacements:
+      amd64: x86_64
+      darwin: osx
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: cog

--- a/registry.yaml
+++ b/registry.yaml
@@ -4478,6 +4478,21 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+dist/(\\S+)$"
+  - type: github_release
+    repo_owner: cocogitto
+    repo_name: cocogitto
+    asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    description: The Conventional Commits toolbox
+    replacements:
+      amd64: x86_64
+      darwin: osx
+      linux: unknown-linux-musl
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: cog
   - type: http
     repo_owner: codeclimate
     repo_name: test-reporter


### PR DESCRIPTION
For the first time, I create a pull request to add a package.

[cocogitto/cocogitto](https://github.com/cocogitto/cocogitto): The Conventional Commits toolbox

```console
$ aqua g -i cocogitto/cocogitto
```

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cog verify 'chore(commit-msg): test cocogitto'
test cocogitto (not committed) - now
        Author: hituzi no sippo
        Type: chore
        Scope: commit-msg

$ cog verify 'test cocogitto'
Error: Missing commit type separator `:`

Caused by:
     --> 1:5
      |
    1 | test cocogitto
      |     ^---
      |
      = expected scope or type_separator

```

If files such as configuration file are needed, please share them.

None

Reference

- https://github.com/cocogitto/cocogitto/releases/tag/5.2.0
- http://cocogitto.io/