### PR TITLE
fix(google/go-jsonnet): add jsonnet-lint and jsonnet-deps

### DIFF
--- a/pkgs/google/go-jsonnet/pkg.yaml
+++ b/pkgs/google/go-jsonnet/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: google/go-jsonnet@v0.20.0
+  - name: google/go-jsonnet
+    version: v0.19.1

--- a/pkgs/google/go-jsonnet/registry.yaml
+++ b/pkgs/google/go-jsonnet/registry.yaml
@@ -18,6 +18,8 @@ packages:
       amd64: x86_64
     files:
       - name: jsonnet
+      - name: jsonnet-deps
+      - name: jsonnet-lint
       - name: jsonnetfmt
     checksum:
       type: github_release

--- a/pkgs/google/go-jsonnet/registry.yaml
+++ b/pkgs/google/go-jsonnet/registry.yaml
@@ -25,3 +25,9 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.20.0")
+    version_overrides:
+      - version_constraint: semver("< 0.20.0")
+        files:
+          - name: jsonnet
+          - name: jsonnetfmt

--- a/registry.yaml
+++ b/registry.yaml
@@ -10441,6 +10441,12 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.20.0")
+    version_overrides:
+      - version_constraint: semver("< 0.20.0")
+        files:
+          - name: jsonnet
+          - name: jsonnetfmt
   - type: github_release
     repo_owner: google
     repo_name: jsonnet

--- a/registry.yaml
+++ b/registry.yaml
@@ -10238,6 +10238,8 @@ packages:
       amd64: x86_64
     files:
       - name: jsonnet
+      - name: jsonnet-deps
+      - name: jsonnet-lint
       - name: jsonnetfmt
     checksum:
       type: github_release


### PR DESCRIPTION
https://github.com/google/go-jsonnet

```console
$ jsonnet-deps --help
Jsonnet static dependency parser v0.20.0

jsonnet-deps {<option>} <filename>...

Available options:
  -h / --help                This message
  -J / --jpath <dir>         Specify an additional library search dir
                             (right-most wins)
  -o / --output-file <file>  Write to the output file rather than stdout
  --version                  Print version

Environment variables:
  JSONNET_PATH is a colon (semicolon on Windows) separated list of directories
  added in reverse order before the paths specified by --jpath (i.e. left-most
  wins). E.g. these are equivalent:
    JSONNET_PATH=a:b jsonnet -J c -J d
    JSONNET_PATH=d:c:a:b jsonnet
    jsonnet -J b -J a -J c -J d

In all cases:
  Multichar options are expanded e.g. -abc becomes -a -b -c.
  The -- option suppresses option processing for subsequent arguments.
  Note that since filenames and jsonnet programs can begin with -, it is
  advised to use -- if the argument is unknown, e.g. jsonnet-deps -- "$FILENAME".
```

```console
$ jsonnet-lint --help
Jsonnet linter v0.20.0

jsonnet-lint {<option>} { <filenames ...> }

Available options:
  -h / --help                This message
  -J / --jpath <dir>         Specify an additional library search dir
                             (right-most wins)
  --version                  Print version

Environment variables:
  JSONNET_PATH is a colon (semicolon on Windows) separated list of directories
  added in reverse order before the paths specified by --jpath (i.e. left-most
  wins). E.g. these are equivalent:
    JSONNET_PATH=a:b jsonnet -J c -J d
    JSONNET_PATH=d:c:a:b jsonnet
    jsonnet -J b -J a -J c -J d

In all cases:
  <filename> can be - (stdin)
  Multichar options are expanded e.g. -abc becomes -a -b -c.
  The -- option suppresses option processing for subsequent arguments.
  Note that since filenames and jsonnet programs can begin with -, it is
  advised to use -- if the argument is unknown, e.g. jsonnet-lint -- "$FILENAME".

Exit code:
  0 – If the file was checked no problems were found.
  1 – If errors occured which prevented checking (e.g. specified file is missing).
  2 – If problems were found.
```