### PR TITLE
feat: add aquaproj/aqua-registry-updater

### DIFF
--- a/pkgs/aquaproj/aqua-registry-updater/pkg.yaml
+++ b/pkgs/aquaproj/aqua-registry-updater/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aquaproj/aqua-registry-updater@v0.1.0-1

--- a/pkgs/aquaproj/aqua-registry-updater/registry.yaml
+++ b/pkgs/aquaproj/aqua-registry-updater/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: aquaproj
+    repo_name: aqua-registry-updater
+    description: Renovate alternative only for aqua-registry. Overcome Renovate's scalability issue
+    asset: aqua-registry-updater_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+    checksum:
+      type: github_release
+      asset: aqua-registry-updater_{{trimV .Version}}_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -3179,6 +3179,18 @@ packages:
       - linux
   - type: github_release
     repo_owner: aquaproj
+    repo_name: aqua-registry-updater
+    description: Renovate alternative only for aqua-registry. Overcome Renovate's scalability issue
+    asset: aqua-registry-updater_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+    checksum:
+      type: github_release
+      asset: aqua-registry-updater_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: aquaproj
     repo_name: example-go-slsa-provenance
     asset: example-go-slsa-provenance_{{.OS}}_{{.Arch}}.tar.gz
     description: Example Go Application with SLSA Provenance


### PR DESCRIPTION
[aquaproj/aqua-registry-updater](https://github.com/aquaproj/aqua-registry-updater): Renovate alternative only for aqua-registry. Overcome Renovate's scalability issue

```console
$ aqua g -i aquaproj/aqua-registry-updater
```