### PR TITLE
feat: add mozilla/sccache.

### DIFF
--- a/pkgs/mozilla/sccache/pkg.yaml
+++ b/pkgs/mozilla/sccache/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mozilla/sccache@v0.5.3

--- a/pkgs/mozilla/sccache/pkg.yaml
+++ b/pkgs/mozilla/sccache/pkg.yaml
@@ -1,2 +1,20 @@
 packages:
   - name: mozilla/sccache@v0.5.3
+  - name: mozilla/sccache
+    version: v0.5.2
+  - name: mozilla/sccache
+    version: v0.5.1
+  - name: mozilla/sccache
+    version: v0.4.0-pre.2
+  - name: mozilla/sccache
+    version: v0.3.3
+  - name: mozilla/sccache
+    version: 0.2.14
+  - name: mozilla/sccache
+    version: 0.2.13
+  - name: mozilla/sccache
+    version: 0.2.9
+  - name: mozilla/sccache
+    version: 0.2.6
+  - name: mozilla/sccache
+    version: 0.2.4

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -56,6 +56,14 @@ packages:
           - darwin
           - amd64
       - version_constraint: semver(">= 0.2.14")
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+            checksum:
+              # https://github.com/aquaproj/aqua-registry/pull/13027
+              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
+              enabled: false # ERRO[0001] install the package                           actual_checksum=BA6BF184D2B0A78978629AAEF0D9FE3CA57923E228D949B1932EC1A91AB4CEAC aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��B\x00A\x006\x00B\x00F\x001\x008\x004\x00D\x002\x00B\x000\x00A\x007\x008\x009\x007\x008\x006\x002\x009\x00A\x00A\x00E\x00F\x000\x00D\x009\x00F\x00E\x003\x00C\x00A\x005\x007\x009\x002\x003\x00E\x002\x002\x008\x00D\x009\x004\x009\x00B\x001\x009\x003\x002\x00E\x00C\x001\x00A\x009\x001\x00A\x00B\x004\x00C\x00E\x00A\x00C\x00" package_name=mozilla/sccache package_version=0.2.14 program=aqua registry=standard
       - version_constraint: semver(">= 0.2.13")
         overrides: []
         replacements:
@@ -67,7 +75,12 @@ packages:
           - darwin
         rosetta2: true
       - version_constraint: semver(">= 0.2.9")
-        overrides: []
+        overrides:
+          - goos: windows
+            checksum:
+              # https://github.com/aquaproj/aqua-registry/pull/13027
+              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
+              enabled: false # ERRO[0001] install the package                           actual_checksum=6DD85F65FCCB1CDB00E7C5804C3F3BA523C1ED20EA8F777D454826EEF17C636F aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��6\x00D\x00D\x008\x005\x00F\x006\x005\x00F\x00C\x00C\x00B\x001\x00C\x00D\x00B\x000\x000\x00E\x007\x00C\x005\x008\x000\x004\x00C\x003\x00F\x003\x00B\x00A\x005\x002\x003\x00C\x001\x00E\x00D\x002\x000\x00E\x00A\x008\x00F\x007\x007\x007\x00D\x004\x005\x004\x008\x002\x006\x00E\x00E\x00F\x001\x007\x00C\x006\x003\x006\x00F\x00" package_name=mozilla/sccache package_version=0.2.9 program=aqua registry=standard
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -5,6 +5,9 @@ packages:
     description: sccache is ccache with cloud storage
     asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    files:
+      - name: sccache
+        src: sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache
     overrides:
       - goos: windows
         replacements:

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -2,9 +2,13 @@ packages:
   - type: github_release
     repo_owner: mozilla
     repo_name: sccache
-    asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    description: sccache is ccache with cloud storage
+    asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: Shared Compilation Cache
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
     replacements:
       amd64: x86_64
       arm64: aarch64
@@ -12,15 +16,86 @@ packages:
       linux: unknown-linux-musl
       windows: pc-windows-msvc
     supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
-      - windows/amd64
-    files:
-      - name: sccache
-        src: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache'
+      - darwin
+      - linux
+      - amd64
     checksum:
       type: github_release
-      asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}.sha256'
+      asset: "{{.Asset}}.sha256"
       algorithm: sha256
