### PR TITLE
feat: add kdash-rs/kdash

### DIFF
--- a/pkgs/kdash-rs/kdash/pkg.yaml
+++ b/pkgs/kdash-rs/kdash/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: kdash-rs/kdash@v0.3.6
+  - name: kdash-rs/kdash
+    version: v0.3.0
+  - name: kdash-rs/kdash
+    version: v0.0.3

--- a/pkgs/kdash-rs/kdash/pkg.yaml
+++ b/pkgs/kdash-rs/kdash/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kdash-rs/kdash@v0.3.6

--- a/pkgs/kdash-rs/kdash/registry.yaml
+++ b/pkgs/kdash-rs/kdash/registry.yaml
@@ -11,6 +11,13 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    overrides:
+      - goos: windows
+        checksum:
+          type: github_release
+          asset: kdash-{{.OS}}.sha256
+          algorithm: sha256
+          file_format: raw
     rosetta2: true
     checksum:
       type: github_release

--- a/pkgs/kdash-rs/kdash/registry.yaml
+++ b/pkgs/kdash-rs/kdash/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: kdash-rs
+    repo_name: kdash
+    asset: kdash-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A simple and fast dashboard for Kubernetes
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: linux
+        asset: kdash-{{.OS}}-musl.{{.Format}}
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: kdash-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/kdash-rs/kdash/registry.yaml
+++ b/pkgs/kdash-rs/kdash/registry.yaml
@@ -2,15 +2,9 @@ packages:
   - type: github_release
     repo_owner: kdash-rs
     repo_name: kdash
+    description: A simple and fast dashboard for Kubernetes
     asset: kdash-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: A simple and fast dashboard for Kubernetes
-    replacements:
-      darwin: macos
-      linux: linux-musl
-    supported_envs:
-      - darwin
-      - amd64
     overrides:
       - goos: windows
         checksum:
@@ -18,6 +12,17 @@ packages:
           asset: kdash-{{.OS}}.sha256
           algorithm: sha256
           file_format: raw
+      - goos: linux
+        goarch: arm64
+        asset: kdash-aarch64-musl.tar.gz
+        checksum:
+          type: github_release
+          asset: kdash-aarch64-musl.sha256
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     rosetta2: true
     checksum:
       type: github_release
@@ -27,3 +32,26 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.3")
+    replacements:
+      darwin: macos
+      linux: linux-musl
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.0.4")
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: macos
+          linux: linux-musl
+      - version_constraint: semver("< 0.0.4")
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: macos
+      - version_constraint: "true"

--- a/pkgs/kdash-rs/kdash/registry.yaml
+++ b/pkgs/kdash-rs/kdash/registry.yaml
@@ -7,9 +7,7 @@ packages:
     description: A simple and fast dashboard for Kubernetes
     replacements:
       darwin: macos
-    overrides:
-      - goos: linux
-        asset: kdash-{{.OS}}-musl.{{.Format}}
+      linux: linux-musl
     supported_envs:
       - darwin
       - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -11415,6 +11415,13 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    overrides:
+      - goos: windows
+        checksum:
+          type: github_release
+          asset: kdash-{{.OS}}.sha256
+          algorithm: sha256
+          file_format: raw
     rosetta2: true
     checksum:
       type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -11406,15 +11406,9 @@ packages:
   - type: github_release
     repo_owner: kdash-rs
     repo_name: kdash
+    description: A simple and fast dashboard for Kubernetes
     asset: kdash-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: A simple and fast dashboard for Kubernetes
-    replacements:
-      darwin: macos
-      linux: linux-musl
-    supported_envs:
-      - darwin
-      - amd64
     overrides:
       - goos: windows
         checksum:
@@ -11422,6 +11416,17 @@ packages:
           asset: kdash-{{.OS}}.sha256
           algorithm: sha256
           file_format: raw
+      - goos: linux
+        goarch: arm64
+        asset: kdash-aarch64-musl.tar.gz
+        checksum:
+          type: github_release
+          asset: kdash-aarch64-musl.sha256
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     rosetta2: true
     checksum:
       type: github_release
@@ -11431,6 +11436,29 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.3")
+    replacements:
+      darwin: macos
+      linux: linux-musl
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_overrides:
+      - version_constraint: semver(">= 0.0.4")
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: macos
+          linux: linux-musl
+      - version_constraint: semver("< 0.0.4")
+        supported_envs:
+          - darwin
+          - amd64
+        replacements:
+          darwin: macos
+      - version_constraint: "true"
   - type: github_release
     repo_owner: kentaro-m
     repo_name: md2confl

--- a/registry.yaml
+++ b/registry.yaml
@@ -11411,9 +11411,7 @@ packages:
     description: A simple and fast dashboard for Kubernetes
     replacements:
       darwin: macos
-    overrides:
-      - goos: linux
-        asset: kdash-{{.OS}}-musl.{{.Format}}
+      linux: linux-musl
     supported_envs:
       - darwin
       - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -11404,6 +11404,29 @@ packages:
     path: has
     description: checks presence of various command line tools and their versions on the path
   - type: github_release
+    repo_owner: kdash-rs
+    repo_name: kdash
+    asset: kdash-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A simple and fast dashboard for Kubernetes
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: linux
+        asset: kdash-{{.OS}}-musl.{{.Format}}
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: kdash-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kentaro-m
     repo_name: md2confl
     asset: md2confl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[kdash-rs/kdash](https://github.com/kdash-rs/kdash): A simple and fast dashboard for Kubernetes

```console
$ aqua g -i kdash-rs/kdash
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kdash --help
_  ______            _
 | |/ /  _ \  __ _ ___| |__
 | ' /| | | |/ _` / __| '_ \
 | . \| |_| | (_| \__ \ | | |
 |_|\_\____/ \__,_|___/_| |_|


A fast and simple dashboard for Kubernetes


Usage: Press `?` while running the app to see keybindings

Options:
  -t, --tick-rate <TICK_RATE>  Set the tick rate (milliseconds): the lower the number the higher the FPS [default: 250]
  -p, --poll-rate <POLL_RATE>  Set the network call polling rate (milliseconds, should be multiples of tick-rate): the lower the number the higher the network calls [default: 5000]
  -e, --enhanced-graphics      whether unicode symbols are used to improve the overall look of the app
  -h, --help                   Print help information
  -V, --version                Print version information
```