### PR TITLE
fix(sachaos/viddy): follow up changes of viddy v0.3.7

### DIFF
--- a/pkgs/sachaos/viddy/pkg.yaml
+++ b/pkgs/sachaos/viddy/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: sachaos/viddy@v0.3.6
+  - name: sachaos/viddy@v0.3.7
+  - name: sachaos/viddy
+    version: v0.3.1
+  - name: sachaos/viddy
+    version: v0.1.0

--- a/pkgs/sachaos/viddy/registry.yaml
+++ b/pkgs/sachaos/viddy/registry.yaml
@@ -2,15 +2,25 @@ packages:
   - type: github_release
     repo_owner: sachaos
     repo_name: viddy
-    asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: Modern watch command
+    description: A modern watch command. Time machine and pager etc
+    asset: viddy_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
     replacements:
+      amd64: x86_64
       darwin: Darwin
       linux: Linux
       windows: Windows
-      386: i386
-      amd64: x86_64
     checksum:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.3.7")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.1")
+        asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("< 0.3.1")
+        asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -21065,18 +21065,28 @@ packages:
   - type: github_release
     repo_owner: sachaos
     repo_name: viddy
-    asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: Modern watch command
+    description: A modern watch command. Time machine and pager etc
+    asset: viddy_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
     replacements:
+      amd64: x86_64
       darwin: Darwin
       linux: Linux
       windows: Windows
-      386: i386
-      amd64: x86_64
     checksum:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.3.7")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.1")
+        asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("< 0.3.1")
+        asset: viddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: sahilm
     repo_name: yamldiff


### PR DESCRIPTION
Assets were renamed.

https://github.com/sachaos/viddy/commit/74ca6ef207a8158e5cfbb82122db73efd3bcab40