### PR TITLE
feat: add tamasfe/taplo/full

### DIFF
--- a/pkgs/tamasfe/taplo/full/pkg.yaml
+++ b/pkgs/tamasfe/taplo/full/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: tamasfe/taplo@0.8.0
+  - name: tamasfe/taplo
+    version: release-taplo-cli-0.6.7
+  - name: tamasfe/taplo
+    version: release-cli-0.6.0

--- a/pkgs/tamasfe/taplo/full/registry.yaml
+++ b/pkgs/tamasfe/taplo/full/registry.yaml
@@ -1,0 +1,54 @@
+packages:
+  - type: github_release
+    repo_owner: tamasfe
+    repo_name: taplo
+    name: tamasfe/taplo/full
+    description: A TOML toolkit written in Rust
+    version_constraint: not (Version startsWith "release-taplo-cli-") and not (Version startsWith "release-cli-") and semver(">= 0.8.0")
+    asset: taplo-full-{{.OS}}-{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    format: gz
+    files:
+      - name: taplo
+        src: taplo-full-{{.OS}}-{{.Arch}}
+    overrides:
+      - goos: windows
+        format: zip
+        files:
+          - name: taplo
+            src: taplo.exe
+    version_overrides:
+      - version_constraint: Version startsWith "release-taplo-cli-"
+        asset: taplo-full-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        rosetta2: true
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux
+        overrides: []
+        files:
+          - name: taplo
+      - version_constraint: Version startsWith "release-cli-" and semverWithVersion(">= 0.6.0", trimPrefix(Version, "release-cli-"))
+        asset: taplo-full-{{trimPrefix "release-cli-" .Version}}-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        rosetta2: true
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux
+        overrides: []
+        files:
+          - name: taplo

--- a/registry.yaml
+++ b/registry.yaml
@@ -17863,6 +17863,59 @@ packages:
           - darwin
           - amd64
   - type: github_release
+    repo_owner: tamasfe
+    repo_name: taplo
+    name: tamasfe/taplo/full
+    description: A TOML toolkit written in Rust
+    version_constraint: not (Version startsWith "release-taplo-cli-") and not (Version startsWith "release-cli-") and semver(">= 0.8.0")
+    asset: taplo-full-{{.OS}}-{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    format: gz
+    files:
+      - name: taplo
+        src: taplo-full-{{.OS}}-{{.Arch}}
+    overrides:
+      - goos: windows
+        format: zip
+        files:
+          - name: taplo
+            src: taplo.exe
+    version_overrides:
+      - version_constraint: Version startsWith "release-taplo-cli-"
+        asset: taplo-full-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        rosetta2: true
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux
+        overrides: []
+        files:
+          - name: taplo
+      - version_constraint: Version startsWith "release-cli-" and semverWithVersion(">= 0.6.0", trimPrefix(Version, "release-cli-"))
+        asset: taplo-full-{{trimPrefix "release-cli-" .Version}}-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        rosetta2: true
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux
+        overrides: []
+        files:
+          - name: taplo
+  - type: github_release
     repo_owner: taskctl
     repo_name: taskctl
     asset: taskctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
Taplo full build has been created since v0.6.0.

[tamasfe/taplo/full](https://github.com/tamasfe/taplo): A TOML toolkit written in Rust

```console
$ aqua g -i tamasfe/taplo/full
```

Command and output

```console
$ echo 'a       = 123' | taplo fmt --diff -
a = 123
$ echo 'a       =' | taplo check -
error: invalid TOML
  ┌─ -:1:10
  │
1 │   a       =
  │ ╭─────────^
2 │ │
  │ ╰^ expected value

ERROR operation failed error=syntax errors found
$ echo 'a=1' | taplo toml-test
{"a":{"type":"integer","value":"1"}}⏎
$ echo 'a=' | taplo toml-test
expected value (2..3)
ERROR operation failed error=invalid toml
```

If files such as configuration file are needed, please share them.

* None

Reference

- https://taplo.tamasfe.dev
- https://github.com/tamasfe/taplo/releases/tag/0.8.0
- https://github.com/tamasfe/taplo/releases/tag/release-taplo-cli-0.6.7
- https://github.com/tamasfe/taplo/releases/tag/release-cli-0.6.0