### PR TITLE
feat: add dlvhdr/gh-dash

### DIFF
--- a/pkgs/dlvhdr/gh-dash/pkg.yaml
+++ b/pkgs/dlvhdr/gh-dash/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: dlvhdr/gh-dash@v3.7.6
+  - name: dlvhdr/gh-dash
+    version: v3.7.4

--- a/pkgs/dlvhdr/gh-dash/pkg.yaml
+++ b/pkgs/dlvhdr/gh-dash/pkg.yaml
@@ -1,4 +1,18 @@
 packages:
   - name: dlvhdr/gh-dash@v3.7.6
   - name: dlvhdr/gh-dash
+    version: v3.7.5
+  - name: dlvhdr/gh-dash
     version: v3.7.4
+  - name: dlvhdr/gh-dash
+    version: v3.7.3-next
+  - name: dlvhdr/gh-dash
+    version: v3.7.0
+  - name: dlvhdr/gh-dash
+    version: v1.2.3
+  - name: dlvhdr/gh-dash
+    version: v1.2.2
+  - name: dlvhdr/gh-dash
+    version: v1.2.1
+  - name: dlvhdr/gh-dash
+    version: v1.0.3

--- a/pkgs/dlvhdr/gh-dash/registry.yaml
+++ b/pkgs/dlvhdr/gh-dash/registry.yaml
@@ -53,7 +53,8 @@ packages:
         complete_windows_ext: false
         overrides:
           - goos: darwin
-            replacements: {}
+            replacements:
+              amd64: amd64
       - version_constraint: semver("= 1.2.1")
         checksum:
           enabled: false

--- a/pkgs/dlvhdr/gh-dash/registry.yaml
+++ b/pkgs/dlvhdr/gh-dash/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - type: github_release
+    repo_owner: dlvhdr
+    repo_name: gh-dash
+    asset: "{{.OS}}-{{.Arch}}"
+    format: raw
+    description: A beautiful CLI dashboard for GitHub
+    version_constraint: semver(">= 3.7.5")
+    version_overrides:
+      - version_constraint: semver(">= 3.7.3")
+        format: tar.gz
+        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: "{{.OS}}-{{.Arch}}"
+        format: raw
+        checksum:
+          enabled: false
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/dlvhdr/gh-dash/registry.yaml
+++ b/pkgs/dlvhdr/gh-dash/registry.yaml
@@ -30,6 +30,8 @@ packages:
       - version_constraint: Version == "v3.7.3-next"
         asset: gh-dash_{{title .OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/dlvhdr/gh-dash/registry.yaml
+++ b/pkgs/dlvhdr/gh-dash/registry.yaml
@@ -2,22 +2,8 @@ packages:
   - type: github_release
     repo_owner: dlvhdr
     repo_name: gh-dash
-    asset: "{{.OS}}-{{.Arch}}"
-    format: raw
     description: A beautiful CLI dashboard for GitHub
-    version_constraint: semver(">= 3.7.5")
-    version_overrides:
-      - version_constraint: semver(">= 3.7.3")
-        format: tar.gz
-        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
-        asset: "{{.OS}}-{{.Arch}}"
-        format: raw
-        checksum:
-          enabled: false
+    version_constraint: semver(">= 3.7.6")
     checksum:
       type: github_release
       asset: checksums.txt
@@ -26,3 +12,64 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    asset: "{{.OS}}-{{.Arch}}"
+    format: raw
+    version_overrides:
+      - version_constraint: semver("= 3.7.5")
+        asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("= 3.7.4")
+        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.7.3-next"
+        asset: gh-dash_{{title .OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("= 1.2.3")
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: semver("= 1.2.2")
+        checksum:
+          enabled: false
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+        overrides:
+          - goos: darwin
+            replacements: {}
+      - version_constraint: semver("= 1.2.1")
+        checksum:
+          enabled: false
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: semver("= 1.0.3")
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 3.7.0")
+        checksum:
+          enabled: false
+      - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5965,6 +5965,8 @@ packages:
       - version_constraint: Version == "v3.7.3-next"
         asset: gh-dash_{{title .OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -5937,22 +5937,8 @@ packages:
   - type: github_release
     repo_owner: dlvhdr
     repo_name: gh-dash
-    asset: "{{.OS}}-{{.Arch}}"
-    format: raw
     description: A beautiful CLI dashboard for GitHub
-    version_constraint: semver(">= 3.7.5")
-    version_overrides:
-      - version_constraint: semver(">= 3.7.3")
-        format: tar.gz
-        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
-        asset: "{{.OS}}-{{.Arch}}"
-        format: raw
-        checksum:
-          enabled: false
+    version_constraint: semver(">= 3.7.6")
     checksum:
       type: github_release
       asset: checksums.txt
@@ -5961,6 +5947,67 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    asset: "{{.OS}}-{{.Arch}}"
+    format: raw
+    version_overrides:
+      - version_constraint: semver("= 3.7.5")
+        asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("= 3.7.4")
+        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.7.3-next"
+        asset: gh-dash_{{title .OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("= 1.2.3")
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: semver("= 1.2.2")
+        checksum:
+          enabled: false
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+        overrides:
+          - goos: darwin
+            replacements: {}
+      - version_constraint: semver("= 1.2.1")
+        checksum:
+          enabled: false
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: semver("= 1.0.3")
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 3.7.0")
+        checksum:
+          enabled: false
+      - version_constraint: "true"
   - type: github_release
     repo_owner: dnnrly
     repo_name: abbreviate

--- a/registry.yaml
+++ b/registry.yaml
@@ -5935,6 +5935,33 @@ packages:
     files:
       - name: registry
   - type: github_release
+    repo_owner: dlvhdr
+    repo_name: gh-dash
+    asset: "{{.OS}}-{{.Arch}}"
+    format: raw
+    description: A beautiful CLI dashboard for GitHub
+    version_constraint: semver(">= 3.7.5")
+    version_overrides:
+      - version_constraint: semver(">= 3.7.3")
+        format: tar.gz
+        asset: gh-dash_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: "{{.OS}}-{{.Arch}}"
+        format: raw
+        checksum:
+          enabled: false
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: dnnrly
     repo_name: abbreviate
     description: Supporting your devops by shortening your strings using common abbreviations and clever guesswork

--- a/registry.yaml
+++ b/registry.yaml
@@ -5988,7 +5988,8 @@ packages:
         complete_windows_ext: false
         overrides:
           - goos: darwin
-            replacements: {}
+            replacements:
+              amd64: amd64
       - version_constraint: semver("= 1.2.1")
         checksum:
           enabled: false


### PR DESCRIPTION
[dlvhdr/gh-dash](https://github.com/dlvhdr/gh-dash): A beautiful CLI dashboard for GitHub

```console
$ aqua g -i dlvhdr/gh-dash
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gh-dash --help
A gh extension that shows a configurable dashboard of pull requests and issues.

Usage:
  gh dash [flags]

Flags:
  -c, --config string   use this configuration file (default is $XDG_CONFIG_HOME/gh-dash/config.yml)
      --debug           passing this flag will allow writing debug output to debug.log
  -h, --help            help for gh-dash
  -v, --version         version for gh
```