### PR TITLE
feat: add comtrya/comtrya

### DIFF
--- a/pkgs/comtrya/comtrya/pkg.yaml
+++ b/pkgs/comtrya/comtrya/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: comtrya/comtrya@v0.8.3

--- a/pkgs/comtrya/comtrya/pkg.yaml
+++ b/pkgs/comtrya/comtrya/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: comtrya/comtrya@v0.8.3
+  - name: comtrya/comtrya
+    version: v0.3.16

--- a/pkgs/comtrya/comtrya/registry.yaml
+++ b/pkgs/comtrya/comtrya/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: comtrya
+    repo_name: comtrya
+    asset: comtrya-{{.Arch}}-{{.OS}}
+    format: raw
+    description: Configuration Management for Localhost / dotfiles
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/comtrya/comtrya/registry.yaml
+++ b/pkgs/comtrya/comtrya/registry.yaml
@@ -2,7 +2,6 @@ packages:
   - type: github_release
     repo_owner: comtrya
     repo_name: comtrya
-    asset: comtrya-{{.Arch}}-{{.OS}}
     format: raw
     description: Configuration Management for Localhost / dotfiles
     replacements:
@@ -20,3 +19,11 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.19")
+    asset: comtrya-{{.Arch}}-{{.OS}}
+    version_overrides:
+      - version_constraint: "true"
+        asset: comtrya
+        supported_envs:
+          - linux/amd64
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4683,6 +4683,27 @@ packages:
     supported_envs:
       - darwin
       - amd64
+  - type: github_release
+    repo_owner: comtrya
+    repo_name: comtrya
+    asset: comtrya-{{.Arch}}-{{.OS}}
+    format: raw
+    description: Configuration Management for Localhost / dotfiles
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
   - name: concourse/concourse/concourse
     type: github_release
     repo_owner: concourse

--- a/registry.yaml
+++ b/registry.yaml
@@ -4686,7 +4686,6 @@ packages:
   - type: github_release
     repo_owner: comtrya
     repo_name: comtrya
-    asset: comtrya-{{.Arch}}-{{.OS}}
     format: raw
     description: Configuration Management for Localhost / dotfiles
     replacements:
@@ -4704,6 +4703,14 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.19")
+    asset: comtrya-{{.Arch}}-{{.OS}}
+    version_overrides:
+      - version_constraint: "true"
+        asset: comtrya
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
   - name: concourse/concourse/concourse
     type: github_release
     repo_owner: concourse


### PR DESCRIPTION
[comtrya/comtrya](https://github.com/comtrya/comtrya): Configuration Management for Localhost / dotfiles

```console
$ aqua g -i comtrya/comtrya
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ comtrya --help
comtrya 0.8.2

USAGE:
    comtrya-x86_64-apple-darwin [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help        Prints help information
        --no-color    Disable color printing
    -V, --version     Prints version information
    -v, --verbose     Debug & tracing mode (-v, -vv)

OPTIONS:
    -d, --manifest-directory <manifest-directory>    Directory

SUBCOMMANDS:
    apply
    help       Prints this message or the help of the given subcommand(s)
    version
```