### PR TITLE
feat: add cockroachdb/cockroach

### DIFF
--- a/pkgs/cockroachdb/cockroach/pkg.yaml
+++ b/pkgs/cockroachdb/cockroach/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: cockroachdb/cockroach@v23.1.8
+  - name: cockroachdb/cockroach
+    version: v22.2.13
+  - name: cockroachdb/cockroach
+    version: v22.1.22

--- a/pkgs/cockroachdb/cockroach/registry.yaml
+++ b/pkgs/cockroachdb/cockroach/registry.yaml
@@ -1,0 +1,38 @@
+packages:
+  - type: http
+    repo_owner: cockroachdb
+    repo_name: cockroach
+    version_source: github_tag
+    description: A distributed SQL database designed for speed, scale, and survival
+    url: https://binaries.cockroachdb.com/cockroach-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        replacements:
+          darwin: darwin-10.9
+      - goos: darwin
+        goarch: arm64
+        replacements:
+          darwin: darwin-11.0
+      - goos: windows
+        format: zip
+    files:
+      - name: cockroach
+        src: cockroach-{{.Version}}.{{.OS}}-{{.Arch}}/cockroach
+    checksum:
+      type: http
+      url: https://binaries.cockroachdb.com/cockroach-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}.sha256sum
+      algorithm: sha256
+    version_constraint: semver(">= 22.2.0")
+    version_overrides:
+    - version_constraint: semver("< 22.2.0")
+      supported_envs:
+        - darwin
+        - linux
+        - windows
+        - amd64

--- a/pkgs/cockroachdb/cockroach/registry.yaml
+++ b/pkgs/cockroachdb/cockroach/registry.yaml
@@ -40,11 +40,6 @@ packages:
         - windows/amd64
       overrides:
         - goos: darwin
-          goarch: amd64
-          replacements:
-            darwin: darwin-10.9
-        - goos: darwin
-          goarch: arm64
           replacements:
             darwin: darwin-10.9
         - goos: windows

--- a/pkgs/cockroachdb/cockroach/registry.yaml
+++ b/pkgs/cockroachdb/cockroach/registry.yaml
@@ -21,6 +21,8 @@ packages:
           darwin: darwin-11.0
       - goos: windows
         format: zip
+        replacements:
+          windows: windows-6.2
     files:
       - name: cockroach
         src: cockroach-{{.Version}}.{{.OS}}-{{.Arch}}/cockroach
@@ -31,8 +33,21 @@ packages:
     version_constraint: semver(">= 22.2.0")
     version_overrides:
     - version_constraint: semver("< 22.2.0")
+      rosetta2: true
       supported_envs:
         - darwin
-        - linux
-        - windows
-        - amd64
+        - linux/amd64
+        - windows/amd64
+      overrides:
+        - goos: darwin
+          goarch: amd64
+          replacements:
+            darwin: darwin-10.9
+        - goos: darwin
+          goarch: arm64
+          replacements:
+            darwin: darwin-10.9
+        - goos: windows
+          format: zip
+          replacements:
+            windows: windows-6.2

--- a/registry.yaml
+++ b/registry.yaml
@@ -6738,11 +6738,6 @@ packages:
         - windows/amd64
       overrides:
         - goos: darwin
-          goarch: amd64
-          replacements:
-            darwin: darwin-10.9
-        - goos: darwin
-          goarch: arm64
           replacements:
             darwin: darwin-10.9
         - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -6697,6 +6697,43 @@ packages:
       type: github_release
       asset: sha256sum.txt
       algorithm: sha256
+  - type: http
+    repo_owner: cockroachdb
+    repo_name: cockroach
+    version_source: github_tag
+    description: A distributed SQL database designed for speed, scale, and survival
+    url: https://binaries.cockroachdb.com/cockroach-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tgz
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        replacements:
+          darwin: darwin-10.9
+      - goos: darwin
+        goarch: arm64
+        replacements:
+          darwin: darwin-11.0
+      - goos: windows
+        format: zip
+    files:
+      - name: cockroach
+        src: cockroach-{{.Version}}.{{.OS}}-{{.Arch}}/cockroach
+    checksum:
+      type: http
+      url: https://binaries.cockroachdb.com/cockroach-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}.sha256sum
+      algorithm: sha256
+    version_constraint: semver(">= 22.2.0")
+    version_overrides:
+    - version_constraint: semver("< 22.2.0")
+      supported_envs:
+        - darwin
+        - linux
+        - windows
+        - amd64
   - type: github_release
     repo_owner: cocogitto
     repo_name: cocogitto

--- a/registry.yaml
+++ b/registry.yaml
@@ -6719,6 +6719,8 @@ packages:
           darwin: darwin-11.0
       - goos: windows
         format: zip
+        replacements:
+          windows: windows-6.2
     files:
       - name: cockroach
         src: cockroach-{{.Version}}.{{.OS}}-{{.Arch}}/cockroach
@@ -6729,11 +6731,24 @@ packages:
     version_constraint: semver(">= 22.2.0")
     version_overrides:
     - version_constraint: semver("< 22.2.0")
