### PR TITLE
chore: decrease the capacity of Renovate to avoid API rate limiting

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,12 +2,14 @@
   extends: [
     "config:base",
     "helpers:pinGitHubActionDigests",
-    "github>suzuki-shunsuke/renovate-config:nolimit#2.0.0",
     "github>aquaproj/aqua-renovate-config#1.5.2",
     "github>aquaproj/aqua-renovate-config:file#1.5.2(CONTRIBUTING\\.md)",
     "github>aquaproj/aqua-renovate-config:file#1.5.2(pkgs/.*/pkg\\.yaml)",
     "github>aquaproj/aqua-renovate-config:installer-script#1.5.2(Earthfile)",
   ],
+  branchConcurrentLimit: 10,
+  prConcurrentLimit: 10,
+  prHourlyLimit: 0,
   automerge: true,
   rebaseWhen: "conflicted", // To decrease API call and avoid API rate limiting
   packageRules: [


### PR DESCRIPTION
Recently Renovate often stops working due to API rate limiting. So I'd like to decrease the capacity of Renovate.