### PR TITLE
feat: add controlplaneio/kubectl-kubesec

### DIFF
--- a/pkgs/controlplaneio/kubectl-kubesec/pkg.yaml
+++ b/pkgs/controlplaneio/kubectl-kubesec/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: controlplaneio/kubectl-kubesec@v1.1.0
+  - name: controlplaneio/kubectl-kubesec
+    version: 1.0.2
+  - name: controlplaneio/kubectl-kubesec
+    version: 1.0.1
+  - name: controlplaneio/kubectl-kubesec
+    version: 0.1.0

--- a/pkgs/controlplaneio/kubectl-kubesec/registry.yaml
+++ b/pkgs/controlplaneio/kubectl-kubesec/registry.yaml
@@ -1,0 +1,47 @@
+packages:
+  - type: github_release
+    repo_owner: controlplaneio
+    repo_name: kubectl-kubesec
+    description: Security risk analysis for Kubernetes resources
+    asset: kubectl-kubesec_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: kubectl-kubesec_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: kubectl-kubesec_scan
+        src: kubectl-scan
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.2")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.0.1")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 1.0.1")
+        asset: kubectl-kubesec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        files:
+          - name: kubectl-kubesec_scan
+            src: scan
+        checksum:
+          type: github_release
+          asset: kubectl-kubesec_{{.Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5498,6 +5498,52 @@ packages:
       - linux
   - type: github_release
     repo_owner: controlplaneio
+    repo_name: kubectl-kubesec
+    description: Security risk analysis for Kubernetes resources
+    asset: kubectl-kubesec_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: kubectl-kubesec_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    files:
+      - name: kubectl-kubesec_scan
+        src: kubectl-scan
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.2")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.0.1")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 1.0.1")
+        asset: kubectl-kubesec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        files:
+          - name: kubectl-kubesec_scan
+            src: scan
+        checksum:
+          type: github_release
+          asset: kubectl-kubesec_{{.Version}}_checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: controlplaneio
     repo_name: kubesec
     asset: kubesec_{{.OS}}_{{.Arch}}.tar.gz
     description: Security risk analysis for Kubernetes resources


### PR DESCRIPTION
[controlplaneio/kubectl-kubesec](https://github.com/controlplaneio/kubectl-kubesec): Security risk analysis for Kubernetes resources

```console
$ aqua g -i controlplaneio/kubectl-kubesec
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl kubesec-scan

kubesec.io command line utilities

Usage:
  scan [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  daemonset   Scans daemonset object
  deployment  Scans deployment object
  help        Help about any command
  pod         Scans pod object
  statefulset Scans statefulset object
  version     Prints kubesec version

Flags:
  -h, --help                help for scan
  -k, --kubeconfig string   Path to kubeconfig, overrides KUBECONFIG environment variable
  -n, --namespace string    Kubernetes namespace (default "default")
  -t, --timeout int         Scan timeout in seconds (default 120)
  -u, --url string          URL to send the request for scanning (default "https://v2.kubesec.io")

Use "scan [command] --help" for more information about a command.
```
