### PR TITLE
fix(watchexec/watchexec): follow up changes of watchexec v1.20.6

### DIFF
--- a/pkgs/watchexec/watchexec/pkg.yaml
+++ b/pkgs/watchexec/watchexec/pkg.yaml
@@ -1,6 +1,10 @@
 packages:
   - name: watchexec/watchexec@v1.22.3
   - name: watchexec/watchexec
+    version: v1.21.1
+  - name: watchexec/watchexec
+    version: v1.21.0
+  - name: watchexec/watchexec
     version: v1.20.6
   - name: watchexec/watchexec
     version: cli-v1.20.5

--- a/pkgs/watchexec/watchexec/pkg.yaml
+++ b/pkgs/watchexec/watchexec/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
-  - name: watchexec/watchexec@cli-v1.17.1
+  - name: watchexec/watchexec@v1.22.3
+  - name: watchexec/watchexec
+    version: v1.20.6
+  - name: watchexec/watchexec
+    version: cli-v1.20.5
+  - name: watchexec/watchexec
+    version: cli-v1.17.1

--- a/pkgs/watchexec/watchexec/registry.yaml
+++ b/pkgs/watchexec/watchexec/registry.yaml
@@ -3,7 +3,6 @@ packages:
     repo_owner: watchexec
     repo_name: watchexec
     description: Executes commands in response to file modifications
-    rosetta2: true
     asset: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
     supported_envs:
       - darwin
@@ -29,7 +28,15 @@ packages:
       type: github_release
       asset: SHA512SUMS
       algorithm: sha512
-    version_constraint: semver(">= 1.20.6")
+    version_constraint: semver(">= 1.21.1")
     version_overrides:
-      - version_constraint: semver("< 1.20.6")
+      - version_constraint: semver(">= 1.21.0")
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.20.6")
+        rosetta2: true
+      - version_constraint: semver(">= 1.18.0")
         version_prefix: cli-
+      - version_constraint: semver("< 1.18.0")
+        version_prefix: cli-
+        rosetta2: true

--- a/pkgs/watchexec/watchexec/registry.yaml
+++ b/pkgs/watchexec/watchexec/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_name: watchexec
     description: Executes commands in response to file modifications
     rosetta2: true
-    asset: 'watchexec-{{trimPrefix "cli-v" .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    asset: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
     supported_envs:
       - darwin
       - linux
@@ -24,8 +24,12 @@ packages:
           linux: unknown-linux-gnu
     files:
       - name: watchexec
-        src: 'watchexec-{{trimPrefix "cli-v" .Version}}-{{.Arch}}-{{.OS}}/watchexec'
+        src: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}/watchexec
     checksum:
       type: github_release
       asset: SHA512SUMS
       algorithm: sha512
+    version_constraint: semver(">= 1.20.6")
+    version_overrides:
+      - version_constraint: semver("< 1.20.6")
+        version_prefix: cli-

--- a/registry.yaml
+++ b/registry.yaml
@@ -24256,7 +24256,6 @@ packages:
     repo_owner: watchexec
     repo_name: watchexec
     description: Executes commands in response to file modifications
-    rosetta2: true
     asset: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
     supported_envs:
       - darwin
@@ -24282,10 +24281,18 @@ packages:
       type: github_release
       asset: SHA512SUMS
       algorithm: sha512
-    version_constraint: semver(">= 1.20.6")
+    version_constraint: semver(">= 1.21.1")
     version_overrides:
-      - version_constraint: semver("< 1.20.6")
+      - version_constraint: semver(">= 1.21.0")
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.20.6")
+        rosetta2: true
+      - version_constraint: semver(">= 1.18.0")
         version_prefix: cli-
+      - version_constraint: semver("< 1.18.0")
+        version_prefix: cli-
+        rosetta2: true
   - type: github_release
     repo_owner: weaveworks
     repo_name: eksctl

--- a/registry.yaml
+++ b/registry.yaml
@@ -24257,7 +24257,7 @@ packages:
     repo_name: watchexec
     description: Executes commands in response to file modifications
     rosetta2: true
-    asset: 'watchexec-{{trimPrefix "cli-v" .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}'
+    asset: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
     supported_envs:
       - darwin
       - linux
@@ -24277,11 +24277,15 @@ packages:
           linux: unknown-linux-gnu
     files:
       - name: watchexec
-        src: 'watchexec-{{trimPrefix "cli-v" .Version}}-{{.Arch}}-{{.OS}}/watchexec'
+        src: watchexec-{{trimV .SemVer}}-{{.Arch}}-{{.OS}}/watchexec
     checksum:
       type: github_release
       asset: SHA512SUMS
       algorithm: sha512
+    version_constraint: semver(">= 1.20.6")
+    version_overrides:
+      - version_constraint: semver("< 1.20.6")
+        version_prefix: cli-
   - type: github_release
     repo_owner: weaveworks
     repo_name: eksctl


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/pull/13825#issuecomment-1647903009
- https://github.com/watchexec/watchexec/releases/tag/v1.20.6

> Releng: change tag scheme. CLI versions are tagged v1.2.3, all other crates are strictly {crate-name}-v1.2.3.
> Historical tag names are preserved as aliases.