### PR TITLE
feat: add oligot/go-mod-upgrade

### DIFF
--- a/pkgs/oligot/go-mod-upgrade/pkg.yaml
+++ b/pkgs/oligot/go-mod-upgrade/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: oligot/go-mod-upgrade@v0.9.1
+  - name: oligot/go-mod-upgrade
+    version: v0.8.0
+  - name: oligot/go-mod-upgrade
+    version: v0.6.1
+  - name: oligot/go-mod-upgrade
+    version: v0.6.0
+  - name: oligot/go-mod-upgrade
+    version: v0.4.0
+  - name: oligot/go-mod-upgrade
+    version: v0.1.1
+  - name: oligot/go-mod-upgrade
+    version: v0.1.0

--- a/pkgs/oligot/go-mod-upgrade/registry.yaml
+++ b/pkgs/oligot/go-mod-upgrade/registry.yaml
@@ -1,0 +1,49 @@
+packages:
+  - type: github_release
+    repo_owner: oligot
+    repo_name: go-mod-upgrade
+    description: Update outdated Go dependencies interactively
+    asset: go-mod-upgrade_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.8.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.1")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.6.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.4.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.1.1")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -15669,6 +15669,54 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
   - type: github_release
+    repo_owner: oligot
+    repo_name: go-mod-upgrade
+    description: Update outdated Go dependencies interactively
+    asset: go-mod-upgrade_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.8.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.1")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.6.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.4.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.1.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.1.1")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+  - type: github_release
     repo_owner: omegion
     repo_name: ssh-manager
     description: SSH Key Manager for 1Password, Bitwarden and AWS S3


### PR DESCRIPTION
[oligot/go-mod-upgrade](https://github.com/oligot/go-mod-upgrade): Update outdated Go dependencies interactively

```console
$ aqua g -i oligot/go-mod-upgrade
```