### PR TITLE
feat: add hashicorp/terraform-config-inspect

### DIFF
--- a/pkgs/hashicorp/terraform-config-inspect/pkg.yaml
+++ b/pkgs/hashicorp/terraform-config-inspect/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: hashicorp/terraform-config-inspect
+    version: 5a6f8d18746d3c23cd25f7a6d48429545f20962f

--- a/pkgs/hashicorp/terraform-config-inspect/registry.yaml
+++ b/pkgs/hashicorp/terraform-config-inspect/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: hashicorp
+    repo_name: terraform-config-inspect
+    description: A helper library for shallow inspection of Terraform configurations

--- a/registry.yaml
+++ b/registry.yaml
@@ -12930,6 +12930,10 @@ packages:
     version_overrides:
       - version_constraint: "true"
         rosetta2: true
+  - type: go_install
+    repo_owner: hashicorp
+    repo_name: terraform-config-inspect
+    description: A helper library for shallow inspection of Terraform configurations
   - repo_owner: hashicorp
     repo_name: terraform-ls
     description: Terraform Language Server


### PR DESCRIPTION
[hashicorp/terraform-config-inspect](https://github.com/hashicorp/terraform-config-inspect): A helper library for shallow inspection of Terraform configurations

```console
$ aqua g -i hashicorp/terraform-config-inspect
```

Close #15963

This tool has no tag, so you need to specify a commit hash. Go is also necessary.

e.g.

```yaml
packages:
  - name: hashicorp/terraform-config-inspect
    version: 5a6f8d18746d3c23cd25f7a6d48429545f20962f
```