### PR TITLE
feat: add domoritz/arrow-tools/csv2arrow

### DIFF
--- a/pkgs/domoritz/arrow-tools/csv2arrow/pkg.yaml
+++ b/pkgs/domoritz/arrow-tools/csv2arrow/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: domoritz/arrow-tools/csv2arrow@v0.7.2

--- a/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - name: domoritz/arrow-tools/csv2arrow
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: csv2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: csv2arrow
+        src: csv2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/csv2arrow

--- a/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
@@ -14,6 +14,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: csv2arrow
+            src: csv2arrow.exe
     supported_envs:
       - darwin
       - amd64

--- a/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/csv2arrow/registry.yaml
@@ -17,6 +17,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: csv2arrow
+            src: csv2arrow.exe
     supported_envs:
       - darwin
       - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6126,6 +6126,28 @@ packages:
     version_overrides:
       - version_constraint: "true"
         rosetta2: false
+  - name: domoritz/arrow-tools/csv2arrow
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: csv2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: csv2arrow
+        src: csv2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/csv2arrow
   - name: domoritz/arrow-tools/csv2parquet
     type: github_release
     repo_owner: domoritz

--- a/registry.yaml
+++ b/registry.yaml
@@ -6141,6 +6141,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: csv2arrow
+            src: csv2arrow.exe
     supported_envs:
       - darwin
       - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6144,6 +6144,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: csv2arrow
+            src: csv2arrow.exe
     supported_envs:
       - darwin
       - amd64


### PR DESCRIPTION
[domoritz/arrow-tools/csv2arrow](https://github.com/domoritz/arrow-tools): A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet

```console
$ aqua g -i domoritz/arrow-tools/csv2arrow
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ csv2arrow --help
Usage: csv2arrow [OPTIONS] <CSV> [ARROW]

Arguments:
  <CSV>    Input CSV file
  [ARROW]  Output file, stdout if not present

Options:
  -s, --schema-file <SCHEMA_FILE>
          File with Arrow schema in JSON format
  -m, --max-read-records <MAX_READ_RECORDS>
          The number of records to infer the schema from. All rows if not present. Setting max-read-records to zero will stop schema inference and all columns will be string typed
      --header <HEADER>
          Set whether the CSV file has headers [possible values: true, false]
  -d, --delimiter <DELIMITER>
          Set the CSV file's column delimiter as a byte character [default: ,]
  -p, --print-schema
          Print the schema to stderr
  -n, --dry
          Only print the schema
  -h, --help
          Print help
  -V, --version
          Print version
```