### PR TITLE
feat: add aws/session-manager-plugin

### DIFF
--- a/pkgs/aws/session-manager-plugin/pkg.yaml
+++ b/pkgs/aws/session-manager-plugin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aws/session-manager-plugin@1.2.497.0

--- a/pkgs/aws/session-manager-plugin/registry.yaml
+++ b/pkgs/aws/session-manager-plugin/registry.yaml
@@ -4,7 +4,11 @@ packages:
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
     version_source: github_tag
-    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
     files:
       - name: session-manager-plugin
         src: sessionmanager-bundle/bin/session-manager-plugin

--- a/pkgs/aws/session-manager-plugin/registry.yaml
+++ b/pkgs/aws/session-manager-plugin/registry.yaml
@@ -14,3 +14,5 @@ packages:
         src: sessionmanager-bundle/bin/session-manager-plugin
     supported_envs:
       - darwin
+    search_words:
+      - macOS Only

--- a/pkgs/aws/session-manager-plugin/registry.yaml
+++ b/pkgs/aws/session-manager-plugin/registry.yaml
@@ -3,7 +3,6 @@ packages:
     repo_owner: aws
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
-    version_source: github_release
     url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
     overrides:
       - goos: darwin

--- a/pkgs/aws/session-manager-plugin/registry.yaml
+++ b/pkgs/aws/session-manager-plugin/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: aws
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
-    version_source: github_tag
+    version_source: github_release
     url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
     overrides:
       - goos: darwin

--- a/pkgs/aws/session-manager-plugin/registry.yaml
+++ b/pkgs/aws/session-manager-plugin/registry.yaml
@@ -1,0 +1,12 @@
+packages:
+  - type: http
+    repo_owner: aws
+    repo_name: session-manager-plugin
+    description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
+    version_source: github_tag
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
+    files:
+      - name: session-manager-plugin
+        src: sessionmanager-bundle/bin/session-manager-plugin
+    supported_envs:
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -4195,7 +4195,6 @@ packages:
     repo_owner: aws
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
-    version_source: github_release
     url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
     overrides:
       - goos: darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -4196,7 +4196,11 @@ packages:
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
     version_source: github_tag
-    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
     files:
       - name: session-manager-plugin
         src: sessionmanager-bundle/bin/session-manager-plugin

--- a/registry.yaml
+++ b/registry.yaml
@@ -4206,6 +4206,8 @@ packages:
         src: sessionmanager-bundle/bin/session-manager-plugin
     supported_envs:
       - darwin
+    search_words:
+      - macOS Only
   - type: http
     repo_owner: awslabs
     repo_name: amazon-ecr-credential-helper

--- a/registry.yaml
+++ b/registry.yaml
@@ -4192,6 +4192,17 @@ packages:
     files:
       - name: copilot
   - type: http
+    repo_owner: aws
+    repo_name: session-manager-plugin
+    description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
+    version_source: github_tag
+    url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac_{{.Arch}}/sessionmanager-bundle.zip
+    files:
+      - name: session-manager-plugin
+        src: sessionmanager-bundle/bin/session-manager-plugin
+    supported_envs:
+      - darwin
+  - type: http
     repo_owner: awslabs
     repo_name: amazon-ecr-credential-helper
     description: Automatically gets credentials for Amazon ECR on docker push/docker pull

--- a/registry.yaml
+++ b/registry.yaml
@@ -4195,7 +4195,7 @@ packages:
     repo_owner: aws
     repo_name: session-manager-plugin
     description: This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances Resources
-    version_source: github_tag
+    version_source: github_release
     url: https://s3.amazonaws.com/session-manager-downloads/plugin/{{.Version}}/mac/sessionmanager-bundle.zip
     overrides:
       - goos: darwin


### PR DESCRIPTION
[aws/session-manager-plugin](https://github.com/aws/session-manager-plugin): This plugin helps you to use the AWS Command Line Interface (AWS CLI) to start and end sessions to your managed instances

```console
$ aqua g -i aws/session-manager-plugin
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ session-manager-plugin --version
1.2.497.0
```

Note `session-manager-plugin` command doesn't have help command.

You can verify to work the command with aws cli.
https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html

Reference

- https://github.com/aws/session-manager-plugin
