### PR TITLE
feat: add cloudspannerecosystem/spanner-cli

### DIFF
--- a/pkgs/cloudspannerecosystem/spanner-cli/pkg.yaml
+++ b/pkgs/cloudspannerecosystem/spanner-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudspannerecosystem/spanner-cli@v0.9.18

--- a/pkgs/cloudspannerecosystem/spanner-cli/registry.yaml
+++ b/pkgs/cloudspannerecosystem/spanner-cli/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: cloudspannerecosystem
+    repo_name: spanner-cli
+    description: Interactive command line tool for Cloud Spanner

--- a/pkgs/cloudspannerecosystem/spanner-dump/pkg.yaml
+++ b/pkgs/cloudspannerecosystem/spanner-dump/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudspannerecosystem/spanner-dump@v0.2.2

--- a/pkgs/cloudspannerecosystem/spanner-dump/registry.yaml
+++ b/pkgs/cloudspannerecosystem/spanner-dump/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: cloudspannerecosystem
+    repo_name: spanner-dump
+    description: Command line tool for exporting a Cloud Spanner database in text format

--- a/registry.yaml
+++ b/registry.yaml
@@ -6198,6 +6198,10 @@ packages:
     description: Interactive command line tool for Cloud Spanner
   - type: go_install
     repo_owner: cloudspannerecosystem
+    repo_name: spanner-dump
+    description: Command line tool for exporting a Cloud Spanner database in text format
+  - type: go_install
+    repo_owner: cloudspannerecosystem
     repo_name: spool
     path: github.com/cloudspannerecosystem/spool/cmd/spool
     description: A CLI tool to manage Cloud Spanner databases for testing

--- a/registry.yaml
+++ b/registry.yaml
@@ -6194,6 +6194,10 @@ packages:
           windows: Windows
   - type: go_install
     repo_owner: cloudspannerecosystem
+    repo_name: spanner-cli
+    description: Interactive command line tool for Cloud Spanner
+  - type: go_install
+    repo_owner: cloudspannerecosystem
     repo_name: spool
     path: github.com/cloudspannerecosystem/spool/cmd/spool
     description: A CLI tool to manage Cloud Spanner databases for testing


### PR DESCRIPTION
Add two packages for Cloud Spanner

- [cloudspannerecosystem/spanner\-dump: Command line tool for exporting a Cloud Spanner database in text format](https://github.com/cloudspannerecosystem/spanner-dump)
- [cloudspannerecosystem/spanner\-cli: Interactive command line tool for Cloud Spanner](https://github.com/cloudspannerecosystem/spanner-cli)