### PR TITLE
fix(awslabs/amazon-ecr-credential-helper): added checksum and rosetta2

### DIFF
--- a/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
@@ -2,5 +2,3 @@ packages:
   - name: awslabs/amazon-ecr-credential-helper@v0.7.1
   - name: awslabs/amazon-ecr-credential-helper
     version: v0.3.1
-  - name: awslabs/amazon-ecr-credential-helper
-    version: v0.3.0

--- a/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: awslabs/amazon-ecr-credential-helper@v0.7.1
+  - name: awslabs/amazon-ecr-credential-helper
+    version: v0.3.1
+  - name: awslabs/amazon-ecr-credential-helper
+    version: v0.3.0

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -19,7 +19,3 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 0.3.1")
         rosetta2: true
-      - version_constraint: "true"
-        rosetta2: true
-        checksum:
-          enabled: false

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -15,6 +15,10 @@ packages:
       type: http
       algorithm: sha256
       url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.sha256
+    overrides:
+      - goos: windows
+        checksum:
+          url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.exe.sha256
     version_constraint: semver(">= 0.6.0")
     version_overrides:
       - version_constraint: semver(">= 0.3.1")

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -18,6 +18,8 @@ packages:
     overrides:
       - goos: windows
         checksum:
+          type: http
+          algorithm: sha256
           url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.exe.sha256
     version_constraint: semver(">= 0.6.0")
     version_overrides:

--- a/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
+++ b/pkgs/awslabs/amazon-ecr-credential-helper/registry.yaml
@@ -11,3 +11,15 @@ packages:
       - amd64
     files:
       - name: docker-credential-ecr-login
+    checksum:
+      type: http
+      algorithm: sha256
+      url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.sha256
+    version_constraint: semver(">= 0.6.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.1")
+        rosetta2: true
+      - version_constraint: "true"
+        rosetta2: true
+        checksum:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -4505,6 +4505,8 @@ packages:
     overrides:
       - goos: windows
         checksum:
+          type: http
+          algorithm: sha256
           url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.exe.sha256
     version_constraint: semver(">= 0.6.0")
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -4498,6 +4498,18 @@ packages:
       - amd64
     files:
       - name: docker-credential-ecr-login
+    checksum:
+      type: http
+      algorithm: sha256
+      url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.sha256
+    version_constraint: semver(">= 0.6.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.1")
+        rosetta2: true
+      - version_constraint: "true"
+        rosetta2: true
+        checksum:
+          enabled: false
   - type: github_content
     repo_owner: awslabs
     repo_name: git-secrets

--- a/registry.yaml
+++ b/registry.yaml
@@ -4506,10 +4506,6 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 0.3.1")
         rosetta2: true
-      - version_constraint: "true"
-        rosetta2: true
-        checksum:
-          enabled: false
   - type: github_content
     repo_owner: awslabs
     repo_name: git-secrets

--- a/registry.yaml
+++ b/registry.yaml
@@ -4502,6 +4502,10 @@ packages:
       type: http
       algorithm: sha256
       url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.sha256
+    overrides:
+      - goos: windows
+        checksum:
+          url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{trimV .Version}}/{{.OS}}-{{.Arch}}/docker-credential-ecr-login.exe.sha256
     version_constraint: semver(">= 0.6.0")
     version_overrides:
       - version_constraint: semver(">= 0.3.1")


### PR DESCRIPTION
Some functionality fixes have been added.

- Enabled rosetta2 (<= 0.5.0)
	- https://github.com/awslabs/amazon-ecr-credential-helper/releases
- Enabled checksum (>= 0.3.1)
	- https://github.com/awslabs/amazon-ecr-credential-helper/releases