### PR TITLE
feat: add veeso/termscp

### DIFF
--- a/pkgs/veeso/termscp/pkg.yaml
+++ b/pkgs/veeso/termscp/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: veeso/termscp@v0.10.0
+  - name: veeso/termscp
+    version: v0.8.0
+  - name: veeso/termscp
+    version: v0.6.0

--- a/pkgs/veeso/termscp/registry.yaml
+++ b/pkgs/veeso/termscp/registry.yaml
@@ -1,0 +1,38 @@
+packages:
+  - type: github_release
+    repo_owner: veeso
+    repo_name: termscp
+    asset: termscp-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A feature rich terminal UI file transfer and explorer with support for SCP/SFTP/FTP/S3
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.8.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.1")
+        rosetta2: true
+      - version_constraint: "true"
+        asset: termscp-{{.OS}}.{{.Format}}
+        rosetta2: true
+        replacements:
+          darwin: mac
+          windows: msvc
+        overrides:
+          - goos: linux
+            format: txz
+            asset: termscp-{{trimV .Version}}.{{.Format}}
+            files:
+              - name: termscp
+                src: usr/local/bin/termscp
+          - goos: windows
+            format: zip
+            asset: termscp-{{trimV .Version}}-{{.OS}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -19999,6 +19999,43 @@ packages:
             checksum:
               enabled: false
   - type: github_release
+    repo_owner: veeso
+    repo_name: termscp
+    asset: termscp-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: A feature rich terminal UI file transfer and explorer with support for SCP/SFTP/FTP/S3
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.8.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.1")
+        rosetta2: true
+      - version_constraint: "true"
+        asset: termscp-{{.OS}}.{{.Format}}
+        rosetta2: true
+        replacements:
+          darwin: mac
+          windows: msvc
+        overrides:
+          - goos: linux
+            format: txz
+            asset: termscp-{{trimV .Version}}.{{.Format}}
+            files:
+              - name: termscp
+                src: usr/local/bin/termscp
+          - goos: windows
+            format: zip
+            asset: termscp-{{trimV .Version}}-{{.OS}}.{{.Format}}
+  - type: github_release
     repo_owner: vektra
     repo_name: mockery
     rosetta2: true


### PR DESCRIPTION
[veeso/termscp](https://github.com/veeso/termscp): A feature rich terminal UI file transfer and explorer with support for SCP/SFTP/FTP/S3

```console
$ aqua g -i veeso/termscp
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ termscp --help
Usage: termscp [<positional...>] [-c] [-P <password>] [-q] [-t <theme>] [-T <ticks>] [-v]

where positional can be: [protocol://user@address:port:wrkdir] [local-wrkdir]

Please, report issues to <https://github.com/veeso/termscp>
Please, consider supporting the author <https://www.buymeacoffee.com/veeso>

Options:
  -c, --config      open termscp configuration
  -P, --password    provide password from CLI
  -q, --quiet       disable logging
  -t, --theme       import specified theme
  -T, --ticks       set UI ticks; default 10ms
  -v, --version     print version
  --help            display usage information
```