### PR TITLE
feat: add nicarl/somafm

### DIFF
--- a/pkgs/nicarl/somafm/pkg.yaml
+++ b/pkgs/nicarl/somafm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: nicarl/somafm@v0.3.0

--- a/pkgs/nicarl/somafm/registry.yaml
+++ b/pkgs/nicarl/somafm/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: nicarl
+    repo_name: somafm
+    asset: somafm-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    description: CLI application to listen to SomaFM stations
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -14590,6 +14590,18 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: nicarl
+    repo_name: somafm
+    asset: somafm-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    description: CLI application to listen to SomaFM stations
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      enabled: false
+  - type: github_release
     repo_owner: nikochiko
     repo_name: autosaved
     description: Never worry about losing your code. Written in Go


### PR DESCRIPTION
[nicarl/somafm](https://github.com/nicarl/somafm): CLI application to listen to SomaFM stations

```console
$ aqua g -i nicarl/somafm
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ somafm
```