### PR TITLE
feat: add koki-develop/clive

### DIFF
--- a/pkgs/koki-develop/clive/pkg.yaml
+++ b/pkgs/koki-develop/clive/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: koki-develop/clive@v0.10.1

--- a/pkgs/koki-develop/clive/registry.yaml
+++ b/pkgs/koki-develop/clive/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: koki-develop
+    repo_name: clive
+    asset: clive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Automates terminal operations and lets you view them live via a browser
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+

--- a/registry.yaml
+++ b/registry.yaml
@@ -11237,6 +11237,25 @@ packages:
         files:
           - name: shellcheck
   - type: github_release
+    repo_owner: koki-develop
+    repo_name: clive
+    asset: clive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Automates terminal operations and lets you view them live via a browser
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+
+  - type: github_release
     repo_owner: koluku
     repo_name: s3s
     asset: s3s_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/8976 [koki-develop/clive](https://github.com/koki-develop/clive): Automates terminal operations and lets you view them live via a browser

```console
$ aqua g -i koki-develop/clive
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ clive --help
Automates terminal operations and lets you view them live via a browser.

Usage:
  clive [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  init        Create a config file
  start       Start cLive actions
  validate    Validate a config file

Flags:
  -h, --help      help for clive
  -v, --version   version for clive

Use "clive [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

※ This tool is `ttyd` command required. (refer to [Prerequisite](https://github.com/koki-develop/clive#information_source-prerequisite))

```console
$ clive init
Created ./clive.yml

$ cat clive.yml
# documentation: https://github.com/koki-develop/clive#settings
settings:
  loginCommand: ["bash", "--login"]
  fontSize: 22
  defaultSpeed: 10

# documentation: https://github.com/koki-develop/clive#actions
actions:
  - pause
  - type: echo 'Welcome to cLive!'
  - key: enter

$ clive start
Starting...

Reference
 Actions
#1 > Pause: Press enter to continue
#2   Type: echo 'Welcome to cLive!'
#3   Key: enter
```

Reference

- README.md
	- https://github.com/koki-develop/clive/blob/main/README.md
- Blog (Japanese)
	- https://zenn.dev/kou_pg_0131/articles/clive-introduction