### PR TITLE
feat: add zyedidia/eget

### DIFF
--- a/pkgs/zyedidia/eget/pkg.yaml
+++ b/pkgs/zyedidia/eget/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: zyedidia/eget@v1.3.3
+  - name: zyedidia/eget
+    version: v1.1.0
+  - name: zyedidia/eget
+    version: v0.1.1
+  - name: zyedidia/eget
+    version: v0.1.0

--- a/pkgs/zyedidia/eget/registry.yaml
+++ b/pkgs/zyedidia/eget/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: zyedidia
+    repo_name: eget
+    description: Easily install prebuilt binaries from GitHub
+    asset: eget-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: eget
+        src: eget-{{trimV .Version}}-{{.OS}}_{{.Arch}}/eget
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        rosetta2: true
+      - version_constraint: semver("< 0.1.1")

--- a/registry.yaml
+++ b/registry.yaml
@@ -22563,6 +22563,27 @@ packages:
           enabled: false
   - type: github_release
     repo_owner: zyedidia
+    repo_name: eget
+    description: Easily install prebuilt binaries from GitHub
+    asset: eget-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: eget
+        src: eget-{{trimV .Version}}-{{.OS}}_{{.Arch}}/eget
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        rosetta2: true
+      - version_constraint: semver("< 0.1.1")
+  - type: github_release
+    repo_owner: zyedidia
     repo_name: micro
     asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
[zyedidia/eget](https://github.com/zyedidia/eget): Easily install prebuilt binaries from GitHub

```console
$ aqua g -i zyedidia/eget
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ eget --help
Usage:
  eget [OPTIONS] TARGET

Application Options:
  -t, --tag=           tagged release to use instead of latest
      --pre-release    include pre-releases when fetching the latest version
      --source         download the source code for the target repo instead of a release
      --to=            move to given location after extracting
  -s, --system=        target system to download for (use "all" for all choices)
  -f, --file=          glob to select files for extraction
      --all            extract all candidate files
  -q, --quiet          only print essential output
  -d, --download-only  stop after downloading the asset (no extraction)
      --upgrade-only   only download if release is more recent than current version
  -a, --asset=         download a specific asset containing the given string; can be specified multiple times for additional filtering; use ^ for anti-match
      --sha256         show the SHA-256 hash of the downloaded asset
      --verify-sha256= verify the downloaded asset checksum against the one provided
      --rate           show GitHub API rate limiting information
  -r, --remove         remove the given file from $EGET_BIN or the current directory
  -v, --version        show version information
  -h, --help           show this help message
  -D, --download-all   download all projects defined in the config file
  -k, --disable-ssl    disable SSL verification for download requests
```