### PR TITLE
feat: add birdayz/kaf

### DIFF
--- a/pkgs/birdayz/kaf/pkg.yaml
+++ b/pkgs/birdayz/kaf/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: birdayz/kaf@v0.2.3

--- a/pkgs/birdayz/kaf/pkg.yaml
+++ b/pkgs/birdayz/kaf/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: birdayz/kaf@v0.2.3
+  - name: birdayz/kaf
+    version: v0.1.43
+  - name: birdayz/kaf
+    version: v0.1.42

--- a/pkgs/birdayz/kaf/registry.yaml
+++ b/pkgs/birdayz/kaf/registry.yaml
@@ -17,3 +17,17 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.44")
+    version_overrides:
+      - version_constraint: semver("= 0.1.43")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver("< 0.1.43")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"

--- a/pkgs/birdayz/kaf/registry.yaml
+++ b/pkgs/birdayz/kaf/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: birdayz
+    repo_name: kaf
+    asset: kaf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Modern CLI for Apache Kafka, written in Go
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3354,6 +3354,20 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.1.44")
+    version_overrides:
+      - version_constraint: semver("= 0.1.43")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver("< 0.1.43")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
   - type: github_release
     repo_owner: bitnami-labs
     repo_name: sealed-secrets

--- a/registry.yaml
+++ b/registry.yaml
@@ -3337,6 +3337,24 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: birdayz
+    repo_name: kaf
+    asset: kaf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: Modern CLI for Apache Kafka, written in Go
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: bitnami-labs
     repo_name: sealed-secrets
     asset: kubeseal-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz


### PR DESCRIPTION
[birdayz/kaf](https://github.com/birdayz/kaf): Modern CLI for Apache Kafka, written in Go

```console
$ aqua g -i birdayz/kaf
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kaf
Kafka Command Line utility for cluster management

Usage:
  kaf [command]

Available Commands:
  completion  Generate completion script for bash, zsh, fish or powershell
  config      Handle kaf configuration
  consume     Consume messages
  group       Display information about consumer groups.
  groups      List groups
  help        Help about any command
  node        Describe and List nodes
  nodes       List nodes in a cluster
  produce     Produce record. Reads data from stdin.
  query       Query topic by key
  topic       Create and describe topics.
  topics      List topics

Flags:
  -b, --brokers strings          Comma separated list of broker ip:port pairs
  -c, --cluster string           set a temporary current cluster
      --config string            config file (default is $HOME/.kaf/config)
  -h, --help                     help for kaf
      --schema-registry string   URL to a Confluent schema registry. Used for attempting to decode Avro-encoded messages
  -v, --verbose                  Whether to turn on sarama logging
      --version                  version for kaf

Use "kaf [command] --help" for more information about a command.
```