### PR TITLE
feat: add go-to-k/delstack

### DIFF
--- a/pkgs/go-to-k/delstack/pkg.yaml
+++ b/pkgs/go-to-k/delstack/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-to-k/delstack@v1.0.4

--- a/pkgs/go-to-k/delstack/registry.yaml
+++ b/pkgs/go-to-k/delstack/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: go-to-k
+    repo_name: delstack
+    description: CLI tool to force delete the entire AWS CloudFormation stack, even if it contains resources that fail to delete by the CloudFormation delete operation
+    asset: delstack_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -10975,6 +10975,21 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: go-to-k
+    repo_name: delstack
+    description: CLI tool to force delete the entire AWS CloudFormation stack, even if it contains resources that fail to delete by the CloudFormation delete operation
+    asset: delstack_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: go-to-k
     repo_name: lamver
     description: CLI tool to search AWS Lambda runtime and versions across regions
     asset: lamver_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[go-to-k/delstack](https://github.com/go-to-k/delstack): CLI tool to force delete the entire AWS CloudFormation stack, even if it contains resources that fail to delete by the CloudFormation delete operation

```console
$ aqua g -i go-to-k/delstack
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ delstack --help
NAME:
   delstack - A CLI tool to force delete the entire CloudFormation stack.

USAGE:
   delstack [global options] [arguments...]

VERSION:
   1.0.4

GLOBAL OPTIONS:
   --stackName value, -s value  CloudFormation stack name
   --profile value, -p value    AWS profile name
   --region value, -r value     AWS region
   --interactive, -i            Interactive Mode (default: false)
   --help, -h                   show help
   --version, -v                print the version
```

Reference

- README.md
	- https://github.com/go-to-k/delstack/blob/main/README.md
- Blog (Japanese)
	- https://go-to-k.hatenablog.com/entry/delstack
