### PR TITLE
feat: add sayanarijit/xplr

### DIFF
--- a/pkgs/sayanarijit/xplr/pkg.yaml
+++ b/pkgs/sayanarijit/xplr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sayanarijit/xplr@v0.20.2

--- a/pkgs/sayanarijit/xplr/registry.yaml
+++ b/pkgs/sayanarijit/xplr/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: sayanarijit
+    repo_name: xplr
+    description: A hackable, minimal, fast TUI file explorer
+    asset: xplr-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: xplr-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -18441,6 +18441,26 @@ packages:
       - version_constraint: semver("< 0.7.0")
         no_asset: true
   - type: github_release
+    repo_owner: sayanarijit
+    repo_name: xplr
+    description: A hackable, minimal, fast TUI file explorer
+    asset: xplr-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: xplr-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: sbstp
     repo_name: kubie
     description: A more powerful alternative to kubectx and kubens


### PR DESCRIPTION
[sayanarijit/xplr](https://github.com/sayanarijit/xplr): A hackable, minimal, fast TUI file explorer

```console
$ aqua g -i sayanarijit/xplr
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ xplr --help
xplr 0.20.2
Arijit Basu <hi@arijitbasu.in>
A hackable, minimal, fast TUI file explorer

USAGE:
    xplr [FLAG]... [OPTION]... [PATH] [SELECTION]...

FLAGS:
    -                            Reads new-line (\n) separated paths from stdin
    --                           Denotes the end of command-line flags and options
        --force-focus            Focuses on the given <PATH>, even if it is a directory
    -h, --help                   Prints help information
    -m, --pipe-msg-in            Helps safely passing messages to the active xplr
                                   session, use %%, %s and %q as the placeholders
    -M, --print-msg-in           Like --pipe-msg-in, but prints the message instead of
                                   passing to the active xplr session
        --print-pwd-as-result    Prints the present working directory when quitting
                                   with `PrintResultAndQuit`
        --read-only              Enables read-only mode (config.general.read_only)
        --read0                  Reads paths separated using the null character (\0)
        --write0                 Prints paths separated using the null character (\0)
    -0  --null                   Combines --read0 and --write0
    -V, --version                Prints version information

OPTIONS:
    -c, --config <PATH>             Specifies a custom config file (default is
                                      "$HOME/.config/xplr/init.lua")
    -C, --extra-config <PATH>...    Specifies extra config files to load
        --on-load <MESSAGE>...      Sends messages when xplr loads
        --vroot <PATH>              Treats the specified path as the virtual root

ARGS:
    <PATH>            Path to focus on, or enter if directory, (default is `.`)
    <SELECTION>...    Paths to select, requires <PATH> to be set explicitly
```