### PR TITLE
chore(99designs/aws-vault): support darwin

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
           - runs-on: macos-latest
           - runs-on: ubuntu-latest
             goarch: arm64
-          - runs-on: ubuntu-latest
+          - runs-on: macos-latest
             goos: darwin
             goarch: arm64
           - runs-on: windows-latest

--- a/pkgs/99designs/aws-vault/pkg.yaml
+++ b/pkgs/99designs/aws-vault/pkg.yaml
@@ -3,6 +3,8 @@ packages:
   - name: 99designs/aws-vault
     version: v6.5.0
   - name: 99designs/aws-vault
+    version: v6.3.0
+  - name: 99designs/aws-vault
     version: v5.2.0
   - name: 99designs/aws-vault
     version: v5.1.0

--- a/pkgs/99designs/aws-vault/registry.yaml
+++ b/pkgs/99designs/aws-vault/registry.yaml
@@ -8,6 +8,7 @@ packages:
     supported_envs:
       - linux
       - windows/arm64
+      - darwin
     checksum:
       type: github_release
       asset: SHA256SUMS
@@ -16,6 +17,10 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    overrides:
+      - goos: darwin
+        format: dmg
+        asset: aws-vault-darwin-{{.Arch}}.{{.Format}}
     version_constraint: semver(">= 6.5.0")
     version_overrides:
       - version_constraint: semver(">= 5.2.0")

--- a/pkgs/99designs/aws-vault/registry.yaml
+++ b/pkgs/99designs/aws-vault/registry.yaml
@@ -5,10 +5,14 @@ packages:
     description: A vault for securely storing and accessing AWS credentials in development environments
     asset: aws-vault-{{.OS}}-{{.Arch}}
     format: raw
+    overrides:
+      - goos: darwin
+        format: dmg
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
     supported_envs:
       - linux
-      - windows/arm64
       - darwin
+      - windows/arm64
     checksum:
       type: github_release
       asset: SHA256SUMS
@@ -17,26 +21,57 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    overrides:
-      - goos: darwin
-        format: dmg
-        asset: aws-vault-darwin-{{.Arch}}.{{.Format}}
     version_constraint: semver(">= 6.5.0")
     version_overrides:
+      - version_constraint: semver(">= 6.3.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: semver(">= 5.2.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
+          - darwin
+        rosetta2: true
       - version_constraint: semver(">= 5.1.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
+          - darwin
+        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 4.7.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
+          - darwin
+        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 3.5.0")
+        overrides: []
         supported_envs:
           - linux/amd64
           - darwin
@@ -44,6 +79,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 3.0.0-dev")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -53,6 +89,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.4.0")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -64,6 +101,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.3.3")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -73,6 +111,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.3.2")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -84,6 +123,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver("< 2.3.2")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -20,6 +20,7 @@ packages:
     supported_envs:
       - linux
       - windows/arm64
+      - darwin
     checksum:
       type: github_release
       asset: SHA256SUMS
@@ -28,6 +29,10 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    overrides:
+      - goos: darwin
+        format: dmg
+        asset: aws-vault-darwin-{{.Arch}}.{{.Format}}
     version_constraint: semver(">= 6.5.0")
     version_overrides:
       - version_constraint: semver(">= 5.2.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -17,10 +17,14 @@ packages:
     description: A vault for securely storing and accessing AWS credentials in development environments
     asset: aws-vault-{{.OS}}-{{.Arch}}
     format: raw
+    overrides:
+      - goos: darwin
+        format: dmg
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
     supported_envs:
       - linux
-      - windows/arm64
       - darwin
+      - windows/arm64
     checksum:
       type: github_release
       asset: SHA256SUMS
@@ -29,26 +33,57 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
-    overrides:
-      - goos: darwin
-        format: dmg
-        asset: aws-vault-darwin-{{.Arch}}.{{.Format}}
     version_constraint: semver(">= 6.5.0")
     version_overrides:
+      - version_constraint: semver(">= 6.3.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: semver(">= 5.2.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
+          - darwin
+        rosetta2: true
       - version_constraint: semver(">= 5.1.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
+          - darwin
+        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 4.7.0")
+        asset: aws-vault-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: dmg
+        overrides:
+          - goos: linux
+            format: raw
+            asset: aws-vault-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
+          - darwin
+        rosetta2: true
         checksum:
           enabled: false
       - version_constraint: semver(">= 3.5.0")
+        overrides: []
         supported_envs:
           - linux/amd64
           - darwin
@@ -56,6 +91,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 3.0.0-dev")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -65,6 +101,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.4.0")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -76,6 +113,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.3.3")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -85,6 +123,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 2.3.2")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -96,6 +135,7 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver("< 2.3.2")
+        overrides: []
         replacements:
           amd64: x86_64
           darwin: Darwin


### PR DESCRIPTION
Now that we have support for the dmg format, we have also added it to the aqua-registry

https://github.com/aquaproj/aqua/blob/main/tests/macos/registry.yaml#L8-L23