### PR TITLE
fix(exoscale/cli): follow up changes of exo v1.70.0

### DIFF
--- a/pkgs/exoscale/cli/pkg.yaml
+++ b/pkgs/exoscale/cli/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: exoscale/cli@v1.69.0
+  - name: exoscale/cli@v1.70.0
+  - name: exoscale/cli
+    version: v1.69.0

--- a/pkgs/exoscale/cli/registry.yaml
+++ b/pkgs/exoscale/cli/registry.yaml
@@ -12,10 +12,18 @@ packages:
         format: zip
       - goos: darwin
         asset: exoscale-cli_{{trimV .Version}}_darwin_all.tar.gz
-        files:
-          - name: exo
-            src: exoscale-cli
     checksum:
       type: github_release
       asset: exoscale-cli_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 1.70.0")
+    version_overrides:
+      - version_constraint: semver("< 1.70.0")
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            asset: exoscale-cli_{{trimV .Version}}_darwin_all.tar.gz
+            files:
+              - name: exo
+                src: exoscale-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -8602,13 +8602,21 @@ packages:
         format: zip
       - goos: darwin
         asset: exoscale-cli_{{trimV .Version}}_darwin_all.tar.gz
-        files:
-          - name: exo
-            src: exoscale-cli
     checksum:
       type: github_release
       asset: exoscale-cli_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 1.70.0")
+    version_overrides:
+      - version_constraint: semver("< 1.70.0")
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            asset: exoscale-cli_{{trimV .Version}}_darwin_all.tar.gz
+            files:
+              - name: exo
+                src: exoscale-cli
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui


### PR DESCRIPTION
https://github.com/exoscale/cli/blob/v1.70.0/CHANGELOG.md#improvements

> Update MacOS compiled unified binary name to be inline with others

- https://github.com/exoscale/cli/pull/517