### PR TITLE
feat: add one2nc/cloudlens

### DIFF
--- a/pkgs/one2nc/cloudlens/pkg.yaml
+++ b/pkgs/one2nc/cloudlens/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: one2nc/cloudlens@v0.1.1

--- a/pkgs/one2nc/cloudlens/registry.yaml
+++ b/pkgs/one2nc/cloudlens/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: one2nc
+    repo_name: cloudlens
+    description: k9s like CLI for AWS
+    asset: cloudlens_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        asset: cloudlens_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -16245,6 +16245,24 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: one2nc
+    repo_name: cloudlens
+    description: k9s like CLI for AWS
+    asset: cloudlens_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        asset: cloudlens_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: open-policy-agent
     repo_name: conftest
     asset: conftest_{{trimV .Version}}_{{title .OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[one2nc/cloudlens](https://github.com/one2nc/cloudlens): k9s like CLI for AWS

```console
$ aqua g -i one2nc/cloudlens
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cloudlens --help
cli for aws services[s3, ec2, security-groups, iam]

Usage:
  cloudlens [flags]
  cloudlens [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     Print version/build info

Flags:
  -h, --help             help for cloudlens
  -p, --profile string   Read aws profile (default "default")
  -r, --region string    Read aws region

Use "cloudlens [command] --help" for more information about a command.
```