### PR TITLE
feat: add schemalex/schemalex

### DIFF
--- a/pkgs/regclient/regclient/regbot/registry.yaml
+++ b/pkgs/regclient/regclient/regbot/registry.yaml
@@ -7,7 +7,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API
     supported_envs:
       - darwin
       - linux

--- a/pkgs/schemalex/schemalex/pkg.yaml
+++ b/pkgs/schemalex/schemalex/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: schemalex/schemalex@v0.1.1

--- a/pkgs/schemalex/schemalex/registry.yaml
+++ b/pkgs/schemalex/schemalex/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: schemalex
+    repo_name: schemalex
+    asset: schemalex_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Generate difference sql of two mysql schema
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: schemadiff
+        src: schemalex_{{.OS}}_{{.Arch}}/schemadiff
+      - name: schemalex
+        src: schemalex_{{.OS}}_{{.Arch}}/schemalex
+      - name: schemalint
+        src: schemalex_{{.OS}}_{{.Arch}}/schemalint

--- a/pkgs/tsl0922/ttyd/registry.yaml
+++ b/pkgs/tsl0922/ttyd/registry.yaml
@@ -27,7 +27,7 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
-      - version_constraint: semver("< 1.7.0") 
+      - version_constraint: semver("< 1.7.0")
         supported_envs:
           - linux
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -16914,7 +16914,7 @@ packages:
     format: raw
     files:
       - name: regbot
-    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API 
+    description: A scripting tool on top of the regclient (Docker and OCI Registry Client) API
     supported_envs:
       - darwin
       - linux
@@ -17619,6 +17619,26 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: schemalex
+    repo_name: schemalex
+    asset: schemalex_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    description: Generate difference sql of two mysql schema
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: schemadiff
+        src: schemalex_{{.OS}}_{{.Arch}}/schemadiff
+      - name: schemalex
+        src: schemalex_{{.OS}}_{{.Arch}}/schemalex
+      - name: schemalint
+        src: schemalex_{{.OS}}_{{.Arch}}/schemalint
   - type: github_release
     repo_owner: schollz
     repo_name: croc
@@ -20391,7 +20411,7 @@ packages:
           - goos: windows
             goarch: amd64
             asset: ttyd.{{.OS}}.exe
-      - version_constraint: semver("< 1.7.0") 
+      - version_constraint: semver("< 1.7.0")
         supported_envs:
           - linux
       - version_constraint: "true"


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/10219 [schemalex/schemalex](https://github.com/schemalex/schemalex): Generate difference sql of two mysql schema

```console
$ aqua g -i schemalex/schemalex
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ schemalex --help
schemalex version v0.1.1

schemalex -version
schemalex [options...] before after

-v            Print out the version and exit
-o file       Output the result to the specified file (default: stdout)
-t[=true]     Enable/Disable transaction in the output (default: true)

"before" and "after" may be a file path, or a URI.
Special URI schemes "mysql" and "local-git" are supported on top of
"file". If the special path "-" is used, it is treated as stdin

Examples:

* Compare local files
  schemalex /path/to/file /another/path/to/file
  schemalex file:///path/to/file /another/path/to/file

* Compare local file against online mysql schema
  schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"

* Compare file in local git repository against local file
  schemalex "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file

* Compare schema from stdin against local file
        .... | schemalex - /path/to/file
```

```console
$ schemadiff --help
schemadiff version v0.1.1

schemadiff -version
schemadiff [options...] before after

-v            Print out the version and exit
-o file	      Output the result to the specified file (default: stdout)
-t[=true]     Enable/Disable transaction in the output (default: true)

"before" and "after" may be a file path, or a URI.
Special URI schemes "mysql" and "local-git" are supported on top of
"file". If the special path "-" is used, it is treated as stdin

Examples:

* Compare local files
  schemadiff /path/to/file /another/path/to/file
  schemadiff file:///path/to/file /another/path/to/file

* Compare local file against online mysql schema
  schemadiff /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"

* Compare file in local git repository against local file
  schemadiff "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file

* Compare schema from stdin against local file
	.... | schemadiff - /path/to/file
```

```console
$ schemalint --help
schemalint version v0.1.1

schemalint -version
schemalint [options...] source

-v            Print out the version and exit
-o file	      Output the result to the specified file (default: stdout)
-i number     Number of spaces to insert as indent (default: 2)

"source" may be a file path, or a URI.
Special URI schemes "mysql" and "local-git" are supported on top of
"file". If the special path "-" is used, it is treated as stdin.

Examples:

* Lint a local file
  schemalint /path/to/file
  schemalint file:///path/to/file

* Lint an online mysql schema
  schemalint "mysql://user:password@tcp(host:port)/dbname?option=value"

* Lint a file in local git repository 
  schemalint "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf"

* Lint schema from stdin against local file
	.... | schemalint -
```

Reference

- README.md (SYNOPSIS)
	- https://github.com/schemalex/schemalex/blob/master/README.md#synopsis