### PR TITLE
feat: add omegion/ssh-manager

### DIFF
--- a/pkgs/omegion/ssh-manager/pkg.yaml
+++ b/pkgs/omegion/ssh-manager/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: omegion/ssh-manager@v1.2.0
+  - name: omegion/ssh-manager
+    version: v0.13.0
+  - name: omegion/ssh-manager
+    version: v0.11.0
+  - name: omegion/ssh-manager
+    version: v0.10.0

--- a/pkgs/omegion/ssh-manager/registry.yaml
+++ b/pkgs/omegion/ssh-manager/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: omegion
+    repo_name: ssh-manager
+    description: SSH Key Manager for 1Password, Bitwarden and AWS S3
+    asset: ssh-manager-{{.OS}}-{{.Arch}}
+    format: raw
+    complete_windows_ext: false
+    version_constraint: semver(">= 0.13.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.11.0")
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver(">= 0.10.0")
+        supported_envs:
+          - darwin/arm64
+      - version_constraint: semver("< 0.10.0")
+        supported_envs:
+          - linux/arm64

--- a/pkgs/omegion/ssh-manager/registry.yaml
+++ b/pkgs/omegion/ssh-manager/registry.yaml
@@ -12,9 +12,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver(">= 0.10.0")
-        supported_envs:
-          - darwin/arm64
-      - version_constraint: semver("< 0.10.0")
+      - version_constraint: semver("< 0.11.0")
         supported_envs:
           - linux/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15740,6 +15740,25 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+bin/(\\S+)$"
   - type: github_release
+    repo_owner: omegion
+    repo_name: ssh-manager
+    description: SSH Key Manager for 1Password, Bitwarden and AWS S3
+    asset: ssh-manager-{{.OS}}-{{.Arch}}
+    format: raw
+    complete_windows_ext: false
+    version_constraint: semver(">= 0.13.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.11.0")
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver(">= 0.10.0")
+        supported_envs:
+          - darwin/arm64
+      - version_constraint: semver("< 0.10.0")
+        supported_envs:
+          - linux/arm64
+  - type: github_release
     repo_owner: omrikiei
     repo_name: ktunnel
     asset: ktunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -15752,10 +15752,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver(">= 0.10.0")
-        supported_envs:
-          - darwin/arm64
-      - version_constraint: semver("< 0.10.0")
+      - version_constraint: semver("< 0.11.0")
         supported_envs:
           - linux/arm64
   - type: github_release


### PR DESCRIPTION
[omegion/ssh-manager](https://github.com/omegion/ssh-manager): SSH Key Manager for 1Password, Bitwarden and AWS S3

```console
$ aqua g -i omegion/ssh-manager
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ssh-manager
SSH Key Manager for 1Password, Bitwarden and AWS S3.

Usage:
  ssh-manager [command]

Available Commands:
  add         Add Manager key to given provider.
  completion  Generate the autocompletion script for the specified shell
  get         Get Manager key from given provider.
  help        Help about any command
  list        List Manager keys from given provider.
  version     Print the version/build number

Flags:
  -h, --help               help for ssh-manager
      --logFormat string   Set the logging format. One of: text|json (default "text") (default "text")
      --logLevel string    Set the logging level. One of: debug|info|warn|error (default "info")

Use "ssh-manager [command] --help" for more information about a command.
```