### PR TITLE
feat: add pete911/jwt

### DIFF
--- a/pkgs/pete911/jwt/pkg.yaml
+++ b/pkgs/pete911/jwt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pete911/jwt@v1.0.4

--- a/pkgs/pete911/jwt/registry.yaml
+++ b/pkgs/pete911/jwt/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: pete911
+    repo_name: jwt
+    asset: jwt_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: jwt cli to decode and encode jwt tokens
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -15978,6 +15978,19 @@ packages:
       - name: pen
         src: target/release/pen
   - type: github_release
+    repo_owner: pete911
+    repo_name: jwt
+    asset: jwt_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: jwt cli to decode and encode jwt tokens
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: pfnet-research
     repo_name: git-ghost
     asset: git-ghost_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[pete911/jwt](https://github.com/pete911/jwt): jwt cli to decode and encode jwt tokens

```console
$ aqua g -i pete911/jwt
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ jwt
jwt utilities

Usage:
  jwt [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  decode      decode jwt token
  encode      encode jwt token
  help        Help about any command
  version     jwt cli version

Flags:
  -h, --help     help for jwt
      --silent   suppress logs (warn, debug, ...)

Use "jwt [command] --help" for more information about a command.
```