### PR TITLE
fix(nao1215/gup): follow up changes of gup v0.23.0

### DIFF
--- a/pkgs/nao1215/gup/pkg.yaml
+++ b/pkgs/nao1215/gup/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: nao1215/gup@v0.22.0
+  - name: nao1215/gup@v0.23.0
+  - name: nao1215/gup
+    version: v0.7.2

--- a/pkgs/nao1215/gup/registry.yaml
+++ b/pkgs/nao1215/gup/registry.yaml
@@ -2,14 +2,9 @@ packages:
   - type: github_release
     repo_owner: nao1215
     repo_name: gup
+    description: gup - Update binaries installed by "go install" with goroutines
     asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: gup - Update binaries installed by "go install"
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
     overrides:
       - goos: windows
         format: zip
@@ -17,3 +12,11 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.23.0")
+    version_overrides:
+      - version_constraint: semver("< 0.23.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -19211,14 +19211,9 @@ packages:
   - type: github_release
     repo_owner: nao1215
     repo_name: gup
+    description: gup - Update binaries installed by "go install" with goroutines
     asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
-    description: gup - Update binaries installed by "go install"
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
     overrides:
       - goos: windows
         format: zip
@@ -19226,6 +19221,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.23.0")
+    version_overrides:
+      - version_constraint: semver("< 0.23.0")
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
   - type: github_release
     repo_owner: nats-io
     repo_name: natscli


### PR DESCRIPTION
Assets were renamed. https://github.com/nao1215/gup/commit/178ff57559e987af6beaf5da3c311f99d46c1b26