### PR TITLE
fix(smallstep/certificates): src incorrect after 0.23.0-rc.1

### DIFF
--- a/pkgs/smallstep/certificates/pkg.yaml
+++ b/pkgs/smallstep/certificates/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: smallstep/certificates@v0.24.3-rc1
   - name: smallstep/certificates
-    version: v0.23.0-rc.1
+    version: v0.23.0-rc.2
   - name: smallstep/certificates
     version: v0.22.2-rc9
   - name: smallstep/certificates

--- a/pkgs/smallstep/certificates/registry.yaml
+++ b/pkgs/smallstep/certificates/registry.yaml
@@ -19,16 +19,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.24.3-rc.1")
+    version_constraint: semver(">= 0.23.0-rc.2")
     version_overrides:
-      - version_constraint: semver("= 0.23.0-rc.1")
-        files: &step_ca_files2
-          - name: step-ca
-            src: step-ca_{{trimV .Version}}/bin/step-ca
       - version_constraint: semver(">= 0.22.2-rc9")
         overrides:
           - goos: darwin
-            files: *step_ca_files2
+            files: &step_ca_files2
+              - name: step-ca
+                src: step-ca_{{trimV .Version}}/bin/step-ca
         supported_envs:
           - linux/amd64
           - darwin

--- a/pkgs/smallstep/certificates/registry.yaml
+++ b/pkgs/smallstep/certificates/registry.yaml
@@ -21,7 +21,7 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 0.24.3-rc.1")
     version_overrides:
-      - version_constraint: semver(">= 0.23.0-rc.1")
+      - version_constraint: semver("= 0.23.0-rc.1")
         files: &step_ca_files2
           - name: step-ca
             src: step-ca_{{trimV .Version}}/bin/step-ca

--- a/registry.yaml
+++ b/registry.yaml
@@ -23095,16 +23095,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
-    version_constraint: semver(">= 0.24.3-rc.1")
+    version_constraint: semver(">= 0.23.0-rc.2")
     version_overrides:
-      - version_constraint: semver("= 0.23.0-rc.1")
-        files: &step_ca_files2
-          - name: step-ca
-            src: step-ca_{{trimV .Version}}/bin/step-ca
       - version_constraint: semver(">= 0.22.2-rc9")
         overrides:
           - goos: darwin
-            files: *step_ca_files2
+            files: &step_ca_files2
+              - name: step-ca
+                src: step-ca_{{trimV .Version}}/bin/step-ca
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -23097,7 +23097,7 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 0.24.3-rc.1")
     version_overrides:
-      - version_constraint: semver(">= 0.23.0-rc.1")
+      - version_constraint: semver("= 0.23.0-rc.1")
         files: &step_ca_files2
           - name: step-ca
             src: step-ca_{{trimV .Version}}/bin/step-ca


### PR DESCRIPTION
Follow up to #14385.

Fixes smallstep/certificates to only use 'bin/' path in 0.23.0-rc.1 as after this it is no longer present and breaks versions after this.