### PR TITLE
feat: add ponkio-o/ec2x

### DIFF
--- a/pkgs/ponkio-o/ec2x/pkg.yaml
+++ b/pkgs/ponkio-o/ec2x/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ponkio-o/ec2x@v0.0.8

--- a/pkgs/ponkio-o/ec2x/registry.yaml
+++ b/pkgs/ponkio-o/ec2x/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: ponkio-o
+    repo_name: ec2x
+    description: A cli tool of connect to ec2 instance
+    asset: ec2x_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18792,6 +18792,19 @@ packages:
       asset: github_link_creator_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: ponkio-o
+    repo_name: ec2x
+    description: A cli tool of connect to ec2 instance
+    asset: ec2x_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: porter-dev
     repo_name: porter
     asset: porter_{{.Version}}_{{title .OS}}_x86_64.zip


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/pull/13657 [ponkio-o/ec2x](https://github.com/ponkio-o/ec2x): A cli tool of connect to ec2 instance

```console
$ aqua g -i ponkio-o/ec2x
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ec2x --help
NAME:
   ec2x - ec2x is connect to EC2 instance using SSM Session Manager

USAGE:
   ec2x [global options] command [command options] [arguments...]

VERSION:
   0.0.8

COMMANDS:
   connect  Connect to EC2 instance with Session Manager
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```

Reference

- README.md
	- https://github.com/ponkio-o/ec2x/blob/main/README.md
