### PR TITLE
feat: add cnosuke/kushi

### DIFF
--- a/pkgs/cnosuke/kushi/pkg.yaml
+++ b/pkgs/cnosuke/kushi/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: cnosuke/kushi@v0.7.0
+  - name: cnosuke/kushi
+    version: v0.1.0

--- a/pkgs/cnosuke/kushi/registry.yaml
+++ b/pkgs/cnosuke/kushi/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: cnosuke
+    repo_name: kushi
+    description: Auto SSH port-fowarding agent which gets forwarding configs from URL
+    asset: kushi-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - linux
+      - darwin
+    version_constraint: semver(">= 0.7.0")
+    version_overrides:
+      - version_constraint: semver("< 0.7.0")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -5982,6 +5982,22 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: cnosuke
+    repo_name: kushi
+    description: Auto SSH port-fowarding agent which gets forwarding configs from URL
+    asset: kushi-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - linux
+      - darwin
+    version_constraint: semver(">= 0.7.0")
+    version_overrides:
+      - version_constraint: semver("< 0.7.0")
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+  - type: github_release
     repo_owner: cnrancher
     repo_name: autok3s
     rosetta2: true


### PR DESCRIPTION
[cnosuke/kushi](https://github.com/cnosuke/kushi): Auto SSH port-fowarding agent which gets forwarding configs from URL

```console
$ aqua g -i cnosuke/kushi
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kushi --help
NAME:
   kushi - SSH Agent to forwarding ports as configs.

USAGE:
   kushi [global options] command [command options] [arguments...]

VERSION:
   v0.6.1-2-g69f4e88 (69f4e88)

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value  Config path
   --help, -h                show help (default: false)
   --pass, -p                passphrase (default: false)
   --stdout                  Output logs to STDOUT (default: false)
   --version, -v             print the version (default: false)
```

If files such as configuration file are needed, please share them.

```
```

Reference

- README.md
    - https://github.com/cnosuke/kushi
