### PR TITLE
ci: use github.token instead of personal access token

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,11 +9,11 @@ env:
   AQUA_GLOBAL_CONFIG: ${{ github.workspace }}/aqua-all.yaml
   AQUA_LOG_COLOR: always
 
-permissions: {}
-
 jobs:
   update-pkgs:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: aquaproj/aqua-installer@294926f94b4233f202a2f03875c604f840cfed70 # v2.1.1
@@ -31,7 +31,5 @@ jobs:
           private_key: ${{secrets.APP_PRIVATE_KEY}}
       - run: aqua-registry-updater
         env:
-          # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
-          # GitHub Packages only supports authentication using a personal access token (classic).
-          AQUA_REGISTRY_UPDATER_CONTAINER_REGISTRY_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN}}
+          AQUA_REGISTRY_UPDATER_CONTAINER_REGISTRY_TOKEN: ${{github.token}}
           GITHUB_TOKEN: ${{steps.generate_token.outputs.token}}


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/pkgs/container/aqua-registry
- https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token