### PR TITLE
feat: add mashiike/prepalert

### DIFF
--- a/pkgs/mashiike/prepalert/pkg.yaml
+++ b/pkgs/mashiike/prepalert/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mashiike/prepalert@v1.0.0

--- a/pkgs/mashiike/prepalert/registry.yaml
+++ b/pkgs/mashiike/prepalert/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: mashiike
+    repo_name: prepalert
+    description: Toil reduction tool to prepare before responding to Mackerel alerts
+    asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18229,6 +18229,16 @@ packages:
     path: github.com/marwan-at-work/mod/cmd/mod
   - type: github_release
     repo_owner: mashiike
+    repo_name: prepalert
+    description: Toil reduction tool to prepare before responding to Mackerel alerts
+    asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: mashiike
     repo_name: stefunny
     description: stefunny is a deployment tool for AWS StepFunctions state machine and the accompanying AWS EventBridge rule
     asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[mashiike/prepalert](https://github.com/mashiike/prepalert): Toil reduction tool to prepare before responding to Mackerel alerts

```console
$ aqua g -i mashiike/prepalert
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ prepalert --help
Usage: prepalert <command>

A webhook server for prepare alert memo

Flags:
  -h, --help                       Show context-sensitive help.
      --log-level="info"           output log-level ($PREPALERT_LOG_LEVEL)
      --mackerel-apikey=STRING     for access mackerel API ($MACKEREL_APIKEY)
      --error-handling=continue    error handling ($PREPALERT_ERROR_HANDLING)
      --config="."                 config path ($PREPALERT_CONFIG)

Commands:
  run
    run server (default command)

  init
    create initial config

  validate
    validate the configuration

  exec <alert-id>
    Generate a virtual webhook from past alert to execute the rule

  version
    Show version

Run "prepalert <command> --help" for more information on a command.
```

Reference

- README.md
	- https://github.com/mashiike/prepalert/blob/main/README.md
