### PR TITLE
feat: add golangci/misspell

### DIFF
--- a/pkgs/golangci/misspell/pkg.yaml
+++ b/pkgs/golangci/misspell/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golangci/misspell@v0.4.1

--- a/pkgs/golangci/misspell/registry.yaml
+++ b/pkgs/golangci/misspell/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: golangci
+    repo_name: misspell
+    description: Correct commonly misspelled English words in source files
+    asset: misspell_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: 64bit
+      darwin: mac
+    checksum:
+      type: github_release
+      asset: misspell_{{trimV .Version}}_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -10816,6 +10816,19 @@ packages:
       asset: golangci-lint-{{trimV .Version}}-checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: golangci
+    repo_name: misspell
+    description: Correct commonly misspelled English words in source files
+    asset: misspell_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: 64bit
+      darwin: mac
+    checksum:
+      type: github_release
+      asset: misspell_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: gomods
     repo_name: athens
     description: A Go module datastore and proxy


### PR DESCRIPTION
[golangci/misspell](https://github.com/golangci/misspell): Correct commonly misspelled English words in source files

```console
$ aqua g -i golangci/misspell
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ misspell -h
Usage of misspell:
  -debug
        Debug matching, very slow
  -error
        Exit with 2 if misspelling found
  -f string
        'csv', 'sqlite3' or custom Golang template for output
  -i string
        ignore the following corrections, comma separated
  -j int
        Number of workers, 0 = number of CPUs
  -legal
        Show legal information and exit
  -locale string
        Correct spellings using locale perferances for US or UK.  Default is to use a neutral variety of English.  Setting locale to US will correct the British spelling of 'colour' to 'color'
  -o string
        output file or [stderr|stdout|] (default "stdout")
  -q    Do not emit misspelling output
  -source string
        Source mode: auto=guess, go=golang source, text=plain or markdown-like text (default "auto")
  -v    Show version and exit
  -w    Overwrite file with corrections (default is just to display)
```

Reference

- README.md
    - https://github.com/golangci/misspell/blob/master/README.md
