### PR TITLE
feat: add google/go-licenses

### DIFF
--- a/pkgs/google/go-licenses/pkg.yaml
+++ b/pkgs/google/go-licenses/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/go-licenses@v1.6.0

--- a/pkgs/google/go-licenses/registry.yaml
+++ b/pkgs/google/go-licenses/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: google
+    repo_name: go-licenses
+    description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time

--- a/registry.yaml
+++ b/registry.yaml
@@ -11178,6 +11178,10 @@ packages:
         supported_envs:
           - linux
           - windows/amd64
+  - type: go_install
+    repo_owner: google
+    repo_name: go-licenses
+    description: A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time
   - type: github_release
     repo_owner: google
     repo_name: jsonnet


### PR DESCRIPTION
[google/go-licenses](https://github.com/google/go-licenses): A lightweight tool to report on the licenses used by a Go package and its dependencies. Highlight! Versioned external URL to licenses can be found at the same time

```console
$ aqua g -i google/go-licenses
```