### PR TITLE
feat: add uber-go/mock

### DIFF
--- a/pkgs/uber-go/mock/pkg.yaml
+++ b/pkgs/uber-go/mock/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: uber-go/mock@v0.2.0

--- a/pkgs/uber-go/mock/registry.yaml
+++ b/pkgs/uber-go/mock/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: go_install
+    repo_owner: uber-go
+    repo_name: mock
+    description: GoMock is a mocking framework for the Go programming language
+    path: go.uber.org/mock/mockgen
+    files:
+      - name: mockgen

--- a/registry.yaml
+++ b/registry.yaml
@@ -24301,6 +24301,13 @@ packages:
       type: github_release
       asset: kubefwd_checksums.txt
       algorithm: sha256
+  - type: go_install
+    repo_owner: uber-go
+    repo_name: mock
+    description: GoMock is a mocking framework for the Go programming language
+    path: go.uber.org/mock/mockgen
+    files:
+      - name: mockgen
   - type: github_release
     repo_owner: updatecli
     repo_name: updatecli


### PR DESCRIPTION
[uber-go/mock](https://github.com/uber-go/mock) is a maintained fork of [golang/mock](https://github.com/golang/mock) that has already been archived.

> Update, June 2023: This repo and tool are no longer maintained. Please see [go.uber.org/mock](https://github.com/uber/mock) for a maintained fork instead.

ref.) https://github.com/golang/mock#gomock

---

[uber-go/mock](https://github.com/uber-go/mock): GoMock is a mocking framework for the Go programming language

```console
$ aqua g -i uber-go/mock
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mockgen -version
v0.2.0
```