+      rosetta2: true
       supported_envs:
         - darwin
-        - linux
-        - windows
-        - amd64
+        - linux/amd64
+        - windows/amd64
+      overrides:
+        - goos: darwin
+          goarch: amd64
+          replacements:
+            darwin: darwin-10.9
+        - goos: darwin
+          goarch: arm64
+          replacements:
+            darwin: darwin-10.9
+        - goos: windows
+          format: zip
+          replacements:
+            windows: windows-6.2
   - type: github_release
     repo_owner: cocogitto
     repo_name: cocogitto


### PR DESCRIPTION
[cockroachdb/cockroach](https://github.com/cockroachdb/cockroach): A distributed SQL database designed for speed, scale, and survival

```console
$ aqua g -i cockroachdb/cockroach
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cockroach --help
CockroachDB command-line interface and server.

Usage:
  cockroach [command]

Available Commands:
  start             start a node in a multi-node cluster
  start-single-node start a single-node cluster
  connect           Create certificates for securely connecting with clusters

  init              initialize a cluster
  cert              create ca, node, and client certs
  sql               open a sql shell
  statement-diag    commands for managing statement diagnostics bundles
  auth-session      log in and out of HTTP sessions
  node              list, inspect, drain or remove nodes

  nodelocal         upload and delete nodelocal files
  userfile          upload, list and delete user scoped files
  import            import a db or table from a local PGDUMP or MYSQLDUMP file
  demo              open a demo sql shell
  convert-url       convert a SQL connection string for use with various client drivers
  gen               generate auxiliary files
  version           output version information
  debug             debugging commands
  sqlfmt            format SQL statements
  workload          generators for data and query loads
  help              Help about any command

Flags:
  -h, --help                               help for cockroach
      --log <string>
                                            Logging configuration, expressed using YAML syntax. For example, you can
                                            change the default logging directory with: --log='file-defaults: {dir: ...}'.
                                            See the documentation for more options and details.  To preview how the log
                                            configuration is applied, or preview the default configuration, you can use
                                            the 'cockroach debug check-log-config' sub-command.

      --log-config-file <file>
                                            File name to read the logging configuration from. This has the same effect as
                                            passing the content of the file via the --log flag.
                                            (default <unset>)
      --log-config-vars strings
                                            Environment variables that will be expanded if present in the body of the
                                            logging configuration.

      --log-dir <string>
                                            --log-dir=XXX is an alias for --log='file-defaults: {dir: XXX}'.

      --logtostderr <severity>[=DEFAULT]
                                            --logtostderr=XXX is an alias for --log='sinks: {stderr: {filter: XXX}}'. If
                                            no value is specified, the default value for the command is inferred: INFO for
                                            server commands, WARNING for client commands.
                                            (default UNKNOWN)
      --redactable-logs
                                            --redactable-logs=XXX is an alias for --log='file-defaults: {redactable:
                                            XXX}}'.

      --version                            version for cockroach
      --vmodule moduleSpec                 comma-separated list of pattern=N settings for file-filtered logging (significantly hurts performance)

Use "cockroach [command] --help" for more information about a command.
```

starts a temporary, in-memory CockroachDB cluster of one or more nodes, with or without a preloaded dataset, and opens an interactive SQL shell to the cluster.

```console
$ cockroach demo
#
# Welcome to the CockroachDB demo database!
#
# You are connected to a temporary, in-memory CockroachDB cluster of 1 node.
#
# This demo session will send telemetry to Cockroach Labs in the background.
# To disable this behavior, set the environment variable
# COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true.
#
# Beginning initialization of the movr dataset, please wait...
#
# The cluster has been preloaded with the "movr" dataset
# (MovR is a fictional vehicle sharing company).
#
# Reminder: your changes to data stored in the demo session will not be saved!
#
# If you wish to access this demo cluster using another tool, you will need
# the following details:
#
#   - Connection parameters:
#      (webui)    http://127.0.0.1:8080/demologin?password=demo61837&username=demo
#      (cli)      cockroach sql --certs-dir=/home/takumi/.cockroach-demo -u demo -d movr
#      (sql)      postgresql://demo:demo61837@127.0.0.1:26257/movr?sslmode=require&sslrootcert=%2Fhome%2Ftakumi%2F.cockroach-demo%2Fca.crt
#
#   - Username: "demo", password: "demo61837"
#   - Directory with certificate files (for certain SQL drivers/tools): /home/takumi/.cockroach-demo
#
# You can enter \info to print these details again.
#
# Server version: CockroachDB CCL v23.1.8 (x86_64-pc-linux-gnu, built 2023/08/04 18:11:44, go1.19.10) (same version as client)
# Cluster ID: 475707a9-147e-4f9e-b9b9-417cf254f6f6
# Organization: Cockroach Demo
#
# Enter \? for a brief introduction.
#
demo@127.0.0.1:26257/movr> quit
```

Reference

- https://www.cockroachlabs.com/docs/releases
- https://www.cockroachlabs.com/docs/releases/release-support-policy