### PR TITLE
feat: add go-acme/lego

### DIFF
--- a/pkgs/go-acme/lego/pkg.yaml
+++ b/pkgs/go-acme/lego/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-acme/lego@v4.10.2

--- a/pkgs/go-acme/lego/pkg.yaml
+++ b/pkgs/go-acme/lego/pkg.yaml
@@ -1,2 +1,14 @@
 packages:
   - name: go-acme/lego@v4.10.2
+  - name: go-acme/lego
+    version: v4.5.2
+  - name: go-acme/lego
+    version: v4.3.0
+  - name: go-acme/lego
+    version: v0.5.0
+  - name: go-acme/lego
+    version: v0.4.0
+  - name: go-acme/lego
+    version: v0.1.1
+  - name: go-acme/lego
+    version: v0.1.0

--- a/pkgs/go-acme/lego/registry.yaml
+++ b/pkgs/go-acme/lego/registry.yaml
@@ -2,9 +2,9 @@ packages:
   - type: github_release
     repo_owner: go-acme
     repo_name: lego
+    description: Let's Encrypt/ACME client and library written in Go
     asset: lego_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: Let's Encrypt/ACME client and library written in Go
     overrides:
       - goos: windows
         format: zip
@@ -16,3 +16,53 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 4.5.2")
+    version_overrides:
+      - version_constraint: semver(">= 4.3.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.5.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.4.0")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.xz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.1.1")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.xz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.1.1")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/pkgs/go-acme/lego/registry.yaml
+++ b/pkgs/go-acme/lego/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: go-acme
+    repo_name: lego
+    asset: lego_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Let's Encrypt/ACME client and library written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: lego_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/go-acme/lego/registry.yaml
+++ b/pkgs/go-acme/lego/registry.yaml
@@ -32,6 +32,9 @@ packages:
       - version_constraint: semver(">= 0.4.0")
         asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: lego
+            src: lego_{{.OS}}_{{.Arch}}
         overrides:
           - goos: linux
             format: tar.xz

--- a/registry.yaml
+++ b/registry.yaml
@@ -9175,6 +9175,23 @@ packages:
             asset: gleam-{{.Version}}-windows-64bit.{{.Format}}
             format: zip
   - type: github_release
+    repo_owner: go-acme
+    repo_name: lego
+    asset: lego_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    description: Let's Encrypt/ACME client and library written in Go
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: lego_{{trimV .Version}}_checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: go-jira
     repo_name: jira
     description: simple jira command line client in Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -9177,9 +9177,9 @@ packages:
   - type: github_release
     repo_owner: go-acme
     repo_name: lego
+    description: Let's Encrypt/ACME client and library written in Go
     asset: lego_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: Let's Encrypt/ACME client and library written in Go
     overrides:
       - goos: windows
         format: zip
@@ -9191,6 +9191,56 @@ packages:
       pattern:
         checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 4.5.2")
+    version_overrides:
+      - version_constraint: semver(">= 4.3.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.5.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.4.0")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.xz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.1.1")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.xz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.1.1")
+        asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
   - type: github_release
     repo_owner: go-jira
     repo_name: jira

--- a/registry.yaml
+++ b/registry.yaml
@@ -9207,6 +9207,9 @@ packages:
       - version_constraint: semver(">= 0.4.0")
         asset: lego_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: lego
+            src: lego_{{.OS}}_{{.Arch}}
         overrides:
           - goos: linux
             format: tar.xz


