### PR TITLE
feat: add banzaicloud/banzai-cli

### DIFF
--- a/pkgs/banzaicloud/banzai-cli/pkg.yaml
+++ b/pkgs/banzaicloud/banzai-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: banzaicloud/banzai-cli@0.21.9

--- a/pkgs/banzaicloud/banzai-cli/registry.yaml
+++ b/pkgs/banzaicloud/banzai-cli/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: banzaicloud
+    repo_name: banzai-cli
+    asset: banzai_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: CLI for Banzai Cloud Pipeline platform
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: banzai
+    checksum:
+      type: github_release
+      asset: banzai_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3114,6 +3114,25 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: banzaicloud
+    repo_name: banzai-cli
+    asset: banzai_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: CLI for Banzai Cloud Pipeline platform
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: banzai
+    checksum:
+      type: github_release
+      asset: banzai_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: barnybug
     repo_name: cli53
     description: Command line tool for Amazon Route 53


### PR DESCRIPTION
[banzaicloud/banzai-cli](https://github.com/banzaicloud/banzai-cli): CLI for Banzai Cloud Pipeline platform

```console
$ aqua g -i banzaicloud/banzai-cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ banzai
A command line client for the Banzai Cloud Pipeline platform.

Usage:
  banzai [command]

Available Commands:
  bucket       Manage buckets
  cluster      Manage clusters
  completion   Generate completion script
  help         Help about any command
  login        Configure and log in to a Banzai Cloud context
  organization List and select organizations
  pipeline     Manage deployment of Banzai Cloud Pipeline instances
  secret       Manage secrets

Flags:
      --color                use colors on non-tty outputs
      --config string        config file (default is $BANZAICONFIG or $HOME/.banzai/config.yaml)
  -h, --help                 help for banzai
      --interactive          ask questions interactively even if stdin or stdout is non-tty
      --no-color             never display color output
      --no-interactive       never ask questions interactively
      --organization int32   organization id
  -o, --output string        output format (default|yaml|json) (default "default")
      --verbose              more verbose output
  -v, --version              version for banzai

Use "banzai [command] --help" for more information about a command.
```