### PR TITLE
feat: add boyter/scc

### DIFF
--- a/pkgs/boyter/scc/pkg.yaml
+++ b/pkgs/boyter/scc/pkg.yaml
@@ -1,0 +1,30 @@
+packages:
+  - name: boyter/scc@v3.1.0
+  - name: boyter/scc
+    version: v3.0.0
+  - name: boyter/scc
+    version: v2.12.0
+  - name: boyter/scc
+    version: v2.11.0
+  - name: boyter/scc
+    version: v2.5.0
+  - name: boyter/scc
+    version: v2.4.0
+  - name: boyter/scc
+    version: v2.1.0
+  - name: boyter/scc
+    version: v2.0.0
+  - name: boyter/scc
+    version: v1.12.1
+  - name: boyter/scc
+    version: v1.12.0
+  - name: boyter/scc
+    version: v1.11.0
+  - name: boyter/scc
+    version: v1.10.0
+  - name: boyter/scc
+    version: v1.2.0
+  - name: boyter/scc
+    version: v1.1.0
+  - name: boyter/scc
+    version: v1.0.0

--- a/pkgs/boyter/scc/registry.yaml
+++ b/pkgs/boyter/scc/registry.yaml
@@ -1,0 +1,256 @@
+packages:
+  - type: github_release
+    repo_owner: boyter
+    repo_name: scc
+    description: "Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go"
+    asset: scc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 3.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 3.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.12.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.11.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.5.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.4.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.1.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.12.1")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.12.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-1.0.0-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.11.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.10.0")
+        asset: scc-1.0.0-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.2.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.1.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/pkgs/boyter/scc/registry.yaml
+++ b/pkgs/boyter/scc/registry.yaml
@@ -19,133 +19,25 @@ packages:
       - version_constraint: semver(">= 3.0.0")
         asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - linux
           - amd64
         checksum:
           enabled: false
-      - version_constraint: semver(">= 2.12.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.11.0")
+      - version_constraint: semver(">= 1.12.1")
         asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.5.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.4.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.1.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.0.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 1.12.1")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -153,16 +45,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.12.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
           - goos: windows
-            asset: scc-1.0.0-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -170,16 +62,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.11.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -187,16 +76,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.10.0")
-        asset: scc-1.0.0-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+          - goos: linux
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -204,16 +93,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.2.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -221,16 +107,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.1.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
           - goos: darwin
             asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -238,16 +124,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.0.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3835,133 +3835,25 @@ packages:
       - version_constraint: semver(">= 3.0.0")
         asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - linux
           - amd64
         checksum:
           enabled: false
-      - version_constraint: semver(">= 2.12.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.11.0")
+      - version_constraint: semver(">= 1.12.1")
         asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.5.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.4.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.1.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 2.0.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-        checksum:
-          enabled: false
-      - version_constraint: semver(">= 1.12.1")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -3969,16 +3861,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.12.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
           - goos: windows
-            asset: scc-1.0.0-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -3986,16 +3878,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.11.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: linux
-            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -4003,16 +3892,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.10.0")
-        asset: scc-1.0.0-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+          - goos: linux
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -4020,16 +3909,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.2.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -4037,16 +3923,16 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.1.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         overrides:
           - goos: darwin
             asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64
@@ -4054,16 +3940,13 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.0.0")
-        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        overrides:
-          - goos: darwin
-            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          windows: pc-windows
+          linux: unknown-linux
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3816,6 +3816,261 @@ packages:
       - name: dust
         src: dust-{{.Version}}-{{.Arch}}-{{.OS}}/dust
   - type: github_release
