### PR TITLE
feat: add fujiapple852/trippy

### DIFF
--- a/pkgs/fujiapple852/trippy/pkg.yaml
+++ b/pkgs/fujiapple852/trippy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiapple852/trippy@0.6.0

--- a/pkgs/fujiapple852/trippy/registry.yaml
+++ b/pkgs/fujiapple852/trippy/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - type: github_release
+    repo_owner: fujiapple852
+    repo_name: trippy
+    description: A network diagnostic tool
+    asset: trippy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: trip
+        src: trippy-{{.Version}}-{{.Arch}}-{{.OS}}/trip
+    overrides:
+      - goos: linux
+        goarch: amd64
+        replacements:
+          linux: unknown-linux-musl
+      - goos: linux
+        goarch: arm64
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+    supported_envs:
+      - linux
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -8078,6 +8078,32 @@ packages:
     files:
       - name: semver
   - type: github_release
+    repo_owner: fujiapple852
+    repo_name: trippy
+    description: A network diagnostic tool
+    asset: trippy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: trip
+        src: trippy-{{.Version}}-{{.Arch}}-{{.OS}}/trip
+    overrides:
+      - goos: linux
+        goarch: amd64
+        replacements:
+          linux: unknown-linux-musl
+      - goos: linux
+        goarch: arm64
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+    supported_envs:
+      - linux
+      - darwin
+    rosetta2: true
+  - type: github_release
     repo_owner: fujiwara
     repo_name: ecrm
     asset: ecrm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[fujiapple852/trippy](https://github.com/fujiapple852/trippy): A network diagnostic tool

```console
$ aqua g -i fujiapple852/trippy
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ trip --help
trippy 0.6.0
FujiApple <fujiapple852@gmail.com>
A network diagnostic tool

USAGE:
    trip [OPTIONS] <TARGETS>...

ARGS:
    <TARGETS>...    A space delimited list of hostnames and IPs to trace

OPTIONS:
    -m, --mode <MODE>                                Output mode [default: tui] [possible values: tui, stream, pretty, markdown, csv, json]
    -p, --protocol <PROTOCOL>                        Tracing protocol [default: icmp] [possible values: icmp, udp, tcp]
        --udp                                        Trace using the UDP protocol
        --tcp                                        Trace using the TCP protocol
    -4, --ipv4                                       use IPv4 only
    -6, --ipv6                                       Use IPv6 only
    -P, --target-port <TARGET_PORT>                  The target port (TCP & UDP only) [default: 80]
    -S, --source-port <SOURCE_PORT>                  The source port (TCP & UDP only) [default: auto]
    -A, --source-address <SOURCE_ADDRESS>            The source IP address [default: auto]
    -I, --interface <INTERFACE>                      The network interface [default: auto]
    -i, --min-round-duration <MIN_ROUND_DURATION>    The minimum duration of every round [default: 1s]
    -T, --max-round-duration <MAX_ROUND_DURATION>    The maximum duration of every round [default: 1s]
        --initial-sequence <INITIAL_SEQUENCE>        The initial sequence number [default: 33000]
    -R, --multipath-strategy <MULTIPATH_STRATEGY>    The Equal-cost Multi-Path routing strategy (IPv4/UDP only) [default: classic] [possible values: classic, paris, dublin]
    -g, --grace-duration <GRACE_DURATION>            The period of time to wait for additional ICMP responses after the target has responded [default: 100ms]
    -U, --max-inflight <MAX_INFLIGHT>                The maximum number of in-flight ICMP echo requests [default: 24]
    -f, --first-ttl <FIRST_TTL>                      The TTL to start from [default: 1]
    -t, --max-ttl <MAX_TTL>                          The maximum number of TTL hops [default: 64]
        --packet-size <PACKET_SIZE>                  The size of IP packet to send (IP header + ICMP header + payload) [default: 84]
        --payload-pattern <PAYLOAD_PATTERN>          The repeating pattern in the payload of the ICMP packet [default: 0]
    -Q, --tos <TOS>                                  The TOS (i.e. DSCP+ECN) IP header value (TCP and UDP only) [default: 0]
        --read-timeout <READ_TIMEOUT>                The socket read timeout [default: 10ms]
    -r, --dns-resolve-method <DNS_RESOLVE_METHOD>    How to perform DNS queries [default: system] [possible values: system, resolv, google, cloudflare]
        --dns-timeout <DNS_TIMEOUT>                  The maximum time to wait to perform DNS queries [default: 5s]
    -z, --dns-lookup-as-info                         Lookup autonomous system (AS) information during DNS queries
    -a, --tui-address-mode <TUI_ADDRESS_MODE>        How to render addresses [default: host] [possible values: ip, host, both]
    -M, --tui-max-addrs <TUI_MAX_ADDRS>              The maximum number of addresses to show per hop
    -s, --tui-max-samples <TUI_MAX_SAMPLES>          The maximum number of samples to record per hop [default: 256]
        --tui-preserve-screen                        Preserve the screen on exit
        --tui-refresh-rate <TUI_REFRESH_RATE>        The TUI refresh rate [default: 100ms]
    -c, --report-cycles <REPORT_CYCLES>              The number of report cycles to run [default: 10]
    -h, --help                                       Print help information
    -V, --version                                    Print version information
```