### PR TITLE
feat: add dnote/dnote/cli

### DIFF
--- a/pkgs/dnote/dnote/cli/pkg.yaml
+++ b/pkgs/dnote/dnote/cli/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: dnote/dnote/cli@cli-v0.14.0
+  - name: dnote/dnote/cli
+    version: cli-v0.11.1
+  - name: dnote/dnote/cli
+    version: cli-v0.6.3
+  - name: dnote/dnote/cli
+    version: v0.4.8
+  - name: dnote/dnote/cli
+    version: v0.4.7
+  - name: dnote/dnote/cli
+    version: v0.4.6

--- a/pkgs/dnote/dnote/cli/registry.yaml
+++ b/pkgs/dnote/dnote/cli/registry.yaml
@@ -1,0 +1,61 @@
+packages:
+  - type: github_release
+    name: dnote/dnote/cli
+    repo_owner: dnote
+    repo_name: dnote
+    description: A simple command line notebook for programmers
+    asset: dnote_{{trimPrefix "cli-v" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: dnote_{{trimPrefix "cli-v" .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_filter: Version startsWith "cli-"
+    version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
+    version_overrides:
+      - version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
+        supported_envs:
+          - linux
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.4.8")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("= 0.4.7")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.4.7")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/pkgs/dnote/dnote/cli/registry.yaml
+++ b/pkgs/dnote/dnote/cli/registry.yaml
@@ -54,7 +54,6 @@ packages:
         asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
-          - linux/amd64
           - amd64
         rosetta2: true
         checksum:

--- a/pkgs/dnote/dnote/cli/registry.yaml
+++ b/pkgs/dnote/dnote/cli/registry.yaml
@@ -18,6 +18,7 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    rosetta2: true # pre built binary for darwin/arm64 doesn't work at the moment. https://github.com/dnote/dnote/issues/572#issuecomment-1465315535
     version_filter: Version startsWith "cli-"
     version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
     version_overrides:
@@ -26,12 +27,10 @@ packages:
           - linux
           - darwin
           - amd64
-        rosetta2: true
       - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 0.4.8")
@@ -39,7 +38,6 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver("= 0.4.7")
@@ -47,7 +45,6 @@ packages:
         supported_envs:
           - darwin
           - linux/amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver("< 0.4.7")
@@ -55,6 +52,5 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false

--- a/pkgs/dnote/dnote/cli/registry.yaml
+++ b/pkgs/dnote/dnote/cli/registry.yaml
@@ -20,13 +20,8 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     rosetta2: true # pre built binary for darwin/arm64 doesn't work at the moment. https://github.com/dnote/dnote/issues/572#issuecomment-1465315535
     version_filter: Version startsWith "cli-"
-    version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
+    version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
     version_overrides:
-      - version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
-        supported_envs:
-          - linux
-          - darwin
-          - amd64
       - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -6681,13 +6681,8 @@ packages:
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
     rosetta2: true # pre built binary for darwin/arm64 doesn't work at the moment. https://github.com/dnote/dnote/issues/572#issuecomment-1465315535
     version_filter: Version startsWith "cli-"
-    version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
+    version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
     version_overrides:
-      - version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
-        supported_envs:
-          - linux
-          - darwin
-          - amd64
       - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -6660,6 +6660,66 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    name: dnote/dnote/cli
+    repo_owner: dnote
+    repo_name: dnote
+    description: A simple command line notebook for programmers
+    asset: dnote_{{trimPrefix "cli-v" .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: dnote_{{trimPrefix "cli-v" .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_filter: Version startsWith "cli-"
+    version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
+    version_overrides:
+      - version_constraint: semverWithVersion(">= 0.11.1", trimPrefix(Version, "cli-"))
+        supported_envs:
+          - linux
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.4.8")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("= 0.4.7")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.4.7")
+        asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
   - type: http
     repo_owner: docker-slim
     repo_name: docker-slim

--- a/registry.yaml
+++ b/registry.yaml
@@ -6715,7 +6715,6 @@ packages:
         asset: dnote_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
-          - linux/amd64
           - amd64
         rosetta2: true
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -6679,6 +6679,7 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    rosetta2: true # pre built binary for darwin/arm64 doesn't work at the moment. https://github.com/dnote/dnote/issues/572#issuecomment-1465315535
     version_filter: Version startsWith "cli-"
     version_constraint: semverWithVersion(">= 0.13.0", trimPrefix(Version, "cli-"))
     version_overrides:
@@ -6687,12 +6688,10 @@ packages:
           - linux
           - darwin
           - amd64
-        rosetta2: true
       - version_constraint: semverWithVersion(">= 0.6.3", trimPrefix(Version, "cli-"))
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 0.4.8")
@@ -6700,7 +6699,6 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver("= 0.4.7")
@@ -6708,7 +6706,6 @@ packages:
         supported_envs:
           - darwin
           - linux/amd64
-        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver("< 0.4.7")
@@ -6716,7 +6713,6 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
         checksum:
           enabled: false
   - type: http


### PR DESCRIPTION
[dnote/dnote/cli](https://github.com/dnote/dnote): A simple command line notebook for programmers

```console
$ aqua g -i dnote/dnote/cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ dnote
Dnote - a simple command line notebook

Usage:
  dnote [command]

Available Commands:
  add         Add a new note
  edit        Edit a note or a book
  find        Find notes by keywords
  help        Help about any command
  login       Login to dnote server
  logout      Logout from the server
  remove      Remove a note or a book
  sync        Sync data with the server
  version     Print the version number of Dnote
  view        List books, notes or view a content

Flags:
  -h, --help   help for dnote

Use "dnote [command] --help" for more information about a command.
```
