### PR TITLE
fix(fastly/cli): support windows

### DIFF
--- a/pkgs/fastly/cli/pkg.yaml
+++ b/pkgs/fastly/cli/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: fastly/cli@v4.5.0
+  - name: fastly/cli@v4.6.0
+  - name: fastly/cli
+    version: v4.5.0

--- a/pkgs/fastly/cli/registry.yaml
+++ b/pkgs/fastly/cli/registry.yaml
@@ -2,12 +2,9 @@ packages:
   - type: github_release
     repo_owner: fastly
     repo_name: cli
+    description: A CLI for interacting with the Fastly platform
     asset: fastly_{{.Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: A CLI for interacting with the Fastly platform
-    overrides:
-      - goos: windows
-        format: zip
     files:
       - name: fastly
     checksum:
@@ -18,3 +15,9 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 4.6.0")
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -6508,12 +6508,9 @@ packages:
   - type: github_release
     repo_owner: fastly
     repo_name: cli
+    description: A CLI for interacting with the Fastly platform
     asset: fastly_{{.Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: A CLI for interacting with the Fastly platform
-    overrides:
-      - goos: windows
-        format: zip
     files:
       - name: fastly
     checksum:
@@ -6524,6 +6521,12 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 4.6.0")
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: fastly
     repo_name: terrctl


### PR DESCRIPTION
File extension was changed from .zip to .tar.gz.

https://github.com/fastly/cli/releases/tag/v4.6.0