### PR TITLE
feat: add magodo/hclgrep

### DIFF
--- a/pkgs/magodo/hclgrep/pkg.yaml
+++ b/pkgs/magodo/hclgrep/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: magodo/hclgrep
+    version: 1b2b24c7caf63d2966ab110b37017197339ed371

--- a/pkgs/magodo/hclgrep/registry.yaml
+++ b/pkgs/magodo/hclgrep/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: magodo
+    repo_name: hclgrep
+    description: Syntax based grep for HCL(v2)

--- a/registry.yaml
+++ b/registry.yaml
@@ -18182,6 +18182,10 @@ packages:
       asset: mage_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: go_install
+    repo_owner: magodo
+    repo_name: hclgrep
+    description: Syntax based grep for HCL(v2)
+  - type: go_install
     repo_owner: mailru
     repo_name: easyjson
     description: Fast JSON serializer for golang


### PR DESCRIPTION
[magodo/hclgrep](https://github.com/magodo/hclgrep): Syntax based grep for HCL(v2)

```console
$ aqua g -i magodo/hclgrep
```

Close #15965