### PR TITLE
feat: add okta/okta-aws-cli

### DIFF
--- a/pkgs/okta/okta-aws-cli/pkg.yaml
+++ b/pkgs/okta/okta-aws-cli/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: okta/okta-aws-cli@v1.2.2
+  - name: okta/okta-aws-cli
+    version: v1.0.0
+  - name: okta/okta-aws-cli
+    version: v0.3.0
+  - name: okta/okta-aws-cli
+    version: v0.2.0
+  - name: okta/okta-aws-cli
+    version: v0.1.0
+  - name: okta/okta-aws-cli
+    version: v0.0.4
+  - name: okta/okta-aws-cli
+    version: v0.0.2

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: okta
+    repo_name: okta-aws-cli
+    description: A CLI for having Okta as the IdP for AWS CLI operations
+    asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: okta-aws-cli
+        src: okta-aws-cli_{{.Version}}
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 1.0.0")
+    version_overrides:
+        # checksums.txt isn't normalised
+      - version_constraint: semver("= 0.3.0")
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.2.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.1.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.0.4")
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}_signed.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver("< 0.0.4")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -15,15 +15,9 @@ packages:
     version_constraint: semver(">= 1.0.0")
     version_overrides:
       - version_constraint: semver(">= 0.3.0")
+        # checksum files isn't normalized
         checksum:
-          type: github_release
-          asset: checksums-signed.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            # checksum files isn't normalized
-            checksum:
-              enabled: false
+          enabled: false
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -18,12 +18,6 @@ packages:
       - version_constraint: semver("= 0.3.0")
         checksum:
           enabled: false
-      - version_constraint: semver(">= 0.2.0")
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -21,7 +21,6 @@ packages:
           algorithm: sha256
         overrides:
           - goos: linux
-            goarch: amd64
             # checksum files isn't normalized
             checksum:
               enabled: false

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -14,29 +14,30 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 1.0.0")
     version_overrides:
-        # checksums.txt isn't normalised
-      - version_constraint: semver("= 0.3.0")
+      - version_constraint: semver(">= 0.3.0")
         checksum:
-          enabled: false
+          type: github_release
+          asset: checksums-signed.txt
+          algorithm: sha256
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        # signed.tar.gz doesn't exist in checksum file
       - version_constraint: semver(">= 0.0.4")
         overrides:
           - goos: darwin
             goarch: amd64
             asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}_signed.{{.Format}}
+            # signed.tar.gz doesn't exist in checksum file
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        checksum:
-          enabled: false
       - version_constraint: semver("< 0.0.4")
         replacements:
           amd64: x86_64

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -30,6 +30,7 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        # signed.tar.gz doesn't exist in checksum file
       - version_constraint: semver(">= 0.0.4")
         overrides:
           - goos: darwin
@@ -40,6 +41,8 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          enabled: false
       - version_constraint: semver("< 0.0.4")
         replacements:
           amd64: x86_64

--- a/pkgs/okta/okta-aws-cli/registry.yaml
+++ b/pkgs/okta/okta-aws-cli/registry.yaml
@@ -19,6 +19,12 @@ packages:
           type: github_release
           asset: checksums-signed.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            # checksum files isn't normalized
+            checksum:
+              enabled: false
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19479,6 +19479,12 @@ packages:
           type: github_release
           asset: checksums-signed.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            # checksum files isn't normalized
+            checksum:
+              enabled: false
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19481,7 +19481,6 @@ packages:
           algorithm: sha256
         overrides:
           - goos: linux
-            goarch: amd64
             # checksum files isn't normalized
             checksum:
               enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -19478,12 +19478,6 @@ packages:
       - version_constraint: semver("= 0.3.0")
         checksum:
           enabled: false
-      - version_constraint: semver(">= 0.2.0")
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19457,6 +19457,7 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 1.0.0")
     version_overrides:
+        # checksums.txt isn't normalised
       - version_constraint: semver("= 0.3.0")
         checksum:
           enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -19474,29 +19474,30 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 1.0.0")
     version_overrides:
-        # checksums.txt isn't normalised
-      - version_constraint: semver("= 0.3.0")
+      - version_constraint: semver(">= 0.3.0")
         checksum:
