### PR TITLE
feat: add lycheeverse/lychee

### DIFF
--- a/pkgs/lycheeverse/lychee/pkg.yaml
+++ b/pkgs/lycheeverse/lychee/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: lycheeverse/lychee@v0.10.3

--- a/pkgs/lycheeverse/lychee/registry.yaml
+++ b/pkgs/lycheeverse/lychee/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: lycheeverse
+    repo_name: lychee
+    asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      linux: unknown-linux-musl
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+      - goos: windows
+        format: raw
+        asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - linux
+      - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -12485,6 +12485,27 @@ packages:
     files:
       - name: sk
   - type: github_release
+    repo_owner: lycheeverse
+    repo_name: lychee
+    asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      linux: unknown-linux-musl
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+      - goos: windows
+        format: raw
+        asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - linux
+      - windows/amd64
+  - type: github_release
     repo_owner: maaslalani
     repo_name: slides
     asset: slides_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[lycheeverse/lychee](https://github.com/lycheeverse/lychee): Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more

```console
$ aqua g -i lycheeverse/lychee
```

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ echo 'https://aquaproj.github.io' | lychee -
🔍 1 Total ✅ 1 OK 🚫 0 Errors
$ echo 'https://aquaproj.github.io/unknown' | lychee -
Issues found in 1 input. Find details below.

[stdin]:
✗ [404] https://aquaproj.github.io/unknown | Failed: Network error: Not Found

🔍 1 Total ✅ 0 OK 🚫 1 Error (HTTP:1)
```

If files such as configuration file are needed, please share them.

None

Reference

- https://lychee.cli.rs
- https://github.com/lycheeverse/lychee/releases/tag/v0.10.3