### PR TITLE
fix: Use getsops/sops instead of deprecated mozilla/sops

### DIFF
--- a/pkgs/getsops/sops/pkg.yaml
+++ b/pkgs/getsops/sops/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: getsops/sops@v3.7.3

--- a/pkgs/getsops/sops/registry.yaml
+++ b/pkgs/getsops/sops/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: mozilla
+    repo_owner: getsops
     repo_name: sops
+    aliases:
+      - name: mozilla/sops
     description: Simple and flexible tool for managing secrets
     format: raw
     overrides:

--- a/pkgs/mozilla/sops/pkg.yaml
+++ b/pkgs/mozilla/sops/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: mozilla/sops@v3.7.3
-  - name: mozilla/sops
-    version: v3.7.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -10497,6 +10497,29 @@ packages:
         replacements:
           arm64: aarch64
   - type: github_release
+    repo_owner: getsops
+    repo_name: sops
+    aliases:
+      - name: mozilla/sops
+    description: Simple and flexible tool for managing secrets
+    format: raw
+    overrides:
+      - goos: windows
+        asset: sops-{{.Version}}.exe
+    version_constraint: semver(">= 3.7.2")
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+    version_overrides:
+      - version_constraint: "true"
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+        asset: sops-{{.Version}}.{{.OS}}
+  - type: github_release
     repo_owner: getzola
     repo_name: zola
     description: A fast static site generator in a single binary with everything built-in
@@ -18514,27 +18537,6 @@ packages:
         rosetta2: true
         checksum:
           enabled: false
-  - type: github_release
-    repo_owner: mozilla
-    repo_name: sops
-    description: Simple and flexible tool for managing secrets
-    format: raw
-    overrides:
-      - goos: windows
-        asset: sops-{{.Version}}.exe
-    version_constraint: semver(">= 3.7.2")
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
-    version_overrides:
-      - version_constraint: "true"
-        rosetta2: true
-        supported_envs:
-          - darwin
-          - amd64
-        asset: sops-{{.Version}}.{{.OS}}
   - type: github_release
     repo_owner: mpostument
     repo_name: awstaghelper


### PR DESCRIPTION
The Mozilla team has stopped development of SOPS and donated the project
to the CNCF. The GitHub repo has changed from `mozilla/sops` to
`getsops/sops` as well.

This updates the sops package to reflect the new Github owner and repo.

Old: [`mozilla/sops`](https://github.com/mozilla/sops)
New: [`getsops/sops`](https://github.com/getsops/sops)
