### PR TITLE
feat: add k1LoW/gh-do

### DIFF
--- a/pkgs/k1LoW/gh-do/pkg.yaml
+++ b/pkgs/k1LoW/gh-do/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/gh-do@v0.3.2

--- a/pkgs/k1LoW/gh-do/registry.yaml
+++ b/pkgs/k1LoW/gh-do/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: gh-do
+    description: gh-do is a tool to do anything using GitHub credentials
+    asset: gh-do_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -13226,6 +13226,22 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: k1LoW
+    repo_name: gh-do
+    description: gh-do is a tool to do anything using GitHub credentials
+    asset: gh-do_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - darwin
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: gh-setup
     description: Setup asset of Github releases
     asset: gh-setup_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[k1LoW/gh-do](https://github.com/k1LoW/gh-do): gh-do is a tool to do anything using GitHub credentials

```console
$ aqua g -i k1LoW/gh-do
```

⚠️ aqua installs gh-do as not GitHub CLI extension but standalone CLI

```console
$ gh-do --help
gh-do is a tool to do anything using GitHub credentials.

Usage:
  gh-do [flags]

Flags:
  -e, --credential-env-key strings   Set credential to specified env key
      --help                         
  -h, --hostname string              The hostname of the GitHub instance to do
      --insecure                     Use insecure credentials
  -v, --version                      version for gh-do
```