### PR TITLE
feat: add joerdav/xc

### DIFF
--- a/pkgs/joerdav/xc/pkg.yaml
+++ b/pkgs/joerdav/xc/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: joerdav/xc@v0.0.175
+  - name: joerdav/xc
+    version: v0.0.44
+  - name: joerdav/xc
+    version: v0.0.33
+  - name: joerdav/xc
+    version: v0.0.30

--- a/pkgs/joerdav/xc/registry.yaml
+++ b/pkgs/joerdav/xc/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+  - type: github_release
+    repo_owner: joerdav
+    repo_name: xc
+    description: Markdown defined task runner
+    asset: xc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.44")
+    version_overrides:
+      - version_constraint: semver(">= 0.0.33")
+        asset: xc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+      - version_constraint: semver("< 0.0.33")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -11546,6 +11546,31 @@ packages:
     supported_envs:
       - linux
       - darwin
+  - type: github_release
+    repo_owner: joerdav
+    repo_name: xc
+    description: Markdown defined task runner
+    asset: xc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.44")
+    version_overrides:
+      - version_constraint: semver(">= 0.0.33")
+        asset: xc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+      - version_constraint: semver("< 0.0.33")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
   - type: github_content
     repo_owner: johanhaleby
     repo_name: kubetail


### PR DESCRIPTION
[joerdav/xc](https://github.com/joerdav/xc): Markdown defined task runner

```console
$ aqua g -i joerdav/xc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ xc --help
xc <task> [inputs...]
  Run a task from an xc compatible markdown file.
  If -file is not specified and no README.md is found in the current directory,
    xc will search in parent files for convenience.
  -f -file <string>
        Specify a markdown file that contains tasks (default "README.md").
  -md
        Print the markdown for a task rather than running it.
  -H -heading <string>
        Specify the heading for xc tasks. (default "Tasks")

xc
  List tasks from an xc compatible markdown file.
  If -file is not specified and no README.md is found in the current directory,
    xc will search in parent files for convenience.
  -s -short
        List task names in a short format.
  -h -help
        Print this help text.
  -f -file <string>
        Specify a markdown file that contains tasks (default "README.md").
  -H -heading <string>
        Specify the heading for xc tasks. (default "Tasks")
  -version
        Show xc version.
  -complete
        Install completion for xc.
  -uncomplete
        Uninstall completion for xc.
  -y    Don't prompt user for typing 'yes' when installing completion.
```
