### PR TITLE
fix(vmware-tanzu) moved to carvel-dev

### DIFF
--- a/pkgs/carvel-dev/kapp/pkg.yaml
+++ b/pkgs/carvel-dev/kapp/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: carvel-dev/kapp@v0.54.3
+  - name: carvel-dev/kapp
+    version: v0.45.0
+  - name: carvel-dev/kapp
+    version: v0.38.0
+  - name: carvel-dev/kapp
+    version: v0.34.0

--- a/pkgs/carvel-dev/kapp/registry.yaml
+++ b/pkgs/carvel-dev/kapp/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-kapp
+    repo_owner: carvel-dev
+    repo_name: kapp
+    aliases:
+      - name: vmware-tanzu/carvel-kapp
     format: raw
     asset: kapp-{{.OS}}-{{.Arch}}
     description: 'kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label'

--- a/pkgs/carvel-dev/kwt/pkg.yaml
+++ b/pkgs/carvel-dev/kwt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: carvel-dev/kwt@v0.0.6

--- a/pkgs/carvel-dev/kwt/registry.yaml
+++ b/pkgs/carvel-dev/kwt/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-kwt
+    repo_owner: carvel-dev
+    repo_name: kwt
+    aliases:
+      - name: vmware-tanzu/carvel-kwt
     description: Kubernetes Workstation Tools CLI
     rosetta2: true
     format: raw

--- a/pkgs/carvel-dev/vendir/pkg.yaml
+++ b/pkgs/carvel-dev/vendir/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: carvel-dev/vendir@v0.32.5
+  - name: carvel-dev/vendir
+    version: v0.24.0

--- a/pkgs/carvel-dev/vendir/registry.yaml
+++ b/pkgs/carvel-dev/vendir/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-vendir
+    repo_owner: carvel-dev
+    repo_name: vendir
+    aliases:
+      - name: vmware-tanzu/carvel-vendir
     asset: vendir-{{.OS}}-{{.Arch}}
     description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
     files:

--- a/pkgs/carvel-dev/ytt/pkg.yaml
+++ b/pkgs/carvel-dev/ytt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: carvel-dev/ytt@v0.44.3

--- a/pkgs/carvel-dev/ytt/registry.yaml
+++ b/pkgs/carvel-dev/ytt/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-ytt
+    repo_owner: carvel-dev
+    repo_name: ytt
+    aliases:
+      - name: vmware-tanzu/carvel-ytt
     asset: ytt-{{.OS}}-{{.Arch}}
     description: YAML templating tool that works on YAML structure instead of text
     files:

--- a/pkgs/vmware-tanzu/carvel-kapp/pkg.yaml
+++ b/pkgs/vmware-tanzu/carvel-kapp/pkg.yaml
@@ -1,8 +1,0 @@
-packages:
-  - name: vmware-tanzu/carvel-kapp@v0.54.3
-  - name: vmware-tanzu/carvel-kapp
-    version: v0.45.0
-  - name: vmware-tanzu/carvel-kapp
-    version: v0.38.0
-  - name: vmware-tanzu/carvel-kapp
-    version: v0.34.0

--- a/pkgs/vmware-tanzu/carvel-kwt/pkg.yaml
+++ b/pkgs/vmware-tanzu/carvel-kwt/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: vmware-tanzu/carvel-kwt@v0.0.6

--- a/pkgs/vmware-tanzu/carvel-vendir/pkg.yaml
+++ b/pkgs/vmware-tanzu/carvel-vendir/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: vmware-tanzu/carvel-vendir@v0.32.5
-  - name: vmware-tanzu/carvel-vendir
-    version: v0.24.0

--- a/pkgs/vmware-tanzu/carvel-ytt/pkg.yaml
+++ b/pkgs/vmware-tanzu/carvel-ytt/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: vmware-tanzu/carvel-ytt@v0.44.3

