### PR TITLE
feat: add regclient/regclient/regbot

### DIFF
--- a/pkgs/regclient/regclient/regbot/pkg.yaml
+++ b/pkgs/regclient/regclient/regbot/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: regclient/regclient/regbot@v0.4.5
+  - name: regclient/regclient/regbot
+    version: v0.3.8

--- a/pkgs/regclient/regclient/regbot/pkg.yaml
+++ b/pkgs/regclient/regclient/regbot/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: regclient/regclient/regbot@v0.4.5

--- a/pkgs/regclient/regclient/regbot/registry.yaml
+++ b/pkgs/regclient/regclient/regbot/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: regclient/regclient/regbot
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regbot-{{.OS}}-{{.Arch}}
+    format: raw
+    files:
+      - name: regbot
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/regclient/regclient/regbot/registry.yaml
+++ b/pkgs/regclient/regclient/regbot/registry.yaml
@@ -12,3 +12,8 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.9")
+    version_overrides:
+      - version_constraint: semver("< 0.3.9")
+        rosetta2: true
+      - version_constraint: "true"

--- a/pkgs/regclient/regclient/regbot/registry.yaml
+++ b/pkgs/regclient/regclient/regbot/registry.yaml
@@ -7,7 +7,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -16302,6 +16302,19 @@ packages:
     files:
       - name: aws-nuke
         src: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}
+  - name: regclient/regclient/regbot
+    type: github_release
+    repo_owner: regclient
+    repo_name: regclient
+    asset: regbot-{{.OS}}-{{.Arch}}
+    format: raw
+    files:
+      - name: regbot
+    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
   - type: github_release
     repo_owner: replicatedhq
     repo_name: kots

--- a/registry.yaml
+++ b/registry.yaml
@@ -16310,7 +16310,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: Docker and OCI Registry Client in Go and tooling using those libraries
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -16315,6 +16315,11 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 0.3.9")
+    version_overrides:
+      - version_constraint: semver("< 0.3.9")
+        rosetta2: true
+      - version_constraint: "true"
   - name: regclient/regclient/regctl
     type: github_release
     repo_owner: regclient


### PR DESCRIPTION
[regclient/regclient/regbot](https://github.com/regclient/regclient): Docker and OCI Registry Client in Go and tooling using those libraries

```console
$ aqua g -i regclient/regclient/regbot
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ regbot
Utility for automating repository actions
More details at https://github.com/regclient/regclient

Usage:
  regbot [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  once        runs each script once
  server      run the regbot server
  version     Show the version

Flags:
  -c, --config string        Config file
      --dry-run              Dry Run, skip all external actions
  -h, --help                 help for regbot
      --logopt stringArray   Log options
  -v, --verbosity string     Log level (debug, info, warn, error, fatal, panic) (default "info")

Use "regbot [command] --help" for more information about a command.
```