### PR TITLE
feat: add mvisonneau/vac

### DIFF
--- a/pkgs/mvisonneau/vac/pkg.yaml
+++ b/pkgs/mvisonneau/vac/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: mvisonneau/vac@v0.0.8
+  - name: mvisonneau/vac
+    version: v0.0.6
+  - name: mvisonneau/vac
+    version: v0.0.5
+  - name: mvisonneau/vac
+    version: edge
+  - name: mvisonneau/vac
+    version: 0.0.4
+  - name: mvisonneau/vac
+    version: 0.0.1

--- a/pkgs/mvisonneau/vac/pkg.yaml
+++ b/pkgs/mvisonneau/vac/pkg.yaml
@@ -5,8 +5,6 @@ packages:
   - name: mvisonneau/vac
     version: v0.0.5
   - name: mvisonneau/vac
-    version: edge
-  - name: mvisonneau/vac
     version: 0.0.4
   - name: mvisonneau/vac
     version: 0.0.1

--- a/pkgs/mvisonneau/vac/registry.yaml
+++ b/pkgs/mvisonneau/vac/registry.yaml
@@ -1,0 +1,47 @@
+packages:
+  - type: github_release
+    repo_owner: mvisonneau
+    repo_name: vac
+    description: AWS credentials management leveraging Vault
+    asset: vac_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: vac_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.6")
+    version_overrides:
+      - version_constraint: semver(">= 0.0.5")
+        rosetta2: true
+      - version_constraint: Version >= "edge"
+      - version_constraint: semver(">= 0.0.4")
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: vac_{{.Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      - version_constraint: semver("< 0.0.4")
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/mvisonneau/vac/registry.yaml
+++ b/pkgs/mvisonneau/vac/registry.yaml
@@ -24,7 +24,6 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 0.0.5")
         rosetta2: true
-      - version_constraint: Version >= "edge"
       - version_constraint: semver(">= 0.0.4")
         rosetta2: true
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16719,7 +16719,6 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 0.0.5")
         rosetta2: true
-      - version_constraint: Version >= "edge"
       - version_constraint: semver(">= 0.0.4")
         rosetta2: true
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16695,6 +16695,52 @@ packages:
             checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
             file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: mvisonneau
+    repo_name: vac
+    description: AWS credentials management leveraging Vault
+    asset: vac_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: vac_{{.Version}}_sha512sums.txt
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{128}\\b)"
+        file: "^\\b[A-Fa-f0-9]{128}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 0.0.6")
+    version_overrides:
+      - version_constraint: semver(">= 0.0.5")
+        rosetta2: true
+      - version_constraint: Version >= "edge"
+      - version_constraint: semver(">= 0.0.4")
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: vac_{{.Version}}_SHA256SUMS
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+      - version_constraint: semver("< 0.0.4")
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          file_format: regexp
+          algorithm: sha256
+          pattern:
+            checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+            file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: naggie
     repo_name: dstask
     description: Git powered terminal-based todo manager -- markdown note page per task. Single binary


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/11364 [mvisonneau/vac](https://github.com/mvisonneau/vac): AWS credentials management leveraging Vault

```console
$ aqua g -i mvisonneau/vac
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ vac --help
NAME:
   vac - Manage AWS credentials dynamically using Vault

USAGE:
   vac [global options] command [command options] [arguments...]

VERSION:
   0.0.8

COMMANDS:
   get      get the creds in credential_process format (json)
   status   returns some info about the current context, cached credentials and Vault server connectivity
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --engine path, -e path  engine path [$VAC_ENGINE]
   --role name, -r name    role name [$VAC_ROLE]
   --state path, -s path   state path (default: "~/.vac_state") [$VAC_STATE_PATH]
   --log-level level       log level (debug,info,warn,fatal,panic) (default: "info") [$VAC_LOG_LEVEL]
   --log-format format     log format (json,text) (default: "text") [$VAC_LOG_FORMAT]
   --help, -h              show help (default: false)
   --version, -v           print the version (default: false)
```

Reference

- README.md
	- https://github.com/mvisonneau/vac#quickstart
