### PR TITLE
feat: add terrastruct/tala

### DIFF
--- a/pkgs/terrastruct/tala/pkg.yaml
+++ b/pkgs/terrastruct/tala/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: terrastruct/tala@v0.2.11

--- a/pkgs/terrastruct/tala/registry.yaml
+++ b/pkgs/terrastruct/tala/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: terrastruct
+    repo_name: tala
+    asset: tala-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: A diagram layout engine designed specifically for software architecture diagrams
+    replacements:
+      darwin: macos
+    files:
+      - name: d2plugin-tala
+        src: tala-{{.Version}}/bin/d2plugin-tala

--- a/registry.yaml
+++ b/registry.yaml
@@ -17922,6 +17922,16 @@ packages:
       - name: d2
         src: d2-{{.Version}}/bin/d2
   - type: github_release
+    repo_owner: terrastruct
+    repo_name: tala
+    asset: tala-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    description: A diagram layout engine designed specifically for software architecture diagrams
+    replacements:
+      darwin: macos
+    files:
+      - name: d2plugin-tala
+        src: tala-{{.Version}}/bin/d2plugin-tala
+  - type: github_release
     repo_owner: tfmigrator
     repo_name: cli
     asset: tfmigrator_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
[terrastruct/tala](https://github.com/terrastruct/tala): A diagram layout engine designed specifically for software architecture diagrams

```console
$ aqua g -i terrastruct/tala
```