### PR TITLE
fix(protocolbuffers/protobuf/protoc): Set supported_envs

### DIFF
--- a/pkgs/protocolbuffers/protobuf/protoc/registry.yaml
+++ b/pkgs/protocolbuffers/protobuf/protoc/registry.yaml
@@ -14,6 +14,10 @@ packages:
       amd64: x86_64
       darwin: osx
       windows: win64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     overrides:
       - goos: windows
         asset: protoc-{{trimV .Version}}-{{.OS}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -21185,6 +21185,10 @@ packages:
       amd64: x86_64
       darwin: osx
       windows: win64
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     overrides:
       - goos: windows
         asset: protoc-{{trimV .Version}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
Follow up #15602

protoc does not support `windows/arm64`.
