### PR TITLE
Rename kyleconroy/sqlc to sqlc-dev/sqlc as of repository migration

### DIFF
--- a/pkgs/kyleconroy/sqlc/pkg.yaml
+++ b/pkgs/kyleconroy/sqlc/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: kyleconroy/sqlc@v1.20.0

--- a/pkgs/sqlc-dev/sqlc/pkg.yaml
+++ b/pkgs/sqlc-dev/sqlc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sqlc-dev/sqlc@v1.20.0

--- a/pkgs/sqlc-dev/sqlc/registry.yaml
+++ b/pkgs/sqlc-dev/sqlc/registry.yaml
@@ -3,8 +3,9 @@ packages:
     repo_owner: sqlc-dev
     repo_name: sqlc
     description: Generate type-safe code from SQL
-    rosetta2: true
-    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
     supported_envs:
       - darwin
+      - linux
       - amd64

--- a/pkgs/sqlc-dev/sqlc/registry.yaml
+++ b/pkgs/sqlc-dev/sqlc/registry.yaml
@@ -2,6 +2,8 @@ packages:
   - type: github_release
     repo_owner: sqlc-dev
     repo_name: sqlc
+    aliases:
+      - name: kyleconroy/sqlc
     description: Generate type-safe code from SQL
     asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz

--- a/pkgs/sqlc-dev/sqlc/registry.yaml
+++ b/pkgs/sqlc-dev/sqlc/registry.yaml
@@ -1,6 +1,6 @@
 packages:
   - type: github_release
-    repo_owner: kyleconroy
+    repo_owner: sqlc-dev
     repo_name: sqlc
     description: Generate type-safe code from SQL
     rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -22156,10 +22156,11 @@ packages:
     repo_owner: sqlc-dev
     repo_name: sqlc
     description: Generate type-safe code from SQL
-    rosetta2: true
-    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
     supported_envs:
       - darwin
+      - linux
       - amd64
   - type: github_release
     repo_owner: sqshq

--- a/registry.yaml
+++ b/registry.yaml
@@ -22155,6 +22155,8 @@ packages:
   - type: github_release
     repo_owner: sqlc-dev
     repo_name: sqlc
+    aliases:
+      - name: kyleconroy/sqlc
     description: Generate type-safe code from SQL
     asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -16228,15 +16228,6 @@ packages:
           - name: json2hcl
             src: json2hcl_{{.OS}}_{{.Arch}}/json2hcl
   - type: github_release
-    repo_owner: kyleconroy
-    repo_name: sqlc
-    description: Generate type-safe code from SQL
-    rosetta2: true
-    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    supported_envs:
-      - darwin
-      - amd64
-  - type: github_release
     repo_owner: kyoh86
     repo_name: richgo
     description: Enrich `go test` outputs with text decorations
@@ -22161,6 +22152,15 @@ packages:
       - linux/amd64
       - darwin
     rosetta2: true
+  - type: github_release
+    repo_owner: sqlc-dev
+    repo_name: sqlc
+    description: Generate type-safe code from SQL
+    rosetta2: true
+    asset: sqlc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    supported_envs:
+      - darwin
+      - amd64
   - type: github_release
     repo_owner: sqshq
     repo_name: sampler


### PR DESCRIPTION
The kyleconroy/sqlc repository has recently been moved to [sqlc-dev/sqlc](https://github.com/sqlc-dev/sqlc). The old repository no longer exists and redirects to the new repository, so I'd like to rename existing pkg to the new one.

> We also created a new GitHub organization ([sqlc-dev](https://github.com/sqlc-dev)) to house existing and future work. We’ve already migrated most sqlc-related repositories, but we’re waiting to move the [sqlc-dev/sqlc](https://github.com/sqlc-dev/sqlc) repo. The plan is to migrate it in the next week or two.

ref.) https://sqlc.dev/posts/2023/07/06/working-on-sqlc-full-time/

---

[sqlc-dev/sqlc](https://github.com/sqlc-dev/sqlc): Generate type-safe code from SQL

```console
$ aqua g -i sqlc-dev/sqlc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ sqlc version
v1.20.0
```
