### PR TITLE
fix(jqlang/jq): Optimize version_overrides

### DIFF
--- a/pkgs/jqlang/jq/registry.yaml
+++ b/pkgs/jqlang/jq/registry.yaml
@@ -3,6 +3,8 @@ packages:
     repo_owner: jqlang
     repo_name: jq
     description: Command-line JSON processor
+    aliases:
+      - name: stedolan/jq
     asset: jq-{{.OS}}-{{.Arch}}
     format: raw
     replacements:
@@ -19,17 +21,13 @@ packages:
     version_constraint: semver(">= 1.7rc1")
     version_overrides:
       - version_constraint: semver(">= 1.5")
-        asset: jq-{{.OS}}64
+        asset: jq-{{.OS}}
         overrides:
-          - goos: linux
-            replacements:
-              amd64: x64
           - goos: darwin
             asset: jq-{{.OS}}-{{.Arch}}
-          - goos: windows
-            asset: jq-{{.OS}}
         replacements:
           darwin: osx
+          linux: linux64
           windows: win64
         supported_envs:
           - darwin
@@ -52,14 +50,11 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.5rc1")
-        asset: jq-{{.OS}}-{{.Arch}}-static
         overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
           - goos: windows
             asset: jq-{{.OS}}
         replacements:
+          amd64: x86_64-static
           windows: win64
         supported_envs:
           - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -14622,6 +14622,8 @@ packages:
     repo_owner: jqlang
     repo_name: jq
     description: Command-line JSON processor
+    aliases:
+      - name: stedolan/jq
     asset: jq-{{.OS}}-{{.Arch}}
     format: raw
     replacements:
@@ -14638,17 +14640,13 @@ packages:
     version_constraint: semver(">= 1.7rc1")
     version_overrides:
       - version_constraint: semver(">= 1.5")
-        asset: jq-{{.OS}}64
+        asset: jq-{{.OS}}
         overrides:
-          - goos: linux
-            replacements:
-              amd64: x64
           - goos: darwin
             asset: jq-{{.OS}}-{{.Arch}}
-          - goos: windows
-            asset: jq-{{.OS}}
         replacements:
           darwin: osx
+          linux: linux64
           windows: win64
         supported_envs:
           - darwin
@@ -14671,14 +14669,11 @@ packages:
         checksum:
           enabled: false
       - version_constraint: semver(">= 1.5rc1")
-        asset: jq-{{.OS}}-{{.Arch}}-static
         overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
           - goos: windows
             asset: jq-{{.OS}}
         replacements:
+          amd64: x86_64-static
           windows: win64
         supported_envs:
           - linux/amd64


### PR DESCRIPTION
#15233 seemed that generate `verrion_overrides` from `aqua-registry` cli, and it is not optimized.

Also add `aliases` property for backword compatibility.