### PR DESCRIPTION
[go-acme/lego](https://github.com/go-acme/lego): Let's Encrypt/ACME client and library written in Go

```console
$ aqua g -i go-acme/lego
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
# lego
NAME:
   lego - Let's Encrypt client written in Go

USAGE:
   lego [global options] command [command options] [arguments...]

VERSION:
   4.10.2

COMMANDS:
   run      Register an account, then create and install a certificate
   revoke   Revoke a certificate
   renew    Renew a certificate
   dnshelp  Shows additional help for the '--dns' global option
   list     Display certificates and accounts information.
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --accept-tos, -a                                             By setting this flag to true you indicate that you accept the current Let's Encrypt terms of service. (default: false)
   --cert.timeout value                                         Set the certificate timeout value to a specific value in seconds. Only used when obtaining certificates. (default: 30)
   --csr value, -c value                                        Certificate signing request filename, if an external CSR is to be used.
   --dns value                                                  Solve a DNS challenge using the specified provider. Can be mixed with other types of challenges. Run 'lego dnshelp' for help on usage.
   --dns-timeout value                                          Set the DNS timeout value to a specific value in seconds. Used only when performing authoritative name servers queries. (default: 10)
   --dns.disable-cp                                             By setting this flag to true, disables the need to wait the propagation of the TXT record to all authoritative name servers. (default: false)
   --dns.resolvers value [ --dns.resolvers value ]              Set the resolvers to use for performing (recursive) CNAME resolving and apex domain determination. For DNS challenge verification, the authoritative DNS server is queried directly. Supported: host:port. The default is to use the system resolvers, or Google's DNS resolvers if the system's cannot be determined.
   --domains value, -d value [ --domains value, -d value ]      Add a domain to the process. Can be specified multiple times.
   --eab                                                        Use External Account Binding for account registration. Requires --kid and --hmac. (default: false)
   --email value, -m value                                      Email used for registration and recovery contact.
   --filename value                                             (deprecated) Filename of the generated certificate.
   --help, -h                                                   show help (default: false)
   --hmac value                                                 MAC key from External CA. Should be in Base64 URL Encoding without padding format. Used for External Account Binding.
   --http                                                       Use the HTTP challenge to solve challenges. Can be mixed with other types of challenges. (default: false)
   --http-timeout value                                         Set the HTTP timeout value to a specific value in seconds. (default: 0)
   --http.memcached-host value [ --http.memcached-host value ]  Set the memcached host(s) to use for HTTP based challenges. Challenges will be written to all specified hosts.
   --http.port value                                            Set the port and interface to use for HTTP based challenges to listen on.Supported: interface:port or :port. (default: ":80")
   --http.proxy-header value                                    Validate against this HTTP header when solving HTTP based challenges behind a reverse proxy. (default: "Host")
   --http.webroot value                                         Set the webroot folder to use for HTTP based challenges to write directly in a file in .well-known/acme-challenge. This disables the built-in server and expects the given directory to be publicly served with access to .well-known/acme-challenge
   --key-type value, -k value                                   Key type to use for private keys. Supported: rsa2048, rsa4096, rsa8192, ec256, ec384. (default: "ec256")
   --kid value                                                  Key identifier from External CA. Used for External Account Binding.
   --path value                                                 Directory to use for storing the data. (default: "/Users/01041923/src/quipper/aqua-registry/.lego") [$LEGO_PATH]
   --pem                                                        Generate a .pem file by concatenating the .key and .crt files together. (default: false)
   --pfx                                                        Generate a .pfx (PKCS#12) file by with the .key and .crt and issuer .crt files together. (default: false)
   --pfx.pass value                                             The password used to encrypt the .pfx (PCKS#12) file. (default: "changeit")
   --server value, -s value                                     CA hostname (and optionally :port). The server certificate must be trusted in order to avoid further modifications to the client. (default: "https://acme-v02.api.letsencrypt.org/directory")
   --tls                                                        Use the TLS challenge to solve challenges. Can be mixed with other types of challenges. (default: false)
   --tls.port value                                             Set the port and interface to use for TLS based challenges to listen on. Supported: interface:port or :port. (default: ":443")
   --user-agent value                                           Add to the user-agent sent to the CA to identify an application embedding lego-cli
   --version, -v                                                print the version (default: false)
```

Reference

- https://go-acme.github.io/lego/