### PR TITLE
feat: add future-architect/tftarget

### DIFF
--- a/pkgs/future-architect/tftarget/pkg.yaml
+++ b/pkgs/future-architect/tftarget/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: future-architect/tftarget@v0.0.2

--- a/pkgs/future-architect/tftarget/registry.yaml
+++ b/pkgs/future-architect/tftarget/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: future-architect
+    repo_name: tftarget
+    description: tftarget is a CLI tool for Terraform ( plan | apply | destroy ) with target option. You can interactivity select resource to ( plan | apply | destroy )  with target option
+    asset: tftarget_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -8849,6 +8849,24 @@ packages:
       asset: grpcurl_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: future-architect
+    repo_name: tftarget
+    description: tftarget is a CLI tool for Terraform ( plan | apply | destroy ) with target option. You can interactivity select resource to ( plan | apply | destroy )  with target option
+    asset: tftarget_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: gabrie30
     repo_name: ghorg
     description: Quickly clone an entire org/users repositories into one directory - Supports GitHub, GitLab, Bitbucket, and more


### PR DESCRIPTION
[future-architect/tftarget](https://github.com/future-architect/tftarget): tftarget is a CLI tool for Terraform ( plan | apply | destroy ) with target option. You can interactivity select resource to ( plan | apply | destroy )  with target option

```console
$ aqua g -i future-architect/tftarget
```