### PR TITLE
feat: add goark/gnkf

### DIFF
--- a/pkgs/goark/gnkf/pkg.yaml
+++ b/pkgs/goark/gnkf/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: goark/gnkf@v0.7.6
+  - name: goark/gnkf
+    version: v0.7.5
+  - name: goark/gnkf
+    version: v0.7.4
+  - name: goark/gnkf
+    version: v0.6.0
+  - name: goark/gnkf
+    version: v0.4.0
+  - name: goark/gnkf
+    version: v0.1.0

--- a/pkgs/goark/gnkf/registry.yaml
+++ b/pkgs/goark/gnkf/registry.yaml
@@ -1,0 +1,68 @@
+packages:
+  - type: github_release
+    repo_owner: goark
+    repo_name: gnkf
+    description: Network Kanji Filter by Golang
+    asset: gnkf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: gnkf_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.7.5")
+    version_overrides:
+      - version_constraint: semver(">= 0.7.4")
+        asset: gnkf_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver(">= 0.6.0")
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.4.0")
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver("< 0.4.0")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: ARM64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: 64bit
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true

--- a/pkgs/goark/gnkf/registry.yaml
+++ b/pkgs/goark/gnkf/registry.yaml
@@ -24,8 +24,10 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.7.5")
     version_overrides:
-      - version_constraint: semver(">= 0.7.4")
+      - version_constraint: Version == "v0.7.4"
         asset: gnkf_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        checksum:
+          enabled: false # checksum file was broken. https://github.com/aquaproj/aqua-registry/pull/10446#issuecomment-1455275091
       - version_constraint: semver(">= 0.6.0")
         replacements:
           amd64: 64bit

--- a/registry.yaml
+++ b/registry.yaml
@@ -8487,6 +8487,73 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: goark
+    repo_name: gnkf
+    description: Network Kanji Filter by Golang
+    asset: gnkf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: 64bit
+      arm64: ARM64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: gnkf_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.7.5")
+    version_overrides:
+      - version_constraint: semver(">= 0.7.4")
+        asset: gnkf_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver(">= 0.6.0")
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.4.0")
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver("< 0.4.0")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: ARM64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: 64bit
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+  - type: github_release
     repo_owner: goccy
     repo_name: bigquery-emulator
     asset: bigquery-emulator-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -8511,8 +8511,10 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     version_constraint: semver(">= 0.7.5")
     version_overrides:
-      - version_constraint: semver(">= 0.7.4")
+      - version_constraint: Version == "v0.7.4"
         asset: gnkf_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        checksum:
+          enabled: false # checksum file was broken. https://github.com/aquaproj/aqua-registry/pull/10446#issuecomment-1455275091
       - version_constraint: semver(">= 0.6.0")
         replacements:
           amd64: 64bit


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/10446 [goark/gnkf](https://github.com/goark/gnkf): Network Kanji Filter by Golang

```console
$ aqua g -i goark/gnkf
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gnkf --help
Network Kanji Filter by Golang

Usage:
  gnkf [flags]
  gnkf [command]

Available Commands:
  base64      Encode/Decode BASE64
  bcrypt      Hash and compare by BCrypt
  completion  Generate completion script
  dump        Hexadecimal view of octet data stream
  enc         Convert character encoding of the text
  guess       Guess character encoding of the text
  hash        Print or check hash value
  help        Help about any command
  kana        Convert kana characters in the text
  newline     Convert newline form in the text
  norm        Unicode normalization of the text
  remove-bom  Remove BOM character in UTF-8 string
  version     Print the version number
  width       Convert character width in the text

Flags:
      --debug   for debug
  -h, --help    help for gnkf

Use "gnkf [command] --help" for more information about a command.
```


```console
$ echo おはよう | gnkf guess
UTF-8
```

Reference

- README.md
	- https://github.com/goark/gnkf