### PR TITLE
feat: add ribice/glice

### DIFF
--- a/pkgs/ribice/glice/pkg.yaml
+++ b/pkgs/ribice/glice/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ribice/glice@v2.5.0

--- a/pkgs/ribice/glice/registry.yaml
+++ b/pkgs/ribice/glice/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: go_install
+    repo_owner: ribice
+    repo_name: glice
+    description: Go license and dependency checker
+    path: github.com/ribice/glice/v2/cmd/glice

--- a/registry.yaml
+++ b/registry.yaml
@@ -20502,6 +20502,11 @@ packages:
       type: github_release
       asset: vim-startuptime_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - type: go_install
+    repo_owner: ribice
+    repo_name: glice
+    description: Go license and dependency checker
+    path: github.com/ribice/glice/v2/cmd/glice
   - type: github_release
     repo_owner: rikatz
     repo_name: kubepug


### PR DESCRIPTION
[ribice/glice](https://github.com/ribice/glice): Go license and dependency checker

```console
$ aqua g -i ribice/glice
```