### PR TITLE
feat: add orangekame3/viff

### DIFF
--- a/pkgs/orangekame3/viff/pkg.yaml
+++ b/pkgs/orangekame3/viff/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: orangekame3/viff@v0.0.12
+  - name: orangekame3/viff
+    version: v0.0.9
+  - name: orangekame3/viff
+    version: v0.0.1

--- a/pkgs/orangekame3/viff/registry.yaml
+++ b/pkgs/orangekame3/viff/registry.yaml
@@ -1,0 +1,29 @@
+packages:
+  - type: github_release
+    repo_owner: orangekame3
+    repo_name: viff
+    description: Visual Diff Viewer
+    asset: viff_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.0.9")
+    version_overrides:
+      - version_constraint: semver("< 0.0.9")
+        asset: viff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides: []
+        replacements: {}
+        checksum:
+          type: github_release
+          asset: viff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -20776,6 +20776,16 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.0.9")
+    version_overrides:
+      - version_constraint: semver("< 0.0.9")
+        asset: viff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        overrides: []
+        replacements: {}
+        checksum:
+          type: github_release
+          asset: viff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: oras-project
     repo_name: oras

--- a/registry.yaml
+++ b/registry.yaml
@@ -20759,6 +20759,24 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: orangekame3
+    repo_name: viff
+    description: Visual Diff Viewer
+    asset: viff_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: oras-project
     repo_name: oras
     asset: oras_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[orangekame3/viff](https://github.com/orangekame3/viff): Visual Diff Viewer

```console
$ aqua g -i orangekame3/viff
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ viff --help
viff is a CLI tool that takes two file paths as arguments and displays the contents side by side in the terminal.

Usage:
  viff [flags]
  viff [command]

Available Commands:
  compare     compaare two files
  completion  Generate the autocompletion script for the specified shell
  configure   Configure the system settings
  help        Help about any command

Flags:
  -h, --help      help for viff
  -v, --version   version for viff

Use "viff [command] --help" for more information about a command.
```

Reference

- README.md
	- https://github.com/orangekame3/viff/blob/main/README.md
