### PR TITLE
feat: add hashicorp/copywrite

### DIFF
--- a/pkgs/hashicorp/copywrite/pkg.yaml
+++ b/pkgs/hashicorp/copywrite/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hashicorp/copywrite@v0.16.4

--- a/pkgs/hashicorp/copywrite/registry.yaml
+++ b/pkgs/hashicorp/copywrite/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: hashicorp
+    repo_name: copywrite
+    description: Automate copyright headers and license files at scale
+    asset: copywrite_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -11710,6 +11710,21 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: hashicorp
+    repo_name: copywrite
+    description: Automate copyright headers and license files at scale
+    asset: copywrite_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      algorithm: sha256
+  - type: github_release
+    repo_owner: hashicorp
     repo_name: go-getter
     description: Package for downloading things from a string URL using a variety of protocols
     rosetta2: true


### PR DESCRIPTION
[hashicorp/copywrite](https://github.com/hashicorp/copywrite): Automate copyright headers and license files at scale

```console
$ aqua g -i hashicorp/copywrite
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ copywrite --help
Copywrite provides utilities for managing copyright headers and license
files in HashiCorp repos.

You can use it to report on what licenses repos are using, add LICENSE files,
and add or validate the presence of copyright headers on source code files.

Usage:
  copywrite [command]

Common Commands:
  headers     Adds missing copyright headers to all source code files
  init        Generates a .copywrite.hcl config for a new project
  license     Validates that a LICENSE file is present and remediates any issues if found

Additional Commands:
  completion  Generate the autocompletion script for the specified shell
  debug       Prints env-specific debug information about copywrite
  dispatch    Dispatches audit jobs for a list of repos
  help        Help about any command
  report      Performs a variety of reporting tasks

Flags:
      --config string   config file (default ".copywrite.hcl")
  -h, --help            help for copywrite
  -v, --version         version for copywrite

Use "copywrite [command] --help" for more information about a command.
```

Reference

- README.md
	- https://github.com/hashicorp/copywrite/blob/main/README.md
