### PR TITLE
feat: add koki-develop/gat

### DIFF
--- a/pkgs/koki-develop/gat/pkg.yaml
+++ b/pkgs/koki-develop/gat/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: koki-develop/gat@v0.8.2

--- a/pkgs/koki-develop/gat/registry.yaml
+++ b/pkgs/koki-develop/gat/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: koki-develop
+    repo_name: gat
+    description: cat alternative written in Go
+    asset: gat_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -14381,6 +14381,24 @@ packages:
         overrides: []
   - type: github_release
     repo_owner: koki-develop
+    repo_name: gat
+    description: cat alternative written in Go
+    asset: gat_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: koki-develop
     repo_name: sheep
     description: Sleep with Sheep
     asset: sheep_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[koki-develop/gat](https://github.com/koki-develop/gat): cat alternative written in Go

```console
$ aqua g -i koki-develop/gat
```