### PR TITLE
feat: add domoritz/arrow-tools/json2arrow

### DIFF
--- a/pkgs/domoritz/arrow-tools/json2arrow/pkg.yaml
+++ b/pkgs/domoritz/arrow-tools/json2arrow/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: domoritz/arrow-tools/json2arrow@v0.7.2

--- a/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
@@ -17,6 +17,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: json2arrow
+            src: json2arrow.exe
     supported_envs:
       - darwin
       - amd64

--- a/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
@@ -5,7 +5,7 @@ packages:
     repo_name: arrow-tools
     asset: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.xz
-    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    description: Convert JSON files to Apache Arrow. This package is part of Arrow CLI tools
     files:
       - name: json2arrow
         src: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/json2arrow

--- a/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2arrow/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - name: domoritz/arrow-tools/json2arrow
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    files:
+      - name: json2arrow
+        src: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/json2arrow
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6132,7 +6132,7 @@ packages:
     repo_name: arrow-tools
     asset: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.xz
-    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    description: Convert JSON files to Apache Arrow. This package is part of Arrow CLI tools
     files:
       - name: json2arrow
         src: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/json2arrow

--- a/registry.yaml
+++ b/registry.yaml
@@ -6144,6 +6144,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: json2arrow
+            src: json2arrow.exe
     supported_envs:
       - darwin
       - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6126,6 +6126,28 @@ packages:
     version_overrides:
       - version_constraint: "true"
         rosetta2: false
+  - name: domoritz/arrow-tools/json2arrow
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    files:
+      - name: json2arrow
+        src: json2arrow-{{.Version}}-{{.Arch}}-{{.OS}}/json2arrow
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
   - type: github_release
     repo_owner: dotenv-linter
     repo_name: dotenv-linter


### PR DESCRIPTION
#9765 [domoritz/arrow-tools/json2arrow](https://github.com/domoritz/arrow-tools): Convert JSON files to Apache Arrow. This package is part of Arrow CLI tools

```console
$ aqua g -i domoritz/arrow-tools/json2arrow
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ json2arrow --help
WARN[0000] package isn't found                           aqua_version=1.33.0 env=darwin/amd64 exe_name=json2arrow package_name=domoritz/arrow-tools/csv2arrow program=aqua registry_name=standard
WARN[0000] package isn't found                           aqua_version=1.33.0 env=darwin/amd64 exe_name=json2arrow package_name=domoritz/arrow-tools/csv2parquet program=aqua registry_name=standard
Usage: json2arrow [OPTIONS] <JSON> [ARROW]

Arguments:
  <JSON>   Input JSON file
  [ARROW]  Output file, stdout if not present

Options:
  -s, --schema-file <SCHEMA_FILE>
          File with Arrow schema in JSON format
  -m, --max-read-records <MAX_READ_RECORDS>
          The number of records to infer the schema from. All rows if not present. Setting max-read-records to zero will stop schema inference and all columns will be string typed
  -p, --print-schema
          Print the schema to stderr
  -n, --dry
          Only print the schema
  -h, --help
          Print help
  -V, --version
          Print version
```