### PR TITLE
feat(cli/cli) Support cli/cli 2.28.0 and newer in darwin

### DIFF
--- a/pkgs/cli/cli/pkg.yaml
+++ b/pkgs/cli/cli/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
   - name: cli/cli@v2.28.0
+  - name: cli/cli
+    version: v2.24.0
+  - name: cli/cli
+    version: v2.20.1
+  - name: cli/cli
+    version: v0.8.0

--- a/pkgs/cli/cli/pkg.yaml
+++ b/pkgs/cli/cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: cli/cli@v2.27.0
+  - name: cli/cli@v2.28.0

--- a/pkgs/cli/cli/registry.yaml
+++ b/pkgs/cli/cli/registry.yaml
@@ -5,6 +5,9 @@ packages:
     description: GitHub’s official command line tool
     asset: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
+    files:
+      - name: gh
+        src: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}/bin/gh
     overrides:
       - goos: linux
         format: tar.gz

--- a/pkgs/cli/cli/registry.yaml
+++ b/pkgs/cli/cli/registry.yaml
@@ -3,37 +3,41 @@ packages:
     repo_owner: cli
     repo_name: cli
     description: GitHub’s official command line tool
-    search_words:
-      - github
-    supported_envs:
-      - linux
-      - darwin
-      - amd64
-    rosetta2: true
     asset: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    files:
-      - name: gh
-        src: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}/bin/gh
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
     replacements:
       darwin: macOS
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-        files:
-          - name: gh
-            src: bin/gh.exe
     checksum:
       type: github_release
       asset: gh_{{trimV .Version}}_checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 2.28.0")
     version_overrides:
-      # https://github.com/cli/cli/releases/tag/v2.28.0
-      - version_constraint: semver(">= 2.28.0")
+      - version_constraint: semver(">= 2.24.0")
+        format: tar.gz
         overrides:
-          - goos: darwin
+          - goos: windows
             format: zip
+      - version_constraint: semver(">= 2.20.1")
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver("< 2.20.1")
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true

--- a/pkgs/cli/cli/registry.yaml
+++ b/pkgs/cli/cli/registry.yaml
@@ -11,6 +11,12 @@ packages:
     overrides:
       - goos: linux
         format: tar.gz
+      - &cli_cli_windows_override
+        goos: windows
+        format: zip
+        files:
+          - name: gh
+            src: bin/gh.exe
     replacements:
       darwin: macOS
     checksum:
@@ -26,19 +32,16 @@ packages:
       - version_constraint: semver(">= 2.24.0")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
       - version_constraint: semver(">= 2.20.1")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
         rosetta2: true
       - version_constraint: semver("< 2.20.1")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
         supported_envs:
           - darwin
           - linux

--- a/pkgs/cli/cli/registry.yaml
+++ b/pkgs/cli/cli/registry.yaml
@@ -31,3 +31,9 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      # https://github.com/cli/cli/releases/tag/v2.28.0
+      - version_constraint: semver(">= 2.28.0")
+        overrides:
+          - goos: darwin
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -5116,40 +5116,44 @@ packages:
     repo_owner: cli
     repo_name: cli
     description: GitHub’s official command line tool
-    search_words:
-      - github
-    supported_envs:
-      - linux
-      - darwin
-      - amd64
-    rosetta2: true
     asset: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    files:
-      - name: gh
-        src: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}/bin/gh
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
     replacements:
       darwin: macOS
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-        files:
-          - name: gh
-            src: bin/gh.exe
     checksum:
       type: github_release
       asset: gh_{{trimV .Version}}_checksums.txt
       file_format: regexp
       algorithm: sha256
       pattern:
-        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_constraint: semver(">= 2.28.0")
     version_overrides:
-      # https://github.com/cli/cli/releases/tag/v2.28.0
-      - version_constraint: semver(">= 2.28.0")
+      - version_constraint: semver(">= 2.24.0")
+        format: tar.gz
         overrides:
-          - goos: darwin
+          - goos: windows
             format: zip
+      - version_constraint: semver(">= 2.20.1")
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver("< 2.20.1")
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: climech
     repo_name: grit

--- a/registry.yaml
+++ b/registry.yaml
@@ -5118,6 +5118,9 @@ packages:
     description: GitHub’s official command line tool
     asset: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip
+    files:
+      - name: gh
+        src: gh_{{trimV .Version}}_{{.OS}}_{{.Arch}}/bin/gh
     overrides:
       - goos: linux
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -5144,6 +5144,12 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+    version_overrides:
+      # https://github.com/cli/cli/releases/tag/v2.28.0
+      - version_constraint: semver(">= 2.28.0")
+        overrides:
+          - goos: darwin
+            format: zip
   - type: github_release
     repo_owner: climech
     repo_name: grit

--- a/registry.yaml
+++ b/registry.yaml
@@ -5124,6 +5124,12 @@ packages:
     overrides:
       - goos: linux
         format: tar.gz
+      - &cli_cli_windows_override
+        goos: windows
+        format: zip
+        files:
+          - name: gh
+            src: bin/gh.exe
     replacements:
       darwin: macOS
     checksum:
@@ -5139,19 +5145,16 @@ packages:
       - version_constraint: semver(">= 2.24.0")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
       - version_constraint: semver(">= 2.20.1")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
         rosetta2: true
       - version_constraint: semver("< 2.20.1")
         format: tar.gz
         overrides:
-          - goos: windows
-            format: zip
+          - *cli_cli_windows_override
         supported_envs:
           - darwin
           - linux


### PR DESCRIPTION
GitHub's CLI (cli/cli) changed format for macOS to zip (from tar.gz) since v2.28.0

See https://github.com/cli/cli/releases/tag/v2.28.0 for details.

I tried to fix the registry, but it seems not working well...

```console
# cat aqua.yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
checksum:
  enabled: true
registries:
  - name: standard
    type: local
    path: registry.yaml
packages:
  - import: aqua-local.yaml
  - name: aquaproj/registry-tool@v0.1.10
  - name: rhysd/actionlint@v1.6.24

# cat aqua-local.yaml
---
# aqua - Declarative CLI Version Manager
# https://aquaproj.github.io/
packages:
- import: pkgs/cli/cli/pkg.yaml

# cat pkgs/cli/cli/pkg.yaml
packages:
  - name: cli/cli@v2.28.0

# gh
INFO[0000] download and unarchive the package            aqua_version=2.3.4 env=darwin/arm64 exe_name=gh package=cli/cli package_name=cli/cli package_version=v2.28.0 program=aqua registry=standard
FATA[0000] aqua failed                                   aqua_version=2.3.4 env=darwin/arm64 error="the asset isn't found: gh_2.28.0_macOS_amd64.tar.gz" exe_name=gh package=cli/cli package_version=v2.28.0 program=aqua
```

@suzuki-shunsuke Could you help fixing this? Thanks.