### PR TITLE
feat: add chmln/handlr

### DIFF
--- a/pkgs/chmln/handlr/pkg.yaml
+++ b/pkgs/chmln/handlr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chmln/handlr@v0.6.4

--- a/pkgs/chmln/handlr/registry.yaml
+++ b/pkgs/chmln/handlr/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: chmln
+    repo_name: handlr
+    asset: handlr
+    format: raw
+    description: A better xdg-utils
+    supported_envs:
+      - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4326,6 +4326,14 @@ packages:
           - amd64
   - type: github_release
     repo_owner: chmln
+    repo_name: handlr
+    asset: handlr
+    format: raw
+    description: A better xdg-utils
+    supported_envs:
+      - linux/amd64
+  - type: github_release
+    repo_owner: chmln
     repo_name: sd
     asset: sd-{{.Version}}-{{.Arch}}-{{.OS}}
     format: raw


### PR DESCRIPTION
[chmln/handlr](https://github.com/chmln/handlr): A better xdg-utils

```console
$ aqua g -i chmln/handlr
```

**Note:** handlr only provides releases that contains raw binary for `linux/amd64`. Please see references.

## How to confirm if this package works well

Command and output

```console
$ handlr --help
```

Reference

- [latest release](https://github.com/chmln/handlr/releases/tag/v0.6.4)
- [release workflow of handlr](https://github.com/chmln/handlr/blob/master/.github/workflows/main.yml)
