### PR TITLE
feat: add imuxin/kubectl-watch

### DIFF
--- a/pkgs/imuxin/kubectl-watch/pkg.yaml
+++ b/pkgs/imuxin/kubectl-watch/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: imuxin/kubectl-watch@v0.2.3
+  - name: imuxin/kubectl-watch
+    version: 0.1.6
+  - name: imuxin/kubectl-watch
+    version: 0.1.5

--- a/pkgs/imuxin/kubectl-watch/registry.yaml
+++ b/pkgs/imuxin/kubectl-watch/registry.yaml
@@ -1,0 +1,36 @@
+packages:
+  - type: github_release
+    repo_owner: imuxin
+    repo_name: kubectl-watch
+    description: A kubectl plugin to provide a pretty delta change view of being watched kubernetes resources
+    asset: kubectl-watch-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    version_constraint: semver(">= 0.1.6")
+    version_overrides:
+      - version_constraint: semver("< 0.1.6")
+        asset: kubectl-watch_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - amd64
+        checksum:
+          type: github_release
+          asset: kubectl-watch_{{.Version}}_{{.Arch}}-{{.OS}}.zip.sha256sum
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -10319,6 +10319,41 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: imuxin
+    repo_name: kubectl-watch
+    description: A kubectl plugin to provide a pretty delta change view of being watched kubernetes resources
+    asset: kubectl-watch-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    version_constraint: semver(">= 0.1.6")
+    version_overrides:
+      - version_constraint: semver("< 0.1.6")
+        asset: kubectl-watch_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - amd64
+        checksum:
+          type: github_release
+          asset: kubectl-watch_{{.Version}}_{{.Arch}}-{{.OS}}.zip.sha256sum
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: go_install
     repo_owner: in-toto
     repo_name: in-toto-golang


### PR DESCRIPTION
[imuxin/kubectl-watch](https://github.com/imuxin/kubectl-watch): A kubectl plugin to provide a pretty delta change view of being watched kubernetes resources

```console
$ aqua g -i imuxin/kubectl-watch
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl-watch --help
kubectl-watch 0.2.3
A kubectl plugin to provide a pretty delta change view of being watched kubernetes resources

USAGE:
    kubectl-watch [OPTIONS] [ARGS]

ARGS:
    <RESOURCE>    Support resource 'plural', 'kind' and 'shortname'
    <NAME>        Resource name, optional

OPTIONS:
    -A, --all                       If present, list the requested object(s) across all namespaces
        --export <EXPORT>           A path, where all watched resources will be strored
    -h, --help                      Print help information
        --include-managed-fields    Set ture to show managed fields delta changes
    -l, --selector <SELECTOR>       Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
        --mode <MODE>               delta changes view mode [default: tui] [possible values: tui, simple]
    -n, --namespace <NAMESPACE>     If present, the namespace scope for this CLI request
        --use-tls                   Use tls to request api-server
    -V, --version                   Print version information
```
