### PR TITLE
feat: add getgauge/gauge-java

### DIFF
--- a/pkgs/getgauge/gauge-java/pkg.yaml
+++ b/pkgs/getgauge/gauge-java/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: getgauge/gauge-java@v0.9.1

--- a/pkgs/getgauge/gauge-java/registry.yaml
+++ b/pkgs/getgauge/gauge-java/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: getgauge
+    repo_name: gauge-java
+    description: Java runner for Gauge
+    asset: gauge-java-{{trimV .Version}}-{{.OS}}.{{.Arch}}.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -9181,6 +9181,18 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: getgauge
+    repo_name: gauge-java
+    description: Java runner for Gauge
+    asset: gauge-java-{{trimV .Version}}-{{.OS}}.{{.Arch}}.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+  - type: github_release
     repo_owner: getsentry
     repo_name: sentry-cli
     description: A command line utility to work with Sentry


### PR DESCRIPTION
[getgauge/gauge-java](https://github.com/getgauge/gauge-java): Java runner for Gauge

```console
$ aqua g -i getgauge/gauge-java
```