### PR TITLE
feat: add tohjustin/kube-lineage

### DIFF
--- a/pkgs/tohjustin/kube-lineage/pkg.yaml
+++ b/pkgs/tohjustin/kube-lineage/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: tohjustin/kube-lineage@v0.5.0
+  - name: tohjustin/kube-lineage
+    version: v0.1.0

--- a/pkgs/tohjustin/kube-lineage/registry.yaml
+++ b/pkgs/tohjustin/kube-lineage/registry.yaml
@@ -1,0 +1,32 @@
+packages:
+  - type: github_release
+    repo_owner: tohjustin
+    repo_name: kube-lineage
+    description: A CLI tool to display all dependencies or dependents of an object in a Kubernetes cluster
+    asset: kube-lineage_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: kubectl-lineage
+        src: kube-lineage
+      - name: kube-lineage
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.2.0")
+    version_overrides:
+      - version_constraint: semver("< 0.2.0")
+        files:
+          - name: kubectl-lineage
+        asset: kubectl-lineage_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -20596,6 +20596,37 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: tohjustin
+    repo_name: kube-lineage
+    description: A CLI tool to display all dependencies or dependents of an object in a Kubernetes cluster
+    asset: kube-lineage_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: kubectl-lineage
+        src: kube-lineage
+      - name: kube-lineage
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.2.0")
+    version_overrides:
+      - version_constraint: semver("< 0.2.0")
+        files:
+          - name: kubectl-lineage
+        asset: kubectl-lineage_{{.OS}}_{{.Arch}}.{{.Format}}
+  - type: github_release
     repo_owner: tomnomnom
     repo_name: gron
     asset: gron-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}


### PR DESCRIPTION
[tohjustin/kube-lineage](https://github.com/tohjustin/kube-lineage): A CLI tool to display all dependencies or dependents of an object in a Kubernetes cluster

```console
$ aqua g -i tohjustin/kube-lineage
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl-lineage --help
Display all dependencies or dependents of a Kubernetes object.

 TYPE is a Kubernetes resource. Shortcuts and groups will be resolved. NAME is the name of a particular Kubernetes resource.

Usage:
  kube-lineage (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME) [flags]
  kube-lineage [command]

Examples:
  # List all dependents of the deployment named "bar" in the current namespace
  kube-lineage deployments bar

  # List all dependents of the cronjob named "bar" in namespace "foo"
  kube-lineage cronjobs.batch/bar --namespace=foo

  # List all dependents of the node named "k3d-dev-server" & the corresponding relationship type(s)
  kube-lineage node/k3d-dev-server --output=wide

  # List all dependents of the persistentvolume named "disk", excluding event & secret resource types
  kube-lineage pv/disk --dependencies --exclude-types=ev,secret

  # List all dependencies of the pod named "bar-5cc79d4bf5-xgvkc"
  kube-lineage pod.v1. bar-5cc79d4bf5-xgvkc --dependencies

  # List all dependencies of the serviceaccount named "default" in the current namespace, grouped by resource type
  kube-lineage sa/default --dependencies --output=split

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  helm        Display resources associated with a Helm release & their dependents
  help        Help about any command

Flags:
  -A, --all-namespaces                 If present, list object relationships across all namespaces
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/Users/lars/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
  -D, --dependencies                   If present, list object dependencies instead of dependents
  -d, --depth uint                     Maximum depth to find relationships
      --exclude-types strings          Accepts a comma separated list of resource types to exclude from relationship discovery. You can also use multiple flag options like --exclude-types kind1 --exclude-types kind1...
  -h, --help                           help for kube-lineage
      --include-types strings          Accepts a comma separated list of resource types to only include in relationship discovery. You can also use multiple flag options like --include-types kind1 --include-types kind1...
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -L, --label-columns strings          Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...
  -n, --namespace string               If present, the namespace scope for this CLI request
      --no-headers                     When using the default output format, don't print headers (default print headers)
  -o, --output string                  Output format. One of: wide|split|split-wide.
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -S, --scopes strings                 Accepts a comma separated list of additional namespaces to find relationships. You can also use multiple flag options like -S namespace1 -S namespace2...
  -s, --server string                  The address and port of the Kubernetes API server
      --show-group                     If present, include the resource group for the requested object(s)
      --show-labels                    When printing, show all labels as the last column (default hide labels column)
      --show-namespace                 When printing, show namespace as the first column (default hide namespace column if all objects are in the same namespace)
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --version                        version for kube-lineage

Use "kube-lineage [command] --help" for more information about a command.
```