### PR TITLE
feat: add knadh/listmonk

### DIFF
--- a/pkgs/knadh/listmonk/pkg.yaml
+++ b/pkgs/knadh/listmonk/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: knadh/listmonk@v2.4.0

--- a/pkgs/knadh/listmonk/registry.yaml
+++ b/pkgs/knadh/listmonk/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: knadh
+    repo_name: listmonk
+    description: High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app
+    asset: listmonk_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: listmonk_{{trimV .Version}}_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -14103,6 +14103,20 @@ packages:
       asset: youtubedr_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: knadh
+    repo_name: listmonk
+    description: High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app
+    asset: listmonk_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: listmonk_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: knative
     repo_name: client
     format: raw


### PR DESCRIPTION
[knadh/listmonk](https://github.com/knadh/listmonk): High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app

```console
$ aqua g -i knadh/listmonk
```