### PR TITLE
feat: add sunny0826/kubectl-pod-lens

### DIFF
--- a/pkgs/sunny0826/kubectl-pod-lens/pkg.yaml
+++ b/pkgs/sunny0826/kubectl-pod-lens/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: sunny0826/kubectl-pod-lens@v0.3.1
+  - name: sunny0826/kubectl-pod-lens
+    version: v0.3.0
+  - name: sunny0826/kubectl-pod-lens
+    version: v0.2.2
+  - name: sunny0826/kubectl-pod-lens
+    version: v0.2.1
+  - name: sunny0826/kubectl-pod-lens
+    version: v0.1.0

--- a/pkgs/sunny0826/kubectl-pod-lens/registry.yaml
+++ b/pkgs/sunny0826/kubectl-pod-lens/registry.yaml
@@ -1,0 +1,40 @@
+packages:
+  - type: github_release
+    repo_owner: sunny0826
+    repo_name: kubectl-pod-lens
+    description: kubectl plugin for show pod-related resources
+    asset: pod-lens_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: kubectl-pod_lens
+        src: pod-lens
+      - name: pod-lens
+    checksum:
+      type: github_release
+      asset: pod-lens_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.2")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.2.1")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.2.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -19528,6 +19528,45 @@ packages:
           - darwin
           - linux/amd64
   - type: github_release
+    repo_owner: sunny0826
+    repo_name: kubectl-pod-lens
+    description: kubectl plugin for show pod-related resources
+    asset: pod-lens_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: kubectl-pod_lens
+        src: pod-lens
+      - name: pod-lens
+    checksum:
+      type: github_release
+      asset: pod-lens_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.3.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.2")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.2.1")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.2.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+  - type: github_release
     repo_owner: supabase
     repo_name: cli
     asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[sunny0826/kubectl-pod-lens](https://github.com/sunny0826/kubectl-pod-lens): kubectl plugin for show pod-related resources

```console
$ aqua g -i sunny0826/kubectl-pod-lens
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ pod-lens --help

                           /$$         /$$
                          | $$        | $$
  /$$$$$$   /$$$$$$   /$$$$$$$        | $$  /$$$$$$  /$$$$$$$   /$$$$$$$
 /$$__  $$ /$$__  $$ /$$__  $$ /$$$$$$| $$ /$$__  $$| $$__  $$ /$$_____/
| $$  \ $$| $$  \ $$| $$  | $$|______/| $$| $$$$$$$$| $$  \ $$|  $$$$$$
| $$  | $$| $$  | $$| $$  | $$        | $$| $$_____/| $$  | $$ \____  $$
| $$$$$$$/|  $$$$$$/|  $$$$$$$        | $$|  $$$$$$$| $$  | $$ /$$$$$$$/
| $$____/  \______/  \_______/        |__/ \_______/|__/  |__/|_______/
| $$
| $$
|__/

Find related workloads, namespace, node, service, configmap, secret,
ingress, PVC, HPA and PDB by pod name and display them in a tree and table.
Find more information at: https://pod-lens.guoxudong.io/

Usage:
  kubectl pod-lens [pod name] [flags]

Examples:

# Interactive operation
$ kubectl pod-lens
# Show pod-related resources
$ kubectl pod-lens prometheus-prometheus-operator-prometheus-0
# Support input pod name fuzzy matching
$ kubectl pod-lens prometheus-prometheus-operator-prometheus-
$ kubectl pod-lens prometheus-prometheus-operator-prometheus-*


Flags:
  -A, --all-namespaces           query all objects in all API groups, both namespaced and non-namespaced
      --as-uid string            UID to impersonate for the operation.
      --context string           The name of the kubeconfig context to use
      --disable-compression      If true, opt-out of response compression for all requests to the server
  -h, --help                     help for kubectl
      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string         If present, the namespace scope for this CLI request
  -l, --selector string          Selector (label query) to filter on, only supports '=' and a parameter (e.g. -l key1=value1)
      --tls-server-name string   Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
  -v, --v Level                  number for the log level verbosity
```