### PR TITLE
feat: add k0kubun/xremap

### DIFF
--- a/pkgs/k0kubun/xremap/gnome/pkg.yaml
+++ b/pkgs/k0kubun/xremap/gnome/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: k0kubun/xremap/gnome@v0.8.5
+  - name: k0kubun/xremap/gnome
+    version: v0.5.0
+  - name: k0kubun/xremap/gnome
+    version: v0.1.0

--- a/pkgs/k0kubun/xremap/gnome/registry.yaml
+++ b/pkgs/k0kubun/xremap/gnome/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - name: k0kubun/xremap/gnome
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for GNOME Wayland)
+    asset: xremap-{{.OS}}-{{.Arch}}-gnome.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64

--- a/pkgs/k0kubun/xremap/hypr/pkg.yaml
+++ b/pkgs/k0kubun/xremap/hypr/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: k0kubun/xremap/hypr@v0.8.5
+  - name: k0kubun/xremap/hypr
+    version: v0.7.13

--- a/pkgs/k0kubun/xremap/hypr/registry.yaml
+++ b/pkgs/k0kubun/xremap/hypr/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - name: k0kubun/xremap/hypr
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for Hyprland)
+    asset: xremap-{{.OS}}-{{.Arch}}-hypr.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux/amd64
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.7.13")
+    version_overrides:
+      - version_constraint: semver("< 0.7.13")
+        no_asset: true

--- a/pkgs/k0kubun/xremap/kde/pkg.yaml
+++ b/pkgs/k0kubun/xremap/kde/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: k0kubun/xremap/kde@v0.8.5
+  - name: k0kubun/xremap/kde
+    version: v0.8.3

--- a/pkgs/k0kubun/xremap/kde/registry.yaml
+++ b/pkgs/k0kubun/xremap/kde/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - name: k0kubun/xremap/kde
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for KDE-Plasma Wayland)
+    asset: xremap-{{.OS}}-{{.Arch}}-kde.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.8.3")
+    version_overrides:
+      - version_constraint: semver("< 0.8.3")
+        no_asset: true

--- a/pkgs/k0kubun/xremap/sway/pkg.yaml
+++ b/pkgs/k0kubun/xremap/sway/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: k0kubun/xremap/sway@v0.8.5
+  - name: k0kubun/xremap/sway
+    version: v0.5.0
+  - name: k0kubun/xremap/sway
+    version: v0.1.0

--- a/pkgs/k0kubun/xremap/sway/registry.yaml
+++ b/pkgs/k0kubun/xremap/sway/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - name: k0kubun/xremap/sway
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for Sway)
+    asset: xremap-{{.OS}}-{{.Arch}}-sway.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64

--- a/pkgs/k0kubun/xremap/x11/pkg.yaml
+++ b/pkgs/k0kubun/xremap/x11/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: k0kubun/xremap/x11@v0.8.5
+  - name: k0kubun/xremap/x11
+    version: v0.5.0
+  - name: k0kubun/xremap/x11
+    version: v0.1.0

--- a/pkgs/k0kubun/xremap/x11/registry.yaml
+++ b/pkgs/k0kubun/xremap/x11/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - name: k0kubun/xremap/x11
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for X11)
+    asset: xremap-{{.OS}}-{{.Arch}}-x11.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -13861,6 +13861,98 @@ packages:
       - darwin
       - linux
       - windows/amd64
+  - name: k0kubun/xremap/gnome
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for GNOME Wayland)
+    asset: xremap-{{.OS}}-{{.Arch}}-gnome.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64
+  - name: k0kubun/xremap/hypr
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for Hyprland)
+    asset: xremap-{{.OS}}-{{.Arch}}-hypr.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux/amd64
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.7.13")
+    version_overrides:
+      - version_constraint: semver("< 0.7.13")
+        no_asset: true
+  - name: k0kubun/xremap/kde
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for KDE-Plasma Wayland)
+    asset: xremap-{{.OS}}-{{.Arch}}-kde.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.8.3")
+    version_overrides:
+      - version_constraint: semver("< 0.8.3")
+        no_asset: true
+  - name: k0kubun/xremap/sway
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for Sway)
+    asset: xremap-{{.OS}}-{{.Arch}}-sway.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64
+  - name: k0kubun/xremap/x11
+    type: github_release
+    repo_owner: k0kubun
+    repo_name: xremap
+    description: Key remapper for X11 and Wayland (for X11)
+    asset: xremap-{{.OS}}-{{.Arch}}-x11.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux
+    files:
+      - name: xremap
+    version_constraint: semver(">= 0.5.0")
+    version_overrides:
+      - version_constraint: semver("< 0.5.0")
+        supported_envs:
+          - linux/amd64
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0s


### PR DESCRIPTION
- [k0kubun/xremap/gnome](https://github.com/k0kubun/xremap): Key remapper for X11 and Wayland (for GNOME Wayland)
- [k0kubun/xremap/hypr](https://github.com/k0kubun/xremap): Key remapper for X11 and Wayland (for Hyprland)
- [k0kubun/xremap/kde](https://github.com/k0kubun/xremap): Key remapper for X11 and Wayland (for KDE-Plasma Wayland)
- [k0kubun/xremap/sway](https://github.com/k0kubun/xremap): Key remapper for X11 and Wayland (for Sway)
- [k0kubun/xremap/x11](https://github.com/k0kubun/xremap): Key remapper for X11 and Wayland (for X11)

```console
$ aqua g -i k0kubun/xremap/gnome
$ aqua g -i k0kubun/xremap/hypr
$ aqua g -i k0kubun/xremap/kde
$ aqua g -i k0kubun/xremap/sway
$ aqua g -i k0kubun/xremap/x11
```

## Notes

1. Xremap supports a lot of desktop environment (DE) for Linux.
I appended a few words from README for description to clarify supported DE.

2. `k0kubun/xremap/hypr` has been added in vesion `0.7.13` (and only support `linux/amd64`).
`k0kubun/xremap/kde` has been added in vesion `0.8.3`.
So in these packages `no_asset` is set for older versions.
