### PR TITLE
feat: add utkuozdemir/pv-migrate

### DIFF
--- a/pkgs/utkuozdemir/pv-migrate/pkg.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: utkuozdemir/pv-migrate@v1.1.0
+  - name: utkuozdemir/pv-migrate
+    version: v0.8.1
+  - name: utkuozdemir/pv-migrate
+    version: v0.6.3
+  - name: utkuozdemir/pv-migrate
+    version: v0.5.5
+  - name: utkuozdemir/pv-migrate
+    version: v0.5.4
+  - name: utkuozdemir/pv-migrate
+    version: v0.2.1
+  - name: utkuozdemir/pv-migrate
+    version: v0.1.0

--- a/pkgs/utkuozdemir/pv-migrate/registry.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/registry.yaml
@@ -47,4 +47,5 @@ packages:
         checksum:
           enabled: false
         files:
-          - src: bin/{{.OS}}/pv-migrate
+          - name: pv-migrate
+            src: bin/{{.OS}}/pv-migrate

--- a/pkgs/utkuozdemir/pv-migrate/registry.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/registry.yaml
@@ -47,4 +47,4 @@ packages:
         checksum:
           enabled: false
         files:
-          src: bin/{{.OS}}/pv-migrate
+          - src: bin/{{.OS}}/pv-migrate

--- a/pkgs/utkuozdemir/pv-migrate/registry.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/registry.yaml
@@ -31,6 +31,10 @@ packages:
           - darwin
           - amd64
         rosetta2: true
+        # disable checksum because asset names in the checksum file are different from actual asset names.
+        # https://github.com/aquaproj/aqua-registry/pull/12352#issuecomment-1558413383
+        checksum:
+          enabled: false
       - version_constraint: semver(">= 0.2.1")
         supported_envs:
           - darwin

--- a/pkgs/utkuozdemir/pv-migrate/registry.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/registry.yaml
@@ -46,3 +46,5 @@ packages:
         rosetta2: true
         checksum:
           enabled: false
+        files:
+          src: bin/{{.OS}}/pv-migrate

--- a/pkgs/utkuozdemir/pv-migrate/registry.yaml
+++ b/pkgs/utkuozdemir/pv-migrate/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: utkuozdemir
+    repo_name: pv-migrate
+    description: CLI tool to easily migrate Kubernetes persistent volumes
+    asset: pv-migrate_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.8.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.3")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver(">= 0.5.5")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver(">= 0.5.4")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.2.1")
+        asset: pv-migrate-{{.OS}}.{{.Format}}
+        overrides: []
+        replacements: {}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -21952,6 +21952,10 @@ packages:
           - darwin
           - amd64
         rosetta2: true
+        # disable checksum because asset names in the checksum file are different from actual asset names.
+        # https://github.com/aquaproj/aqua-registry/pull/12352#issuecomment-1558413383
+        checksum:
+          enabled: false
       - version_constraint: semver(">= 0.2.1")
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -21968,7 +21968,8 @@ packages:
         checksum:
           enabled: false
         files:
-          - src: bin/{{.OS}}/pv-migrate
+          - name: pv-migrate
+            src: bin/{{.OS}}/pv-migrate
   - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox

--- a/registry.yaml
+++ b/registry.yaml
@@ -21921,6 +21921,53 @@ packages:
       - name: upx
         src: upx-{{trimV .Version}}-{{.OS}}/upx
   - type: github_release
+    repo_owner: utkuozdemir
+    repo_name: pv-migrate
+    description: CLI tool to easily migrate Kubernetes persistent volumes
+    asset: pv-migrate_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.8.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.6.3")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver(">= 0.5.5")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver(">= 0.5.4")
+        asset: pv-migrate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.2.1")
+        asset: pv-migrate-{{.OS}}.{{.Format}}
+        overrides: []
+        replacements: {}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox
     description: Encryption for git users

--- a/registry.yaml
+++ b/registry.yaml
@@ -21968,7 +21968,7 @@ packages:
         checksum:
           enabled: false
         files:
-          src: bin/{{.OS}}/pv-migrate
+          - src: bin/{{.OS}}/pv-migrate
   - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox

--- a/registry.yaml
+++ b/registry.yaml
@@ -21967,6 +21967,8 @@ packages:
         rosetta2: true
         checksum:
           enabled: false
+        files:
+          src: bin/{{.OS}}/pv-migrate
   - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox


### PR DESCRIPTION
[utkuozdemir/pv-migrate](https://github.com/utkuozdemir/pv-migrate): CLI tool to easily migrate Kubernetes persistent volumes

```console
$ aqua g -i utkuozdemir/pv-migrate
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ pv-migrate --help
A command-line utility to migrate data from one Kubernetes PersistentVolumeClaim to another

Usage:
  pv-migrate [command]

Available Commands:
  completion  Generate completion script
  help        Help about any command
  migrate     Migrate data from one Kubernetes PersistentVolumeClaim to another

Flags:
  -h, --help                help for pv-migrate
      --log-format string   log format, must be one of: json, fancy (default "fancy")
      --log-level string    log level, must be one of: trace, debug, info, warn, error, fatal, panic (default "info")
  -v, --version             version for pv-migrate

Use "pv-migrate [command] --help" for more information about a command.
```

Reference

- Usage
	- https://github.com/utkuozdemir/pv-migrate/blob/master/USAGE.md
