### PR TITLE
feat: add knipferrc/fm

### DIFF
--- a/pkgs/knipferrc/fm/pkg.yaml
+++ b/pkgs/knipferrc/fm/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
   - name: knipferrc/fm@v0.15.10
+  - name: knipferrc/fm
+    version: v0.13.0
+  - name: knipferrc/fm
+    version: v0.9.1
+  - name: knipferrc/fm
+    version: v0.4.1

--- a/pkgs/knipferrc/fm/pkg.yaml
+++ b/pkgs/knipferrc/fm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: knipferrc/fm@v0.15.10

--- a/pkgs/knipferrc/fm/registry.yaml
+++ b/pkgs/knipferrc/fm/registry.yaml
@@ -2,16 +2,12 @@ packages:
   - type: github_release
     repo_owner: knipferrc
     repo_name: fm
+    description: A terminal based file manager
     asset: fm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: A terminal based file manager
     overrides:
       - goos: windows
         format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     checksum:
       type: github_release
       asset: fm_{{trimV .Version}}_checksums.txt
@@ -20,3 +16,25 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.13.1")
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: Version == "v0.13.0"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.9.1")
+      - version_constraint: semver(">= 0.4.1")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"

--- a/pkgs/knipferrc/fm/registry.yaml
+++ b/pkgs/knipferrc/fm/registry.yaml
@@ -32,9 +32,11 @@ packages:
           - linux
           - amd64
       - version_constraint: semver(">= 0.9.1")
+        overrides: []
       - version_constraint: semver(">= 0.4.1")
         rosetta2: true
         supported_envs:
           - darwin
           - amd64
+        overrides: []
       - version_constraint: "true"

--- a/pkgs/knipferrc/fm/registry.yaml
+++ b/pkgs/knipferrc/fm/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: knipferrc
+    repo_name: fm
+    asset: fm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A terminal based file manager
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: fm_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -11343,16 +11343,12 @@ packages:
   - type: github_release
     repo_owner: knipferrc
     repo_name: fm
+    description: A terminal based file manager
     asset: fm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: A terminal based file manager
     overrides:
       - goos: windows
         format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     checksum:
       type: github_release
       asset: fm_{{trimV .Version}}_checksums.txt
@@ -11361,6 +11357,28 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.13.1")
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: Version == "v0.13.0"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.9.1")
+      - version_constraint: semver(">= 0.4.1")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
   - type: github_release
     repo_owner: knqyf263
     repo_name: cob

--- a/registry.yaml
+++ b/registry.yaml
@@ -11373,11 +11373,13 @@ packages:
           - linux
           - amd64
       - version_constraint: semver(">= 0.9.1")
+        overrides: []
       - version_constraint: semver(">= 0.4.1")
         rosetta2: true
         supported_envs:
           - darwin
           - amd64
+        overrides: []
       - version_constraint: "true"
   - type: github_release
     repo_owner: knqyf263

--- a/registry.yaml
+++ b/registry.yaml
@@ -11341,6 +11341,27 @@ packages:
           - name: faas
             src: faas_{{.OS}}_{{.Arch}}
   - type: github_release
+    repo_owner: knipferrc
+    repo_name: fm
+    asset: fm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A terminal based file manager
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: fm_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: knqyf263
     repo_name: cob
     description: Continuous Benchmark for Go Project


### PR DESCRIPTION
[knipferrc/fm](https://github.com/knipferrc/fm): A terminal based file manager

```console
$ aqua g -i knipferrc/fm
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ fm --help
FM is a simple, configurable, and fun to use file manager

Usage:
  fm [flags]
  fm [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  update      Update FM to the latest version

Flags:
  -h, --help                    help for fm
      --selection-path string   Path to write to file on open.
      --start-dir string        Starting directory for FM
  -v, --version                 version for fm

Use "fm [command] --help" for more information about a command.
```
