### PR TITLE
chore: update bitwarden/clients cli-v2022.10.0 to cli-v2023.4.0

### DIFF
--- a/pkgs/bitwarden/clients/pkg.yaml
+++ b/pkgs/bitwarden/clients/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: bitwarden/clients@cli-v2022.10.0
+  - name: bitwarden/clients@cli-v2023.4.0


### PR DESCRIPTION
[cli-v2023.4.0](https://github.com/bitwarden/clients/releases/tag/cli-v2023.4.0) [compare](https://github.com/bitwarden/clients/compare/cli-v2022.10.0...cli-v2023.4.0)