### PR TITLE
fix(mattn/efm-langserver): Ignore v0.0.45

### DIFF
--- a/pkgs/mattn/efm-langserver/registry.yaml
+++ b/pkgs/mattn/efm-langserver/registry.yaml
@@ -11,3 +11,7 @@ packages:
     files:
       - name: efm-langserver
         src: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver
+    version_constraint: semver("!= 0.0.45")
+    version_overrides:
+      - version_constraint: semver("= 0.0.45")
+        no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -16717,6 +16717,10 @@ packages:
     files:
       - name: efm-langserver
         src: efm-langserver_{{.Version}}_{{.OS}}_{{.Arch}}/efm-langserver
+    version_constraint: semver("!= 0.0.45")
+    version_overrides:
+      - version_constraint: semver("= 0.0.45")
+        no_asset: true
   - type: github_release
     repo_owner: mattn
     repo_name: files


### PR DESCRIPTION
The release has been deleted.

Close #13983
