### PR TITLE
feat: add zurawiki/gptcommit

### DIFF
--- a/pkgs/zurawiki/gptcommit/pkg.yaml
+++ b/pkgs/zurawiki/gptcommit/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: zurawiki/gptcommit@v0.4.1
+  - name: zurawiki/gptcommit
+    version: v0.1.8
+  - name: zurawiki/gptcommit
+    version: v0.1.7

--- a/pkgs/zurawiki/gptcommit/registry.yaml
+++ b/pkgs/zurawiki/gptcommit/registry.yaml
@@ -1,0 +1,35 @@
+packages:
+  - type: github_release
+    repo_owner: zurawiki
+    repo_name: gptcommit
+    description: A git prepare-commit-msg hook for authoring commit messages with GPT-3
+    asset: gptcommit-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        replacements:
+          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.1.8")
+    version_overrides:
+      - version_constraint: semver("< 0.1.8")
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -23157,6 +23157,40 @@ packages:
       - name: s
         src: s-{{.OS}}_{{.Arch}}/s
   - type: github_release
+    repo_owner: zurawiki
+    repo_name: gptcommit
+    description: A git prepare-commit-msg hook for authoring commit messages with GPT-3
+    asset: gptcommit-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        replacements:
+          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.1.8")
+    version_overrides:
+      - version_constraint: semver("< 0.1.8")
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+  - type: github_release
     repo_owner: zyedidia
     repo_name: eget
     description: Easily install prebuilt binaries from GitHub


### PR DESCRIPTION
[zurawiki/gptcommit](https://github.com/zurawiki/gptcommit): A git prepare-commit-msg hook for authoring commit messages with GPT-3

```console
$ aqua g -i zurawiki/gptcommit
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gptcommit --help
A git prepare-commit-msg hook for summarizing commits with LLMs.

Usage: gptcommit [OPTIONS] <COMMAND>

Commands:
  install             Install the git hook
  uninstall           Uninstall the git hook
  config              Read and modify settings
  prepare-commit-msg  Run on the prepare-commit-msg hook
  help                Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose  Enable verbose logging
  -h, --help     Print help
  -V, --version  Print version
```