### PR TITLE
feat: add zitadel/zitadel

### DIFF
--- a/pkgs/zitadel/zitadel/pkg.yaml
+++ b/pkgs/zitadel/zitadel/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: zitadel/zitadel@v2.33.0

--- a/pkgs/zitadel/zitadel/registry.yaml
+++ b/pkgs/zitadel/zitadel/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: zitadel
+    repo_name: zitadel
+    description: ZITADEL - The best of Auth0 and Keycloak combined. Built for the serverless era
+    asset: zitadel-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    files:
+      - name: zitadel
+        src: zitadel-{{.OS}}-{{.Arch}}/zitadel

--- a/registry.yaml
+++ b/registry.yaml
@@ -25924,6 +25924,19 @@ packages:
           - amd64
         rosetta2: true
   - type: github_release
+    repo_owner: zitadel
+    repo_name: zitadel
+    description: ZITADEL - The best of Auth0 and Keycloak combined. Built for the serverless era
+    asset: zitadel-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    files:
+      - name: zitadel
+        src: zitadel-{{.OS}}-{{.Arch}}/zitadel
+  - type: github_release
     repo_owner: zix99
     repo_name: rare
     description: Realtime regex-extraction and aggregation into common formats such as histograms, bar graphs, numerical summaries, tables, and more


### PR DESCRIPTION
[zitadel/zitadel](https://github.com/zitadel/zitadel): ZITADEL - The best of Auth0 and Keycloak combined. Built for the serverless era

```console
$ aqua g -i zitadel/zitadel
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ zitadel --help
The ZITADEL CLI lets you interact with ZITADEL

Usage:
  zitadel [flags]
  zitadel [command]

Available Commands:
  completion       Generate the autocompletion script for the specified shell
  help             Help about any command
  init             initialize ZITADEL instance
  keys             manage encryption keys
  ready            Checks if zitadel is ready
  setup            setup ZITADEL instance
  start            starts ZITADEL instance
  start-from-init  cold starts zitadel
  start-from-setup cold starts zitadel

Flags:
      --config stringArray   path to config file to overwrite system defaults
  -h, --help                 help for zitadel
  -v, --version              version for zitadel

Use "zitadel [command] --help" for more information about a command.
```

Reference

- MacOS Install: https://zitadel.com/docs/self-hosting/deploy/macos#unpack-the-archive
- Linux Install: https://zitadel.com/docs/self-hosting/deploy/linux#unpack-the-archive