### PR TITLE
feat: add WebAssembly/binaryen

### DIFF
--- a/pkgs/WebAssembly/binaryen/pkg.yaml
+++ b/pkgs/WebAssembly/binaryen/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: WebAssembly/binaryen@version_112

--- a/pkgs/WebAssembly/binaryen/registry.yaml
+++ b/pkgs/WebAssembly/binaryen/registry.yaml
@@ -13,5 +13,27 @@ packages:
       darwin: macos
       amd64: x86_64
     files:
+      - name: binaryen-unittests
+        src: binaryen-{{.Version}}/bin/binaryen-unittests
+      - name: wasm-as
+        src: binaryen-{{.Version}}/bin/wasm-as
+      - name: wasm-ctor-eval
+        src: binaryen-{{.Version}}/bin/wasm-ctor-eval
+      - name: wasm-dis
+        src: binaryen-{{.Version}}/bin/wasm-dis
+      - name: wasm-emscripten-finalize
+        src: binaryen-{{.Version}}/bin/wasm-emscripten-finalize
+      - name: wasm-fuzz-types
+        src: binaryen-{{.Version}}/bin/wasm-fuzz-types
+      - name: wasm-metadce
+        src: binaryen-{{.Version}}/bin/wasm-metadce
       - name: wasm-opt
         src: binaryen-{{.Version}}/bin/wasm-opt
+      - name: wasm-reduce
+        src: binaryen-{{.Version}}/bin/wasm-reduce
+      - name: wasm-shell
+        src: binaryen-{{.Version}}/bin/wasm-shell
+      - name: wasm-split
+        src: binaryen-{{.Version}}/bin/wasm-split
+      - name: wasm2js
+        src: binaryen-{{.Version}}/bin/wasm2js

--- a/pkgs/WebAssembly/binaryen/registry.yaml
+++ b/pkgs/WebAssembly/binaryen/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: WebAssembly
+    repo_name: binaryen
+    rosetta2: true
+    supported_envs:
+      - darwin/arm64
+      - amd64
+    asset: binaryen-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    description: Optimizer and compiler/toolchain library for WebAssembly
+    format: tar.gz
+    replacements:
+      darwin: macos
+      amd64: x86_64
+    files:
+      - name: wasm-opt
+        src: binaryen-{{.Version}}/bin/wasm-opt

--- a/registry.yaml
+++ b/registry.yaml
@@ -2064,8 +2064,30 @@ packages:
       darwin: macos
       amd64: x86_64
     files:
+      - name: binaryen-unittests
+        src: binaryen-{{.Version}}/bin/binaryen-unittests
+      - name: wasm-as
+        src: binaryen-{{.Version}}/bin/wasm-as
+      - name: wasm-ctor-eval
+        src: binaryen-{{.Version}}/bin/wasm-ctor-eval
+      - name: wasm-dis
+        src: binaryen-{{.Version}}/bin/wasm-dis
+      - name: wasm-emscripten-finalize
+        src: binaryen-{{.Version}}/bin/wasm-emscripten-finalize
+      - name: wasm-fuzz-types
+        src: binaryen-{{.Version}}/bin/wasm-fuzz-types
+      - name: wasm-metadce
+        src: binaryen-{{.Version}}/bin/wasm-metadce
       - name: wasm-opt
         src: binaryen-{{.Version}}/bin/wasm-opt
+      - name: wasm-reduce
+        src: binaryen-{{.Version}}/bin/wasm-reduce
+      - name: wasm-shell
+        src: binaryen-{{.Version}}/bin/wasm-shell
+      - name: wasm-split
+        src: binaryen-{{.Version}}/bin/wasm-split
+      - name: wasm2js
+        src: binaryen-{{.Version}}/bin/wasm2js
   - type: github_release
     repo_owner: Wilfred
     repo_name: difftastic

--- a/registry.yaml
+++ b/registry.yaml
@@ -2051,6 +2051,22 @@ packages:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
+    repo_owner: WebAssembly
+    repo_name: binaryen
+    rosetta2: true
+    supported_envs:
+      - darwin/arm64
+      - amd64
+    asset: binaryen-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    description: Optimizer and compiler/toolchain library for WebAssembly
+    format: tar.gz
+    replacements:
+      darwin: macos
+      amd64: x86_64
+    files:
+      - name: wasm-opt
+        src: binaryen-{{.Version}}/bin/wasm-opt
+  - type: github_release
     repo_owner: Wilfred
     repo_name: difftastic
     asset: difft-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
If I understand correctly, TinyGo requires wasm-opt on macOS from v0.27.0.
https://github.com/tinygo-org/tinygo/releases/tag/v0.27.0

The Homebrew formula actually depends on binaryen.
https://github.com/tinygo-org/homebrew-tools/blob/a58834aadc48fbcd0ea4a8c3dab4c77bed4ee240/tinygo.rb#L6

[WebAssembly/binaryen](https://github.com/WebAssembly/binaryen): Optimizer and compiler/toolchain library for WebAssembly