### PR TITLE
feat: add kellyjonbrazil/jc

### DIFF
--- a/pkgs/kellyjonbrazil/jc/pkg.yaml
+++ b/pkgs/kellyjonbrazil/jc/pkg.yaml
@@ -1,39 +1,9 @@
 packages:
   - name: kellyjonbrazil/jc@v1.23.4
   - name: kellyjonbrazil/jc
-    version: v1.23.3
-  - name: kellyjonbrazil/jc
-    version: v1.23.2
-  - name: kellyjonbrazil/jc
-    version: v1.23.1
-  - name: kellyjonbrazil/jc
-    version: v1.23.0
-  - name: kellyjonbrazil/jc
-    version: v1.22.5
-  - name: kellyjonbrazil/jc
-    version: v1.22.4
-  - name: kellyjonbrazil/jc
-    version: v1.22.3
-  - name: kellyjonbrazil/jc
-    version: v1.22.2
-  - name: kellyjonbrazil/jc
-    version: v1.22.1
-  - name: kellyjonbrazil/jc
-    version: v1.22.0
-  - name: kellyjonbrazil/jc
-    version: v1.21.2
-  - name: kellyjonbrazil/jc
-    version: v1.21.1
-  - name: kellyjonbrazil/jc
     version: v1.21.0
   - name: kellyjonbrazil/jc
     version: v1.20.4
-  - name: kellyjonbrazil/jc
-    version: v1.20.2
-  - name: kellyjonbrazil/jc
-    version: v1.20.1
-  - name: kellyjonbrazil/jc
-    version: v1.20.0
   - name: kellyjonbrazil/jc
     version: v1.19.0
   - name: kellyjonbrazil/jc

--- a/pkgs/kellyjonbrazil/jc/pkg.yaml
+++ b/pkgs/kellyjonbrazil/jc/pkg.yaml
@@ -1,6 +1,40 @@
 packages:
   - name: kellyjonbrazil/jc@v1.23.4
   - name: kellyjonbrazil/jc
+    version: v1.23.3
+  - name: kellyjonbrazil/jc
+    version: v1.23.2
+  - name: kellyjonbrazil/jc
+    version: v1.23.1
+  - name: kellyjonbrazil/jc
+    version: v1.23.0
+  - name: kellyjonbrazil/jc
+    version: v1.22.5
+  - name: kellyjonbrazil/jc
+    version: v1.22.4
+  - name: kellyjonbrazil/jc
+    version: v1.22.3
+  - name: kellyjonbrazil/jc
+    version: v1.22.2
+  - name: kellyjonbrazil/jc
+    version: v1.22.1
+  - name: kellyjonbrazil/jc
+    version: v1.22.0
+  - name: kellyjonbrazil/jc
+    version: v1.21.2
+  - name: kellyjonbrazil/jc
+    version: v1.21.1
+  - name: kellyjonbrazil/jc
+    version: v1.21.0
+  - name: kellyjonbrazil/jc
+    version: v1.20.4
+  - name: kellyjonbrazil/jc
+    version: v1.20.2
+  - name: kellyjonbrazil/jc
+    version: v1.20.1
+  - name: kellyjonbrazil/jc
+    version: v1.20.0
+  - name: kellyjonbrazil/jc
     version: v1.19.0
   - name: kellyjonbrazil/jc
     version: v1.13.4

--- a/pkgs/kellyjonbrazil/jc/pkg.yaml
+++ b/pkgs/kellyjonbrazil/jc/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: kellyjonbrazil/jc@v1.23.4
+  - name: kellyjonbrazil/jc
+    version: v1.19.0
+  - name: kellyjonbrazil/jc
+    version: v1.13.4

--- a/pkgs/kellyjonbrazil/jc/registry.yaml
+++ b/pkgs/kellyjonbrazil/jc/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - goos: windows
         format: zip
         asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jc
+            src: jc-{{trimV .Version}}-windows\jc.exe
     replacements:
       amd64: x86_64
     supported_envs:

--- a/pkgs/kellyjonbrazil/jc/registry.yaml
+++ b/pkgs/kellyjonbrazil/jc/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: kellyjonbrazil
+    repo_name: jc
+    description: CLI tool and python library that converts the output of popular command-line tools, file-types, and common strings to JSON, YAML, or Dictionaries. This allows piping of output to tools like jq and simplifying automation scripts
+    asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+        asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 1.19.0")
+    version_overrides:
+      - version_constraint: semver("< 1.19.0")
+        overrides: []
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/pkgs/kellyjonbrazil/jc/registry.yaml
+++ b/pkgs/kellyjonbrazil/jc/registry.yaml
@@ -11,15 +11,20 @@ packages:
         asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
         files:
           - name: jc
-            src: jc-{{trimV .Version}}-windows\jc.exe
+            src: jc-{{trimV .Version}}-windows/jc.exe
     replacements:
       amd64: x86_64
     supported_envs:
       - darwin
       - amd64
     rosetta2: true
-    version_constraint: semver(">= 1.19.0")
+    version_constraint: semver(">= 1.21.0")
     version_overrides:
+      - version_constraint: semver(">= 1.19.0")
+        overrides:
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
       - version_constraint: semver("< 1.19.0")
         overrides: []
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16397,6 +16397,9 @@ packages:
       - goos: windows
         format: zip
         asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jc
+            src: jc-{{trimV .Version}}-windows\jc.exe
     replacements:
       amd64: x86_64
     supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16399,15 +16399,20 @@ packages:
         asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
         files:
           - name: jc
-            src: jc-{{trimV .Version}}-windows\jc.exe
+            src: jc-{{trimV .Version}}-windows/jc.exe
     replacements:
       amd64: x86_64
     supported_envs:
       - darwin
       - amd64
     rosetta2: true
-    version_constraint: semver(">= 1.19.0")
+    version_constraint: semver(">= 1.21.0")
     version_overrides:
+      - version_constraint: semver(">= 1.19.0")
+        overrides:
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
       - version_constraint: semver("< 1.19.0")
         overrides: []
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16388,6 +16388,29 @@ packages:
           asset: kubectl-explore_{{.Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: kellyjonbrazil
+    repo_name: jc
+    description: CLI tool and python library that converts the output of popular command-line tools, file-types, and common strings to JSON, YAML, or Dictionaries. This allows piping of output to tools like jq and simplifying automation scripts
+    asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+        asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 1.19.0")
+    version_overrides:
+      - version_constraint: semver("< 1.19.0")
+        overrides: []
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: kentaro-m
     repo_name: md2confl
     asset: md2confl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[kellyjonbrazil/jc](https://github.com/kellyjonbrazil/jc): CLI tool and python library that converts the output of popular command-line tools, file-types, and common strings to JSON, YAML, or Dictionaries. This allows piping of output to tools like jq and simplifying automation scripts

```console
$ aqua g -i kellyjonbrazil/jc
```

Close #16024