### PR TITLE
feat: add gesquive/git-user

### DIFF
--- a/pkgs/gesquive/git-user/pkg.yaml
+++ b/pkgs/gesquive/git-user/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: gesquive/git-user@v2.0.6
+  - name: gesquive/git-user
+    version: v2.0.3
+  - name: gesquive/git-user
+    version: v2.0.0

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -34,7 +34,7 @@ packages:
           src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false
-      - version_constraint: semver(">= 2.0.0")
+      - version_constraint: "true"
         supported_envs:
           - darwin
           - linux

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -21,6 +21,10 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
         replacements:
           amd64: x64
           darwin: osx
@@ -31,6 +35,10 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.0.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
         replacements:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -1,0 +1,41 @@
+packages:
+  - type: github_release
+    repo_owner: gesquive
+    repo_name: git-user
+    asset: git-user_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Git plugin that allows you to save multiple user profiles and set them as project defaults
+    overrides:
+      - goos: windows
+        format: zip
+    version_constraint: semver(">= 2.0.6")
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: git-user_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver(">= 2.0.3")
+        replacements:
+          amd64: x64
+          darwin: osx
+        asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+        - name: git-user
+          src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.0.0")
+        replacements:
+          amd64: amd64
+        asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+        - name: git-user
+          src: "{{.OS}}-{{.Arch}}/git-user"
+        checksum:
+          enabled: false

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -30,8 +30,8 @@ packages:
           darwin: osx
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
-        - name: git-user
-          src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
+          - name: git-user
+            src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false
       - version_constraint: "true"
@@ -43,7 +43,7 @@ packages:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
-        - name: git-user
-          src: "{{.OS}}-{{.Arch}}/git-user"
+          - name: git-user
+            src: "{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -22,9 +22,8 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
         supported_envs:
-          - darwin
-          - linux
-          - amd64
+          - darwin/amd64
+          - linux/amd64
         replacements:
           amd64: x64
           darwin: osx
@@ -36,9 +35,8 @@ packages:
           enabled: false
       - version_constraint: "true"
         supported_envs:
-          - darwin
-          - linux
-          - amd64
+          - darwin/amd64
+          - linux/amd64
         replacements:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/gesquive/git-user/registry.yaml
+++ b/pkgs/gesquive/git-user/registry.yaml
@@ -21,8 +21,9 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
+        rosetta2: true
         supported_envs:
-          - darwin/amd64
+          - darwin
           - linux/amd64
         replacements:
           amd64: x64
@@ -34,8 +35,9 @@ packages:
         checksum:
           enabled: false
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
-          - darwin/amd64
+          - darwin
           - linux/amd64
         replacements:
           amd64: amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7527,7 +7527,7 @@ packages:
           src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false
-      - version_constraint: semver(">= 2.0.0")
+      - version_constraint: "true"
         supported_envs:
           - darwin
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -7493,6 +7493,46 @@ packages:
           - darwin
           - amd64
   - type: github_release
+    repo_owner: gesquive
+    repo_name: git-user
+    asset: git-user_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Git plugin that allows you to save multiple user profiles and set them as project defaults
+    overrides:
+      - goos: windows
+        format: zip
+    version_constraint: semver(">= 2.0.6")
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: git-user_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: semver(">= 2.0.3")
+        replacements:
+          amd64: x64
+          darwin: osx
+        asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+        - name: git-user
+          src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.0.0")
+        replacements:
+          amd64: amd64
+        asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+        - name: git-user
+          src: "{{.OS}}-{{.Arch}}/git-user"
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: getgauge
     repo_name: gauge
     asset: gauge-{{trimV .Version}}-{{.OS}}.{{.Arch}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -7514,8 +7514,9 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
+        rosetta2: true
         supported_envs:
-          - darwin/amd64
+          - darwin
           - linux/amd64
         replacements:
           amd64: x64
@@ -7527,8 +7528,9 @@ packages:
         checksum:
           enabled: false
       - version_constraint: "true"
+        rosetta2: true
         supported_envs:
-          - darwin/amd64
+          - darwin
           - linux/amd64
         replacements:
           amd64: amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7514,6 +7514,10 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
         replacements:
           amd64: x64
           darwin: osx
@@ -7524,6 +7528,10 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.0.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
         replacements:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -7523,8 +7523,8 @@ packages:
           darwin: osx
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
-        - name: git-user
-          src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
+          - name: git-user
+            src: "git-user-{{.Version}}-{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false
       - version_constraint: "true"
@@ -7536,8 +7536,8 @@ packages:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
-        - name: git-user
-          src: "{{.OS}}-{{.Arch}}/git-user"
+          - name: git-user
+            src: "{{.OS}}-{{.Arch}}/git-user"
         checksum:
           enabled: false
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -7515,9 +7515,8 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 2.0.3")
         supported_envs:
-          - darwin
-          - linux
-          - amd64
+          - darwin/amd64
+          - linux/amd64
         replacements:
           amd64: x64
           darwin: osx
@@ -7529,9 +7528,8 @@ packages:
           enabled: false
       - version_constraint: "true"
         supported_envs:
-          - darwin
-          - linux
-          - amd64
+          - darwin/amd64
+          - linux/amd64
         replacements:
           amd64: amd64
         asset: git-user-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[gesquive/git-user](https://github.com/gesquive/git-user): Git plugin that allows you to save multiple user profiles and set them as project defaults

```console
$ aqua g -i gesquive/git-user
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ git user help
git-user lets you quickly switch between multiple git user profiles

Usage:
  git-user [flags]

Available Commands:
  add         Add a new profile
  completion  Generate the autocompletion script for the specified shell
  del         Delete a profile
  edit        Edit a profile
  help        Help about any command
  list        List all saved profiles
  rm          Remove a profile from the current project
  set         Set the profile for the current project

Flags:
  -c, --config string     config file (default "~/.git-profiles")
  -g, --git-path string   The git executable to use (default "git")
  -h, --help              help for git-user
  -p, --path string       The project to get/set the user (default ".")
  -v, --version           Show the version and exit

Use "git-user [command] --help" for more information about a command.

Version:
  github.com/gesquive/git-user 2.0.6
```