### PR TITLE
feat: add enokawa/taskdiff

### DIFF
--- a/pkgs/enokawa/taskdiff/pkg.yaml
+++ b/pkgs/enokawa/taskdiff/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: enokawa/taskdiff@v0.0.1

--- a/pkgs/enokawa/taskdiff/registry.yaml
+++ b/pkgs/enokawa/taskdiff/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: enokawa
+    repo_name: taskdiff
+    description: Diff tool for ECS Task Definition
+    asset: taskdiff_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: taskdiff
+        src: taskdiff_{{.Version}}_{{.OS}}_{{.Arch}}/taskdiff

--- a/registry.yaml
+++ b/registry.yaml
@@ -8121,6 +8121,22 @@ packages:
         rosetta2: true
         asset: kubectl-doctor_{{.OS}}_{{.Arch}}.zip
   - type: github_release
+    repo_owner: enokawa
+    repo_name: taskdiff
+    description: Diff tool for ECS Task Definition
+    asset: taskdiff_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    overrides:
+      - goos: linux
+        format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    files:
+      - name: taskdiff
+        src: taskdiff_{{.Version}}_{{.OS}}_{{.Arch}}/taskdiff
+  - type: github_release
     repo_owner: env0
     repo_name: terratag
     asset: terratag_{{trimV .Version}}_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
[enokawa/taskdiff](https://github.com/enokawa/taskdiff): Diff tool for ECS Task Definition

```console
$ aqua g -i enokawa/taskdiff
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ taskdiff --help
Two arguments must be specified
```

Reference

- Blog (Japanese)
	- https://enokawa.hatenablog.jp/entry/2020/10/21/183111