### PR TITLE
feat: add Scalingo/cli

### DIFF
--- a/pkgs/Scalingo/cli/pkg.yaml
+++ b/pkgs/Scalingo/cli/pkg.yaml
@@ -1,14 +1,6 @@
 packages:
   - name: Scalingo/cli@1.29.1
   - name: Scalingo/cli
-    version: 1.29.0
-  - name: Scalingo/cli
-    version: 1.28.2
-  - name: Scalingo/cli
-    version: 1.28.0
-  - name: Scalingo/cli
-    version: 1.27.2
-  - name: Scalingo/cli
     version: 1.24.1
   - name: Scalingo/cli
     version: 1.24.0

--- a/pkgs/Scalingo/cli/pkg.yaml
+++ b/pkgs/Scalingo/cli/pkg.yaml
@@ -1,0 +1,20 @@
+packages:
+  - name: Scalingo/cli@1.29.1
+  - name: Scalingo/cli
+    version: 1.29.0
+  - name: Scalingo/cli
+    version: 1.28.2
+  - name: Scalingo/cli
+    version: 1.28.0
+  - name: Scalingo/cli
+    version: 1.27.2
+  - name: Scalingo/cli
+    version: 1.24.1
+  - name: Scalingo/cli
+    version: 1.24.0
+  - name: Scalingo/cli
+    version: 1.21.0
+  - name: Scalingo/cli
+    version: 1.20.1
+  - name: Scalingo/cli
+    version: 1.0.0-alpha1

--- a/pkgs/Scalingo/cli/registry.yaml
+++ b/pkgs/Scalingo/cli/registry.yaml
@@ -1,0 +1,54 @@
+packages:
+  - type: github_release
+    repo_owner: Scalingo
+    repo_name: cli
+    description: Command Line client for Scalingo PaaS
+    asset: scalingo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: scalingo
+        src: scalingo_{{.Version}}_{{.OS}}_{{.Arch}}/scalingo
+    overrides:
+      - goos: windows
+        format: zip
+        checksum:
+          type: github_release
+          asset: checksums_windows.txt
+          algorithm: sha256
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 1.26.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.24.0")
+        overrides: []
+      - version_constraint: semver(">= 1.21.0")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.20.1")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 1.20.1")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/pkgs/Scalingo/cli/registry.yaml
+++ b/pkgs/Scalingo/cli/registry.yaml
@@ -22,7 +22,9 @@ packages:
     version_constraint: semver(">= 1.26.0")
     version_overrides:
       - version_constraint: semver(">= 1.24.0")
-        overrides: []
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver(">= 1.21.0")
         format: zip
         overrides:

--- a/pkgs/Scalingo/cli/registry.yaml
+++ b/pkgs/Scalingo/cli/registry.yaml
@@ -21,10 +21,12 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 1.26.0")
     version_overrides:
-      - version_constraint: semver(">= 1.24.0")
+      - version_constraint: semver(">= 1.24.1")
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver(">= 1.24.0")
+        overrides: []
       - version_constraint: semver(">= 1.21.0")
         format: zip
         overrides:
@@ -48,6 +50,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            files:
+              - name: scalingo
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1428,6 +1428,59 @@ packages:
           asset: spotify-tui-{{.OS}}.sha256
           algorithm: sha256
   - type: github_release
+    repo_owner: Scalingo
+    repo_name: cli
+    description: Command Line client for Scalingo PaaS
+    asset: scalingo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: scalingo
+        src: scalingo_{{.Version}}_{{.OS}}_{{.Arch}}/scalingo
+    overrides:
+      - goos: windows
+        format: zip
+        checksum:
+          type: github_release
+          asset: checksums_windows.txt
+          algorithm: sha256
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 1.26.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.24.0")
+        overrides: []
+      - version_constraint: semver(">= 1.21.0")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 1.20.1")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 1.20.1")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: Schniz
     repo_name: fnm
     description: Fast and simple Node.js version manager, built in Rust

--- a/registry.yaml
+++ b/registry.yaml
@@ -1449,10 +1449,12 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 1.26.0")
     version_overrides:
-      - version_constraint: semver(">= 1.24.0")
+      - version_constraint: semver(">= 1.24.1")
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver(">= 1.24.0")
+        overrides: []
       - version_constraint: semver(">= 1.21.0")
         format: zip
         overrides:
@@ -1476,6 +1478,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            files:
+              - name: scalingo
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1450,7 +1450,9 @@ packages:
     version_constraint: semver(">= 1.26.0")
     version_overrides:
       - version_constraint: semver(">= 1.24.0")
-        overrides: []
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver(">= 1.21.0")
         format: zip
         overrides:


### PR DESCRIPTION
Close #13691

[Scalingo/cli](https://github.com/Scalingo/cli): Command Line client for Scalingo PaaS

```console
$ aqua g -i Scalingo/cli
```