### PR TITLE
feat: add aws/amazon-ecs-cli

### DIFF
--- a/pkgs/aws/amazon-ecs-cli/pkg.yaml
+++ b/pkgs/aws/amazon-ecs-cli/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: aws/amazon-ecs-cli@v1.21.0
+  - name: aws/amazon-ecs-cli
+    version: v1.0.0
+  - name: aws/amazon-ecs-cli
+    version: v0.6.6

--- a/pkgs/aws/amazon-ecs-cli/registry.yaml
+++ b/pkgs/aws/amazon-ecs-cli/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - type: http
+    repo_owner: aws
+    repo_name: amazon-ecs-cli
+    description: The Amazon ECS CLI enables users to run their applications on ECS/Fargate using the Docker Compose file format, quickly provision resources, push/pull images in ECR, and monitor running applications on ECS/Fargate
+    format: raw
+    url: https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-{{.OS}}-{{.Arch}}-{{.Version}}
+    supported_envs:
+      - darwin
+      - linux
+    rosetta2: true
+    files:
+      - name: ecs-cli
+    checksum:
+      type: http
+      algorithm: md5
+      url: https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-{{.OS}}-{{.Arch}}-{{.Version}}.md5
+    version_constraint: semver(">= 1.20.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.0")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -3980,6 +3980,32 @@ packages:
       algorithm: sha256
   - type: http
     repo_owner: aws
+    repo_name: amazon-ecs-cli
+    description: The Amazon ECS CLI enables users to run their applications on ECS/Fargate using the Docker Compose file format, quickly provision resources, push/pull images in ECR, and monitor running applications on ECS/Fargate
+    format: raw
+    url: https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-{{.OS}}-{{.Arch}}-{{.Version}}
+    supported_envs:
+      - darwin
+      - linux
+    rosetta2: true
+    files:
+      - name: ecs-cli
+    checksum:
+      type: http
+      algorithm: md5
+      url: https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-{{.OS}}-{{.Arch}}-{{.Version}}.md5
+    version_constraint: semver(">= 1.20.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.0.0")
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux/amd64
+  - type: http
+    repo_owner: aws
     repo_name: aws-cli
     description: The AWS Command Line Interface (AWS CLI) is a unified tool that provides a consistent interface for interacting with all parts of Amazon Web Services
     version_source: github_tag


### PR DESCRIPTION
[aws/amazon-ecs-cli](https://github.com/aws/amazon-ecs-cli): The Amazon ECS CLI enables users to run their applications on ECS/Fargate using the Docker Compose file format, quickly provision resources, push/pull images in ECR, and monitor running applications on ECS/Fargate

```console
$ aqua g -i aws/amazon-ecs-cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ecs-cli --help
NAME:
   ecs-cli - Command line interface for Amazon ECS

USAGE:
   ecs-cli-darwin-amd64-v1.21.0 [global options] command [command options] [arguments...]

VERSION:
   1.21.0 (bb0b8f0)

AUTHOR:
   Amazon Web Services

COMMANDS:
     configure         Stores a single cluster configuration.
     up                Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.
     down              Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources.
     scale             Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.
     ps                Lists all of the running containers in your ECS cluster.
     push              Pushes an image to an Amazon ECR repository.
     pull              Pulls an image from an Amazon ECR repository.
     images            Lists images from an Amazon ECR repository. Lists all images in all repositories by default.
     license           Prints the LICENSE files for the ECS CLI and its dependencies.
     compose           Executes docker-compose-style commands on an ECS cluster.
     check-attributes  Checks if a given list of container instances can run a given task definition by checking their attributes. Outputs attributes that are required by the task definition but not present on the container instances.
     logs              Retrieves container logs from CloudWatch logs. Assumes your Task Definition uses the awslogs driver and has a log stream prefix specified.
     registry-creds    Facilitates the creation and use of private registry credentials within ECS.
     local             Runs your ECS tasks locally.
     help, h           Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --endpoint value  Use a custom endpoint with the ECS CLI
   --help, -h        show help
   --version, -v     print the version
```

Reference

- README.md
    - https://github.com/aws/amazon-ecs-cli/blob/mainline/README.md