--- a/registry.yaml
+++ b/registry.yaml
@@ -3874,6 +3874,47 @@ packages:
           - amd64
   - type: github_release
     repo_owner: carvel-dev
+    repo_name: kapp
+    aliases:
+      - name: vmware-tanzu/carvel-kapp
+    format: raw
+    asset: kapp-{{.OS}}-{{.Arch}}
+    description: 'kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label'
+    files:
+      - name: kapp
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_constraint: semver(">= 0.46.0")
+    # support checksum
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\./(\\S+)$"
+    version_overrides:
+      # support darwin/arm64
+      - version_constraint: semver(">= 0.39.0")
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.35.0")
+        # support linux/arm64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: "true"
+        rosetta2: true
+        checksum:
+          enabled: false
+        supported_envs:
+          - darwin
+          - amd64
+  - type: github_release
+    repo_owner: carvel-dev
     repo_name: kbld
     aliases:
       - name: vmware-tanzu/carvel-kbld
@@ -3890,6 +3931,64 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(?:\\./)?(\\S+)$"
+  - type: github_release
+    repo_owner: carvel-dev
+    repo_name: kwt
+    aliases:
+      - name: vmware-tanzu/carvel-kwt
+    description: Kubernetes Workstation Tools CLI
+    rosetta2: true
+    format: raw
+    asset: kwt-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux/amd64
+    files:
+      - name: kwt
+  - type: github_release
+    repo_owner: carvel-dev
+    repo_name: vendir
+    aliases:
+      - name: vmware-tanzu/carvel-vendir
+    asset: vendir-{{.OS}}-{{.Arch}}
+    description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
+    files:
+      - name: vendir
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_constraint: semver(">= 0.25.0")
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        checksum:
+          enabled: false
+  - type: github_release
+    repo_owner: carvel-dev
+    repo_name: ytt
+    aliases:
+      - name: vmware-tanzu/carvel-ytt
+    asset: ytt-{{.OS}}-{{.Arch}}
+    description: YAML templating tool that works on YAML structure instead of text
+    files:
+      - name: ytt
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: casey
     repo_name: just
@@ -20428,97 +20527,6 @@ packages:
     checksum:
       type: github_release
       asset: confused_{{trimV .Version}}_checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-  - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-kapp
-    format: raw
-    asset: kapp-{{.OS}}-{{.Arch}}
-    description: 'kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label'
-    files:
-      - name: kapp
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.46.0")
-    # support checksum
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+\\./(\\S+)$"
-    version_overrides:
-      # support darwin/arm64
-      - version_constraint: semver(">= 0.39.0")
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 0.35.0")
-        # support linux/arm64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: "true"
-        rosetta2: true
-        checksum:
-          enabled: false
-        supported_envs:
-          - darwin
-          - amd64
-  - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-kwt
-    description: Kubernetes Workstation Tools CLI
-    rosetta2: true
-    format: raw
-    asset: kwt-{{.OS}}-{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux/amd64
-    files:
-      - name: kwt
-  - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-vendir
-    asset: vendir-{{.OS}}-{{.Arch}}
-    description: Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively
-    files:
-      - name: vendir
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.25.0")
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      file_format: regexp
-      algorithm: sha256
-      pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
-        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    version_overrides:
-      - version_constraint: "true"
-        rosetta2: true
-        checksum:
-          enabled: false
-  - type: github_release
-    repo_owner: vmware-tanzu
-    repo_name: carvel-ytt
-    asset: ytt-{{.OS}}-{{.Arch}}
-    description: YAML templating tool that works on YAML structure instead of text
-    files:
-      - name: ytt
-    checksum:
-      type: github_release
-      asset: checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:


### PR DESCRIPTION
vmware-tanzu/carvel-kwt -> carvel-dev/kwt
vmware-tanzu/carvel-kapp -> carvel-dev/kapp
vmware-tanzu/carvel-vendir -> carvel-dev/vendir
vmware-tanzu/carvel-ytt -> carvel-dev/ytt

These repositores were renamed and transferred.