### PR TITLE
feat: add domoritz/arrow-tools/json2parquet

### DIFF
--- a/pkgs/domoritz/arrow-tools/json2parquet/pkg.yaml
+++ b/pkgs/domoritz/arrow-tools/json2parquet/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: domoritz/arrow-tools/json2parquet@v0.7.2

--- a/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
@@ -17,6 +17,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: json2parquet
+            src: json2parquet.exe
     supported_envs:
       - darwin
       - amd64

--- a/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
@@ -5,7 +5,7 @@ packages:
     repo_name: arrow-tools
     asset: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.xz
-    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    description: Convert JSON files to Apache Parquet. This package is part of Arrow CLI tools
     files:
       - name: json2parquet
         src: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}/json2parquet

--- a/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
+++ b/pkgs/domoritz/arrow-tools/json2parquet/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - name: domoritz/arrow-tools/json2parquet
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    files:
+      - name: json2parquet
+        src: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}/json2parquet
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6132,7 +6132,7 @@ packages:
     repo_name: arrow-tools
     asset: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.xz
-    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    description: Convert JSON files to Apache Parquet. This package is part of Arrow CLI tools
     files:
       - name: json2parquet
         src: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}/json2parquet

--- a/registry.yaml
+++ b/registry.yaml
@@ -6126,6 +6126,28 @@ packages:
     version_overrides:
       - version_constraint: "true"
         rosetta2: false
+  - name: domoritz/arrow-tools/json2parquet
+    type: github_release
+    repo_owner: domoritz
+    repo_name: arrow-tools
+    asset: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    description: A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet
+    files:
+      - name: json2parquet
+        src: json2parquet-{{.Version}}-{{.Arch}}-{{.OS}}/json2parquet
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
   - type: github_release
     repo_owner: dotenv-linter
     repo_name: dotenv-linter

--- a/registry.yaml
+++ b/registry.yaml
@@ -6144,6 +6144,9 @@ packages:
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: json2parquet
+            src: json2parquet.exe
     supported_envs:
       - darwin
       - amd64


### PR DESCRIPTION
[domoritz/arrow-tools/json2parquet](https://github.com/domoritz/arrow-tools): A collection of handy CLI tools to convert CSV and JSON to Apache Arrow and Parquet

```console
$ aqua g -i domoritz/arrow-tools/json2parquet
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ json2parquet --help
Usage: json2parquet [OPTIONS] <JSON> <PARQUET>

Arguments:
  <JSON>     Input JSON file
  <PARQUET>  Output file

Options:
  -s, --schema-file <SCHEMA_FILE>
          File with Arrow schema in JSON format
      --max-read-records <MAX_READ_RECORDS>
          The number of records to infer the schema from. All rows if not present. Setting max-read-records to zero will stop schema inference and all columns will be string typed
  -c, --compression <COMPRESSION>
          Set the compression [possible values: uncompressed, snappy, gzip, lzo, brotli, lz4, zstd, lz4-raw]
  -e, --encoding <ENCODING>
          Sets encoding for any column [possible values: plain, rle, bit-packed, delta-binary-packed, delta-length-byte-array, delta-byte-array, rle-dictionary]
      --data-pagesize-limit <DATA_PAGESIZE_LIMIT>
          Sets data page size limit
      --dictionary-pagesize-limit <DICTIONARY_PAGESIZE_LIMIT>
          Sets dictionary page size limit
      --write-batch-size <WRITE_BATCH_SIZE>
          Sets write batch size
      --max-row-group-size <MAX_ROW_GROUP_SIZE>
          Sets max size for a row group
      --created-by <CREATED_BY>
          Sets "created by" property
      --dictionary
          Sets flag to enable/disable dictionary encoding for any column
      --statistics <STATISTICS>
          Sets flag to enable/disable statistics for any column [possible values: none, chunk, page]
      --max-statistics-size <MAX_STATISTICS_SIZE>
          Sets max statistics size for any column. Applicable only if statistics are enabled
  -p, --print-schema
          Print the schema to stderr
  -n, --dry
          Only print the schema
  -h, --help
          Print help
  -V, --version
          Print version
```