### PR TITLE
feat: add SimonTheLeg/konf-go

### DIFF
--- a/pkgs/SimonTheLeg/konf-go/pkg.yaml
+++ b/pkgs/SimonTheLeg/konf-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: SimonTheLeg/konf-go@v0.5.1

--- a/pkgs/SimonTheLeg/konf-go/registry.yaml
+++ b/pkgs/SimonTheLeg/konf-go/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: SimonTheLeg
+    repo_name: konf-go
+    description: konf is a lightweight kubeconfig manager. With konf you can use different kubeconfigs at the same time. And because it does not need subshells, konf is blazing fast
+    asset: konf-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: konf-go
+      - name: konf
+        src: konf-go
+    checksum:
+      type: github_release
+      asset: konf-go_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1330,6 +1330,24 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: SimonTheLeg
+    repo_name: konf-go
+    description: konf is a lightweight kubeconfig manager. With konf you can use different kubeconfigs at the same time. And because it does not need subshells, konf is blazing fast
+    asset: konf-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: konf-go
+      - name: konf
+        src: konf-go
+    checksum:
+      type: github_release
+      asset: konf-go_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: Songmu
     repo_name: ecschedule
     description: ecschedule is a tool to manage ECS Scheduled Tasks


### PR DESCRIPTION
#10357 [SimonTheLeg/konf-go](https://github.com/SimonTheLeg/konf-go): konf is a lightweight kubeconfig manager. With konf you can use different kubeconfigs at the same time. And because it does not need subshells, konf is blazing fast

```console
$ aqua g -i SimonTheLeg/konf-go
```