### PR TITLE
feat: add opentofu/opentofu

### DIFF
--- a/pkgs/opentofu/opentofu/pkg.yaml
+++ b/pkgs/opentofu/opentofu/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: opentofu/opentofu@v1.6.0-alpha2

--- a/pkgs/opentofu/opentofu/registry.yaml
+++ b/pkgs/opentofu/opentofu/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: opentofu
+    repo_name: opentofu
+    description: OpenTofu lets you declaratively manage your cloud infrastructure
+    asset: tofu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: tofu_{{trimV .Version}}_SHA256SUMS
+      algorithm: sha256
+    files:
+      - name: tofu

--- a/registry.yaml
+++ b/registry.yaml
@@ -20850,6 +20850,22 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
   - type: github_release
+    repo_owner: opentofu
+    repo_name: opentofu
+    description: OpenTofu lets you declaratively manage your cloud infrastructure
+    asset: tofu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: tofu_{{trimV .Version}}_SHA256SUMS
+      algorithm: sha256
+    files:
+      - name: tofu
+  - type: github_release
     repo_owner: openziti
     repo_name: zrok
     description: Geo-scale, next-generation sharing platform built on top of OpenZiti
@@ -27676,6 +27692,16 @@ packages:
       - darwin
       - linux/amd64
     asset: gossh-{{.Version}}-{{.OS}}-{{.Arch}}
+  - type: github_release
+    repo_owner: winebarrel
+    repo_name: cronplan
+    description: Cron expression parser for Amazon EventBridge
+    asset: cronviz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
   - name: winebarrel/cronplan/cronmatch
     type: github_release
     repo_owner: winebarrel

--- a/registry.yaml
+++ b/registry.yaml
@@ -27692,16 +27692,6 @@ packages:
       - darwin
       - linux/amd64
     asset: gossh-{{.Version}}-{{.OS}}-{{.Arch}}
-  - type: github_release
-    repo_owner: winebarrel
-    repo_name: cronplan
-    description: Cron expression parser for Amazon EventBridge
-    asset: cronviz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
   - name: winebarrel/cronplan/cronmatch
     type: github_release
     repo_owner: winebarrel


### PR DESCRIPTION
[opentofu/opentofu](https://github.com/opentofu/opentofu): OpenTofu lets you declaratively manage your cloud infrastructure

```console
$ aqua g -i opentofu/opentofu
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ tofu --help
The available commands for execution are listed below.
The primary workflow commands are given first, followed by
less common or more advanced commands.

Main commands:
  init          Prepare your working directory for other commands
  validate      Check whether the configuration is valid
  plan          Show changes required by the current configuration
  apply         Create or update infrastructure
  destroy       Destroy previously-created infrastructure

All other commands:
  console       Try OpenTofu expressions at an interactive command prompt
  fmt           Reformat your configuration in the standard style
  force-unlock  Release a stuck lock on the current workspace
  get           Install or upgrade remote OpenTofu modules
  graph         Generate a Graphviz graph of the steps in an operation
  import        Associate existing infrastructure with a OpenTofu resource
  login         Obtain and save credentials for a remote host
  logout        Remove locally-stored credentials for a remote host
  metadata      Metadata related commands
  output        Show output values from your root module
  providers     Show the providers required for this configuration
  refresh       Update the state to match remote systems
  show          Show the current state or a saved plan
  state         Advanced state management
  taint         Mark a resource instance as not fully functional
  test          Execute integration tests for OpenTofu modules
  untaint       Remove the 'tainted' state from a resource instance
  version       Show the current OpenTofu version
  workspace     Workspace management

Global options (use these before the subcommand, if any):
  -chdir=DIR    Switch to a different working directory before executing the
                given subcommand.
  -help         Show this help output, or the help for a specified subcommand.
  -version      An alias for the "version" subcommand.
```

Reference

- README.md
	- https://github.com/opentofu/opentofu/blob/main/README.md
