### PR TITLE
feat: add bflad/tfproviderdocs

### DIFF
--- a/pkgs/bflad/tfproviderdocs/pkg.yaml
+++ b/pkgs/bflad/tfproviderdocs/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: bflad/tfproviderdocs@v0.11.1
+  - name: bflad/tfproviderdocs
+    version: v0.10.0
+  - name: bflad/tfproviderdocs
+    version: v0.1.0

--- a/pkgs/bflad/tfproviderdocs/registry.yaml
+++ b/pkgs/bflad/tfproviderdocs/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: bflad
+    repo_name: tfproviderdocs
+    description: Terraform Provider Documentation Tool
+    asset: tfproviderdocs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: tfproviderdocs_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.10.0")
+    version_overrides:
+      - version_constraint: semver("< 0.10.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -4498,6 +4498,19 @@ packages:
           asset: s3deploy_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: bflad
+    repo_name: tfproviderdocs
+    description: Terraform Provider Documentation Tool
+    asset: tfproviderdocs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: tfproviderdocs_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: binwiederhier
     repo_name: ntfy
     description: Send push notifications to your phone or desktop using PUT/POST

--- a/registry.yaml
+++ b/registry.yaml
@@ -4510,6 +4510,13 @@ packages:
       type: github_release
       asset: tfproviderdocs_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.10.0")
+    version_overrides:
+      - version_constraint: semver("< 0.10.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: binwiederhier
     repo_name: ntfy


### PR DESCRIPTION
[bflad/tfproviderdocs](https://github.com/bflad/tfproviderdocs): Terraform Provider Documentation Tool

```console
$ aqua g -i bflad/tfproviderdocs
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ tfproviderdocs help
Usage: tfproviderdocs [--version] [--help] <command> [<args>]

Available commands are:
    check      Checks Terraform Provider documentation
    version    Prints the version
```

Reference

- README.md
	- https://github.com/bflad/tfproviderdocs/blob/main/README.md
