### PR TITLE
feat: add oberblastmeister/trashy

### DIFF
--- a/pkgs/oberblastmeister/trashy/pkg.yaml
+++ b/pkgs/oberblastmeister/trashy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: oberblastmeister/trashy@v2.0.0

--- a/pkgs/oberblastmeister/trashy/registry.yaml
+++ b/pkgs/oberblastmeister/trashy/registry.yaml
@@ -5,14 +5,12 @@ packages:
     description: A cli system trash manager, alternative to rm and trash-cli
     asset: trash-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    files:
+      - name: trash
     overrides:
       - goos: windows
         format: raw
         asset: trash-{{.Arch}}-{{.OS}}
-      - goos: linux
-        files:
-          - name: trashy
-            src: trash
     replacements:
       amd64: x86_64
       linux: unknown-linux-gnu

--- a/pkgs/oberblastmeister/trashy/registry.yaml
+++ b/pkgs/oberblastmeister/trashy/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: oberblastmeister
+    repo_name: trashy
+    description: A cli system trash manager, alternative to rm and trash-cli
+    asset: trash-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: raw
+        asset: trash-{{.Arch}}-{{.OS}}
+      - goos: linux
+        files:
+          - name: trashy
+            src: trash
+    replacements:
+      amd64: x86_64
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - linux/amd64
+      - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -16370,14 +16370,12 @@ packages:
     description: A cli system trash manager, alternative to rm and trash-cli
     asset: trash-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    files:
+      - name: trash
     overrides:
       - goos: windows
         format: raw
         asset: trash-{{.Arch}}-{{.OS}}
-      - goos: linux
-        files:
-          - name: trashy
-            src: trash
     replacements:
       amd64: x86_64
       linux: unknown-linux-gnu

--- a/registry.yaml
+++ b/registry.yaml
@@ -16365,6 +16365,27 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: oberblastmeister
+    repo_name: trashy
+    description: A cli system trash manager, alternative to rm and trash-cli
+    asset: trash-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: raw
+        asset: trash-{{.Arch}}-{{.OS}}
+      - goos: linux
+        files:
+          - name: trashy
+            src: trash
+    replacements:
+      amd64: x86_64
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - linux/amd64
+      - windows/amd64
+  - type: github_release
     repo_owner: octohelm
     repo_name: cuemod
     description: experimental cuelang mod tool


### PR DESCRIPTION
[oberblastmeister/trashy](https://github.com/oberblastmeister/trashy): A cli system trash manager, alternative to rm and trash-cli

```console
$ aqua g -i oberblastmeister/trashy
```
