### PR TITLE
feat: add PaddiM8/kalker

### DIFF
--- a/pkgs/PaddiM8/kalker/pkg.yaml
+++ b/pkgs/PaddiM8/kalker/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: PaddiM8/kalker@v2.0.3
+  - name: PaddiM8/kalker
+    version: v1.0.0
+  - name: PaddiM8/kalker
+    version: v0.3.4
+  - name: PaddiM8/kalker
+    version: v0.3.3
+  - name: PaddiM8/kalker
+    version: 0.2.0
+  - name: PaddiM8/kalker
+    version: 0.1.7

--- a/pkgs/PaddiM8/kalker/registry.yaml
+++ b/pkgs/PaddiM8/kalker/registry.yaml
@@ -1,0 +1,63 @@
+packages:
+  - type: github_release
+    repo_owner: PaddiM8
+    repo_name: kalker
+    description: Kalker is a calculator with math syntax that supports user-defined variables and functions, complex numbers, and estimation of derivatives and integrals
+    asset: kalker-{{.OS}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: raw
+        asset: kalker-{{.OS}}
+    replacements:
+      darwin: macOS
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: kalker
+        src: target/release/kalker
+    version_constraint: semver(">= 1.0.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.4")
+        asset: kalk-{{.OS}}.{{.Format}}
+        overrides:
+          - goos: linux
+            format: raw
+            asset: kalk-{{.OS}}
+        files:
+          - name: kalker
+            src: target/release/kalk
+      - version_constraint: semver(">= 0.3.3")
+        asset: kalk-{{.OS}}
+        format: raw
+        overrides:
+          - goos: windows
+            asset: kalk
+        replacements:
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - darwin
+          - amd64
+        files:
+          - name: kalker
+            src: target/release/kalk
+      - version_constraint: semver(">= 0.2.0")
+        asset: kalk_cli_{{.OS}}64
+        format: raw
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+      - version_constraint: semver("< 0.2.0")
+        asset: kalk_cli
+        format: raw
+        overrides: []
+        supported_envs:
+          - linux/amd64
+        rosetta2: false

--- a/pkgs/PaddiM8/kalker/registry.yaml
+++ b/pkgs/PaddiM8/kalker/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: PaddiM8
     repo_name: kalker
-    description: Kalker is a calculator with math syntax that supports user-defined variables and functions, complex numbers, and estimation of derivatives and integrals
+    description: Kalker is a calculator program that supports user-defined variables, functions, differentiation, and integration
     asset: kalker-{{.OS}}.{{.Format}}
     format: zip
     overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -1151,6 +1151,68 @@ packages:
           darwin: osx
           windows: win64
   - type: github_release
+    repo_owner: PaddiM8
+    repo_name: kalker
+    description: Kalker is a calculator with math syntax that supports user-defined variables and functions, complex numbers, and estimation of derivatives and integrals
+    asset: kalker-{{.OS}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: raw
+        asset: kalker-{{.OS}}
+    replacements:
+      darwin: macOS
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    files:
+      - name: kalker
+        src: target/release/kalker
+    version_constraint: semver(">= 1.0.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.4")
+        asset: kalk-{{.OS}}.{{.Format}}
+        overrides:
+          - goos: linux
+            format: raw
+            asset: kalk-{{.OS}}
+        files:
+          - name: kalker
+            src: target/release/kalk
+      - version_constraint: semver(">= 0.3.3")
+        asset: kalk-{{.OS}}
+        format: raw
+        overrides:
+          - goos: windows
+            asset: kalk
+        replacements:
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - darwin
+          - amd64
+        files:
+          - name: kalker
+            src: target/release/kalk
+      - version_constraint: semver(">= 0.2.0")
+        asset: kalk_cli_{{.OS}}64
+        format: raw
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+      - version_constraint: semver("< 0.2.0")
+        asset: kalk_cli
+        format: raw
+        overrides: []
+        supported_envs:
+          - linux/amd64
+        rosetta2: false
+  - type: github_release
     repo_owner: PaulJuliusMartinez
     repo_name: jless
     asset: jless-{{.Version}}-{{.Arch}}-{{.OS}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -1153,7 +1153,7 @@ packages:
   - type: github_release
     repo_owner: PaddiM8
     repo_name: kalker
-    description: Kalker is a calculator with math syntax that supports user-defined variables and functions, complex numbers, and estimation of derivatives and integrals
+    description: Kalker is a calculator program that supports user-defined variables, functions, differentiation, and integration
     asset: kalker-{{.OS}}.{{.Format}}
     format: zip
     overrides:


### PR DESCRIPTION
[PaddiM8/kalker](https://github.com/PaddiM8/kalker): Kalker is a calculator with math syntax that supports user-defined variables and functions, complex numbers, and estimation of derivatives and integrals

```console
$ aqua g -i PaddiM8/kalker
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kalker --help
Name:
        kalker

Author:
        PaddiM8

Usage:
        kalker [options] [input]

Flags:
        -i, --input-file <string> : Load a file with predefined variables and functions. End lines with a semicolon.
        -p, --precision <int>     : Specify number precision
        -a, --angle-unit <string> : Unit used for angles, either rad or deg. This can also be specified using an environment variable with the name 'ANGLE_UNIT'.
        -h, --help                : Show help

Version:
        2.0.3
```