### PR TITLE
feat: add datarootsio/tf-profile

### DIFF
--- a/pkgs/datarootsio/tf-profile/pkg.yaml
+++ b/pkgs/datarootsio/tf-profile/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: datarootsio/tf-profile@v0.2.1
+  - name: datarootsio/tf-profile
+    version: release/0.2.0
+  - name: datarootsio/tf-profile
+    version: release/0.1.0
+  - name: datarootsio/tf-profile
+    version: release/0.0.1

--- a/pkgs/datarootsio/tf-profile/registry.yaml
+++ b/pkgs/datarootsio/tf-profile/registry.yaml
@@ -7,21 +7,10 @@ packages:
     format: zip
     version_constraint: semver(">= 0.2.1")
     version_overrides:
-      - version_constraint: Version >= "release/0.2.0"
-        asset: tf-profile-v0.2.0-{{.OS}}.{{.Format}}
+      - version_constraint: semver("< 0.2.1")
+        version_prefix: release/
+        asset: tf-profile-v{{.SemVer}}-{{.OS}}.{{.Format}}
+        rosetta2: true
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
-      - version_constraint: Version >= "release/0.1.0"
-        asset: tf-profile-v0.1.0-{{.OS}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: Version < "release/0.1.0"
-        asset: tf-profile-v0.0.1-{{.OS}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true

--- a/pkgs/datarootsio/tf-profile/registry.yaml
+++ b/pkgs/datarootsio/tf-profile/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - type: github_release
+    repo_owner: datarootsio
+    repo_name: tf-profile
+    description: CLI tool to profile Terraform runs, written in Go
+    asset: tf-profile-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    version_constraint: semver(">= 0.2.1")
+    version_overrides:
+      - version_constraint: Version >= "release/0.2.0"
+        asset: tf-profile-v0.2.0-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version >= "release/0.1.0"
+        asset: tf-profile-v0.1.0-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version < "release/0.1.0"
+        asset: tf-profile-v0.0.1-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -6993,6 +6993,32 @@ packages:
     files:
       - name: pg_datanymizer
   - type: github_release
+    repo_owner: datarootsio
+    repo_name: tf-profile
+    description: CLI tool to profile Terraform runs, written in Go
+    asset: tf-profile-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: zip
+    version_constraint: semver(">= 0.2.1")
+    version_overrides:
+      - version_constraint: Version >= "release/0.2.0"
+        asset: tf-profile-v0.2.0-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version >= "release/0.1.0"
+        asset: tf-profile-v0.1.0-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version < "release/0.1.0"
+        asset: tf-profile-v0.0.1-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+  - type: github_release
     repo_owner: datastax-labs
     repo_name: astra-cli
     description: DataStax Astra automation CLI

--- a/registry.yaml
+++ b/registry.yaml
@@ -7188,24 +7188,13 @@ packages:
     format: zip
     version_constraint: semver(">= 0.2.1")
     version_overrides:
-      - version_constraint: Version >= "release/0.2.0"
-        asset: tf-profile-v0.2.0-{{.OS}}.{{.Format}}
+      - version_constraint: semver("< 0.2.1")
+        version_prefix: release/
+        asset: tf-profile-v{{.SemVer}}-{{.OS}}.{{.Format}}
+        rosetta2: true
         supported_envs:
           - darwin
           - amd64
-        rosetta2: true
-      - version_constraint: Version >= "release/0.1.0"
-        asset: tf-profile-v0.1.0-{{.OS}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: Version < "release/0.1.0"
-        asset: tf-profile-v0.0.1-{{.OS}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
   - type: github_release
     repo_owner: datastax-labs
     repo_name: astra-cli


### PR DESCRIPTION
[datarootsio/tf-profile](https://github.com/datarootsio/tf-profile): CLI tool to profile Terraform runs, written in Go

```console
$ aqua g -i datarootsio/tf-profile
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ tf-profile --help
tf-profile is a CLI tool to profile Terraform runs

Usage:
  tf-profile [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  graph       Visualize a Terraform run graphically
  help        Help about any command
  stats       Parse a Terraform log and show general statistics
  table       Parse a Terraform log and perform resource-level profiling

Flags:
  -h, --help   help for tf-profile

Use "tf-profile [command] --help" for more information about a command.
```

Reference

- README
	- https://github.com/datarootsio/tf-profile/blob/main/README.md
