### PR TITLE
feat: add ellie/atuin

### DIFF
--- a/pkgs/ellie/atuin/pkg.yaml
+++ b/pkgs/ellie/atuin/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: ellie/atuin@v13.0.1
+  - name: ellie/atuin
+    version: v0.6.4
+  - name: ellie/atuin
+    version: v0.6.3

--- a/pkgs/ellie/atuin/registry.yaml
+++ b/pkgs/ellie/atuin/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - type: github_release
+    repo_owner: ellie
+    repo_name: atuin
+    description: Magical shell history
+    asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    files:
+      - name: atuin
+        src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    version_constraint: semver(">= 0.6.4")
+    version_overrides:
+      - version_constraint: semver("< 0.6.4")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7559,6 +7559,33 @@ packages:
     supported_envs:
       - linux/amd64
   - type: github_release
+    repo_owner: ellie
+    repo_name: atuin
+    description: Magical shell history
+    asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    files:
+      - name: atuin
+        src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    version_constraint: semver(">= 0.6.4")
+    version_overrides:
+      - version_constraint: semver("< 0.6.4")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: elsesiy
     repo_name: kubectl-view-secret
     description: Kubernetes CLI plugin to decode Kubernetes secrets


### PR DESCRIPTION
[ellie/atuin](https://github.com/ellie/atuin): Magical shell history

```console
$ aqua g -i ellie/atuin
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ atuin --help
atuin 13.0.1
Ellie Huxtable <e@elm.sh>
Magical shell history

Usage:
  atuin <COMMAND>

Commands:
  history          Manipulate shell history
  import           Import shell history from file
  stats            Calculate statistics for your history
  search           Interactive history search
  sync             Sync with the configured server
  login            Login to the configured server
  logout           Log out
  register         Register with the configured server
  key              Print the encryption key for transfer to another machine
  server           Start an atuin server
  init             Output shell setup
  uuid             Generate a UUID
  contributors
  gen-completions  Generate shell completions
  help             Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help information
  -V, --version  Print version information
```