### PR TITLE
fix(dandavison/delta): follow up changes of delta 0.16.4

### DIFF
--- a/pkgs/dandavison/delta/pkg.yaml
+++ b/pkgs/dandavison/delta/pkg.yaml
@@ -1,2 +1,24 @@
 packages:
-  - name: dandavison/delta@0.15.1
+  - name: dandavison/delta@0.16.4
+  - name: dandavison/delta
+    version: 0.15.0
+  - name: dandavison/delta
+    version: 0.4.1
+  - name: dandavison/delta
+    version: 0.3.0
+  - name: dandavison/delta
+    version: 0.1.0
+  - name: dandavison/delta
+    version: 0.0.16
+  - name: dandavison/delta
+    version: 0.0.10
+  - name: dandavison/delta
+    version: 0.0.8
+  - name: dandavison/delta
+    version: 0.0.7
+  - name: dandavison/delta
+    version: 0.0.6
+  - name: dandavison/delta
+    version: 0.0.5
+  - name: dandavison/delta
+    version: 0.0.1

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -2,27 +2,201 @@ packages:
   - type: github_release
     repo_owner: dandavison
     repo_name: delta
-    rosetta2: true
+    description: A syntax-highlighting pager for git, diff, and grep output
     asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    description: A syntax-highlighting pager for git
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     format: tar.gz
-    replacements:
-      windows: pc-windows-msvc
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      arm64: aarch64
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: linux
-        goarch: arm64
-        replacements:
-          linux: unknown-linux-gnu
     files:
       - name: delta
         src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
+    overrides:
+      - goos: darwin
+        replacements:
+          arm64: aarch64
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.16.4")
+    version_overrides:
+      - version_constraint: semver(">= 0.15.0")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.4.1")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.3.0")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        rosetta2: true
+      - version_constraint: semver(">= 0.1.0")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.16")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.10")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.8")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.7")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.6")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux/amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.5")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.0.5")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6856,30 +6856,204 @@ packages:
   - type: github_release
     repo_owner: dandavison
     repo_name: delta
-    rosetta2: true
+    description: A syntax-highlighting pager for git, diff, and grep output
     asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    description: A syntax-highlighting pager for git
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     format: tar.gz
-    replacements:
-      windows: pc-windows-msvc
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      arm64: aarch64
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: linux
-        goarch: arm64
-        replacements:
-          linux: unknown-linux-gnu
     files:
       - name: delta
         src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
+    overrides:
+      - goos: darwin
+        replacements:
+          arm64: aarch64
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    version_constraint: semver(">= 0.16.4")
+    version_overrides:
+      - version_constraint: semver(">= 0.15.0")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.4.1")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.3.0")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        rosetta2: true
+      - version_constraint: semver(">= 0.1.0")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.16")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.10")
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.8")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.7")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.6")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux/amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.0.5")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.0.5")
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
   - type: github_release
     repo_owner: danielfoehrKn
     repo_name: kubeswitch


### PR DESCRIPTION
https://github.com/dandavison/delta/releases/tag/0.16.4

> This release does not contain binaries for x86_64-unknown-linux-musl, i686-unknown-linux-gnu, arm-unknown-linux-gnueabihf, or aarch64-unknown-linux-gnu because the cross-compilation GitHub Actions jobs were broken at the time of release. I'll issue a follow-up release including them when that's fixed.