### PR TITLE
fix(dandavison/delta): Follow up changes of v0.16.5

### DIFF
--- a/pkgs/dandavison/delta/pkg.yaml
+++ b/pkgs/dandavison/delta/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: dandavison/delta@0.16.5
   - name: dandavison/delta
+    version: 0.16.4
+  - name: dandavison/delta
     version: 0.15.0
   - name: dandavison/delta
     version: 0.4.1

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -157,6 +157,9 @@ packages:
           - goos: windows
             format: zip
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            files:
+              - name: delta
+                src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/delta
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -9,44 +9,45 @@ packages:
       - name: delta
         src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
     overrides:
-      - goos: darwin
+      - goos: linux
+        goarch: amd64
         replacements:
-          arm64: aarch64
+          linux: unknown-linux-musl
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
       - goos: windows
         format: zip
+        replacements:
+          arm64: arm64
     replacements:
       amd64: x86_64
+      arm64: aarch64
       darwin: apple-darwin
-      linux: unknown-linux-gnu
       windows: pc-windows-msvc
     supported_envs:
       - darwin
+      - linux
       - amd64
-    version_constraint: semver(">= 0.16.4")
+    version_constraint: semver(">= 0.16.5")
     version_overrides:
-      - version_constraint: semver(">= 0.15.0")
+      - version_constraint: semver(">= 0.16.4")
         overrides:
-          - goos: linux
-            goarch: amd64
+          - goos: darwin
             replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
+              arm64: aarch64
           - goos: windows
             format: zip
-            replacements:
-              arm64: arm64
         replacements:
           amd64: x86_64
-          arm64: aarch64
           darwin: apple-darwin
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         supported_envs:
           - darwin
-          - linux
           - amd64
+      - version_constraint: semver(">= 0.15.0")
       - version_constraint: semver(">= 0.4.1")
         overrides:
           - goos: linux
@@ -64,10 +65,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.3.0")
         overrides:
@@ -78,6 +75,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.1.0")
         overrides:
@@ -88,6 +88,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.16")
         overrides: []
@@ -108,6 +111,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.8")
         overrides: []
@@ -136,10 +142,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.6")
         overrides:
@@ -152,13 +154,13 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.5")
         overrides:
@@ -177,10 +179,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver("< 0.0.5")
         overrides:

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -159,7 +159,6 @@ packages:
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
             files:
               - name: delta
-                src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/delta
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7181,6 +7181,9 @@ packages:
           - goos: windows
             format: zip
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            files:
+              - name: delta
+                src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/delta
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7033,44 +7033,45 @@ packages:
       - name: delta
         src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
     overrides:
-      - goos: darwin
+      - goos: linux
+        goarch: amd64
         replacements:
-          arm64: aarch64
+          linux: unknown-linux-musl
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: unknown-linux-gnu
       - goos: windows
         format: zip
+        replacements:
+          arm64: arm64
     replacements:
       amd64: x86_64
+      arm64: aarch64
       darwin: apple-darwin
-      linux: unknown-linux-gnu
       windows: pc-windows-msvc
     supported_envs:
       - darwin
+      - linux
       - amd64
-    version_constraint: semver(">= 0.16.4")
+    version_constraint: semver(">= 0.16.5")
     version_overrides:
-      - version_constraint: semver(">= 0.15.0")
+      - version_constraint: semver(">= 0.16.4")
         overrides:
-          - goos: linux
-            goarch: amd64
+          - goos: darwin
             replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
+              arm64: aarch64
           - goos: windows
             format: zip
-            replacements:
-              arm64: arm64
         replacements:
           amd64: x86_64
-          arm64: aarch64
           darwin: apple-darwin
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         supported_envs:
           - darwin
-          - linux
           - amd64
+      - version_constraint: semver(">= 0.15.0")
       - version_constraint: semver(">= 0.4.1")
         overrides:
           - goos: linux
@@ -7088,10 +7089,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.3.0")
         overrides:
@@ -7102,6 +7099,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.1.0")
         overrides:
@@ -7112,6 +7112,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.16")
         overrides: []
@@ -7132,6 +7135,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.8")
         overrides: []
@@ -7160,10 +7166,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.6")
         overrides:
@@ -7176,13 +7178,13 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 0.0.5")
         overrides:
@@ -7201,10 +7203,6 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
         rosetta2: true
       - version_constraint: semver("< 0.0.5")
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -7183,7 +7183,6 @@ packages:
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
             files:
               - name: delta
-                src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/delta
         replacements:
           amd64: x86_64
           darwin: apple-darwin


### PR DESCRIPTION
The [release 0.16.5](https://github.com/dandavison/delta/releases/tag/0.16.5) provides the various binaries that were not released with 0.16.4 (including for linux/arm64).
