### PR TITLE
feat: add kubewarden/kwctl

### DIFF
--- a/pkgs/kubewarden/kwctl/pkg.yaml
+++ b/pkgs/kubewarden/kwctl/pkg.yaml
@@ -1,2 +1,10 @@
 packages:
   - name: kubewarden/kwctl@v1.5.3
+  - name: kubewarden/kwctl
+    version: v0.2.5-rc3
+  - name: kubewarden/kwctl
+    version: v0.2.5-rc1
+  - name: kubewarden/kwctl
+    version: v0.1.2
+  - name: kubewarden/kwctl
+    version: v0.1.1

--- a/pkgs/kubewarden/kwctl/pkg.yaml
+++ b/pkgs/kubewarden/kwctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubewarden/kwctl@v1.5.3

--- a/pkgs/kubewarden/kwctl/registry.yaml
+++ b/pkgs/kubewarden/kwctl/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: kubewarden
+    repo_name: kwctl
+    asset: kwctl-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: Go-to CLI tool for Kubewarden users
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    files:
+      - name: kwctl
+        src: kwctl-{{.OS}}-{{.Arch}}
+    overrides:
+      - goos: windows
+        asset: kwctl-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/pkgs/kubewarden/kwctl/registry.yaml
+++ b/pkgs/kubewarden/kwctl/registry.yaml
@@ -18,3 +18,25 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 1.1.3")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.5-rc3")
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.5-rc1")
+        rosetta2: true
+        asset: kwctl-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides: []
+      - version_constraint: semver(">= 0.1.2")
+        files:
+          - name: kwctl
+        replacements: {}
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: kwctl.{{.Format}}
+        files:
+          - name: kwctl
+        replacements: {}
+        supported_envs:
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -12734,6 +12734,25 @@ packages:
           - darwin
           - amd64
   - type: github_release
+    repo_owner: kubewarden
+    repo_name: kwctl
+    asset: kwctl-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: Go-to CLI tool for Kubewarden users
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    files:
+      - name: kwctl
+        src: kwctl-{{.OS}}-{{.Arch}}
+    overrides:
+      - goos: windows
+        asset: kwctl-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: kudobuilder
     repo_name: kuttl
     description: KUbernetes Test TooL (kuttl)

--- a/registry.yaml
+++ b/registry.yaml
@@ -12752,6 +12752,28 @@ packages:
       - darwin
       - linux
       - amd64
+    version_constraint: semver(">= 1.1.3")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.5-rc3")
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.5-rc1")
+        rosetta2: true
+        asset: kwctl-{{.OS}}-{{.Arch}}
+        format: raw
+        overrides: []
+      - version_constraint: semver(">= 0.1.2")
+        files:
+          - name: kwctl
+        replacements: {}
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: kwctl.{{.Format}}
+        files:
+          - name: kwctl
+        replacements: {}
+        supported_envs:
+          - linux/amd64
   - type: github_release
     repo_owner: kudobuilder
     repo_name: kuttl


### PR DESCRIPTION
[kubewarden/kwctl](https://github.com/kubewarden/kwctl): Go-to CLI tool for Kubewarden users

```console
$ aqua g -i kubewarden/kwctl
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kwctl --help
Tool to manage Kubewarden policies

Usage: kwctl-darwin-x86_64 [OPTIONS] <COMMAND>

Commands:
  policies     Lists all downloaded policies
  pull         Pulls a Kubewarden policy from a given URI
  verify       Verify a Kubewarden policy from a given URI using Sigstore
  push         Pushes a Kubewarden policy to an OCI registry
  rm           Removes a Kubewarden policy from the store
  run          Runs a Kubewarden policy from a given URI
  annotate     Add Kubewarden metadata to a WebAssembly module
  inspect      Inspect Kubewarden policy
  scaffold     Scaffold a Kubernetes resource or configuration file
  completions  Generate shell completions
  digest       Fetch digest from the OCI manifest of a policy
  bench        Benchmarks a Kubewarden policy from a given URI
  save         save policies to a tar.gz file
  load         load policies from a tar.gz file
  help         Print this message or the help of the given subcommand(s)

Options:
  -v <verbose>      Increase verbosity
  -h, --help        Print help
  -V, --version     Print version
```