+    repo_owner: boyter
+    repo_name: scc
+    description: "Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go"
+    asset: scc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 3.1.0")
+    version_overrides:
+      - version_constraint: semver(">= 3.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.12.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.11.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.5.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.4.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.1.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 2.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.12.1")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.12.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-1.0.0-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.11.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.10.0")
+        asset: scc-1.0.0-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.2.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.1.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-1.0.0-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.0.0")
+        asset: scc-{{trimV .Version}}-{{.Arch}}-unknown-{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            asset: scc-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: scc-{{trimV .Version}}-{{.Arch}}-pc-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: boz
     repo_name: kail
     asset: kail_{{.Version}}_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/12034 [boyter/scc](https://github.com/boyter/scc): Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go

```console
$ aqua g -i boyter/scc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ scc --help
Sloc, Cloc and Code. Count lines of code in a directory with complexity estimation.
Version 3.1.0
Ben Boyter <ben@boyter.org> + Contributors

Usage:
  scc [flags] [files or directories]

Flags:
      --avg-wage int                 average wage value used for basic COCOMO calculation (default 56286)
      --binary                       disable binary file detection
      --by-file                      display output for every file
      --ci                           enable CI output settings where stdout is ASCII
      --cocomo-project-type string   change COCOMO model type [organic, semi-detached, embedded, "custom,1,1,1,1"] (default "organic")
      --count-as string              count extension as language [e.g. jsp:htm,chead:"C Header" maps extension jsp to html and chead to C Header]
      --currency-symbol string       set currency symbol (default "$")
      --debug                        enable debug output
      --eaf float                    the effort adjustment factor derived from the cost drivers (1.0 if rated nominal) (default 1)
      --exclude-dir strings          directories to exclude (default [.git,.hg,.svn])
  -x, --exclude-ext strings          ignore file extensions (overrides include-ext) [comma separated list: e.g. go,java,js]
      --file-gc-count int            number of files to parse before turning the GC on (default 10000)
  -f, --format string                set output format [tabular, wide, json, csv, csv-stream, cloc-yaml, html, html-table, sql, sql-insert, openmetrics] (default "tabular")
      --format-multi string          have multiple format output overriding --format [e.g. tabular:stdout,csv:file.csv,json:file.json]
      --gen                          identify generated files
      --generated-markers strings    string markers in head of generated files (default [do not edit,<auto-generated />])
  -h, --help                         help for scc
  -i, --include-ext strings          limit to file extensions [comma separated list: e.g. go,java,js]
      --include-symlinks             if set will count symlink files
  -l, --languages                    print supported languages and extensions
      --large-byte-count int         number of bytes a file can contain before being removed from output (default 1000000)
      --large-line-count int         number of lines a file can contain before being removed from output (default 40000)
      --min                          identify minified files
  -z, --min-gen                      identify minified or generated files
      --min-gen-line-length int      number of bytes per average line for file to be considered minified or generated (default 255)
      --no-cocomo                    remove COCOMO calculation output
  -c, --no-complexity                skip calculation of code complexity
  -d, --no-duplicates                remove duplicate files from stats and output
      --no-gen                       ignore generated files in output (implies --gen)
      --no-gitignore                 disables .gitignore file logic
      --no-ignore                    disables .ignore file logic
      --no-large                     ignore files over certain byte and line size set by max-line-count and max-byte-count
      --no-min                       ignore minified files in output (implies --min)
      --no-min-gen                   ignore minified or generated files in output (implies --min-gen)
      --no-size                      remove size calculation output
  -M, --not-match stringArray        ignore files and directories matching regular expression
  -o, --output string                output filename (default stdout)
      --overhead float               set the overhead multiplier for corporate overhead (facilities, equipment, accounting, etc.) (default 2.4)
      --remap-all string             inspect every file and remap by checking for a string and remapping the language [e.g. "-*- C++ -*-":"C Header"]
      --remap-unknown string         inspect files of unknown type and remap by checking for a string and remapping the language [e.g. "-*- C++ -*-":"C Header"]
      --size-unit string             set size unit [si, binary, mixed, xkcd-kb, xkcd-kelly, xkcd-imaginary, xkcd-intel, xkcd-drive, xkcd-bakers] (default "si")
      --sloccount-format             print a more SLOCCount like COCOMO calculation
  -s, --sort string                  column to sort by [files, name, lines, blanks, code, comments, complexity] (default "files")
      --sql-project string           use supplied name as the project identifier for the current run. Only valid with the --format sql or sql-insert option
  -t, --trace                        enable trace output (not recommended when processing multiple files)
  -v, --verbose                      verbose output
      --version                      version for scc
  -w, --wide                         wider output with additional statistics (implies --complexity)
```

```
$ cd aqua-registry
$ scc
───────────────────────────────────────────────────────────────────────────────
Language                 Files     Lines   Blanks  Comments     Code Complexity
───────────────────────────────────────────────────────────────────────────────
YAML                      2259     49405       21       294    49090          0
Markdown                     3        80       33         0       47          0
License                      1        21        4         0       17          0
gitignore                    1         4        0         0        4          0
───────────────────────────────────────────────────────────────────────────────
Total                     2264     49510       58       294    49158          0
───────────────────────────────────────────────────────────────────────────────
Estimated Cost to Develop (organic) $1,613,501
Estimated Schedule Effort (organic) 16.50 months
Estimated People Required (organic) 8.69
───────────────────────────────────────────────────────────────────────────────
Processed 1387027 bytes, 1.387 megabytes (SI)
───────────────────────────────────────────────────────────────────────────────
```

Reference

- README.md
	- https://github.com/boyter/scc/blob/master/README.md
