### PR TITLE
feat: add go-to-k/cls3

### DIFF
--- a/pkgs/go-to-k/cls3/pkg.yaml
+++ b/pkgs/go-to-k/cls3/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-to-k/cls3@v0.8.0

--- a/pkgs/go-to-k/cls3/registry.yaml
+++ b/pkgs/go-to-k/cls3/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: go-to-k
+    repo_name: cls3
+    description: The CLI tool "cls3" is to CLear S3 Buckets. It empties (so deletes all objects and versions/delete-markers in) S3 Buckets or deletes the buckets themselves
+    asset: cls3_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -10975,6 +10975,21 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: go-to-k
+    repo_name: cls3
+    description: The CLI tool "cls3" is to CLear S3 Buckets. It empties (so deletes all objects and versions/delete-markers in) S3 Buckets or deletes the buckets themselves
+    asset: cls3_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: go-to-k
     repo_name: lamver
     description: CLI tool to search AWS Lambda runtime and versions across regions
     asset: lamver_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[go-to-k/cls3](https://github.com/go-to-k/cls3): The CLI tool "cls3" is to CLear S3 Buckets. It empties (so deletes all objects and versions/delete-markers in) S3 Buckets or deletes the buckets themselves

```console
$ aqua g -i go-to-k/cls3
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cls3 --help
NAME:
   cls3 - A CLI tool to clear all objects in S3 Buckets or delete Buckets.

USAGE:
   cls3 [global options] [arguments...]

VERSION:
   0.8.0

GLOBAL OPTIONS:
   --bucketName value, -b value [ --bucketName value, -b value ]  S3 bucket names(one or more)
   --profile value, -p value                                      AWS profile name
   --region value, -r value                                       AWS region
   --force, -f                                                    Delete a bucket together (default: false)
   --interactive, -i                                              Interactive Mode (default: false)
   --help, -h                                                     show help
   --version, -v                                                  print the version
```

Reference

- README.md
	- https://github.com/go-to-k/cls3/blob/main/README.md
- Blog (English)
	- https://dev.to/aws-builders/tool-for-fast-deletion-and-emptying-of-s3-buckets-versioning-supported-6dn
- Blog (Japanese)
	- https://go-to-k.hatenablog.com/entry/cls3
