### PR TITLE
feat: add pavius/impi

### DIFF
--- a/pkgs/pavius/impi/pkg.yaml
+++ b/pkgs/pavius/impi/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pavius/impi@v0.0.3

--- a/pkgs/pavius/impi/registry.yaml
+++ b/pkgs/pavius/impi/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: pavius
+    repo_name: impi
+    description: Verify proper golang import directives, beyond the capability of gofmt and goimports
+    asset: impi-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -19058,6 +19058,16 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: pavius
+    repo_name: impi
+    description: Verify proper golang import directives, beyond the capability of gofmt and goimports
+    asset: impi-{{.Version}}-{{.OS}}-{{.Arch}}
+    format: raw
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+  - type: github_release
     repo_owner: peak
     repo_name: s5cmd
     description: Parallel S3 and local filesystem execution tool


### PR DESCRIPTION
[pavius/impi](https://github.com/pavius/impi): Verify proper golang import directives, beyond the capability of gofmt and goimports

```console
$ aqua g -i pavius/impi
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ impi --help
usage: impi-v0.0.3-darwin-amd64 PACKAGE [PACKAGE ...]
  -ignore-generated
        ignore files generated by 'go generate'
  -local string
        prefix of the local repository
  -scheme string
        verification scheme to enforce. one of stdLocalThirdParty/stdThirdPartyLocal
  -skip value
        paths to skip (regex)
```

Reference

- README
	- https://github.com/pavius/impi/blob/master/README.md
