### PR TITLE
fix(jqlang/jq): Transfer the package to jqlang

### DIFF
--- a/pkgs/jqlang/jq/pkg.yaml
+++ b/pkgs/jqlang/jq/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jqlang/jq@jq-1.6

--- a/pkgs/jqlang/jq/registry.yaml
+++ b/pkgs/jqlang/jq/registry.yaml
@@ -1,6 +1,6 @@
 packages:
   - type: github_release
-    repo_owner: stedolan
+    repo_owner: jqlang
     repo_name: jq
     asset: jq-{{.OS}}
     format: raw

--- a/pkgs/jqlang/jq/registry.yaml
+++ b/pkgs/jqlang/jq/registry.yaml
@@ -5,6 +5,8 @@ packages:
     asset: jq-{{.OS}}
     format: raw
     description: Command-line JSON processor
+    aliases:
+      - name: stedolan/jq
     replacements:
       darwin: osx-amd64
       linux: linux64

--- a/pkgs/stedolan/jq/pkg.yaml
+++ b/pkgs/stedolan/jq/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: stedolan/jq@jq-1.6

--- a/registry.yaml
+++ b/registry.yaml
@@ -21313,7 +21313,7 @@ packages:
         repo_name: rdme
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
   - type: github_release
-    repo_owner: stedolan
+    repo_owner: jqlang
     repo_name: jq
     asset: jq-{{.OS}}
     format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -13271,6 +13271,18 @@ packages:
       asset: chisel_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: jqlang
+    repo_name: jq
+    asset: jq-{{.OS}}
+    format: raw
+    description: Command-line JSON processor
+    aliases:
+      - name: stedolan/jq
+    replacements:
+      darwin: osx-amd64
+      linux: linux64
+      windows: win64.exe
+  - type: github_release
     repo_owner: jreisinger
     repo_name: checkip
     description: Get (security) info about IP addresses
@@ -21312,16 +21324,6 @@ packages:
       - version_constraint: "true"
         repo_name: rdme
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
-  - type: github_release
-    repo_owner: jqlang
-    repo_name: jq
-    asset: jq-{{.OS}}
-    format: raw
-    description: Command-line JSON processor
-    replacements:
-      darwin: osx-amd64
-      linux: linux64
-      windows: win64.exe
   - type: github_release
     repo_owner: stefanprodan
     repo_name: timoni


### PR DESCRIPTION
The `stedolan/jq` repository has been transfered to [jqlang organization](https://github.com/jqlang).

Please read [this japanese article](https://itchyny.hatenablog.com/entry/2023/05/30/090000) for detail.
