### PR TITLE
feat: add chmouel/snazy

### DIFF
--- a/pkgs/chmouel/snazy/pkg.yaml
+++ b/pkgs/chmouel/snazy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chmouel/snazy@0.50.0

--- a/pkgs/chmouel/snazy/registry.yaml
+++ b/pkgs/chmouel/snazy/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: chmouel
+    repo_name: snazy
+    asset: snazy_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A snazzy json log viewer
+    replacements:
+      darwin: macOS
+    overrides:
+      - goos: darwin
+        asset: snazy_{{.Version}}_{{.OS}}_all.{{.Format}}
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/chmouel/snazy/registry.yaml
+++ b/pkgs/chmouel/snazy/registry.yaml
@@ -13,7 +13,6 @@ packages:
     supported_envs:
       - linux/amd64
       - darwin
-    rosetta2: true
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -4148,7 +4148,6 @@ packages:
     supported_envs:
       - linux/amd64
       - darwin
-    rosetta2: true
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -4135,6 +4135,29 @@ packages:
       - darwin
     rosetta2: true
   - type: github_release
+    repo_owner: chmouel
+    repo_name: snazy
+    asset: snazy_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: A snazzy json log viewer
+    replacements:
+      darwin: macOS
+    overrides:
+      - goos: darwin
+        asset: snazy_{{.Version}}_{{.OS}}_all.{{.Format}}
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: chriswalz
     repo_name: bit
     asset: bit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[chmouel/snazy](https://github.com/chmouel/snazy): A snazzy json log viewer

```console
$ aqua g -i chmouel/snazy
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ snazy --help
snazy is a snazzy json log viewer

Usage: snazy [OPTIONS] [FILES]...

Arguments:
  [FILES]...


Options:
  -r, --regexp <REGEXP>
          regexp highlight

          Highlight a pattern in a message with a regexp

  -S, --skip-line-regexp <SKIP_LINE_REGEXP>
          Skip a line matching a Regexp.

          Any lines matching the regexp, will be skipped to be printed.

      --shell-completion <SHELL_COMPLETION>
          If provided, outputs the completion file for given shell

          [possible values: bash, elvish, fish, powershell, zsh]

  -f, --filter-levels <FILTER_LEVELS>
          Filter by log level

          Filter the json logs by log level. You can have multiple log levels.

          [possible values: info, debug, warning, error, fatal]

  -c, --color <when>
          When to use colors

          'auto':      show colors if the output goes to an interactive console (default)
          'never':     do not use colorized output
          'always':    always use colorized output

          [default: auto]

      --time-format <TIME_FORMAT>
          Filter by log level

          A timeformat as documented by the strftime(3) manpage.

          [env: SNAZY_TIME_FORMAT=]
          [default: %H:%M:%S]

      --kail-prefix-format <KAIL_PREFIX_FORMAT>
          Set the format on how to print the kail prefix.

          The {namespace}, {pod} and {container} tags will be replaced by their
          values."

          [env: SNAZY_KAIL_PREFIX_FORMAT=]
          [default: {namespace}/{pod}[{container}]]

      --kail-no-prefix
          Hide container prefix when showing the log with kail

      --level-symbols
          Pretty emojis instead of boring text level

          [env: SNAZY_LEVEL_SYMBOLS=]

  -k, --json-keys <JSON_KEYS>
          Keys / Values for JSON Parsing

          The keys needed to be passed are: msg (message), level (logging level),
          ts (timestamp).

          For example:

          `snazy -k msg=message -k level=level -k ts=ts`

          will parse the JSON log file and use the (`message`, `level`, `ts`) keys
          from the json as (`msg`), (`level`) and (`ts`) for snazy.

      --action-regexp <ACTION_REGEXP>
           A regexp to match an action on.

           You can have an action matching a Regexp.
           A good example is when  you have to have a notification on your desktop
           when there is a match in a log.

      --action-command <ACTION_COMMAND>
           The command to run when a regexp match the --action-match

  -h, --help
          Print help information (use `-h` for a summary)

  -V, --version
          Print version information

Snazzy let you watch logs. It tries to be smart with Json logs by showing the levels,
the message and the date in a nice and visual way.
There is many more options to filter or highlight part of the logs or even launch some
actions when a match is found.

Try to stream some logs or specify a log file and let snazy, snazzy them!
```