### PR TITLE
feat: add k1LoW/gostyle

### DIFF
--- a/pkgs/k1LoW/gostyle/pkg.yaml
+++ b/pkgs/k1LoW/gostyle/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/gostyle@v0.18.2

--- a/pkgs/k1LoW/gostyle/registry.yaml
+++ b/pkgs/k1LoW/gostyle/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: gostyle
+    description: gostyle is a set of analyzers for coding styles
+    asset: gostyle_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -15813,6 +15813,23 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: k1LoW
+    repo_name: gostyle
+    description: gostyle is a set of analyzers for coding styles
+    asset: gostyle_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: darwin
+        format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: ndiag
     asset: ndiag_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip


### PR DESCRIPTION
[k1LoW/gostyle](https://github.com/k1LoW/gostyle): gostyle is a set of analyzers for coding styles

```console
$ aqua g -i k1LoW/gostyle
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gostyle help
gostyle is a tool for static analysis of Go programs.

gostyle examines Go source code and reports suspicious constructs,
such as Printf calls whose arguments do not align with the format
string. It uses heuristics that do not guarantee all reports are
genuine problems, but it can find errors not caught by the compilers.

Registered analyzers:

    contexts     Analyzer based on https://github.com/golang/go/wiki/CodeReviewComments#contexts
    dontpanic    Analyzer based on https://github.com/golang/go/wiki/CodeReviewComments#dont-panic
    errorstrings Analyzer based on https://github.com/golang/go/wiki/CodeReviewComments#error-strings
    funcfmt      Analyzer based on https://google.github.io/styleguide/go/decisions#function-formatting
    getters      Analyzer based on https://google.github.io/styleguide/go/decisions#getters
    gostyle      config
    handlerrors  Analyzer based on https://github.com/golang/go/wiki/CodeReviewComments#handle-errors
    ifacenames   Analyzer based on https://go.dev/doc/effective_go#interface-names.
    mixedcaps    Analyzer based on https://google.github.io/styleguide/go/guide#mixed-caps
    nilslices    Analyzer based on https://google.github.io/styleguide/go/decisions#nil-slices
    pkgnames     Analyzer based on https://google.github.io/styleguide/go/decisions#package-names
    recvnames    Analyzer based on https://google.github.io/styleguide/go/decisions#receiver-names
    recvtype     Analyzer based on https://google.github.io/styleguide/go/decisions#receiver-type
    repetition   Analyzer based on https://google.github.io/styleguide/go/decisions#repetition
    underscores  Analyzer based on https://google.github.io/styleguide/go/decisions#underscores
    useany       Analyzer based on https://google.github.io/styleguide/go/decisions#use-any
    useq         Analyzer based on https://google.github.io/styleguide/go/decisions#use-q
    varnames     Analyzer based on https://google.github.io/styleguide/go/decisions#variable-names

By default all analyzers are run.
To select specific analyzers, use the -NAME flag for each one,
 or -NAME=false to run all analyzers not explicitly disabled.

Core flags:

  -V	print version and exit
  -all
    	no effect (deprecated)
  -c int
    	display offending line with this many lines of context (default -1)
  -contexts
    	enable contexts analysis
  -dontpanic
    	enable dontpanic analysis
  -errorstrings
    	enable errorstrings analysis
  -flags
    	print analyzer flags in JSON
  -funcfmt
    	enable funcfmt analysis
  -getters
    	enable getters analysis
  -gostyle
    	enable gostyle analysis
  -handlerrors
    	enable handlerrors analysis
  -ifacenames
    	enable ifacenames analysis
  -json
    	emit JSON output
  -mixedcaps
    	enable mixedcaps analysis
  -nilslices
    	enable nilslices analysis
  -pkgnames
    	enable pkgnames analysis
  -recvnames
    	enable recvnames analysis
  -recvtype
    	enable recvtype analysis
  -repetition
    	enable repetition analysis
  -source
    	no effect (deprecated)
  -tags string
    	no effect (deprecated)
  -underscores
    	enable underscores analysis
  -useany
    	enable useany analysis
  -useq
    	enable useq analysis
  -v	no effect (deprecated)
  -varnames
    	enable varnames analysis

To see details and flags of a specific analyzer, run 'gostyle help name'.
```

Reference

- README
	- https://github.com/k1LoW/gostyle/blob/main/README.md
