### PR TITLE
feat: add kubernetes-sigs/zeitgeist

### DIFF
--- a/pkgs/kubernetes-sigs/zeitgeist/pkg.yaml
+++ b/pkgs/kubernetes-sigs/zeitgeist/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: kubernetes-sigs/zeitgeist@v0.4.1
+  - name: kubernetes-sigs/zeitgeist
+    version: v0.3.5
+  - name: kubernetes-sigs/zeitgeist
+    version: v0.3.4
+  - name: kubernetes-sigs/zeitgeist
+    version: v0.0.3
+  - name: kubernetes-sigs/zeitgeist
+    version: v0.0.2

--- a/pkgs/kubernetes-sigs/zeitgeist/pkg.yaml
+++ b/pkgs/kubernetes-sigs/zeitgeist/pkg.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: kubernetes-sigs/zeitgeist@v0.4.1
   - name: kubernetes-sigs/zeitgeist
-    version: v0.3.5
-  - name: kubernetes-sigs/zeitgeist
     version: v0.3.4
   - name: kubernetes-sigs/zeitgeist
     version: v0.0.3

--- a/pkgs/kubernetes-sigs/zeitgeist/registry.yaml
+++ b/pkgs/kubernetes-sigs/zeitgeist/registry.yaml
@@ -13,10 +13,8 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.4.1")
+    version_constraint: semver(">= 0.3.5")
     version_overrides:
-      - version_constraint: semver(">= 0.3.5")
-        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
       - version_constraint: semver(">= 0.3.4")
         asset: zeitgeist
         supported_envs:

--- a/pkgs/kubernetes-sigs/zeitgeist/registry.yaml
+++ b/pkgs/kubernetes-sigs/zeitgeist/registry.yaml
@@ -1,0 +1,42 @@
+packages:
+  - type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: zeitgeist
+    description: "Zeitgeist: the language-agnostic dependency checker"
+    asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.4.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.5")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+      - version_constraint: semver(">= 0.3.4")
+        asset: zeitgeist
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver(">= 0.0.3")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 0.0.3")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -14295,6 +14295,47 @@ packages:
     files:
       - name: kwokctl
   - type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: zeitgeist
+    description: "Zeitgeist: the language-agnostic dependency checker"
+    asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+    format: raw
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.4.1")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.5")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+      - version_constraint: semver(">= 0.3.4")
+        asset: zeitgeist
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver(">= 0.0.3")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("< 0.0.3")
+        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+  - type: github_release
     repo_owner: kubernetes
     repo_name: kompose
     description: Go from Docker Compose to Kubernetes

--- a/registry.yaml
+++ b/registry.yaml
@@ -14308,10 +14308,8 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.4.1")
+    version_constraint: semver(">= 0.3.5")
     version_overrides:
-      - version_constraint: semver(">= 0.3.5")
-        asset: zeitgeist_{{trimV .Version}}_{{.OS}}_{{.Arch}}
       - version_constraint: semver(">= 0.3.4")
         asset: zeitgeist
         supported_envs:


### PR DESCRIPTION
[kubernetes-sigs/zeitgeist](https://github.com/kubernetes-sigs/zeitgeist): Zeitgeist: the language-agnostic dependency checker

```console
$ aqua g -i kubernetes-sigs/zeitgeist
```