-          enabled: false
+          type: github_release
+          asset: checksums-signed.txt
+          algorithm: sha256
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        # signed.tar.gz doesn't exist in checksum file
       - version_constraint: semver(">= 0.0.4")
         overrides:
           - goos: darwin
             goarch: amd64
             asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}_signed.{{.Format}}
+            # signed.tar.gz doesn't exist in checksum file
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        checksum:
-          enabled: false
       - version_constraint: semver("< 0.0.4")
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19475,15 +19475,9 @@ packages:
     version_constraint: semver(">= 1.0.0")
     version_overrides:
       - version_constraint: semver(">= 0.3.0")
+        # checksum files isn't normalized
         checksum:
-          type: github_release
-          asset: checksums-signed.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            # checksum files isn't normalized
-            checksum:
-              enabled: false
+          enabled: false
       - version_constraint: semver(">= 0.1.0")
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19443,6 +19443,52 @@ packages:
       - name: exa
         src: bin/exa
   - type: github_release
+    repo_owner: okta
+    repo_name: okta-aws-cli
+    description: A CLI for having Okta as the IdP for AWS CLI operations
+    asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: okta-aws-cli
+        src: okta-aws-cli_{{.Version}}
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 1.0.0")
+    version_overrides:
+      - version_constraint: semver("= 0.3.0")
+        checksum:
+          enabled: false
+      - version_constraint: semver(">= 0.2.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.1.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver(">= 0.0.4")
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: okta-aws-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}_signed.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: semver("< 0.0.4")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+  - type: github_release
     repo_owner: okteto
     repo_name: okteto
     description: Develop your applications directly in your Kubernetes Cluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -19490,6 +19490,7 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        # signed.tar.gz doesn't exist in checksum file
       - version_constraint: semver(">= 0.0.4")
         overrides:
           - goos: darwin
@@ -19500,6 +19501,8 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          enabled: false
       - version_constraint: semver("< 0.0.4")
         replacements:
           amd64: x86_64


### PR DESCRIPTION
[okta/okta-aws-cli](https://github.com/okta/okta-aws-cli): A CLI for having Okta as the IdP for AWS CLI operations

```console
$ aqua g -i okta/okta-aws-cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ okta-aws-cli --help
okta-aws-cli - Okta federated identity for AWS CLI

Okta authentication for federated identity providers in support of AWS CLI.
okta-aws-cli handles authentication to the IdP and token exchange with AWS STS
to collect a proper IAM role for the AWS CLI operator.

Usage:
  okta-aws-cli [flags]

Flags:
  -a, --aws-acct-fed-app-id string   AWS Account Federation app ID
  -w, --aws-credentials string       Path to AWS credentials file, only valid with format "aws-credentials" (default "/Users/yuya.koda/.aws/credentials")
  -i, --aws-iam-idp string           Preset IAM Identity Provider ARN
  -r, --aws-iam-role string          Preset IAM Role ARN
  -e, --cache-access-token           Cache Okta access token to reduce need for opening grant URL
  -g, --debug                        Print operational information to the screen for debugging purposes
  -d, --debug-api-calls              Verbosely print all API calls/responses to the screen
  -k, --debug-config                 Inspect current okta.yaml configuration and exit
  -x, --expiry-aws-variables         Emit x_security_token_expires value in profile block of AWS credentials file
  -f, --format string                Output format. [env-var|aws-credentials]
  -h, --help                         help for okta-aws-cli
  -l, --legacy-aws-variables         Emit deprecated AWS Security Token value. WARNING: AWS CLI deprecated this value in November 2014 and is no longer documented
  -c, --oidc-client-id string        OIDC Client ID
  -b, --open-browser                 Automatically open the activation URL with the system web browser
  -o, --org-domain string            Okta Org Domain
  -p, --profile string               AWS Profile
  -q, --qr-code                      Print QR Code of activation URL
  -s, --session-duration string      Session duration for role.
  -v, --version                      version for okta-aws-cli
  -z, --write-aws-credentials        Write the created/updated profile to the "/Users/user/.aws/credentials" file. WARNING: This can inadvertently remove dangling comments and extraneous formatting from the creds file.
```

Reference

- README.md
    - https://github.com/okta/okta-aws-cli/blob/master/README.md
