### PR TITLE
feat: add googleapis/api-linter

### DIFF
--- a/pkgs/googleapis/api-linter/pkg.yaml
+++ b/pkgs/googleapis/api-linter/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: googleapis/api-linter@v1.58.1
+  - name: googleapis/api-linter
+    version: v1.35.1
+  - name: googleapis/api-linter
+    version: v1.0.0

--- a/pkgs/googleapis/api-linter/pkg.yaml
+++ b/pkgs/googleapis/api-linter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: googleapis/api-linter@v1.58.1

--- a/pkgs/googleapis/api-linter/registry.yaml
+++ b/pkgs/googleapis/api-linter/registry.yaml
@@ -8,3 +8,7 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver(">= 1.35.1")
+    version_overrides:
+      - version_constraint: semver("< 1.35.1")
+        rosetta2: true

--- a/pkgs/googleapis/api-linter/registry.yaml
+++ b/pkgs/googleapis/api-linter/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: googleapis
+    repo_name: api-linter
+    description: A linter for APIs defined in protocol buffers
+    asset: api-linter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -12431,6 +12431,15 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: googleapis
+    repo_name: api-linter
+    description: A linter for APIs defined in protocol buffers
+    asset: api-linter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - amd64
+  - type: github_release
     repo_owner: gopasspw
     repo_name: gopass
     description: The slightly more awesome standard unix password manager for teams

--- a/registry.yaml
+++ b/registry.yaml
@@ -12439,6 +12439,10 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver(">= 1.35.1")
+    version_overrides:
+      - version_constraint: semver("< 1.35.1")
+        rosetta2: true
   - type: github_release
     repo_owner: gopasspw
     repo_name: gopass


### PR DESCRIPTION
[googleapis/api-linter](https://github.com/googleapis/api-linter): A linter for APIs defined in protocol buffers

```console
$ aqua g -i googleapis/api-linter
```

## How to confirm if this package works well

```console
$ api-linter --version
api-linter 1.58.1
```

Reference

- https://github.com/googleapis/api-linter
- https://linter.aip.dev/#installation