### PR TITLE
feat: add smallstep/certificates

### DIFF
--- a/pkgs/smallstep/certificates/pkg.yaml
+++ b/pkgs/smallstep/certificates/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: smallstep/certificates@v0.24.2

--- a/pkgs/smallstep/certificates/registry.yaml
+++ b/pkgs/smallstep/certificates/registry.yaml
@@ -11,6 +11,10 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    supported_envs:
+      - windows/amd64
+      - darwin
+      - linux
     checksum:
       type: github_release
       asset: checksums.txt

--- a/pkgs/smallstep/certificates/registry.yaml
+++ b/pkgs/smallstep/certificates/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: smallstep
+    repo_name: certificates
+    asset: step-ca_{{.OS}}_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: step-ca
+        src: step-ca_{{trimV .Version}}/step-ca
+    description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH. # overrides:
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -21843,6 +21843,26 @@ packages:
             format: raw
   - type: github_release
     repo_owner: smallstep
+    repo_name: certificates
+    asset: step-ca_{{.OS}}_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: step-ca
+        src: step-ca_{{trimV .Version}}/step-ca
+    description: A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH. # overrides:
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - type: github_release
+    repo_owner: smallstep
     repo_name: cli
     asset: step_{{.OS}}_{{trimV .Version}}_{{.Arch}}.{{.Format}}
     format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -21853,6 +21853,10 @@ packages:
     overrides:
       - goos: windows
         format: zip
+    supported_envs:
+      - windows/amd64
+      - darwin
+      - linux
     checksum:
       type: github_release
       asset: checksums.txt


### PR DESCRIPTION
[smallstep/certificates](https://github.com/smallstep/certificates): A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH.
