### PR TITLE
feat: add assetnote/surf

### DIFF
--- a/pkgs/assetnote/surf/pkg.yaml
+++ b/pkgs/assetnote/surf/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: assetnote/surf@v0.0.5

--- a/pkgs/assetnote/surf/registry.yaml
+++ b/pkgs/assetnote/surf/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: assetnote
+    repo_name: surf
+    description: Escalate your SSRF vulnerabilities on Modern Cloud Environments. `surf` allows you to filter a list of hosts, returning a list of viable SSRF candidates
+    asset: surf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      darwin: macOS
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: surf_{{trimV .Version}}_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -3713,6 +3713,25 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: assetnote
+    repo_name: surf
+    description: Escalate your SSRF vulnerabilities on Modern Cloud Environments. `surf` allows you to filter a list of hosts, returning a list of viable SSRF candidates
+    asset: surf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      darwin: macOS
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: surf_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: astefanutti
     repo_name: kubebox
     asset: kubebox-{{.OS}}


### PR DESCRIPTION
[assetnote/surf](https://github.com/assetnote/surf): Escalate your SSRF vulnerabilities on Modern Cloud Environments. `surf` allows you to filter a list of hosts, returning a list of viable SSRF candidates

```console
$ aqua g -i assetnote/surf
```