### PR TITLE
feat: add Code-Hex/gqldoc

### DIFF
--- a/pkgs/Code-Hex/gqldoc/pkg.yaml
+++ b/pkgs/Code-Hex/gqldoc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Code-Hex/gqldoc@v0.0.6

--- a/pkgs/Code-Hex/gqldoc/registry.yaml
+++ b/pkgs/Code-Hex/gqldoc/registry.yaml
@@ -1,0 +1,30 @@
+packages:
+  - type: github_release
+    repo_owner: Code-Hex
+    repo_name: gqldoc
+    description: The easiest way to make API documents for GraphQL
+    asset: gqldoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.5")
+    version_overrides:
+      - version_constraint: semver("< 0.0.5")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -535,6 +535,35 @@ packages:
     files:
       - name: btm
   - type: github_release
+    repo_owner: Code-Hex
+    repo_name: gqldoc
+    description: The easiest way to make API documents for GraphQL
+    asset: gqldoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.5")
+    version_overrides:
+      - version_constraint: semver("< 0.0.5")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+  - type: github_release
     repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     asset: cyclonedx-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/11360 [Code-Hex/gqldoc](https://github.com/Code-Hex/gqldoc): The easiest way to make API documents for GraphQL

```console
$ aqua g -i Code-Hex/gqldoc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gqldoc --help
NAME:
   gqldoc - The easiest way to generate documents for GraphQL

USAGE:
   gqldoc [global options] command [command options] [arguments...]

VERSION:
   0.0.6

DESCRIPTION:
   This is a command for quickly generating documents from graphql schema in golang.

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --endpoint value, -e value  GraphQL http endpoint. e.g. "https://example.com/graphql"
   --header value, -x value    HTTP header string for request. (use with --endpoint) e.g. "Authorization: Token cb8795e7"
   --query value, -q value     HTTP query string for request. (use with --endpoint) e.g. "token=cb8795e7"
   --schema value, -s value    GraphQL schema file. "1 json graphql schema" or "1 or more graphql files (.graphqls, .graphql, .gql)".
   --output value, -o value    Output directory.
   --help, -h                  show help (default: false)
   --version, -v               print the version (default: false)
```


Reference

- README.md
	- https://github.com/Code-Hex/gqldoc#how-to-use
