### PR TITLE
feat: add keisku/kubectl-explore

### DIFF
--- a/pkgs/keisku/kubectl-explore/pkg.yaml
+++ b/pkgs/keisku/kubectl-explore/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: keisku/kubectl-explore@v0.7.1
+  - name: keisku/kubectl-explore
+    version: v0.3.0
+  - name: keisku/kubectl-explore
+    version: 0.1.0

--- a/pkgs/keisku/kubectl-explore/registry.yaml
+++ b/pkgs/keisku/kubectl-explore/registry.yaml
@@ -1,0 +1,43 @@
+packages:
+  - type: github_release
+    repo_owner: keisku
+    repo_name: kubectl-explore
+    description: A better kubectl explain with the fuzzy finder
+    asset: kubectl-explore_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-explore_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.0")
+        asset: kubectl-explore_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("< 0.3.0")
+        asset: kubectl-explore_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-explore_{{.Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12173,6 +12173,48 @@ packages:
           darwin: macos
       - version_constraint: "true"
   - type: github_release
+    repo_owner: keisku
+    repo_name: kubectl-explore
+    description: A better kubectl explain with the fuzzy finder
+    asset: kubectl-explore_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: kubectl-explore_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.0")
+        asset: kubectl-explore_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("< 0.3.0")
+        asset: kubectl-explore_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-explore_{{.Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kentaro-m
     repo_name: md2confl
     asset: md2confl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[keisku/kubectl-explore](https://github.com/keisku/kubectl-explore): A better kubectl explain with the fuzzy finder

```console
$ aqua g -i keisku/kubectl-explore
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl-explore --help
This command fuzzy-finds the explanation the field from supported API resources.

Fields are identified via a simple JSONPath identifier:
        <type>.<fieldName>[.<fieldName>]

Usage:
  kubectl explore RESOURCE [options] [flags]

Examples:

# Fuzzy-find the field explanation from supported API resources.
kubectl explore

# Fuzzy-find the field explanation from "pod"
kubectl explore pod

# Fuzzy-find the field explanation from "pod.spec.containers"
kubectl explore pod.spec.containers

# Fuzzy-find the field explanation from supported API resources in the selected cluster.
kubectl explore --context=onecontext


Flags:
      --api-version string             Get different explanations for particular API version (API group/version)
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/Users/lars/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
  -h, --help                           help for kubectl
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
      --match-server-version           Require server version to match client version
  -n, --namespace string               If present, the namespace scope for this CLI request
      --password string                Password for basic authentication to the API server
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --username string                Username for basic authentication to the API server
```