### PR TITLE
chore(renovate): disable Dependency Dashboard to avoid API rate limiting

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   extends: [
     "config:base",
+    ":disableDependencyDashboard",
     "helpers:pinGitHubActionDigests",
     "github>aquaproj/aqua-renovate-config#1.5.2",
     "github>aquaproj/aqua-renovate-config:file#1.5.2(CONTRIBUTING\\.md)",


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/issues/12221#issuecomment-1555353989