### PR TITLE
feat: add go-to-k/lamver

### DIFF
--- a/pkgs/go-to-k/lamver/pkg.yaml
+++ b/pkgs/go-to-k/lamver/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: go-to-k/lamver@v0.5.0
+  - name: go-to-k/lamver
+    version: v0.4.2
+  - name: go-to-k/lamver
+    version: v0.4.1
+  - name: go-to-k/lamver
+    version: v0.0.1

--- a/pkgs/go-to-k/lamver/registry.yaml
+++ b/pkgs/go-to-k/lamver/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: go-to-k
+    repo_name: lamver
+    description: CLI tool to search AWS Lambda runtime and versions across regions
+    asset: lamver_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.4.2")
+    version_overrides:
+      - version_constraint: Version == "v0.4.1"
+        asset: lamver_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.4.1")

--- a/registry.yaml
+++ b/registry.yaml
@@ -10890,6 +10890,28 @@ packages:
       asset: task_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: go-to-k
+    repo_name: lamver
+    description: CLI tool to search AWS Lambda runtime and versions across regions
+    asset: lamver_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.4.2")
+    version_overrides:
+      - version_constraint: Version == "v0.4.1"
+        asset: lamver_.{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.4.1")
+  - type: github_release
     repo_owner: goark
     repo_name: depm
     description: Visualize depndency packages and modules


### PR DESCRIPTION
[go-to-k/lamver](https://github.com/go-to-k/lamver): CLI tool to search AWS Lambda runtime and versions across regions

```console
$ aqua g -i go-to-k/lamver
```