### PR TITLE
feat: add Madh93/tpm

### DIFF
--- a/pkgs/Madh93/tpm/pkg.yaml
+++ b/pkgs/Madh93/tpm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Madh93/tpm@v0.3.0

--- a/pkgs/Madh93/tpm/registry.yaml
+++ b/pkgs/Madh93/tpm/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: Madh93
+    repo_name: tpm
+    description: A package manager for Terraform providers
+    asset: tpm_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1082,6 +1082,28 @@ packages:
     files:
       - name: deno
   - type: github_release
+    repo_owner: Madh93
+    repo_name: tpm
+    description: 🛠️ A package manager for Terraform providers
+    asset: tpm_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
     repo_owner: MiSawa
     repo_name: xq
     asset: xq-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -1084,7 +1084,7 @@ packages:
   - type: github_release
     repo_owner: Madh93
     repo_name: tpm
-    description: 🛠️ A package manager for Terraform providers
+    description: A package manager for Terraform providers
     asset: tpm_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/11839 [Madh93/tpm](https://github.com/Madh93/tpm): A package manager for Terraform providers

```console
$ aqua g -i Madh93/tpm
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ tpm --help
Terraform Provider Manager is a simple CLI to manage Terraform providers in the Terraform plugin cache directory

Usage:
  tpm [flags]
  tpm [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  install     Install a provider
  list        List all installed providers
  purge       Purge all installed providers
  uninstall   Uninstall a provider

Flags:
  -c, --config string                       config file for tpm
  -d, --debug                               enable debug mode
  -h, --help                                help for tpm
  -p, --terraform-plugin-cache-dir string   the location of the Terraform plugin cache directory (default "/Users/yuya-koda/.terraform.d/plugin-cache")
  -r, --terraform-registry string           the Terraform registry provider hostname (default "registry.terraform.io")
  -v, --version                             version for tpm

Use "tpm [command] --help" for more information about a command.
```

Reference

- README
	- https://github.com/Madh93/tpm#install-a-provider
