### PR TITLE
feat: add cilium/cilium-cli

### DIFF
--- a/pkgs/cilium/cilium-cli/pkg.yaml
+++ b/pkgs/cilium/cilium-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cilium/cilium-cli@v0.15.0

--- a/pkgs/cilium/cilium-cli/registry.yaml
+++ b/pkgs/cilium/cilium-cli/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: cilium
+    repo_name: cilium-cli
+    description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cilium-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: cilium-{{.OS}}-{{.Arch}}.{{.Format}}.sha256sum
+      algorithm: sha256
+    files:
+      - name: cilium

--- a/registry.yaml
+++ b/registry.yaml
@@ -5748,6 +5748,22 @@ packages:
       asset: bit_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: cilium
+    repo_name: cilium-cli
+    description: CLI to install, manage & troubleshoot Kubernetes clusters running Cilium
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: cilium-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: cilium-{{.OS}}-{{.Arch}}.{{.Format}}.sha256sum
+      algorithm: sha256
+    files:
+      - name: cilium
+  - type: github_release
     repo_owner: citrusframework
     repo_name: yaks
     asset: yaks-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz


### PR DESCRIPTION
[cilium/cilium-cli](https://github.com/cilium/cilium-cli): CLI to install, manage & troubleshoot Kubernetes clusters running Cilium

Hello! Thank you for always developing aqua.
I propose to add cilium-cli, which is used to set up cilium, a CNI plugin for k8s.
Thanks!