### PR TITLE
feat: add tsl0922/ttyd

### DIFF
--- a/pkgs/tsl0922/ttyd/pkg.yaml
+++ b/pkgs/tsl0922/ttyd/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: tsl0922/ttyd@1.7.3
+  - name: tsl0922/ttyd
+    version: 1.7.0

--- a/pkgs/tsl0922/ttyd/pkg.yaml
+++ b/pkgs/tsl0922/ttyd/pkg.yaml
@@ -2,3 +2,5 @@ packages:
   - name: tsl0922/ttyd@1.7.3
   - name: tsl0922/ttyd
     version: 1.7.0
+  - name: tsl0922/ttyd
+    version: 1.6.3

--- a/pkgs/tsl0922/ttyd/registry.yaml
+++ b/pkgs/tsl0922/ttyd/registry.yaml
@@ -27,3 +27,7 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
+      - version_constraint: semver("< 1.7.0") 
+        supported_envs:
+          - linux
+      - version_constraint: "true"

--- a/pkgs/tsl0922/ttyd/registry.yaml
+++ b/pkgs/tsl0922/ttyd/registry.yaml
@@ -1,0 +1,29 @@
+packages:
+  - type: github_release
+    repo_owner: tsl0922
+    repo_name: ttyd
+    description: Share your terminal over the web
+    asset: ttyd.{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      windows: win32
+    overrides:
+      - goos: windows
+        goarch: amd64
+        asset: ttyd.{{.OS}}.exe
+    supported_envs:
+      - linux
+      - windows/amd64
+    version_constraint: semver(">= 1.7.3")
+    version_overrides:
+      - version_constraint: semver(">= 1.7.0")
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          windows: win10
+        overrides:
+          - goos: windows
+            goarch: amd64
+            asset: ttyd.{{.OS}}.exe

--- a/registry.yaml
+++ b/registry.yaml
@@ -19566,6 +19566,34 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: tsl0922
+    repo_name: ttyd
+    description: Share your terminal over the web
+    asset: ttyd.{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      windows: win32
+    overrides:
+      - goos: windows
+        goarch: amd64
+        asset: ttyd.{{.OS}}.exe
+    supported_envs:
+      - linux
+      - windows/amd64
+    version_constraint: semver(">= 1.7.3")
+    version_overrides:
+      - version_constraint: semver(">= 1.7.0")
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          windows: win10
+        overrides:
+          - goos: windows
+            goarch: amd64
+            asset: ttyd.{{.OS}}.exe
+  - type: github_release
     repo_owner: turbot
     repo_name: steampipe
     asset: steampipe_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -19593,6 +19593,10 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
+      - version_constraint: semver("< 1.7.0") 
+        supported_envs:
+          - linux
+      - version_constraint: "true"
   - type: github_release
     repo_owner: turbot
     repo_name: steampipe


### PR DESCRIPTION
[tsl0922/ttyd](https://github.com/tsl0922/ttyd): Share your terminal over the web

```console
$ aqua g -i tsl0922/ttyd
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ttyd --help
ttyd is a tool for sharing terminal over the web

USAGE:
    ttyd [options] <command> [<arguments...>]

VERSION:
    1.7.3

OPTIONS:
    -p, --port              Port to listen (default: 7681, use `0` for random port)
    -i, --interface         Network interface to bind (eg: eth0), or UNIX domain socket path (eg: /var/run/ttyd.sock)
    -U, --socket-owner      User owner of the UNIX domain socket file, when enabled (eg: user:group)
    -c, --credential        Credential for basic authentication (format: username:password)
    -H, --auth-header       HTTP Header name for auth proxy, this will configure ttyd to let a HTTP reverse proxy handle authentication
    -u, --uid               User id to run with
    -g, --gid               Group id to run with
    -s, --signal            Signal to send to the command when exit it (default: 1, SIGHUP)
    -w, --cwd               Working directory to be set for the child program
    -a, --url-arg           Allow client to send command line arguments in URL (eg: http://localhost:7681?arg=foo&arg=bar)
    -R, --readonly          Do not allow clients to write to the TTY
    -t, --client-option     Send option to client (format: key=value), repeat to add more options
    -T, --terminal-type     Terminal type to report, default: xterm-256color
    -O, --check-origin      Do not allow websocket connection from different origin
    -m, --max-clients       Maximum clients to support (default: 0, no limit)
    -o, --once              Accept only one client and exit on disconnection
    -B, --browser           Open terminal with the default system browser
    -I, --index             Custom index.html path
    -b, --base-path         Expected base path for requests coming from a reverse proxy (eg: /mounted/here, max length: 128)
    -P, --ping-interval     Websocket ping interval(sec) (default: 5)
    -6, --ipv6              Enable IPv6 support
    -S, --ssl               Enable SSL
    -C, --ssl-cert          SSL certificate file path
    -K, --ssl-key           SSL key file path
    -A, --ssl-ca            SSL CA file path for client certificate verification
    -d, --debug             Set log level (default: 7)
    -v, --version           Print the version and exit
    -h, --help              Print this text and exit

Visit https://github.com/tsl0922/ttyd to get more information and report bugs.
```