### PR TITLE
feat: add jdxcode/rtx

### DIFF
--- a/pkgs/jdxcode/rtx/pkg.yaml
+++ b/pkgs/jdxcode/rtx/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jdxcode/rtx@v1.25.4

--- a/pkgs/jdxcode/rtx/registry.yaml
+++ b/pkgs/jdxcode/rtx/registry.yaml
@@ -14,3 +14,11 @@ packages:
     files:
       - name: rtx
         src: rtx/bin/rtx
+    checksum:
+      type: github_release
+      asset: SHASUMS256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(?:\\./)?(\\S+)$"

--- a/pkgs/jdxcode/rtx/registry.yaml
+++ b/pkgs/jdxcode/rtx/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: jdxcode
+    repo_name: rtx
+    description: Runtime Executor (asdf rust clone)
+    asset: rtx-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x64
+      darwin: macos
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: rtx
+        src: rtx/bin/rtx

--- a/registry.yaml
+++ b/registry.yaml
@@ -11765,6 +11765,21 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: jdxcode
+    repo_name: rtx
+    description: Runtime Executor (asdf rust clone)
+    asset: rtx-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x64
+      darwin: macos
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: rtx
+        src: rtx/bin/rtx
+  - type: github_release
     repo_owner: jenkins-x
     repo_name: jx
     asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -11779,6 +11779,14 @@ packages:
     files:
       - name: rtx
         src: rtx/bin/rtx
+    checksum:
+      type: github_release
+      asset: SHASUMS256.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(?:\\./)?(\\S+)$"
   - type: github_release
     repo_owner: jenkins-x
     repo_name: jx


### PR DESCRIPTION
[jdxcode/rtx](https://github.com/jdxcode/rtx): Runtime Executor (asdf rust clone)

```console
$ aqua g -i jdxcode/rtx
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ rtx --help
rtx is a tool for managing runtime versions. https://github.com/jdxcode/rtx

It's a replacement for tools like nvm, nodenv, rbenv, rvm, chruby, pyenv, etc.
that works for any language. It's also great for managing linters/tools like
jq and shellcheck.

It is inspired by asdf and uses asdf's plugin ecosystem under the hood:
https://asdf-vm.com/

Usage: rtx [OPTIONS] <COMMAND>

Commands:
  activate
          Initializes rtx in the current shell
  alias
          Manage aliases [aliases: a]
  bin-paths
          List all the active runtime bin paths
  cache
          Manage the rtx cache
  complete
          Generate shell completions
  current
          Shows current active and installed runtime versions
  deactivate
          Disable rtx for current shell session
  direnv
          Output direnv function to use rtx inside direnv
  doctor
          Check rtx installation for possible problems.
  env
          Exports env vars to activate rtx a single time [aliases: e]
  exec
          Execute a command with runtime(s) set [aliases: x]
  global
          Sets/gets the global runtime version(s) [aliases: g]
  implode
          Removes rtx CLI and all related data
  install
          Install a runtime [aliases: i]
  latest
          Gets the latest available version for a plugin
  local
          Sets/gets tool version in local .tool-versions or .rtx.toml [aliases: l]
  ls
          List installed runtime versions [aliases: list]
  ls-remote
          List runtime versions available for install
  plugins
          Manage plugins [aliases: p]
  prune
          Delete unused versions of tools
  reshim
          [experimental] rebuilds the shim farm
  self-update
          Updates rtx itself
  settings
          Manage settings
  shell
          Sets a tool version for the current shell session
  uninstall
          Removes runtime versions
  version
          Show rtx version
  where
          Display the installation path for a runtime
  which
          Shows the path that a bin name points to
  help
          Print this message or the help of the given subcommand(s)

Options:
      --install-missing
          Automatically install missing tools

  -j, --jobs <jobs>
          Number of plugins and runtimes to install in parallel
          default: 4

      --log-level <LEVEL>
          Set the log output verbosity

          [default: info]

  -r, --raw
          Directly pipe stdin/stdout/stderr to user.
          Sets --jobs=1

  -v, --verbose...
          Show installation output

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Examples:
  rtx install nodejs@18.0.0       Install a specific node version
  rtx install nodejs@18.0         Install a version matching a prefix
  rtx local nodejs@18             Use node-18.x in current project
  rtx global nodejs@18            Use node-18.x as default

  rtx install nodejs              Install the .tool-versions node version
  rtx local nodejs                Use latest node in current directory
  rtx global system               Use system node everywhere unless overridden

  rtx x nodejs@18 -- node app.js  Run `node app.js` with PATH pointing to
                                  node-18.x
```