### PR TITLE
feat: add keilerkonzept/terraform-module-versions

### DIFF
--- a/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: keilerkonzept/terraform-module-versions@3.1.13
+  - name: keilerkonzept/terraform-module-versions
+    version: 3.1.0
+  - name: keilerkonzept/terraform-module-versions
+    version: 0.11.0

--- a/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: keilerkonzept
+    repo_name: terraform-module-versions
+    description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
+    asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: osx
+    supported_envs:
+      - darwin
+    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["3.0.29", "3.1.14"]
+        no_asset: true
+      - version_constraint: semver("< 3.1.14")
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -13339,6 +13339,30 @@ packages:
           darwin: macos
       - version_constraint: "true"
   - type: github_release
+    repo_owner: keilerkonzept
+    repo_name: terraform-module-versions
+    description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
+    asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: osx
+    supported_envs:
+      - darwin
+    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["3.0.29", "3.1.14"]
+        no_asset: true
+      - version_constraint: semver("< 3.1.14")
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+  - type: github_release
     repo_owner: keisku
     repo_name: kubectl-explore
     description: A better kubectl explain with the fuzzy finder


### PR DESCRIPTION
[keilerkonzept/terraform-module-versions](https://github.com/keilerkonzept/terraform-module-versions): CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform

```console
$ aqua g -i keilerkonzept/terraform-module-versions
```