### PR TITLE
feat: add regclient/regclient/regctl

### DIFF
--- a/pkgs/regclient/regclient/regbot/pkg.yaml
+++ b/pkgs/regclient/regclient/regbot/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: regclient/regclient/regbot@v0.4.5

--- a/pkgs/regclient/regclient/regbot/registry.yaml
+++ b/pkgs/regclient/regclient/regbot/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: regclient/regclient/regbot
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regbot-{{.OS}}-{{.Arch}}
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    format: raw
+    files:
+      - name: regbot
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/regclient/regclient/regctl/pkg.yaml
+++ b/pkgs/regclient/regclient/regctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: regclient/regclient/regctl@v0.4.5

--- a/pkgs/regclient/regclient/regctl/registry.yaml
+++ b/pkgs/regclient/regclient/regctl/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: regclient/regclient/regctl
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regctl-{{.OS}}-{{.Arch}}
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    format: raw
+    files:
+      - name: regctl
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -16302,6 +16302,45 @@ packages:
     files:
       - name: aws-nuke
         src: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}
+  - name: regclient/regclient/regbot
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regbot-{{.OS}}-{{.Arch}}
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    format: raw
+    files:
+      - name: regbot
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - name: regclient/regclient/regctl
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regctl-{{.OS}}-{{.Arch}}
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    format: raw
+    files:
+      - name: regctl
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - name: regclient/regclient/regsync
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regsync-{{.OS}}-{{.Arch}}
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    format: raw
+    files:
+      - name: regsync
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
   - type: github_release
     repo_owner: replicatedhq
     repo_name: kots


### PR DESCRIPTION
[regclient/regclient/regctl](https://github.com/regclient/regclient): Docker and OCI Registry Client in Go and tooling using those libraries

```console
$ aqua g -i regclient/regclient/regctl
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ regctl
Utility for accessing docker registries
More details at https://github.com/regclient/regclient

Usage:
  regctl [command]

Available Commands:
  artifact    manage artifacts
  blob        manage image blobs/layers
  completion  Generate completion script
  help        Help about any command
  image       manage images
  index       manage manifest lists and OCI index
  manifest    manage manifests
  registry    manage registries
  repo        manage repositories
  tag         manage tags
  version     Show the version

Flags:
  -h, --help                 help for regctl
      --logopt stringArray   Log options
      --user-agent string    Override user agent
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "warning")

Use "regctl [command] --help" for more information about a command.
```