### PR TITLE
feat: add spotDL/spotify-downloader

### DIFF
--- a/pkgs/spotDL/spotify-downloader/pkg.yaml
+++ b/pkgs/spotDL/spotify-downloader/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: spotDL/spotify-downloader@v4.0.7

--- a/pkgs/spotDL/spotify-downloader/registry.yaml
+++ b/pkgs/spotDL/spotify-downloader/registry.yaml
@@ -12,4 +12,3 @@ packages:
       - linux/amd64
       - darwin
     rosetta2: true
-

--- a/pkgs/spotDL/spotify-downloader/registry.yaml
+++ b/pkgs/spotDL/spotify-downloader/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: spotDL
+    repo_name: spotify-downloader
+    asset: spotdl-{{trimV .Version}}-{{.OS}}
+    format: raw
+    description: Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found)
+    files:
+      - name: spotdl
+        src: spotify-downloader
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+

--- a/registry.yaml
+++ b/registry.yaml
@@ -17260,7 +17260,6 @@ packages:
       - linux/amd64
       - darwin
     rosetta2: true
-
   - type: github_release
     repo_owner: sqshq
     repo_name: sampler

--- a/registry.yaml
+++ b/registry.yaml
@@ -17244,6 +17244,20 @@ packages:
     files:
       - name: spin
   - type: github_release
+    repo_owner: spotDL
+    repo_name: spotify-downloader
+    asset: spotdl-{{trimV .Version}}-{{.OS}}
+    format: raw
+    description: Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found)
+    files:
+      - name: spotdl
+        src: spotify-downloader
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+
+  - type: github_release
     repo_owner: sqshq
     repo_name: sampler
     description: Tool for shell commands execution, visualization and alerting. Configured with a simple YAML file


### PR DESCRIPTION
[spotDL/spotify-downloader](https://github.com/spotDL/spotify-downloader): Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found)

```console
$ aqua g -i spotDL/spotify-downloader
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ spotdl --help
usage: spotdl [-h] [--audio [{youtube,youtube-music} ...]] [--lyrics [{genius,musixmatch,azlyrics} ...]] [--config] [--search-query SEARCH_QUERY] [--dont-filter-results] [--user-auth] [--client-id CLIENT_ID] [--client-secret CLIENT_SECRET] [--auth-token AUTH_TOKEN] [--cache-path CACHE_PATH] [--no-cache] [--cookie-file COOKIE_FILE] [--ffmpeg FFMPEG] [--threads THREADS]
              [--bitrate {8k,16k,24k,32k,40k,48k,64k,80k,96k,112k,128k,160k,192k,224k,256k,320k,0,1,2,3,4,5,6,7,8,9}] [--ffmpeg-args FFMPEG_ARGS] [--preserve-original-audio] [--format {mp3,flac,ogg,opus,m4a}] [--save-file SAVE_FILE] [--preload] [--output OUTPUT] [--m3u [M3U]] [--overwrite {skip,metadata,force}] [--restrict] [--print-errors] [--sponsor-block] [--archive ARCHIVE] [--playlist-numbering] [--host HOST]
              [--port PORT] [--keep-alive] [--allowed-origins [ALLOWED_ORIGINS ...]] [--log-level {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}] [--simple-tui] [--headless] [--download-ffmpeg] [--generate-config] [--check-for-updates] [--profile] [--version]
              [{download,save,web,sync,meta}] query [query ...]

Download your Spotify playlists and songs along with album art and metadata

options:
  -h, --help            show this help message and exit

Main options:
  {download,save,web,sync,meta}
                        The operation to perform.
                        download: Download the songs to the disk and embed metadata.
                        save: Saves the songs metadata to a file for further use.
                        web: Starts a web interface to simplify the download process.
                        sync: Removes songs that are no longer present, downloads new ones
                        meta: Update your audio files with metadata
  query                 Spotify URL for a song/playlist/album/artist/etc. to download. For album searching, include 'album:' and optional 'artist:' tags (ie. 'album:the album name' or 'artist:the artist album: the album'). For manual audio matching, you can use the format 'YouTubeURL|SpotifyURL'
  --audio [{youtube,youtube-music} ...]
                        The audio provider to use. You can provide more than one for fallback.
  --lyrics [{genius,musixmatch,azlyrics} ...]
                        The lyrics provider to use. You can provide more than one for fallback.
  --config              Use the config file to download songs. It's located under C:\Users\user\.spotdl\config.json or ~/.spotdl/config.json under linux
  --search-query SEARCH_QUERY
                        The search query to use, available variables: {title}, {artists}, {artist}, {album}, {album-artist}, {genre}, {disc-number}, {disc-count}, {duration}, {year}, {original-date}, {track-number}, {tracks-count}, {isrc}, {track-id}, {publisher}, {list-length}, {list-position}, {list-name}, {output-ext}
  --dont-filter-results
                        Disable filtering results.
...
```
