### PR TITLE
feat: add soh335/shukujitsu

### DIFF
--- a/pkgs/soh335/shukujitsu/pkg.yaml
+++ b/pkgs/soh335/shukujitsu/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: soh335/shukujitsu@v0.0.5

--- a/pkgs/soh335/shukujitsu/registry.yaml
+++ b/pkgs/soh335/shukujitsu/registry.yaml
@@ -14,4 +14,3 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-

--- a/pkgs/soh335/shukujitsu/registry.yaml
+++ b/pkgs/soh335/shukujitsu/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: soh335
     repo_name: shukujitsu
+    description: shukujitsu determines japanese holiday. Holidays are collected from https://www8.cao.go.jp/chosei/shukujitsu/shukujitsu.csv
     asset: shukujitsu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     supported_envs:
       - linux

--- a/pkgs/soh335/shukujitsu/registry.yaml
+++ b/pkgs/soh335/shukujitsu/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: soh335
+    repo_name: shukujitsu
+    asset: shukujitsu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+

--- a/registry.yaml
+++ b/registry.yaml
@@ -17465,6 +17465,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: soh335
+    repo_name: shukujitsu
+    asset: shukujitsu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+
+  - type: github_release
     repo_owner: sonatype-nexus-community
     repo_name: nancy
     asset: nancy-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -17467,6 +17467,7 @@ packages:
   - type: github_release
     repo_owner: soh335
     repo_name: shukujitsu
+    description: shukujitsu determines japanese holiday. Holidays are collected from https://www8.cao.go.jp/chosei/shukujitsu/shukujitsu.csv
     asset: shukujitsu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     supported_envs:
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -17479,7 +17479,6 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-
   - type: github_release
     repo_owner: sonatype-nexus-community
     repo_name: nancy


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/9556 [soh335/shukujitsu](https://github.com/soh335/shukujitsu): shukujitsu determines japanese holiday. Holidays are collected from https://www8.cao.go.jp/chosei/shukujitsu/shukujitsu.csv

```console
$ aqua g -i soh335/shukujitsu
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ shukujitsu --help
Usage of /Users/user/.local/share/aquaproj-aqua/pkgs/github_release/github.com/soh335/shukujitsu/v0.0.5/shukujitsu_0.0.5_darwin_amd64.tar.gz/shukujitsu:
  -date string
        date (format 2006-01-02)
  -quiet
        quiet
  -version
        show version
```

```console
$ shukujitsu --date 2023-02-23
2023-02-23 天皇誕生日
```

Reference

- Pull Request: Add cli shukujitsu command.
	- https://github.com/soh335/shukujitsu/pull/12