### PR TITLE
feat: add solidiquis/erdtree

### DIFF
--- a/pkgs/solidiquis/erdtree/pkg.yaml
+++ b/pkgs/solidiquis/erdtree/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: solidiquis/erdtree@v1.5.2
+  - name: solidiquis/erdtree
+    version: v1.1.0
+  - name: solidiquis/erdtree
+    version: v1.0

--- a/pkgs/solidiquis/erdtree/registry.yaml
+++ b/pkgs/solidiquis/erdtree/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: solidiquis
+    repo_name: erdtree
+    description: A multi-threaded file-tree visualizer and disk usage analyzer
+    asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: raw
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        replacements:
+          arm64: arm64
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: et
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver("< 1.1.0")
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: et-{{.Arch}}-{{.OS}}
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -20138,6 +20138,53 @@ packages:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: solidiquis
+    repo_name: erdtree
+    description: A multi-threaded file-tree visualizer and disk usage analyzer
+    asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: raw
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        replacements:
+          arm64: arm64
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: et
+    version_constraint: semver(">= 1.1.0")
+    version_overrides:
+      - version_constraint: semver("< 1.1.0")
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: et-{{.Arch}}-{{.OS}}
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+  - type: github_release
     repo_owner: sonatype-nexus-community
     repo_name: nancy
     asset: nancy-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[solidiquis/erdtree](https://github.com/solidiquis/erdtree): A multi-threaded file-tree visualizer and disk usage analyzer

```console
$ aqua g -i solidiquis/erdtree
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ et --help
erdtree (et) is a multi-threaded filetree visualizer and disk usage analyzer.

Usage: et [OPTIONS] [DIR]

Arguments:
  [DIR]
          Root directory to traverse; defaults to current working directory

Options:
  -d, --disk-usage <DISK_USAGE>
          Print physical or logical file size

          [default: logical]

          Possible values:
          - logical:
            How many bytes does a file contain
          - physical:
            How much actual space on disk, taking into account sparse files and compression

  -g, --glob <GLOB>
          Include or exclude files using glob patterns

      --iglob <IGLOB>
          Include or exclude files using glob patterns; case insensitive

      --glob-case-insensitive
          Process all glob patterns case insensitively

  -H, --hidden
          Show hidden files; disabled by default

      --ignore-git
          Disable traversal of .git directory when traversing hidden files; disabled by default

  -I, --icons
          Display file icons; disabled by default

  -i, --ignore-git-ignore
          Ignore .gitignore; disabled by default

  -l, --level <NUM>
          Maximum depth to display

  -n, --scale <NUM>
          Total number of digits after the decimal to display for disk usage

          [default: 2]

  -p, --prefix <PREFIX>
          Display disk usage as binary or SI units

          [default: bin]

          Possible values:
          - bin: Displays disk usage using binary prefixes
          - si:  Displays disk usage using SI prefixes

  -P, --prune
          Disable printing of empty branches

  -s, --sort <SORT>
          Sort-order to display directory content

          [default: none]

          Possible values:
          - name:     Sort entries by file name
          - size:     Sort entries by size smallest to largest, top to bottom
          - size-rev: Sort entries by size largest to smallest, bottom to top
          - none:     Do not sort entries

      --dirs-first
          Always sorts directories above files

  -S, --follow-links
          Traverse symlink directories and consider their disk usage; disabled by default

  -t, --threads <THREADS>
          Number of threads to use

          [default: 4]

      --suppress-size
          Omit disk usage from output; disabled by default

      --size-left
          Show the size on the left, decimal aligned

      --no-config
          Don't read configuration file

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```