### PR TITLE
feat: add its-danny/koji

### DIFF
--- a/pkgs/its-danny/koji/pkg.yaml
+++ b/pkgs/its-danny/koji/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: its-danny/koji@1.5.3
+  - name: its-danny/koji
+    version: 1.4.0
+  - name: its-danny/koji
+    version: 1.2.0

--- a/pkgs/its-danny/koji/pkg.yaml
+++ b/pkgs/its-danny/koji/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: its-danny/koji@1.5.3

--- a/pkgs/its-danny/koji/registry.yaml
+++ b/pkgs/its-danny/koji/registry.yaml
@@ -37,6 +37,7 @@ packages:
       - version_constraint: semver("< 1.3.4")
         asset: koji-{{.OS}}-{{.Arch}}
         format: raw
+        overrides: []
         rosetta2: true
         replacements:
           darwin: macos

--- a/pkgs/its-danny/koji/registry.yaml
+++ b/pkgs/its-danny/koji/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: its-danny
+    repo_name: koji
+    asset: koji-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: An interactive CLI for creating conventional commits
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    files:
+      - name: koji
+        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
+    overrides:
+      - goos: windows
+        format: zip

--- a/pkgs/its-danny/koji/registry.yaml
+++ b/pkgs/its-danny/koji/registry.yaml
@@ -2,18 +2,46 @@ packages:
   - type: github_release
     repo_owner: its-danny
     repo_name: koji
+    description: An interactive CLI for creating conventional commits
+    version_constraint: semver(">= 1.5.0")
     asset: koji-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: An interactive CLI for creating conventional commits
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: koji
+        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
     replacements:
       amd64: x86_64
       arm64: aarch64
       darwin: apple-darwin
       linux: unknown-linux-gnu
       windows: pc-windows-msvc
-    files:
-      - name: koji
-        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
-    overrides:
-      - goos: windows
-        format: zip
+    version_overrides:
+      # error="the asset isn't found: koji-macos-arm64" package_name=its-danny/koji package_version=1.2.0 program=aqua registry=standard
+      # error="the asset isn't found: koji-1.4.0-aarch64-osx.tar.gz" package_name=its-danny/koji package_version=1.4.0 program=aqua registry=standard
+
+      - version_constraint: semver(">= 1.3.4")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: osx
+          linux: unknown-linux-musl
+        files:
+          - name: koji
+      - version_constraint: semver("< 1.3.4")
+        asset: koji-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -10439,21 +10439,49 @@ packages:
   - type: github_release
     repo_owner: its-danny
     repo_name: koji
+    description: An interactive CLI for creating conventional commits
+    version_constraint: semver(">= 1.5.0")
     asset: koji-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: An interactive CLI for creating conventional commits
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: koji
+        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
     replacements:
       amd64: x86_64
       arm64: aarch64
       darwin: apple-darwin
       linux: unknown-linux-gnu
       windows: pc-windows-msvc
-    files:
-      - name: koji
-        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
-    overrides:
-      - goos: windows
-        format: zip
+    version_overrides:
+      # error="the asset isn't found: koji-macos-arm64" package_name=its-danny/koji package_version=1.2.0 program=aqua registry=standard
+      # error="the asset isn't found: koji-1.4.0-aarch64-osx.tar.gz" package_name=its-danny/koji package_version=1.4.0 program=aqua registry=standard
+
+      - version_constraint: semver(">= 1.3.4")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - linux/amd64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: osx
+          linux: unknown-linux-musl
+        files:
+          - name: koji
+      - version_constraint: semver("< 1.3.4")
+        asset: koji-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - amd64
+        complete_windows_ext: false
+      - version_constraint: "true"
   - type: github_release
     repo_owner: ivaaaan
     repo_name: smug

--- a/registry.yaml
+++ b/registry.yaml
@@ -10474,6 +10474,7 @@ packages:
       - version_constraint: semver("< 1.3.4")
         asset: koji-{{.OS}}-{{.Arch}}
         format: raw
+        overrides: []
         rosetta2: true
         replacements:
           darwin: macos

--- a/registry.yaml
+++ b/registry.yaml
@@ -10437,6 +10437,24 @@ packages:
       - name: mmv
         src: mmv_{{.Version}}_{{.OS}}_{{.Arch}}/mmv
   - type: github_release
+    repo_owner: its-danny
+    repo_name: koji
+    asset: koji-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    description: An interactive CLI for creating conventional commits
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    files:
+      - name: koji
+        src: koji-{{.Version}}-{{.Arch}}-{{.OS}}/koji
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: ivaaaan
     repo_name: smug
     asset: smug_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[its-danny/koji](https://github.com/its-danny/koji): An interactive CLI for creating conventional commits

```console
$ aqua g -i its-danny/koji
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ koji --help
🦊 An interactive CLI for creating conventional commits.

Usage: koji [OPTIONS]

Options:
  -c, --config <CONFIG>  Path to a config file containing custom commit types
  -e, --emoji            Prepend the commit summary with relevant emoji based on commit type
      --no-emoji         Bypass the emoji flag
  -a, --autocomplete     Enables auto-complete for scope prompt via scanning commit history
      --no-autocomplete  Bypass the autocopmlete flag
      --hook             Run as a git hook, writing the commit message to COMMIT_EDITMSG instead of committing
  -h, --help             Print help information
  -V, --version          Print version information
```