### PR TITLE
feat: add golang/tools/goyacc

### DIFF
--- a/pkgs/golang/tools/goyacc/pkg.yaml
+++ b/pkgs/golang/tools/goyacc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golang/tools/goyacc@v0.8.0

--- a/pkgs/golang/tools/goyacc/registry.yaml
+++ b/pkgs/golang/tools/goyacc/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - name: golang/tools/goyacc
+    repo_owner: golang
+    repo_name: tools
+    type: go_install
+    path: golang.org/x/tools/cmd/goyacc
+    description: Goyacc is a version of yacc for Go. It is written in Go and generates parsers written in Go
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: goyacc

--- a/registry.yaml
+++ b/registry.yaml
@@ -9718,6 +9718,16 @@ packages:
     version_filter: not (Version startsWith "gopls/")
     files:
       - name: gorename
+  - name: golang/tools/goyacc
+    repo_owner: golang
+    repo_name: tools
+    type: go_install
+    path: golang.org/x/tools/cmd/goyacc
+    description: Goyacc is a version of yacc for Go. It is written in Go and generates parsers written in Go
+    version_source: github_tag
+    version_filter: not (Version startsWith "gopls/")
+    files:
+      - name: goyacc
   - type: go_install
     name: golang/tools/guru
     path: golang.org/x/tools/cmd/guru


### PR DESCRIPTION
#11531 `golang/tools/goyacc`: Goyacc is a version of yacc for Go. It is written in Go and generates parsers written in Go