### PR TITLE
fix(Shopify/kubeaudit) to use as kubectl plugin

### DIFF
--- a/pkgs/Shopify/kubeaudit/registry.yaml
+++ b/pkgs/Shopify/kubeaudit/registry.yaml
@@ -4,6 +4,10 @@ packages:
     repo_name: kubeaudit
     asset: kubeaudit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: kubeaudit helps you audit your Kubernetes clusters against common security controls
+    files:
+      - name: kubeaudit
+      - name: kubectl-audit
+        src: kubeaudit
     checksum:
       type: github_release
       asset: kubeaudit_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -1136,6 +1136,10 @@ packages:
     repo_name: kubeaudit
     asset: kubeaudit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: kubeaudit helps you audit your Kubernetes clusters against common security controls
+    files:
+      - name: kubeaudit
+      - name: kubectl-audit
+        src: kubeaudit
     checksum:
       type: github_release
       asset: kubeaudit_{{trimV .Version}}_checksums.txt


### PR DESCRIPTION
[Shopify/kubeaudit](https://github.com/Shopify/kubeaudit)

https://github.com/Shopify/kubeaudit#kubectl-plugin

> renaming the binary to kubectl-audit and having it available in your path.