### PR TITLE
feat: add sunny0826/kubecm

### DIFF
--- a/pkgs/sunny0826/kubecm/pkg.yaml
+++ b/pkgs/sunny0826/kubecm/pkg.yaml
@@ -1,2 +1,10 @@
 packages:
   - name: sunny0826/kubecm@v0.21.1
+  - name: sunny0826/kubecm
+    version: v0.19.2
+  - name: sunny0826/kubecm
+    version: v0.15.2
+  - name: sunny0826/kubecm
+    version: v0.13.1
+  - name: sunny0826/kubecm
+    version: v0.3.1

--- a/pkgs/sunny0826/kubecm/pkg.yaml
+++ b/pkgs/sunny0826/kubecm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sunny0826/kubecm@v0.21.1

--- a/pkgs/sunny0826/kubecm/registry.yaml
+++ b/pkgs/sunny0826/kubecm/registry.yaml
@@ -2,17 +2,12 @@ packages:
   - type: github_release
     repo_owner: sunny0826
     repo_name: kubecm
-    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Manage your kubeconfig more easily
     replacements:
       amd64: x86_64
       darwin: Darwin
       linux: Linux
       windows: Windows
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     checksum:
       type: github_release
       asset: checksums.txt
@@ -21,3 +16,27 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.19.3")
+    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.15.3")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+      - version_constraint: semver(">= 0.14.0")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+      - version_constraint: semver(">= 0.3.2")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64

--- a/pkgs/sunny0826/kubecm/registry.yaml
+++ b/pkgs/sunny0826/kubecm/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: sunny0826
+    repo_name: kubecm
+    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Manage your kubeconfig more easily
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -17618,17 +17618,12 @@ packages:
   - type: github_release
     repo_owner: sunny0826
     repo_name: kubecm
-    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: Manage your kubeconfig more easily
     replacements:
       amd64: x86_64
       darwin: Darwin
       linux: Linux
       windows: Windows
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     checksum:
       type: github_release
       asset: checksums.txt
@@ -17637,6 +17632,30 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.19.3")
+    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.15.3")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+      - version_constraint: semver(">= 0.14.0")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+      - version_constraint: semver(">= 0.3.2")
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        asset: kubecm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64
   - type: github_release
     repo_owner: superbrothers
     repo_name: ksort

--- a/registry.yaml
+++ b/registry.yaml
@@ -17616,6 +17616,28 @@ packages:
       - name: lua-language-server
         src: bin/lua-language-server
   - type: github_release
+    repo_owner: sunny0826
+    repo_name: kubecm
+    asset: kubecm_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Manage your kubeconfig more easily
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: superbrothers
     repo_name: ksort
     asset: ksort-{{.OS}}-{{.Arch}}.zip


### PR DESCRIPTION
[sunny0826/kubecm](https://github.com/sunny0826/kubecm): Manage your kubeconfig more easily

```console
$ aqua g -i sunny0826/kubecm
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubecm --help


        Manage your kubeconfig more easily.


██   ██ ██    ██ ██████  ███████  ██████ ███    ███
██  ██  ██    ██ ██   ██ ██      ██      ████  ████
█████   ██    ██ ██████  █████   ██      ██ ████ ██
██  ██  ██    ██ ██   ██ ██      ██      ██  ██  ██
██   ██  ██████  ██████  ███████  ██████ ██      ██

 Tips  Find more information at: kubecm.cloud (https://kubecm.cloud)

Usage:
  kubecm [command]

Available Commands:
  add         Add KubeConfig to $HOME/.kube/config
  alias       Generate alias for all contexts
  clear       Clear lapsed context, cluster and user
  cloud       Manage kubeconfig from cloud
  completion  Generate completion script
  create      Create new KubeConfig(experiment)
  delete      Delete the specified context from the kubeconfig
  help        Help about any command
  list        List KubeConfig
  merge       Merge multiple kubeconfig files into one
  namespace   Switch or change namespace interactively
  rename      Rename the contexts of kubeconfig
  switch      Switch Kube Context interactively
  version     Print version info

Flags:
      --config string   path of kubeconfig (default "/Users/lars/.kube/config")
  -h, --help            help for kubecm
  -m, --mac-notify      enable to display Mac notification banner
      --ui-size int     number of list items to show in menu at once (default 4)

Use "kubecm [command] --help" for more information about a command.
```
