### PR TITLE
feat: add terrastruct/d2

### DIFF
--- a/pkgs/terrastruct/d2/pkg.yaml
+++ b/pkgs/terrastruct/d2/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: terrastruct/d2@v0.1.4

--- a/pkgs/terrastruct/d2/registry.yaml
+++ b/pkgs/terrastruct/d2/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: terrastruct
+    repo_name: d2
+    asset: d2-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: D2 is a modern diagram scripting language that turns text to diagrams
+    replacements:
+      darwin: macos
+    files:
+      - name: d2
+        src: d2-{{.Version}}/bin/d2

--- a/registry.yaml
+++ b/registry.yaml
@@ -17912,6 +17912,16 @@ packages:
             checksum: ^(\b[A-Fa-f0-9]{64}\b)
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: terrastruct
+    repo_name: d2
+    asset: d2-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: D2 is a modern diagram scripting language that turns text to diagrams
+    replacements:
+      darwin: macos
+    files:
+      - name: d2
+        src: d2-{{.Version}}/bin/d2
+  - type: github_release
     repo_owner: tfmigrator
     repo_name: cli
     asset: tfmigrator_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
[terrastruct/d2](https://github.com/terrastruct/d2): D2 is a modern diagram scripting language that turns text to diagrams

```console
$ aqua g -i terrastruct/d2
```