### PR TITLE
feat: add regclient/regclient/regsync

### DIFF
--- a/pkgs/regclient/regclient/regsync/pkg.yaml
+++ b/pkgs/regclient/regclient/regsync/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: regclient/regclient/regsync@v0.4.5
+  - name: regclient/regclient/regsync
+    version: v0.3.8

--- a/pkgs/regclient/regclient/regsync/pkg.yaml
+++ b/pkgs/regclient/regclient/regsync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: regclient/regclient/regsync@v0.4.5

--- a/pkgs/regclient/regclient/regsync/registry.yaml
+++ b/pkgs/regclient/regclient/regsync/registry.yaml
@@ -12,3 +12,8 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.9")
+    version_overrides:
+      - version_constraint: semver("< 0.3.9")
+        rosetta2: true
+      - version_constraint: "true"

--- a/pkgs/regclient/regclient/regsync/registry.yaml
+++ b/pkgs/regclient/regclient/regsync/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: regclient/regclient/regsync
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regsync-{{.OS}}-{{.Arch}}
+    format: raw
+    files:
+      - name: regsync
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/regclient/regclient/regsync/registry.yaml
+++ b/pkgs/regclient/regclient/regsync/registry.yaml
@@ -7,7 +7,7 @@ packages:
     format: raw
     files:
       - name: regsync
-    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    description: Docker and OCI image mirroring tool
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -16302,6 +16302,19 @@ packages:
     files:
       - name: aws-nuke
         src: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}
+  - name: regclient/regclient/regsync
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regsync-{{.OS}}-{{.Arch}}
+    format: raw
+    files:
+      - name: regsync
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
   - type: github_release
     repo_owner: replicatedhq
     repo_name: kots

--- a/registry.yaml
+++ b/registry.yaml
@@ -16328,7 +16328,7 @@ packages:
     format: raw
     files:
       - name: regsync
-    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    description: Docker and OCI image mirroring tool
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -16333,6 +16333,11 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.9")
+    version_overrides:
+      - version_constraint: semver("< 0.3.9")
+        rosetta2: true
+      - version_constraint: "true"
   - type: github_release
     repo_owner: replicatedhq
     repo_name: kots


### PR DESCRIPTION
[regclient/regclient/regsync](https://github.com/regclient/regclient): Docker and OCI Registry Client in Go and tooling using those libraries

```console
$ aqua g -i regclient/regclient/regsync
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ regsync
Utility for mirroring docker repositories
More details at https://github.com/regclient/regclient

Usage:
  regsync [command]

Available Commands:
  check       processes each sync command once but skip actual copy
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  once        processes each sync command once, ignoring cron schedule
  server      run the regsync server
  version     Show the version

Flags:
  -c, --config string        Config file
  -h, --help                 help for regsync
      --logopt stringArray   Log options
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "info")

Use "regsync [command] --help" for more information about a command.
```