### PR TITLE
feat: add connectrpc/connect-go/protoc-gen-connect-go

### DIFF
--- a/pkgs/connectrpc/connect-go/protoc-gen-connect-go/pkg.yaml
+++ b/pkgs/connectrpc/connect-go/protoc-gen-connect-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: connectrpc/connect-go/protoc-gen-connect-go@v1.11.0

--- a/pkgs/connectrpc/connect-go/protoc-gen-connect-go/registry.yaml
+++ b/pkgs/connectrpc/connect-go/protoc-gen-connect-go/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - name: connectrpc/connect-go/protoc-gen-connect-go
+    search_words:
+      -  bufbuild
+    type: go_install
+    repo_owner: connectrpc
+    repo_name: connect-go
+    description: Simple, reliable, interoperable. A better gRPC
+    path: connectrpc.com/connect/cmd/protoc-gen-connect-go
+    files:
+      - name: protoc-gen-connect-go

--- a/registry.yaml
+++ b/registry.yaml
@@ -6785,6 +6785,16 @@ packages:
     # https://github.com/aquaproj/aqua/issues/1216
     files:
       - name: fly
+  - name: connectrpc/connect-go/protoc-gen-connect-go
+    search_words:
+      -  bufbuild
+    type: go_install
+    repo_owner: connectrpc
+    repo_name: connect-go
+    description: Simple, reliable, interoperable. A better gRPC
+    path: connectrpc.com/connect/cmd/protoc-gen-connect-go
+    files:
+      - name: protoc-gen-connect-go
   - type: github_release
     repo_owner: container-tools
     repo_name: spectrum


### PR DESCRIPTION
The repository of  [bufbuild/connect-go/protoc-gen-connect-go](https://github.com/bufbuild/connect-go) have recently been moved from https://github.com/bufbuild/connect-go to https://github.com/connectrpc/connect-go.
Therefore, I'd like to add connectrpc/connect-go/protoc-gen-connect-go to aqua-registry.

> This is the first release of Connect in the connectrpc GitHub organization. The import path has changed to connectrpc.com/connect.
> 
> All previous releases are available under the new import path. The code for these releases is identical to the code for github.com/bufbuild/connect-go.

ref.) https://github.com/connectrpc/connect-go/releases/tag/v1.11.0

Related #8760

---
[connectrpc/connect-go/protoc-gen-connect-go](https://github.com/connectrpc/connect-go): Simple, reliable, interoperable. A better gRPC

```console
$ aqua g -i connectrpc/connect-go/protoc-gen-connect-go
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ aqua g -i connectrpc/connect-go/protoc-gen-connect-go
$ protoc-gen-connect-go --version
1.11.0
```
