### PR TITLE
chore(hashicorp/terraform-ls): Fixed download url

### DIFF
--- a/pkgs/hashicorp/terraform-ls/pkg.yaml
+++ b/pkgs/hashicorp/terraform-ls/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: hashicorp/terraform-ls@v0.30.1
+  - name: hashicorp/terraform-ls@v0.30.2
+  - name: hashicorp/terraform-ls
+    version: v0.30.1

--- a/pkgs/hashicorp/terraform-ls/pkg.yaml
+++ b/pkgs/hashicorp/terraform-ls/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: hashicorp/terraform-ls@v0.30.2
-  - name: hashicorp/terraform-ls
-    version: v0.30.1

--- a/pkgs/hashicorp/terraform-ls/registry.yaml
+++ b/pkgs/hashicorp/terraform-ls/registry.yaml
@@ -12,16 +12,3 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    version_constraint: semver(">= 0.30.2")
-    version_overrides:
-      - version_constraint: "true"
-        type: github_release
-        asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
-        checksum:
-          type: github_release
-          asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
-          file_format: regexp
-          algorithm: sha256
-          pattern:
-            checksum: ^(\b[A-Fa-f0-9]{64}\b)
-            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/hashicorp/terraform-ls/registry.yaml
+++ b/pkgs/hashicorp/terraform-ls/registry.yaml
@@ -14,7 +14,7 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.30.2")
     version_overrides:
-      - version_constraint: semver("<= 0.30.1")
+      - version_constraint: "true"
         type: github_release
         asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
         checksum:

--- a/pkgs/hashicorp/terraform-ls/registry.yaml
+++ b/pkgs/hashicorp/terraform-ls/registry.yaml
@@ -1,14 +1,27 @@
 packages:
-  - type: github_release
+  - type: http
     repo_owner: hashicorp
     repo_name: terraform-ls
-    asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     description: Terraform Language Server
+    url: https://releases.hashicorp.com/terraform-ls/{{trimV .Version}}/terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     checksum:
-      type: github_release
-      asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
+      type: http
+      url: https://releases.hashicorp.com/terraform-ls/{{trimV .Version}}/terraform-ls_{{trimV .Version}}_SHA256SUMS
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.30.2")
+    version_overrides:
+      - version_constraint: semver("<= 0.30.1")
+        type: github_release
+        asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        checksum:
+          type: github_release
+          asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -9325,19 +9325,32 @@ packages:
     version_overrides:
       - version_constraint: "true"
         rosetta2: true
-  - type: github_release
+  - type: http
     repo_owner: hashicorp
     repo_name: terraform-ls
-    asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     description: Terraform Language Server
+    url: https://releases.hashicorp.com/terraform-ls/{{trimV .Version}}/terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     checksum:
-      type: github_release
-      asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
+      type: http
+      url: https://releases.hashicorp.com/terraform-ls/{{trimV .Version}}/terraform-ls_{{trimV .Version}}_SHA256SUMS
       file_format: regexp
       algorithm: sha256
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.30.2")
+    version_overrides:
+      - version_constraint: semver("<= 0.30.1")
+        type: github_release
+        asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        checksum:
+          type: github_release
+          asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{64}\b)
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: hashicorp
     repo_name: terraform-plugin-docs
@@ -16714,7 +16727,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API
     supported_envs:
       - darwin
       - linux
@@ -20151,7 +20164,7 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
-      - version_constraint: semver("< 1.7.0") 
+      - version_constraint: semver("< 1.7.0")
         supported_envs:
           - linux
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -9340,7 +9340,7 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.30.2")
     version_overrides:
-      - version_constraint: semver("<= 0.30.1")
+      - version_constraint: "true"
         type: github_release
         asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -9338,19 +9338,6 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    version_constraint: semver(">= 0.30.2")
-    version_overrides:
-      - version_constraint: "true"
-        type: github_release
-        asset: terraform-ls_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
-        checksum:
-          type: github_release
-          asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
-          file_format: regexp
-          algorithm: sha256
-          pattern:
-            checksum: ^(\b[A-Fa-f0-9]{64}\b)
-            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: hashicorp
     repo_name: terraform-plugin-docs

--- a/registry.yaml
+++ b/registry.yaml
@@ -16727,7 +16727,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
     supported_envs:
       - darwin
       - linux
@@ -20164,7 +20164,7 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
-      - version_constraint: semver("< 1.7.0")
+      - version_constraint: semver("< 1.7.0") 
         supported_envs:
           - linux
       - version_constraint: "true"


### PR DESCRIPTION
Hi,

Fixed assets URL of [hashicorp/terraform-ls](https://github.com/hashicorp/terraform-ls) has been changed.

> We have changed our release process: all assets continue to be available from the [HashiCorp Releases site](https://releases.hashicorp.com/terraform-ls) and/or via the [Releases API](https://releases.hashicorp.com/docs/api/v1/), not as GitHub Release assets anymore.

https://github.com/hashicorp/terraform-ls/releases/tag/v0.30.2