+    version_constraint: semver(">= 0.5.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.5.1")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.4.0-pre.2")
+      - version_constraint: semver(">= 0.3.3")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.2.14")
+      - version_constraint: semver(">= 0.2.13")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.9")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.6")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.6")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+  - type: github_release
+    repo_owner: mozilla
+    repo_name: sccache
+    asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    format: tar.gz
+    description: Shared Compilation Cache
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+      - windows/amd64
+    files:
+      - name: sccache
+        src: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache'
+    checksum:
+      type: github_release
+      asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}.sha256'
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -16770,6 +16770,14 @@ packages:
           - darwin
           - amd64
       - version_constraint: semver(">= 0.2.14")
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+            checksum:
+              # https://github.com/aquaproj/aqua-registry/pull/13027
+              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
+              enabled: false # ERRO[0001] install the package                           actual_checksum=BA6BF184D2B0A78978629AAEF0D9FE3CA57923E228D949B1932EC1A91AB4CEAC aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��B\x00A\x006\x00B\x00F\x001\x008\x004\x00D\x002\x00B\x000\x00A\x007\x008\x009\x007\x008\x006\x002\x009\x00A\x00A\x00E\x00F\x000\x00D\x009\x00F\x00E\x003\x00C\x00A\x005\x007\x009\x002\x003\x00E\x002\x002\x008\x00D\x009\x004\x009\x00B\x001\x009\x003\x002\x00E\x00C\x001\x00A\x009\x001\x00A\x00B\x004\x00C\x00E\x00A\x00C\x00" package_name=mozilla/sccache package_version=0.2.14 program=aqua registry=standard
       - version_constraint: semver(">= 0.2.13")
         overrides: []
         replacements:
@@ -16781,7 +16789,12 @@ packages:
           - darwin
         rosetta2: true
       - version_constraint: semver(">= 0.2.9")
-        overrides: []
+        overrides:
+          - goos: windows
+            checksum:
+              # https://github.com/aquaproj/aqua-registry/pull/13027
+              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
+              enabled: false # ERRO[0001] install the package                           actual_checksum=6DD85F65FCCB1CDB00E7C5804C3F3BA523C1ED20EA8F777D454826EEF17C636F aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��6\x00D\x00D\x008\x005\x00F\x006\x005\x00F\x00C\x00C\x00B\x001\x00C\x00D\x00B\x000\x000\x00E\x007\x00C\x005\x008\x000\x004\x00C\x003\x00F\x003\x00B\x00A\x005\x002\x003\x00C\x001\x00E\x00D\x002\x000\x00E\x00A\x008\x00F\x007\x007\x007\x00D\x004\x005\x004\x008\x002\x006\x00E\x00E\x00F\x001\x007\x00C\x006\x003\x006\x00F\x00" package_name=mozilla/sccache package_version=0.2.9 program=aqua registry=standard
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -16716,9 +16716,13 @@ packages:
   - type: github_release
     repo_owner: mozilla
     repo_name: sccache
-    asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    description: sccache is ccache with cloud storage
+    asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
-    description: Shared Compilation Cache
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
     replacements:
       amd64: x86_64
       arm64: aarch64
@@ -16726,18 +16730,89 @@ packages:
       linux: unknown-linux-musl
       windows: pc-windows-msvc
     supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
-      - windows/amd64
-    files:
-      - name: sccache
-        src: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache'
+      - darwin
+      - linux
+      - amd64
     checksum:
       type: github_release
-      asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}.sha256'
+      asset: "{{.Asset}}.sha256"
       algorithm: sha256
+    version_constraint: semver(">= 0.5.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.5.1")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.4.0-pre.2")
+      - version_constraint: semver(">= 0.3.3")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.2.14")
+      - version_constraint: semver(">= 0.2.13")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.9")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 0.2.6")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.6")
+        overrides: []
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false
   - type: github_release
     repo_owner: mozilla
     repo_name: sops

--- a/registry.yaml
+++ b/registry.yaml
@@ -16715,6 +16715,31 @@ packages:
                 src: mongocli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/mongocli
   - type: github_release
     repo_owner: mozilla
+    repo_name: sccache
+    asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    format: tar.gz
+    description: Shared Compilation Cache
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+      - windows/amd64
+    files:
+      - name: sccache
+        src: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache'
+    checksum:
+      type: github_release
+      asset: 'sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}.sha256'
+      algorithm: sha256
+  - type: github_release
+    repo_owner: mozilla
     repo_name: sops
     description: Simple and flexible tool for managing secrets
     format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -16719,6 +16719,9 @@ packages:
     description: sccache is ccache with cloud storage
     asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    files:
+      - name: sccache
+        src: sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache
     overrides:
       - goos: windows
         replacements:


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

---

[mozilla/sccache](https://github.com/mozilla/sccache): sccache is ccache with cloud storage

Installation: https://github.com/mozilla/sccache#installation

> There are prebuilt x86-64 binaries available for Windows, Linux (a portable binary compiled against musl), and macOS [on the releases page](https://github.com/mozilla/sccache/releases/latest)