### PR TITLE
feat: add mesosphere/mindthegap

### DIFF
--- a/pkgs/mesosphere/mindthegap/pkg.yaml
+++ b/pkgs/mesosphere/mindthegap/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: mesosphere/mindthegap@v1.11.1
+  - name: mesosphere/mindthegap
+    version: v0.13.0
+  - name: mesosphere/mindthegap
+    version: v0.10.0
+  - name: mesosphere/mindthegap
+    version: v0.9.1
+  - name: mesosphere/mindthegap
+    version: v0.7.3
+  - name: mesosphere/mindthegap
+    version: v0.6.6
+  - name: mesosphere/mindthegap
+    version: v0.6.5
+  - name: mesosphere/mindthegap
+    version: v0.1.1

--- a/pkgs/mesosphere/mindthegap/pkg.yaml
+++ b/pkgs/mesosphere/mindthegap/pkg.yaml
@@ -3,14 +3,8 @@ packages:
   - name: mesosphere/mindthegap
     version: v0.13.0
   - name: mesosphere/mindthegap
-    version: v0.10.0
-  - name: mesosphere/mindthegap
-    version: v0.9.1
-  - name: mesosphere/mindthegap
     version: v0.7.3
   - name: mesosphere/mindthegap
     version: v0.6.6
-  - name: mesosphere/mindthegap
-    version: v0.6.5
   - name: mesosphere/mindthegap
     version: v0.1.1

--- a/pkgs/mesosphere/mindthegap/registry.yaml
+++ b/pkgs/mesosphere/mindthegap/registry.yaml
@@ -14,43 +14,17 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 0.13.0")
     version_overrides:
-      - version_constraint: semver(">= 0.10.0")
-        overrides:
-          - goos: darwin
-            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-          - goos: windows
-            format: zip
-        rosetta2: true
-      - version_constraint: semver(">= 0.9.1")
-        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-        overrides:
-          - goos: linux
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        rosetta2: true
       - version_constraint: semver(">= 0.7.3")
         overrides:
           - goos: darwin
             asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
-        rosetta2: true
       - version_constraint: semver(">= 0.6.6")
-      - version_constraint: semver(">= 0.6.5")
-        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-        overrides:
-          - goos: linux
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        rosetta2: true
-      - version_constraint: semver("< 0.6.5")
+      - version_constraint: semver("< 0.6.6")
+        asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:
           - goos: darwin
             asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
-        rosetta2: true

--- a/pkgs/mesosphere/mindthegap/registry.yaml
+++ b/pkgs/mesosphere/mindthegap/registry.yaml
@@ -1,0 +1,56 @@
+packages:
+  - type: github_release
+    repo_owner: mesosphere
+    repo_name: mindthegap
+    description: Easily create and use bundles for air-gapped environments
+    asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.13.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.10.0")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver(">= 0.9.1")
+        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver(">= 0.7.3")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver(">= 0.6.6")
+      - version_constraint: semver(">= 0.6.5")
+        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver("< 0.6.5")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -19170,6 +19170,61 @@ packages:
     replacements:
       darwin: macos
   - type: github_release
+    repo_owner: mesosphere
+    repo_name: mindthegap
+    description: Easily create and use bundles for air-gapped environments
+    asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.13.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.10.0")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver(">= 0.9.1")
+        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver(">= 0.7.3")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true
+      - version_constraint: semver(">= 0.6.6")
+      - version_constraint: semver(">= 0.6.5")
+        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+        overrides:
+          - goos: linux
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        rosetta2: true
+      - version_constraint: semver("< 0.6.5")
+        overrides:
+          - goos: darwin
+            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        rosetta2: true
+  - type: github_release
     repo_owner: metalbear-co
     repo_name: mirrord
     description: By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment

--- a/registry.yaml
+++ b/registry.yaml
@@ -19184,46 +19184,20 @@ packages:
       algorithm: sha256
     version_constraint: semver(">= 0.13.0")
     version_overrides:
-      - version_constraint: semver(">= 0.10.0")
-        overrides:
-          - goos: darwin
-            asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-          - goos: windows
-            format: zip
-        rosetta2: true
-      - version_constraint: semver(">= 0.9.1")
-        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-        overrides:
-          - goos: linux
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        rosetta2: true
       - version_constraint: semver(">= 0.7.3")
         overrides:
           - goos: darwin
             asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
-        rosetta2: true
       - version_constraint: semver(">= 0.6.6")
-      - version_constraint: semver(">= 0.6.5")
-        asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
-        overrides:
-          - goos: linux
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        rosetta2: true
-      - version_constraint: semver("< 0.6.5")
+      - version_constraint: semver("< 0.6.6")
+        asset: mindthegap_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         overrides:
           - goos: darwin
             asset: mindthegap_{{.Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
-        rosetta2: true
   - type: github_release
     repo_owner: metalbear-co
     repo_name: mirrord


### PR DESCRIPTION
[mesosphere/mindthegap](https://github.com/mesosphere/mindthegap): Easily create and use bundles for air-gapped environments

```console
$ aqua g -i mesosphere/mindthegap
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mindthegap --help
Usage:
  mindthegap [command]

Available Commands:
  completion       Generate the autocompletion script for the specified shell
  create           Create an image or Helm chart bundle
  help             Help about any command
  import           Import images from an image bundle into Containerd
  push             Push images or Helm charts from bundles into an existing OCI registry
  serve            Serve image or Helm chart bundles from an OCI registry
  version          Print version information

Flags:
  -h, --help          Help for mindthegap
  -v, --verbose int   Output verbosity

Use "mindthegap [command] --help" for more information about a command.
```