### PR TITLE
feat: add kubermatic/kubeone

### DIFF
--- a/pkgs/kubermatic/kubeone/pkg.yaml
+++ b/pkgs/kubermatic/kubeone/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: kubermatic/kubeone@v1.5.6
+  - name: kubermatic/kubeone
+    version: v1.3.5

--- a/pkgs/kubermatic/kubeone/pkg.yaml
+++ b/pkgs/kubermatic/kubeone/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubermatic/kubeone@v1.5.6

--- a/pkgs/kubermatic/kubeone/registry.yaml
+++ b/pkgs/kubermatic/kubeone/registry.yaml
@@ -15,3 +15,10 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.4.2")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/pkgs/kubermatic/kubeone/registry.yaml
+++ b/pkgs/kubermatic/kubeone/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: kubermatic
+    repo_name: kubeone
+    asset: kubeone_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    description: Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: kubeone_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11652,6 +11652,13 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 1.4.2")
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
   - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: aws-iam-authenticator

--- a/registry.yaml
+++ b/registry.yaml
@@ -11637,6 +11637,22 @@ packages:
       - goos: windows
         asset: kubemqctl.exe
   - type: github_release
+    repo_owner: kubermatic
+    repo_name: kubeone
+    asset: kubeone_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    description: Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: kubeone_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: aws-iam-authenticator
     asset: aws-iam-authenticator_{{trimV .Version}}_{{.OS}}_{{.Arch}}


### PR DESCRIPTION
[kubermatic/kubeone](https://github.com/kubermatic/kubeone): Kubermatic KubeOne automate cluster operations on all your cloud, on-prem, edge, and IoT environments

```console
$ aqua g -i kubermatic/kubeone
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubeone --help
Provision and maintain Kubernetes High-Availability clusters with ease

Usage:
  kubeone [flags]
  kubeone [command]

Available Commands:
  addons      Manage addons
  apply       Reconcile the cluster
  completion  Generates completion scripts for bash and zsh
  config      Commands for working with the KubeOneCluster configuration manifests
  document    Generates documentation
  help        Help about any command
  kubeconfig  Download the kubeconfig file from master
  local       Reconcile the local one-node-all-in-one cluster
  migrate     Commands for running different migrations
  proxy       Proxy to the kube-apiserver using SSH tunnel
  reset       Revert changes
  status      Status of the cluster
  version     Display KubeOne version

Flags:
  -c, --credentials string              File to source credentials and secrets from
  -d, --debug                           debug output with stacktrace
  -h, --help                            help for kubeone
  -l, --log-format string               format for logging (default "text")
  -m, --manifest string                 Path to the KubeOne config (default "./kubeone.yaml")
  -t, --tfjson terraform output -json   Source for terraform output in JSON - to read from stdin. If path is a file, contents will be used. If path is a dictionary, terraform output -json is executed in this path
  -v, --verbose                         verbose output

Use "kubeone [command] --help" for more information about a command.
```