### PR TITLE
feat: add Kampfkarren/selene/light

### DIFF
--- a/pkgs/Kampfkarren/selene/light/pkg.yaml
+++ b/pkgs/Kampfkarren/selene/light/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Kampfkarren/selene/light@0.24.0

--- a/pkgs/Kampfkarren/selene/light/registry.yaml
+++ b/pkgs/Kampfkarren/selene/light/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - name: Kampfkarren/selene/light
+    type: github_release
+    repo_owner: Kampfkarren
+    repo_name: selene
+    asset: selene-light-{{.Version}}-{{.OS}}.zip
+    description: A blazing-fast modern Lua linter written in Rust
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -657,6 +657,18 @@ packages:
         overrides:
           - goos: windows
             asset: selene.exe
+  - name: Kampfkarren/selene/light
+    type: github_release
+    repo_owner: Kampfkarren
+    repo_name: selene
+    asset: selene-light-{{.Version}}-{{.OS}}.zip
+    description: A blazing-fast modern Lua linter written in Rust
+    replacements:
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
   - type: github_release
     repo_owner: Kong
     repo_name: deck


### PR DESCRIPTION
Selene light has been created since [0.10.0](https://github.com/Kampfkarren/selene/releases/tag/0.10.0).

- [0.9.2](https://github.com/Kampfkarren/selene/releases/tag/0.9.2)

[Kampfkarren/selene/light](https://github.com/Kampfkarren/selene): A blazing-fast modern Lua linter written in Rust

```console
$ aqua g -i Kampfkarren/selene/light
```

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ echo 'print(123)' | selene -
Results:
0 errors
0 warnings
0 parse errors
$ echo 'a = 123' | selene -
warning[unscoped_variables]: `a` is not declared locally, and will be available in every scope
  ┌─ -:1:1
  │
1 │ a = 123
  │ ^

warning[unused_variable]: a is defined, but never used
  ┌─ -:1:1
  │
1 │ a = 123
  │ ^

Results:
0 errors
2 warnings
0 parse errors
```

If files such as configuration file are needed, please share them.

None

Reference

- https://kampfkarren.github.io/selene/
- https://github.com/Kampfkarren/selene/releases/tag/0.24.0