### PR TITLE
feat: add Azure/azure-dev

### DIFF
--- a/pkgs/Azure/azure-dev/pkg.yaml
+++ b/pkgs/Azure/azure-dev/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Azure/azure-dev@azure-dev-cli_0.6.0-beta.2

--- a/pkgs/Azure/azure-dev/registry.yaml
+++ b/pkgs/Azure/azure-dev/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: Azure
+    repo_name: azure-dev
+    asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications.
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: azd
+        src: azd-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/pkgs/Azure/azure-dev/registry.yaml
+++ b/pkgs/Azure/azure-dev/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_name: azure-dev
     asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
     format: zip
-    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications.
+    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications
     overrides:
       - goos: linux
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -210,7 +210,7 @@ packages:
     repo_name: azure-dev
     asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
     format: zip
-    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications.
+    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications
     overrides:
       - goos: linux
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -207,6 +207,22 @@ packages:
         supported_envs: []
   - type: github_release
     repo_owner: Azure
+    repo_name: azure-dev
+    asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications.
+    overrides:
+      - goos: linux
+        format: tar.gz
+    files:
+      - name: azd
+        src: azd-{{.OS}}-{{.Arch}}
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
+    repo_owner: Azure
     repo_name: draft
     asset: draft-{{.OS}}-{{.Arch}}
     format: raw


### PR DESCRIPTION
[Azure/azure-dev](https://github.com/Azure/azure-dev): The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications.

```console
$ aqua g -i Azure/azure-dev
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ azd
Azure Developer CLI is a command-line interface for developers who build Azure solutions.

To begin working with Azure Developer CLI, run the `azd up` command by supplying a sample template in an empty directory:

        $ azd up –-template todo-nodejs-mongo

You can pick a template by running `azd template list` and then supplying the repo name as a value to `--template`.

The most common next commands are:

        $ azd pipeline config
        $ azd deploy
        $ azd monitor --overview

For more information, visit the Azure Developer CLI Dev Hub: https://aka.ms/azure-dev/devhub.

Usage:
  azd [command]

Available Commands:
  config      Manage the Azure Developer CLI user configuration.
  deploy      Deploy the app's code to Azure.
  down        Delete Azure resources for an app.
  env         Manage environments.
  help        Help about any command
  infra       Manage Azure resources.
  init        Initialize a new app.
  login       Log in to Azure.
  logout      Log out of Azure
  monitor     Monitor a deployed app.
  pipeline    Manage GitHub Actions or Azure Pipelines.
  provision   Provision the Azure resources for an app.
  restore     Restore app dependencies.
  template    Manage templates.
  up          Initialize the app, provision Azure resources, and deploy your project with a single command.
  version     Print the version number of Azure Developer CLI.

Flags:
  -C, --cwd string   Sets the current working directory.
      --debug        Enables debugging and diagnostics logging.
  -h, --help         Gets help for azd.
      --no-prompt    Accepts the default value instead of prompting, or it fails if there is no default.

Use "azd [command] --help" for more information about a command.

Please let us know how we are doing: https://aka.ms/azure-dev/hats
```