### PR TITLE
feat: add spacelift-io/spacectl

### DIFF
--- a/pkgs/spacelift-io/spacectl/pkg.yaml
+++ b/pkgs/spacelift-io/spacectl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: spacelift-io/spacectl@v0.28.0

--- a/pkgs/spacelift-io/spacectl/registry.yaml
+++ b/pkgs/spacelift-io/spacectl/registry.yaml
@@ -1,0 +1,36 @@
+packages:
+  - type: github_release
+    repo_owner: spacelift-io
+    repo_name: spacectl
+    description: Spacelift client and CLI
+    asset: spacectl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    checksum:
+      type: github_release
+      asset: spacectl_{{trimV .Version}}_SHA256SUMS
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.2.0")
+        asset: spacectl-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.0")
+        asset: spacelift-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -24881,6 +24881,41 @@ packages:
           # https://github.com/soywod/himalaya/issues/144
           - name: himalaya
             src: himalaya.exe
+  - type: github_release
+    repo_owner: spacelift-io
+    repo_name: spacectl
+    description: Spacelift client and CLI
+    asset: spacectl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    checksum:
+      type: github_release
+      asset: spacectl_{{trimV .Version}}_SHA256SUMS
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.3.0")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.2.0")
+        asset: spacectl-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
+      - version_constraint: semver("< 0.2.0")
+        asset: spacelift-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          enabled: false
   - type: go_install
     repo_owner: spf13
     repo_name: cobra-cli


### PR DESCRIPTION
[spacelift-io/spacectl](https://github.com/spacelift-io/spacectl): Spacelift client and CLI

```console
$ aqua g -i spacelift-io/spacectl
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ spacectl --help
NAME:
   spacectl - Programmatic access to Spacelift GraphQL API.

USAGE:
   spacectl [global options] command [command options] [arguments...]

VERSION:
   0.28.0

COMMANDS:
   module                   Manage a Spacelift module
   profile                  Manage Spacelift profiles
   provider                 Manage a Terraform provider
   run-external-dependency  Manage Spacelift Run external dependencies
   stack                    Manage a Spacelift stack
   whoami                   Print out logged-in user's information
   version                  Print out CLI version
   workerpool               Manages workerpools and their workers.
   help, h                  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```

Reference

- README
	- https://github.com/spacelift-io/spacectl
