### PR TITLE
feat: add osteele/gojekyll

### DIFF
--- a/pkgs/osteele/gojekyll/pkg.yaml
+++ b/pkgs/osteele/gojekyll/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: osteele/gojekyll@v0.2.8
+  - name: osteele/gojekyll
+    version: v0.2.7
+  - name: osteele/gojekyll
+    version: v0.2.3
+  - name: osteele/gojekyll
+    version: v0.1.1

--- a/pkgs/osteele/gojekyll/registry.yaml
+++ b/pkgs/osteele/gojekyll/registry.yaml
@@ -17,8 +17,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.2.7")
+    version_constraint: semver(">= 0.2.8")
     version_overrides:
+      - version_constraint: semver(">= 0.2.7")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
       - version_constraint: semver(">= 0.2.3")
         asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:

--- a/pkgs/osteele/gojekyll/registry.yaml
+++ b/pkgs/osteele/gojekyll/registry.yaml
@@ -3,24 +3,13 @@ packages:
     repo_owner: osteele
     repo_name: gojekyll
     description: A fast Go implementation of the Jekyll blogging engine
-    asset: gojekyll_{{.OS}}_{{.Arch}}v1.{{.Format}}
+    asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
-      - goos: linux
-        goarch: arm64
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
-      - goos: darwin
-        goarch: arm64
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
       - goos: windows
-        goarch: amd64
         format: zip
-      - goos: windows
-        goarch: arm64
-        format: zip
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
     replacements:
-      amd64: x86_64
+      amd64: x86_64v1
       darwin: Darwin
       linux: Linux
       windows: Windows
@@ -28,13 +17,8 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.2.8")
+    version_constraint: semver(">= 0.2.7")
     version_overrides:
-      - version_constraint: semver(">= 0.2.7")
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver(">= 0.2.3")
         asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:

--- a/pkgs/osteele/gojekyll/registry.yaml
+++ b/pkgs/osteele/gojekyll/registry.yaml
@@ -1,0 +1,67 @@
+packages:
+  - type: github_release
+    repo_owner: osteele
+    repo_name: gojekyll
+    description: A fast Go implementation of the Jekyll blogging engine
+    asset: gojekyll_{{.OS}}_{{.Arch}}v1.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+      - goos: darwin
+        goarch: arm64
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+      - goos: windows
+        goarch: amd64
+        format: zip
+      - goos: windows
+        goarch: arm64
+        format: zip
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.2.8")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.7")
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver(">= 0.2.3")
+        asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: gojekyll_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.3")
+        asset: gojekyll_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: darwin
+            asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -19422,6 +19422,72 @@ packages:
           asset: scorecard_checksums.txt
           algorithm: sha512
   - type: github_release
+    repo_owner: osteele
+    repo_name: gojekyll
+    description: A fast Go implementation of the Jekyll blogging engine
+    asset: gojekyll_{{.OS}}_{{.Arch}}v1.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: linux
+        goarch: arm64
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+      - goos: darwin
+        goarch: arm64
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+      - goos: windows
+        goarch: amd64
+        format: zip
+      - goos: windows
+        goarch: arm64
+        format: zip
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.2.8")
+    version_overrides:
+      - version_constraint: semver(">= 0.2.7")
+        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver(">= 0.2.3")
+        asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: gojekyll_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.3")
+        asset: gojekyll_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides:
+          - goos: darwin
+            asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          enabled: false
+  - type: github_release
     repo_owner: out-of-cheese-error
     repo_name: the-way
     description: A code snippets manager for your terminal

--- a/registry.yaml
+++ b/registry.yaml
@@ -19425,24 +19425,13 @@ packages:
     repo_owner: osteele
     repo_name: gojekyll
     description: A fast Go implementation of the Jekyll blogging engine
-    asset: gojekyll_{{.OS}}_{{.Arch}}v1.{{.Format}}
+    asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
-      - goos: linux
-        goarch: arm64
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
-      - goos: darwin
-        goarch: arm64
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
       - goos: windows
-        goarch: amd64
         format: zip
-      - goos: windows
-        goarch: arm64
-        format: zip
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
     replacements:
-      amd64: x86_64
+      amd64: x86_64v1
       darwin: Darwin
       linux: Linux
       windows: Windows
@@ -19450,13 +19439,8 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.2.8")
+    version_constraint: semver(">= 0.2.7")
     version_overrides:
-      - version_constraint: semver(">= 0.2.7")
-        asset: gojekyll_{{.OS}}_{{.Arch}}.{{.Format}}
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver(">= 0.2.3")
         asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -19439,8 +19439,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.2.7")
+    version_constraint: semver(">= 0.2.8")
     version_overrides:
+      - version_constraint: semver(">= 0.2.7")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
       - version_constraint: semver(">= 0.2.3")
         asset: gojekyll_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:


### PR DESCRIPTION
[osteele/gojekyll](https://github.com/osteele/gojekyll): A fast Go implementation of the Jekyll blogging engine

```console
$ aqua g -i osteele/gojekyll
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gojekyll --help
usage: gojekyll [<flags>] <command> [<args> ...]

a (somewhat) Jekyll-compatible blog generator


Flags:
  -h, --[no-]help                Show context-sensitive help (also try --help-long and --help-man).
  -s, --source=.                 Source directory
  -d, --destination=DESTINATION  Destination directory
  -D, --[no-]drafts              Render posts in the _drafts folder
      --[no-]future              Publishes posts with a future date
      --[no-]unpublished         Render posts that were marked as unpublished
  -v, --[no-]version             Print the name and version
      --[no-]profile             Create a Go pprof CPU profile
  -q, --[no-]quiet               Silence (some) output.
  -V, --[no-]verbose             Print verbose output.
  -I, --[no-]incremental         Enable incremental rebuild.
      --[no-]force_polling       Force watch to use polling

Commands:
help [<command>...]
    Show help.

benchmark
    Repeat build for ten seconds. Implies --profile.

build [<flags>]
    Build your site

clean
    Clean the site (removes site output) without building.

plugins
    List emulated plugins

render [<PATH>]
    Render a file or URL path to standard output

routes [<flags>]
    Display site permalinks and associated files

serve [<flags>]
    Serve your site locally

variables [<PATH>]
    Print site or document variables

version
    Print the name and version
```


Reference

- README.md
    - https://github.com/osteele/gojekyll#binary-downloads