### PR TITLE
fix(sheepla/fzwiki): Follow up changes of v0.1.0-alpha

### DIFF
--- a/pkgs/sheepla/fzwiki/pkg.yaml
+++ b/pkgs/sheepla/fzwiki/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: sheepla/fzwiki@v0.0.9
+  - name: sheepla/fzwiki@v0.1.0-alpha
+  - name: sheepla/fzwiki
+    version: v0.0.3
+  - name: sheepla/fzwiki
+    version: v0.0.2-alpha

--- a/pkgs/sheepla/fzwiki/registry.yaml
+++ b/pkgs/sheepla/fzwiki/registry.yaml
@@ -2,15 +2,37 @@ packages:
   - type: github_release
     repo_owner: sheepla
     repo_name: fzwiki
-    asset: fzwiki_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A command line tool with fzf-like UI to search Wikipedia articles and open it in your browser quickly
+    asset: fzwiki_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
     checksum:
       type: github_release
-      asset: fzwiki_{{trimV .Version}}_checksums.txt
+      asset: checksums.txt
       algorithm: sha256
-    version_constraint: 'Version != "v0.1.0-alpha"'
+    version_constraint: semver(">= 0.1.0-alpha")
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.0.3")
+        overrides: []
+        replacements: {}
         checksum:
           type: github_release
-          asset: checksums.txt
+          asset: fzwiki_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("< 0.0.3")
+        overrides: []
+        replacements: {}
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: fzwiki_{{trimV .Version}}_checksums.txt
           algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -20635,17 +20635,39 @@ packages:
   - type: github_release
     repo_owner: sheepla
     repo_name: fzwiki
-    asset: fzwiki_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: A command line tool with fzf-like UI to search Wikipedia articles and open it in your browser quickly
+    asset: fzwiki_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
     checksum:
       type: github_release
-      asset: fzwiki_{{trimV .Version}}_checksums.txt
+      asset: checksums.txt
       algorithm: sha256
-    version_constraint: 'Version != "v0.1.0-alpha"'
+    version_constraint: semver(">= 0.1.0-alpha")
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.0.3")
+        overrides: []
+        replacements: {}
         checksum:
           type: github_release
-          asset: checksums.txt
+          asset: fzwiki_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("< 0.0.3")
+        overrides: []
+        replacements: {}
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: fzwiki_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
     repo_owner: sheepla


### PR DESCRIPTION
Asset names has been changed.

- https://github.com/sheepla/fzwiki/releases/tag/v0.1.0-alpha

Close #13822
