### PR TITLE
feat: add travis-ci/gimme

### DIFF
--- a/pkgs/travis-ci/gimme/pkg.yaml
+++ b/pkgs/travis-ci/gimme/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: travis-ci/gimme@v1.5.5

--- a/pkgs/travis-ci/gimme/registry.yaml
+++ b/pkgs/travis-ci/gimme/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_content
+    repo_owner: travis-ci
+    repo_name: gimme
+    path: gimme
+    description: Install go, yay
+    supported_envs:
+      - darwin
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -19511,6 +19511,14 @@ packages:
       - linux
       - darwin
     rosetta2: true
+  - type: github_content
+    repo_owner: travis-ci
+    repo_name: gimme
+    path: gimme
+    description: Install go, yay
+    supported_envs:
+      - darwin
+      - linux
   - type: github_release
     repo_owner: trufflesecurity
     repo_name: driftwood


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/9845 [travis-ci/gimme](https://github.com/travis-ci/gimme): Install go, yay

```console
$ aqua g -i travis-ci/gimme
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gimme --help
Usage: gimme [flags] [go-version] [version-prefix]

Version: v1.5.4
Copyright: Copyright (c) 2015-2020 gimme contributors
License URL: https://raw.githubusercontent.com/travis-ci/gimme/v1.5.4/LICENSE

Install go!  There are multiple types of installations available, with 'auto' being the default.
If either 'auto' or 'binary' is specified as GIMME_TYPE, gimme will first check for an existing
go installation.  This behavior may be disabled by providing '-f/--force/force' as first positional
argument.

Option flags:
        -h --help help - show this help text and exit
  -V --version version - show the version only and exit
      -f --force force - remove the existing go installation if present prior to install
        -l --list list - list installed go versions and exit
      -k --known known - list known go versions and exit
  --force-known-update - when used with --known, ignores the cache and updates
  -r --resolve resolve - resolve a version specifier to a version, show that and exit

Influential env vars:

      GIMME_GO_VERSION - version to install (*REQUIRED*, may be given as first positional arg)
  GIMME_VERSION_PREFIX - prefix for installed versions (default '/Users/yuya-koda/.gimme/versions',
                         may be given as second positional arg)
            GIMME_ARCH - arch to install (default 'x86_64')
      GIMME_BINARY_OSX - darwin-specific binary suffix (default 'osx10.8')
      GIMME_ENV_PREFIX - prefix for env files (default '/Users/yuya-koda/.gimme/envs')
   GIMME_GO_GIT_REMOTE - git remote for git-based install (default 'https://github.com/golang/go.git')
              GIMME_OS - os to install (default 'darwin')
             GIMME_TMP - temp directory (default '/var/folders/nk/0_r94lv56ns02p9dvsp7f3y40000gq/T//gimme')
            GIMME_TYPE - install type to perform ('auto', 'binary', 'source', or 'git')
                         (default 'auto')
    GIMME_INSTALL_RACE - install race directory after compile if non-empty.
                         If the install type is 'binary', this option is ignored.
           GIMME_DEBUG - enable tracing if non-empty
    GIMME_NO_ENV_ALIAS - disable creation of env 'alias' file when os and arch match host
      GIMME_SILENT_ENV - omit the 'go version' line from env file
     GIMME_CGO_ENABLED - enable build of cgo support
   GIMME_CC_FOR_TARGET - cross compiler for cgo support
   GIMME_DOWNLOAD_BASE - override base URL dir for download (default 'https://dl.google.com/go')
      GIMME_LIST_KNOWN - override base URL for known go versions (default 'https://golang.org/dl')
 GIMME_KNOWN_CACHE_MAX - seconds the cache for --known is valid for (default '10800')
```

```console
$ eval $(gimme stable)
$ which go
/Users/user/.gimme/versions/go1.20.darwin.amd64/bin/go
$ go version
go version go1.20 darwin/amd64
```

Reference

- README.md
	- https://github.com/travis-ci/gimme/blob/master/README.md
