### PR TITLE
chore(cloudflare/cfssl): rename to cloudflare/cfssl/cfssl

### DIFF
--- a/pkgs/cloudflare/cfssl/cfssl/pkg.yaml
+++ b/pkgs/cloudflare/cfssl/cfssl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudflare/cfssl/cfssl@v1.6.4

--- a/pkgs/cloudflare/cfssl/cfssl/registry.yaml
+++ b/pkgs/cloudflare/cfssl/cfssl/registry.yaml
@@ -1,6 +1,8 @@
 packages:
   - type: github_release
     name: cloudflare/cfssl/cfssl
+    aliases:
+      - name: cloudflare/cfssl
     repo_owner: cloudflare
     repo_name: cfssl
     description: "CFSSL: Cloudflare's PKI and TLS toolkit"

--- a/pkgs/cloudflare/cfssl/cfssl/registry.yaml
+++ b/pkgs/cloudflare/cfssl/cfssl/registry.yaml
@@ -1,5 +1,6 @@
 packages:
   - type: github_release
+    name: cloudflare/cfssl/cfssl
     repo_owner: cloudflare
     repo_name: cfssl
     description: "CFSSL: Cloudflare's PKI and TLS toolkit"

--- a/pkgs/cloudflare/cfssl/pkg.yaml
+++ b/pkgs/cloudflare/cfssl/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: cloudflare/cfssl@v1.6.4

--- a/registry.yaml
+++ b/registry.yaml
@@ -6477,6 +6477,8 @@ packages:
         asset: ch-remote-static-aarch64
   - type: github_release
     name: cloudflare/cfssl/cfssl
+    aliases:
+      - name: cloudflare/cfssl
     repo_owner: cloudflare
     repo_name: cfssl
     description: "CFSSL: Cloudflare's PKI and TLS toolkit"

--- a/registry.yaml
+++ b/registry.yaml
@@ -6476,6 +6476,7 @@ packages:
       - goarch: arm64
         asset: ch-remote-static-aarch64
   - type: github_release
+    name: cloudflare/cfssl/cfssl
     repo_owner: cloudflare
     repo_name: cfssl
     description: "CFSSL: Cloudflare's PKI and TLS toolkit"


### PR DESCRIPTION
I renamed package name  `cloudflare/cfssl` to `cloudflare/cfssl/cfssl`. 
ref. https://github.com/aquaproj/aqua-registry/pull/15600#issuecomment-1728729270