### PR TITLE
chore: stop updating pkgs by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,35 +1,11 @@
 {
   extends: [
     "config:base",
-    ":disableDependencyDashboard",
-    "helpers:pinGitHubActionDigests",
+    "github>suzuki-shunsuke/renovate-config#2.1.0",
     "github>aquaproj/aqua-renovate-config#1.6.0",
+    "github>suzuki-shunsuke/renovate-config:nolimit#2.1.0",
     "github>aquaproj/aqua-renovate-config:file#1.6.0(CONTRIBUTING\\.md)",
-    "github>aquaproj/aqua-renovate-config:file#1.6.0(pkgs/.*/pkg\\.yaml)",
     "github>aquaproj/aqua-renovate-config:installer-script#1.6.0(Earthfile)",
-  ],
-  branchConcurrentLimit: 10,
-  prConcurrentLimit: 10,
-  prHourlyLimit: 50,
-  automerge: true,
-  rebaseWhen: "conflicted", // To decrease API call and avoid API rate limiting
-  packageRules: [
-    // Separate packages with schedule.
-    // Otherwise, Renovate doesn't work because there are too many dependencies.
-    // https://github.com/renovatebot/renovate/discussions/21410
-    // https://github.com/aquaproj/aqua-registry/issues/11363
-    {
-      matchPackagePatterns: ["^[a-g]"],
-      schedule: ["* 0-7 * * *"],
-    },
-    {
-      matchPackagePatterns: ["^[h-o]"],
-      schedule: ["* 8-15 * * *"],
-    },
-    {
-      matchPackagePatterns: ["^[^a-o]"],
-      schedule: ["* 16-23 * * *"],
-    },
   ],
   regexManagers: [
     {


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/issues/12221

Migrated to aqua-registry-updater.