### PR TITLE
fix(solidiquis/erdtree): follow up changes of erdtree v2.0.0

### DIFF
--- a/pkgs/solidiquis/erdtree/pkg.yaml
+++ b/pkgs/solidiquis/erdtree/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: solidiquis/erdtree@v1.7.1
+  - name: solidiquis/erdtree@v2.0.0
   - name: solidiquis/erdtree
     version: v1.1.0
   - name: solidiquis/erdtree

--- a/pkgs/solidiquis/erdtree/registry.yaml
+++ b/pkgs/solidiquis/erdtree/registry.yaml
@@ -3,12 +3,14 @@ packages:
     repo_owner: solidiquis
     repo_name: erdtree
     description: A multi-threaded file-tree visualizer and disk usage analyzer
-    asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    asset: erd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    files:
+      - name: erd
     format: tar.gz
     overrides:
       - goos: windows
         format: raw
-        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        asset: erd-{{.Version}}-{{.Arch}}-{{.OS}}
         replacements:
           arm64: arm64
     replacements:
@@ -21,12 +23,22 @@ packages:
       - darwin
       - linux
       - amd64
-    files:
-      - name: et
-    version_constraint: semver(">= 1.1.0")
+    version_constraint: semver(">= 2.0.0")
     version_overrides:
+      - version_constraint: semver(">= 1.1.0")
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: et
+        overrides:
+          - goos: windows
+            format: raw
+            asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+            replacements:
+              arm64: arm64
       - version_constraint: semver("< 1.1.0")
         asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        files:
+          - name: et
         format: raw
         overrides:
           - goos: linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -20885,12 +20885,14 @@ packages:
     repo_owner: solidiquis
     repo_name: erdtree
     description: A multi-threaded file-tree visualizer and disk usage analyzer
-    asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    asset: erd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    files:
+      - name: erd
     format: tar.gz
     overrides:
       - goos: windows
         format: raw
-        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        asset: erd-{{.Version}}-{{.Arch}}-{{.OS}}
         replacements:
           arm64: arm64
     replacements:
@@ -20903,12 +20905,22 @@ packages:
       - darwin
       - linux
       - amd64
-    files:
-      - name: et
-    version_constraint: semver(">= 1.1.0")
+    version_constraint: semver(">= 2.0.0")
     version_overrides:
+      - version_constraint: semver(">= 1.1.0")
+        asset: et-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: et
+        overrides:
+          - goos: windows
+            format: raw
+            asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+            replacements:
+              arm64: arm64
       - version_constraint: semver("< 1.1.0")
         asset: et-{{.Version}}-{{.Arch}}-{{.OS}}
+        files:
+          - name: et
         format: raw
         overrides:
           - goos: linux


### PR DESCRIPTION
https://github.com/solidiquis/erdtree/releases/tag/v2.0.0

> Perhaps the most important change to note is that the compiled binary has been renamed from et to erd in order to address the following issue
> regarding name collisions with other programs
>
> - https://github.com/solidiquis/erdtree/issues/23