### PR TITLE
Add GHC (Haskell) 9.8.1

### DIFF
--- a/pkgs/ghc/ghc/pkg.yaml
+++ b/pkgs/ghc/ghc/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: ghc/ghc
+    version: 9.8.1

--- a/pkgs/ghc/ghc/registry.yaml
+++ b/pkgs/ghc/ghc/registry.yaml
@@ -1,0 +1,36 @@
+packages:
+  - type: http
+    repo_owner: ghc
+    repo_name: ghc
+    description: The Glorious Glasgow Haskell Compiler.
+    link: https://www.haskell.org/ghc/
+    url: https://downloads.haskell.org/~ghc/{{.Version}}/ghc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    replacements:
+      linux: unknown-linux
+      darwin: apple-darwin
+      windows: unknown-mingw32
+      arm64: aarch64
+      amd64: x86_64
+    overrides:
+      - goos: linux
+        url: https://downloads.haskell.org/~ghc/{{.Version}}/ghc-{{.Version}}-{{.Arch}}-alpine3_12-linux-static.{{.Format}}
+    files:
+      - name: ghc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghc
+      - name: ghc-pkg
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghc-pkg
+      - name: ghci
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghci
+      - name: haddock
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/haddock
+      - name: hp2ps
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hp2ps
+      - name: hpc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hpc
+      - name: hsc2hs
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hsc2hs
+      - name: runghc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/runghc
+      - name: runhaskell
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/runhaskell

--- a/registry.yaml
+++ b/registry.yaml
@@ -11275,6 +11275,41 @@ packages:
     overrides:
       - goos: windows
         format: zip
+  - type: http
+    repo_owner: ghc
+    repo_name: ghc
+    description: The Glorious Glasgow Haskell Compiler.
+    link: https://www.haskell.org/ghc/
+    url: https://downloads.haskell.org/~ghc/{{.Version}}/ghc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    replacements:
+      linux: unknown-linux
+      darwin: apple-darwin
+      windows: unknown-mingw32
+      arm64: aarch64
+      amd64: x86_64
+    overrides:
+      - goos: linux
+        url: https://downloads.haskell.org/~ghc/{{.Version}}/ghc-{{.Version}}-{{.Arch}}-alpine3_12-linux-static.{{.Format}}
+    files:
+      - name: ghc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghc
+      - name: ghc-pkg
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghc-pkg
+      - name: ghci
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/ghci
+      - name: haddock
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/haddock
+      - name: hp2ps
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hp2ps
+      - name: hpc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hpc
+      - name: hsc2hs
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/hsc2hs
+      - name: runghc
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/runghc
+      - name: runhaskell
+        src: ghc-{{.Version}}-{{.Arch}}-{{.OS}}/wrappers/runhaskell
   - type: github_release
     repo_owner: ginuerzh
     repo_name: gost


### PR DESCRIPTION
Just a late-night attempt. I am very new to aqua, and I'm not sure if this can work, and I might give up on this entirely.

(For active development it may be better to use ghcup. I wanted to be able to codify an exact version of GHC direct from aqua)