### PR TITLE
chore(ysugimoto/falco): use tar.gz

### DIFF
--- a/pkgs/ysugimoto/falco/pkg.yaml
+++ b/pkgs/ysugimoto/falco/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: ysugimoto/falco@v0.20.0
+  - name: ysugimoto/falco@v0.20.2
   - name: ysugimoto/falco
-    version: v0.9.1
+    version: v0.9.2
+  - name: ysugimoto/falco
+    version: v0.1.0

--- a/pkgs/ysugimoto/falco/registry.yaml
+++ b/pkgs/ysugimoto/falco/registry.yaml
@@ -2,13 +2,18 @@ packages:
   - type: github_release
     repo_owner: ysugimoto
     repo_name: falco
-    asset: falco-{{.OS}}-{{.Arch}}
-    format: raw
     description: falco is a VCL parser and linter optimized for Fastly
+    asset: falco-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
     supported_envs:
       - linux/amd64
       - darwin
-    version_constraint: semver(">= 0.9.2")
+    version_constraint: semver(">= 0.20.2")
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.9.2")
+        asset: falco-{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: semver("< 0.9.2")
+        asset: falco-{{.OS}}-{{.Arch}}
+        format: raw
         rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -24164,15 +24164,20 @@ packages:
   - type: github_release
     repo_owner: ysugimoto
     repo_name: falco
-    asset: falco-{{.OS}}-{{.Arch}}
-    format: raw
     description: falco is a VCL parser and linter optimized for Fastly
+    asset: falco-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
     supported_envs:
       - linux/amd64
       - darwin
-    version_constraint: semver(">= 0.9.2")
+    version_constraint: semver(">= 0.20.2")
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.9.2")
+        asset: falco-{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: semver("< 0.9.2")
+        asset: falco-{{.OS}}-{{.Arch}}
+        format: raw
         rosetta2: true
   - type: github_release
     repo_owner: yudai


### PR DESCRIPTION
I fixed to use compressed files.
[ysugimoto/falco](https://github.com/ysugimoto/falco) has been added `tar.gz` files since [v0.20.2](https://github.com/ysugimoto/falco/releases/tag/v0.20.2)