### PR TITLE
feat: bump govulncheck up to v1.0.0

### DIFF
--- a/pkgs/golang/vuln/govulncheck/pkg.yaml
+++ b/pkgs/golang/vuln/govulncheck/pkg.yaml
@@ -1,3 +1,4 @@
 packages:
+  - name: golang/vuln/govulncheck@v1.0.0
   - name: golang/vuln/govulncheck
     version: 485fff3f2c84d78d2c259d17fbf0d8bb3625ea0b

--- a/pkgs/golang/vuln/govulncheck/pkg.yaml
+++ b/pkgs/golang/vuln/govulncheck/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: golang/vuln/govulncheck@v1.0.0
-  - name: golang/vuln/govulncheck
-    version: 485fff3f2c84d78d2c259d17fbf0d8bb3625ea0b


### PR DESCRIPTION
Because [govulncheck v1\.0\.0 is released\!](https://go.dev/blog/govulncheck).