### PR TITLE
feat: add TekWizely/bingo

### DIFF
--- a/pkgs/TekWizely/bingo/pkg.yaml
+++ b/pkgs/TekWizely/bingo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: TekWizely/bingo@v0.3.1

--- a/pkgs/TekWizely/bingo/registry.yaml
+++ b/pkgs/TekWizely/bingo/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: github_content
+    repo_owner: TekWizely
+    repo_name: bingo
+    description: The missing package manager for golang binaries (its homebrew for "go install")
+    path: bingo

--- a/registry.yaml
+++ b/registry.yaml
@@ -2021,6 +2021,11 @@ packages:
     files:
       - name: gobang
         src: gobang-{{trimV .Version}}-{{.Arch}}-{{.OS}}/gobang
+  - type: github_content
+    repo_owner: TekWizely
+    repo_name: bingo
+    description: The missing package manager for golang binaries (its homebrew for "go install")
+    path: bingo
   - type: github_release
     repo_owner: TekWizely
     repo_name: run


### PR DESCRIPTION
[TekWizely/bingo](https://github.com/TekWizely/bingo): The missing package manager for golang binaries (its homebrew for "go install")

```console
$ aqua g -i TekWizely/bingo
```

Close #16223