### PR TITLE
fix: Transfer eksctl to eksctl-io

### DIFF
--- a/pkgs/eksctl-io/eksctl/pkg.yaml
+++ b/pkgs/eksctl-io/eksctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: eksctl-io/eksctl@v0.156.0

--- a/pkgs/eksctl-io/eksctl/registry.yaml
+++ b/pkgs/eksctl-io/eksctl/registry.yaml
@@ -1,8 +1,10 @@
 packages:
   - type: github_release
-    repo_owner: weaveworks
+    repo_owner: eksctl-io
     repo_name: eksctl
     description: The official CLI for Amazon EKS
+    aliases:
+      - name: weaveworks/eksctl
     asset: eksctl_{{title .OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:

--- a/pkgs/weaveworks/eksctl/pkg.yaml
+++ b/pkgs/weaveworks/eksctl/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: weaveworks/eksctl@v0.156.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -9383,6 +9383,21 @@ packages:
     files:
       - name: gh-md-toc
   - type: github_release
+    repo_owner: eksctl-io
+    repo_name: eksctl
+    description: The official CLI for Amazon EKS
+    aliases:
+      - name: weaveworks/eksctl
+    asset: eksctl_{{title .OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: eksctl_checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: ekzhang
     repo_name: bore
     asset: bore-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -26124,19 +26139,6 @@ packages:
       - version_constraint: semver("< 1.18.0")
         version_prefix: cli-
         rosetta2: true
-  - type: github_release
-    repo_owner: weaveworks
-    repo_name: eksctl
-    description: The official CLI for Amazon EKS
-    asset: eksctl_{{title .OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: eksctl_checksums.txt
-      algorithm: sha256
   - type: github_release
     name: weaveworks/tf-controller/tfctl
     repo_owner: weaveworks


### PR DESCRIPTION
https://github.com/weaveworks/eksctl is redirected to https://github.com/eksctl-io/eksctl .

[Weaveworks and AWS Collaborate to Enhance the Official CLI for EKS (eksctl)](https://www.weave.works/blog/weaveworks-and-aws-collaborate-to-enhance-the-open-source-eks-cli)