### PR TITLE
feat: add orangekame3/stree

### DIFF
--- a/pkgs/orangekame3/stree/pkg.yaml
+++ b/pkgs/orangekame3/stree/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: orangekame3/stree@v0.0.10

--- a/pkgs/orangekame3/stree/registry.yaml
+++ b/pkgs/orangekame3/stree/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: orangekame3
+    repo_name: stree
+    description: Directory trees of AWS S3 Bucket
+    asset: stree_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -20204,6 +20204,24 @@ packages:
       asset: Mangle_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: orangekame3
+    repo_name: stree
+    description: Directory trees of AWS S3 Bucket
+    asset: stree_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: oras-project
     repo_name: oras
     asset: oras_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[orangekame3/stree](https://github.com/orangekame3/stree): Directory trees of AWS S3 Bucket

```console
$ aqua g -i orangekame3/stree
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ stree --help
stree is a command line tool for visualizing the structure of S3 buckets

Usage:
  stree [bucket/prefix] [flags]

Flags:
  -e, --endpoint-url string   AWS endpoint URL to use (useful for local testing with LocalStack)
  -h, --help                  help for stree
  -l, --local                 Use LocalStack configuration
  -n, --no-color              Disable colorized output
  -p, --profile string        AWS profile to use (default "local")
  -r, --region string         AWS region to use (overrides the region specified in the profile)
  -v, --version               version for stree
```

Reference

- README.md
	- https://github.com/orangekame3/stree/blob/main/README.md
