### PR TITLE
fix(liweiyi88/gosnakego): follow up changes of gosnakego v0.3.0

### DIFF
--- a/pkgs/liweiyi88/gosnakego/pkg.yaml
+++ b/pkgs/liweiyi88/gosnakego/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
-  - name: liweiyi88/gosnakego@v0.2.0
+  - name: liweiyi88/gosnakego@v0.3.1
+  - name: liweiyi88/gosnakego
+    version: v0.3.0
+  - name: liweiyi88/gosnakego
+    version: v0.1.1
+  - name: liweiyi88/gosnakego
+    version: v0.1

--- a/pkgs/liweiyi88/gosnakego/registry.yaml
+++ b/pkgs/liweiyi88/gosnakego/registry.yaml
@@ -7,15 +7,16 @@ packages:
     format: raw
     supported_envs:
       - darwin
+      - linux
       - windows/amd64
     rosetta2: true
+    overrides:
+      - goos: linux
+        type: go_install
     version_constraint: semver(">= 0.3.0")
     version_overrides:
-      - version_constraint: semver(">= 0.1.1")
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver("< 0.1.1")
-        supported_envs:
-          - darwin
-          - amd64
+      - version_constraint: semver("< 0.3.0")
+        overrides:
+          - goos: linux
+            goarch: arm64
+            type: go_install

--- a/pkgs/liweiyi88/gosnakego/registry.yaml
+++ b/pkgs/liweiyi88/gosnakego/registry.yaml
@@ -2,10 +2,20 @@ packages:
   - type: github_release
     repo_owner: liweiyi88
     repo_name: gosnakego
+    description: A snake game written in Go
     asset: gosnakego_{{.OS}}_{{.Arch}}
     format: raw
-    description: A snake game written in Go
     supported_envs:
       - darwin
-      - amd64
+      - windows/amd64
     rosetta2: true
+    version_constraint: semver(">= 0.3.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver("< 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/liweiyi88/gosnakego/registry.yaml
+++ b/pkgs/liweiyi88/gosnakego/registry.yaml
@@ -7,16 +7,11 @@ packages:
     format: raw
     supported_envs:
       - darwin
-      - linux
       - windows/amd64
     rosetta2: true
-    overrides:
-      - goos: linux
-        type: go_install
     version_constraint: semver(">= 0.3.0")
     version_overrides:
       - version_constraint: semver("< 0.3.0")
-        overrides:
-          - goos: linux
-            goarch: arm64
-            type: go_install
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/liweiyi88/gosnakego/registry.yaml
+++ b/pkgs/liweiyi88/gosnakego/registry.yaml
@@ -11,7 +11,12 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 0.3.0")
     version_overrides:
-      - version_constraint: semver("< 0.3.0")
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver("< 0.1.1")
+        complete_windows_ext: false
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15348,19 +15348,14 @@ packages:
     format: raw
     supported_envs:
       - darwin
-      - linux
       - windows/amd64
     rosetta2: true
-    overrides:
-      - goos: linux
-        type: go_install
     version_constraint: semver(">= 0.3.0")
     version_overrides:
       - version_constraint: semver("< 0.3.0")
-        overrides:
-          - goos: linux
-            goarch: arm64
-            type: go_install
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: loft-sh
     repo_name: vcluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -15348,18 +15348,19 @@ packages:
     format: raw
     supported_envs:
       - darwin
+      - linux
       - windows/amd64
     rosetta2: true
+    overrides:
+      - goos: linux
+        type: go_install
     version_constraint: semver(">= 0.3.0")
     version_overrides:
-      - version_constraint: semver(">= 0.1.1")
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver("< 0.1.1")
-        supported_envs:
-          - darwin
-          - amd64
+      - version_constraint: semver("< 0.3.0")
+        overrides:
+          - goos: linux
+            goarch: arm64
+            type: go_install
   - type: github_release
     repo_owner: loft-sh
     repo_name: vcluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -15352,7 +15352,12 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 0.3.0")
     version_overrides:
-      - version_constraint: semver("< 0.3.0")
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver("< 0.1.1")
+        complete_windows_ext: false
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15343,13 +15343,23 @@ packages:
   - type: github_release
     repo_owner: liweiyi88
     repo_name: gosnakego
+    description: A snake game written in Go
     asset: gosnakego_{{.OS}}_{{.Arch}}
     format: raw
-    description: A snake game written in Go
     supported_envs:
       - darwin
-      - amd64
+      - windows/amd64
     rosetta2: true
+    version_constraint: semver(">= 0.3.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver("< 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: loft-sh
     repo_name: vcluster


### PR DESCRIPTION
The pre built binary for linux isn't provided anymore.

https://github.com/liweiyi88/gosnakego/commit/c32acb679b475c5265e8b434f6193ce3def9b9bb