### PR TITLE
feat: add out-of-cheese-error/the-way

### DIFF
--- a/pkgs/out-of-cheese-error/the-way/pkg.yaml
+++ b/pkgs/out-of-cheese-error/the-way/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: out-of-cheese-error/the-way@v0.19.2
+  - name: out-of-cheese-error/the-way
+    version: v0.14.1
+  - name: out-of-cheese-error/the-way
+    version: v0.2.2
+  - name: out-of-cheese-error/the-way
+    version: v0.2.1-osx

--- a/pkgs/out-of-cheese-error/the-way/registry.yaml
+++ b/pkgs/out-of-cheese-error/the-way/registry.yaml
@@ -29,7 +29,7 @@ packages:
           linux: unknown-linux-gnu
         checksum:
           enabled: false
-      - version_constraint: semver("< 0.2.2")
+      - version_constraint: Version == "v0.2.1-osx"
         asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64

--- a/pkgs/out-of-cheese-error/the-way/registry.yaml
+++ b/pkgs/out-of-cheese-error/the-way/registry.yaml
@@ -1,0 +1,40 @@
+packages:
+  - type: github_release
+    repo_owner: out-of-cheese-error
+    repo_name: the-way
+    description: A code snippets manager for your terminal
+    asset: the-way-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: the-way-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.14.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.2")
+        asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.2")
+        asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+        checksum:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -16878,7 +16878,7 @@ packages:
           linux: unknown-linux-gnu
         checksum:
           enabled: false
-      - version_constraint: semver("< 0.2.2")
+      - version_constraint: Version == "v0.2.1-osx"
         asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -16849,6 +16849,45 @@ packages:
             checksum: ^(\b[A-Fa-f0-9]{128}\b)
             file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: out-of-cheese-error
+    repo_name: the-way
+    description: A code snippets manager for your terminal
+    asset: the-way-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: the-way-{{.OS}}.sha256
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.14.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.2")
+        asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.2")
+        asset: the-way-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: oven-sh
     repo_name: bun
     aliases:


### PR DESCRIPTION
[out-of-cheese-error/the-way](https://github.com/out-of-cheese-error/the-way): A code snippets manager for your terminal

```console
$ aqua g -i out-of-cheese-error/the-way
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ the-way --help
A code snippets manager for your terminal

Record, retrieve, search, and categorize code snippets

Usage: the-way [OPTIONS] <COMMAND>

Commands:
  new
          Add a new code snippet
  cmd
          Add a new shell snippet
  search
          Fuzzy search to find a snippet and copy, edit or delete it
  sync
          Sync snippets to a Gist
  list
          Lists (optionally filtered) snippets
  import
          Imports code snippets from JSON
  export
          Saves (optionally filtered) snippets to JSON
  clear
          Clears all data
  complete
          Generate shell completions
  themes
          Manage syntax highlighting themes
  config
          Manage the-way data locations
  edit
          Change snippet
  del
          Delete snippet
  cp
          Copy snippet to clipboard
  view
          View snippet
  help
          Print this message or the help of the given subcommand(s)

Options:
  -c, --colorize
          Force colorization even when not in TTY mode

  -p, --plain
          Turn off colorization

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```