### PR TITLE
fix(hatoo/oha): enable rosetta2

### DIFF
--- a/pkgs/hatoo/oha/registry.yaml
+++ b/pkgs/hatoo/oha/registry.yaml
@@ -4,6 +4,11 @@ packages:
     repo_name: oha
     description: Ohayou(おはよう), HTTP load generator, inspired by rakyll/hey with tui animation
     asset: oha-{{.OS}}-{{.Arch}}
+
+    # https://github.com/aquaproj/aqua-registry/pull/11995#issuecomment-1537367448
+    # Unfortunately, the prebuilt binary for darwin/arm64 doesn't work, so we enable rosetta2
+    rosetta2: true
+
     format: raw
     replacements:
       darwin: macos
@@ -17,10 +22,8 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
       - version_constraint: semver(">= 0.5.3-test")
       - version_constraint: semver("< 0.5.3-test")
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -9809,6 +9809,11 @@ packages:
     repo_name: oha
     description: Ohayou(おはよう), HTTP load generator, inspired by rakyll/hey with tui animation
     asset: oha-{{.OS}}-{{.Arch}}
+
+    # https://github.com/aquaproj/aqua-registry/pull/11995#issuecomment-1537367448
+    # Unfortunately, the prebuilt binary for darwin/arm64 doesn't work, so we enable rosetta2
+    rosetta2: true
+
     format: raw
     replacements:
       darwin: macos
@@ -9822,13 +9827,11 @@ packages:
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
       - version_constraint: semver(">= 0.5.3-test")
       - version_constraint: semver("< 0.5.3-test")
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
   - type: github_release
     repo_owner: heartbeatsjp
     repo_name: check-tls-cert


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/11995#issuecomment-1537367448

Unfortunately, the prebuilt binary for darwin/arm64 doesn't work, so we enable rosetta2.