### PR TITLE
fix: rename the package `acorn-io/acorn` to `acorn-io/runtime`

### DIFF
--- a/pkgs/acorn-io/acorn/pkg.yaml
+++ b/pkgs/acorn-io/acorn/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: acorn-io/acorn@v0.8.0

--- a/pkgs/acorn-io/runtime/pkg.yaml
+++ b/pkgs/acorn-io/runtime/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: acorn-io/runtime@v0.8.0

--- a/pkgs/acorn-io/runtime/registry.yaml
+++ b/pkgs/acorn-io/runtime/registry.yaml
@@ -1,10 +1,14 @@
 packages:
   - type: github_release
     repo_owner: acorn-io
-    repo_name: acorn
-    asset: acorn-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
+    repo_name: runtime
+    aliases:
+      - name: acorn-io/acorn
     description: A simple application deployment framework for Kubernetes
+    asset: acorn-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    files:
+      - name: acorn
+    format: tar.gz
     replacements:
       darwin: macOS
     overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -2885,10 +2885,14 @@ packages:
       - amd64
   - type: github_release
     repo_owner: acorn-io
-    repo_name: acorn
-    asset: acorn-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
+    repo_name: runtime
+    aliases:
+      - name: acorn-io/acorn
     description: A simple application deployment framework for Kubernetes
+    asset: acorn-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    files:
+      - name: acorn
+    format: tar.gz
     replacements:
       darwin: macOS
     overrides:


### PR DESCRIPTION
The repository was transferred.

https://github.com/acorn-io/acorn is redirected to https://github.com/acorn-io/runtime