### PR TITLE
feat: add elsesiy/kubectl-view-secret

### DIFF
--- a/pkgs/elsesiy/kubectl-view-secret/pkg.yaml
+++ b/pkgs/elsesiy/kubectl-view-secret/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: elsesiy/kubectl-view-secret@v0.10.1
+  - name: elsesiy/kubectl-view-secret
+    version: v0.7.0
+  - name: elsesiy/kubectl-view-secret
+    version: v0.6.0

--- a/pkgs/elsesiy/kubectl-view-secret/pkg.yaml
+++ b/pkgs/elsesiy/kubectl-view-secret/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: elsesiy/kubectl-view-secret@v0.10.1

--- a/pkgs/elsesiy/kubectl-view-secret/registry.yaml
+++ b/pkgs/elsesiy/kubectl-view-secret/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: elsesiy
+    repo_name: kubectl-view-secret
+    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Kubernetes CLI plugin to decode Kubernetes secrets
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/elsesiy/kubectl-view-secret/registry.yaml
+++ b/pkgs/elsesiy/kubectl-view-secret/registry.yaml
@@ -8,6 +8,9 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: kubectl-view_secret
+        src: kubectl-view-secret
     checksum:
       type: github_release
       asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt

--- a/pkgs/elsesiy/kubectl-view-secret/registry.yaml
+++ b/pkgs/elsesiy/kubectl-view-secret/registry.yaml
@@ -2,15 +2,16 @@ packages:
   - type: github_release
     repo_owner: elsesiy
     repo_name: kubectl-view-secret
-    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Kubernetes CLI plugin to decode Kubernetes secrets
+    files:
+      - name: kubectl-view_secret
+        src: kubectl-view-secret
+    version_constraint: semver(">= 0.8.0")
+    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     supported_envs:
       - darwin
       - linux
       - amd64
-    files:
-      - name: kubectl-view_secret
-        src: kubectl-view-secret
     checksum:
       type: github_release
       asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt
@@ -19,3 +20,25 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver("= 0.7.0")
+        rosetta2: true
+      - version_constraint: "true"
+        asset: kubectl-view-secret_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: Darwin
+          windows: Windows
+          linux: Linux
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6503,15 +6503,16 @@ packages:
   - type: github_release
     repo_owner: elsesiy
     repo_name: kubectl-view-secret
-    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Kubernetes CLI plugin to decode Kubernetes secrets
+    files:
+      - name: kubectl-view_secret
+        src: kubectl-view-secret
+    version_constraint: semver(">= 0.8.0")
+    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     supported_envs:
       - darwin
       - linux
       - amd64
-    files:
-      - name: kubectl-view_secret
-        src: kubectl-view-secret
     checksum:
       type: github_release
       asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt
@@ -6520,6 +6521,28 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver("= 0.7.0")
+        rosetta2: true
+      - version_constraint: "true"
+        asset: kubectl-view-secret_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: Darwin
+          windows: Windows
+          linux: Linux
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: emirozer
     repo_name: kubectl-doctor

--- a/registry.yaml
+++ b/registry.yaml
@@ -6509,6 +6509,9 @@ packages:
       - darwin
       - linux
       - amd64
+    files:
+      - name: kubectl-view_secret
+        src: kubectl-view-secret
     checksum:
       type: github_release
       asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -6501,6 +6501,23 @@ packages:
     supported_envs:
       - linux/amd64
   - type: github_release
+    repo_owner: elsesiy
+    repo_name: kubectl-view-secret
+    asset: kubectl-view-secret_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Kubernetes CLI plugin to decode Kubernetes secrets
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-view-secret_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: emirozer
     repo_name: kubectl-doctor
     description: kubectl cluster triage plugin for k8s - (brew doctor equivalent)


### PR DESCRIPTION
[elsesiy/kubectl-view-secret](https://github.com/elsesiy/kubectl-view-secret): Kubernetes CLI plugin to decode Kubernetes secrets

```console
$ aqua g -i elsesiy/kubectl-view-secret
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl-view-secret --help
Decode a kubernetes secret by name & key in the current context/cluster/namespace

Usage:
  view-secret [secret-name] [secret-key] [flags]

Examples:

        # print secret keys
        kubectl view-secret <secret>

        # decode specific entry
        kubectl view-secret <secret> <key>

        # decode all contents
        kubectl view-secret <secret> -a/--all

        # print keys for secret in different namespace
        kubectl view-secret <secret> -n/--namespace <ns>

        # print keys for secret in different context
        kubectl view-secret <secret> -c/--context <ctx>

        # print keys for secret by providing kubeconfig
        kubectl view-secret <secret> -k/--kubeconfig <cfg>

        # suppress info output
        kubectl view-secret <secret> -q/--quiet


Flags:
  -a, --all                 if true, decodes all secrets without specifying the individual secret keys
  -c, --context string      override the current context
  -h, --help                help for view-secret
  -k, --kubeconfig string   explicitly provide the kubeconfig to use
  -n, --namespace string    override the namespace defined in the current context
  -q, --quiet               if true, suppresses info output
```
