### PR TITLE
feat: add bitnami-labs/charts-syncer

### DIFF
--- a/pkgs/bitnami-labs/charts-syncer/pkg.yaml
+++ b/pkgs/bitnami-labs/charts-syncer/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: bitnami-labs/charts-syncer@v0.20.1
+  - name: bitnami-labs/charts-syncer
+    version: v0.20.0
+  - name: bitnami-labs/charts-syncer
+    version: v0.10.0
+  - name: bitnami-labs/charts-syncer
+    version: v0.7.0
+  - name: bitnami-labs/charts-syncer
+    version: v0.2.2
+  - name: bitnami-labs/charts-syncer
+    version: v0.1.0

--- a/pkgs/bitnami-labs/charts-syncer/registry.yaml
+++ b/pkgs/bitnami-labs/charts-syncer/registry.yaml
@@ -1,0 +1,41 @@
+packages:
+  - type: github_release
+    repo_owner: bitnami-labs
+    repo_name: charts-syncer
+    description: Tool for synchronizing Helm Chart repositories
+    asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.20.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.10.0")
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver(">= 0.7.0")
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.2")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 0.2.2")
+        asset: c3tsyncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+        files:
+          - name: c3tsyncer
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -3679,6 +3679,46 @@ packages:
       - version_constraint: "true"
   - type: github_release
     repo_owner: bitnami-labs
+    repo_name: charts-syncer
+    description: Tool for synchronizing Helm Chart repositories
+    asset: charts-syncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.20.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.10.0")
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver(">= 0.7.0")
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.2")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 0.2.2")
+        asset: c3tsyncer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+        files:
+          - name: c3tsyncer
+        rosetta2: true
+  - type: github_release
+    repo_owner: bitnami-labs
     repo_name: sealed-secrets
     asset: kubeseal-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
     description: A Kubernetes controller and tool for one-way encrypted Secrets


### PR DESCRIPTION
[bitnami-labs/charts-syncer](https://github.com/bitnami-labs/charts-syncer): Tool for synchronizing Helm Chart repositories

```console
$ aqua g -i bitnami-labs/charts-syncer
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ charts-syncer
charts-syncer is a tool to synchronize chart repositories from a source repository to a target repository

Find more information at: https://github.com/bitnami-labs/charts-syncer

Usage:
  charts-syncer [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  sync        Synchronizes two chart repositories
  version     Print the version number of charts-syncer

Flags:
      --add_dir_header                   If true, adds the file directory to the header
      --alsologtostderr                  log to standard error as well as files (default true)
  -c, --config string                    Config file. Defaults to ./charts-syncer.yaml or $HOME/charts-syncer.yaml)
      --dry-run                          Only shows the charts pending to be synced without syncing them
  -h, --help                             help for charts-syncer
      --insecure                         Allow insecure SSL connections
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          number for the log level verbosity (default 2)
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "charts-syncer [command] --help" for more information about a command.
```