### PR TITLE
feat: add ikanago/omekasy

### DIFF
--- a/pkgs/ikanago/omekasy/pkg.yaml
+++ b/pkgs/ikanago/omekasy/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: ikanago/omekasy@v1.1.1
+  - name: ikanago/omekasy
+    version: v0.2.0
+  - name: ikanago/omekasy
+    version: v0.1.0

--- a/pkgs/ikanago/omekasy/registry.yaml
+++ b/pkgs/ikanago/omekasy/registry.yaml
@@ -1,0 +1,30 @@
+packages:
+  - type: github_release
+    repo_owner: ikanago
+    repo_name: omekasy
+    description: 𝘾𝙤𝙢𝙢𝙖𝙣𝙙 𝙡𝙞𝙣𝙚 𝙖𝙥𝙥𝙡𝙞𝙘𝙖𝙩𝙞𝙤𝙣 𝕥𝕙𝕒𝕥 𝕔𝕠𝕟𝕧𝕖𝕣𝕥𝕤 𝕒𝕝𝕡𝕙𝕒𝕟𝕦𝕞𝕖𝕣𝕚𝕔 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝒕𝒐 𝒗𝒂𝒓𝒊𝒐𝒖𝒔 𝒔𝒕𝒚𝒍𝒆𝒔 𝚍𝚎𝚏𝚒𝚗𝚎𝚍 𝚒𝚗 𝚄𝚗𝚒𝚌𝚘𝚍𝚎
+    asset: omekasy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 0.2.0")
+    version_overrides:
+      - version_constraint: semver("< 0.2.0")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/pkgs/ikanago/omekasy/registry.yaml
+++ b/pkgs/ikanago/omekasy/registry.yaml
@@ -17,6 +17,9 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    files:
+      - name: omekasy
+        src: archive/omekasy
     version_constraint: semver(">= 0.2.0")
     version_overrides:
       - version_constraint: semver("< 0.2.0")

--- a/pkgs/ikanago/omekasy/registry.yaml
+++ b/pkgs/ikanago/omekasy/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: ikanago
     repo_name: omekasy
-    description: 𝘾𝙤𝙢𝙢𝙖𝙣𝙙 𝙡𝙞𝙣𝙚 𝙖𝙥𝙥𝙡𝙞𝙘𝙖𝙩𝙞𝙤𝙣 𝕥𝕙𝕒𝕥 𝕔𝕠𝕟𝕧𝕖𝕣𝕥𝕤 𝕒𝕝𝕡𝕙𝕒𝕟𝕦𝕞𝕖𝕣𝕚𝕔 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝒕𝒐 𝒗𝒂𝒓𝒊𝒐𝒖𝒔 𝒔𝒕𝒚𝒍𝒆𝒔 𝚍𝚎𝚏𝚒𝚗𝚎𝚍 𝚒𝚗 𝚄𝚗𝚒𝚌𝚘𝚍𝚎
+    description: Command line application that converts alphanumeric characters to various styles defined in Unicode
     asset: omekasy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
     overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -10367,6 +10367,9 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+    files:
+      - name: omekasy
+        src: archive/omekasy
     version_constraint: semver(">= 0.2.0")
     version_overrides:
       - version_constraint: semver("< 0.2.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -10352,7 +10352,7 @@ packages:
   - type: github_release
     repo_owner: ikanago
     repo_name: omekasy
-    description: 𝘾𝙤𝙢𝙢𝙖𝙣𝙙 𝙡𝙞𝙣𝙚 𝙖𝙥𝙥𝙡𝙞𝙘𝙖𝙩𝙞𝙤𝙣 𝕥𝕙𝕒𝕥 𝕔𝕠𝕟𝕧𝕖𝕣𝕥𝕤 𝕒𝕝𝕡𝕙𝕒𝕟𝕦𝕞𝕖𝕣𝕚𝕔 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝒕𝒐 𝒗𝒂𝒓𝒊𝒐𝒖𝒔 𝒔𝒕𝒚𝒍𝒆𝒔 𝚍𝚎𝚏𝚒𝚗𝚎𝚍 𝚒𝚗 𝚄𝚗𝚒𝚌𝚘𝚍𝚎
+    description: Command line application that converts alphanumeric characters to various styles defined in Unicode
     asset: omekasy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
     overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -10350,6 +10350,35 @@ packages:
       asset: sopstool_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: ikanago
+    repo_name: omekasy
+    description: 𝘾𝙤𝙢𝙢𝙖𝙣𝙙 𝙡𝙞𝙣𝙚 𝙖𝙥𝙥𝙡𝙞𝙘𝙖𝙩𝙞𝙤𝙣 𝕥𝕙𝕒𝕥 𝕔𝕠𝕟𝕧𝕖𝕣𝕥𝕤 𝕒𝕝𝕡𝕙𝕒𝕟𝕦𝕞𝕖𝕣𝕚𝕔 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝒕𝒐 𝒗𝒂𝒓𝒊𝒐𝒖𝒔 𝒔𝒕𝒚𝒍𝒆𝒔 𝚍𝚎𝚏𝚒𝚗𝚎𝚍 𝚒𝚗 𝚄𝚗𝚒𝚌𝚘𝚍𝚎
+    asset: omekasy-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 0.2.0")
+    version_overrides:
+      - version_constraint: semver("< 0.2.0")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: ilaif
     repo_name: goplicate
     asset: goplicate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[ikanago/omekasy](https://github.com/ikanago/omekasy): 𝘾𝙤𝙢𝙢𝙖𝙣𝙙 𝙡𝙞𝙣𝙚 𝙖𝙥𝙥𝙡𝙞𝙘𝙖𝙩𝙞𝙤𝙣 𝕥𝕙𝕒𝕥 𝕔𝕠𝕟𝕧𝕖𝕣𝕥𝕤 𝕒𝕝𝕡𝕙𝕒𝕟𝕦𝕞𝕖𝕣𝕚𝕔 𝕔𝕙𝕒𝕣𝕒𝕔𝕥𝕖𝕣𝕤 𝒕𝒐 𝒗𝒂𝒓𝒊𝒐𝒖𝒔 𝒔𝒕𝒚𝒍𝒆𝒔 𝚍𝚎𝚏𝚒𝚗𝚎𝚍 𝚒𝚗 𝚄𝚗𝚒𝚌𝚘𝚍𝚎

```console
$ aqua g -i ikanago/omekasy
```

**NOTE:** Should we change the style of description to default unicode charactors?

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ omekasy
```
