### PR TITLE
feat: add mitchellh/golicense

### DIFF
--- a/pkgs/mitchellh/golicense/pkg.yaml
+++ b/pkgs/mitchellh/golicense/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mitchellh/golicense@v0.2.0

--- a/pkgs/mitchellh/golicense/registry.yaml
+++ b/pkgs/mitchellh/golicense/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: mitchellh
+    repo_name: golicense
+    description: Scan and analyze OSS dependencies and licenses from compiled Go binaries
+    asset: golicense_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -17546,6 +17546,23 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: mitchellh
+    repo_name: golicense
+    description: Scan and analyze OSS dependencies and licenses from compiled Go binaries
+    asset: golicense_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: mitchellh
     repo_name: gon
     asset: gon_{{.OS}}.zip
     description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library


### PR DESCRIPTION
[mitchellh/golicense](https://github.com/mitchellh/golicense): Scan and analyze OSS dependencies and licenses from compiled Go binaries

```console
$ aqua g -i mitchellh/golicense
```