### PR TITLE
feat: add sayanarijit/jf

### DIFF
--- a/pkgs/sayanarijit/jf/pkg.yaml
+++ b/pkgs/sayanarijit/jf/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sayanarijit/jf@v0.6.2

--- a/pkgs/sayanarijit/jf/registry.yaml
+++ b/pkgs/sayanarijit/jf/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: sayanarijit
+    repo_name: jf
+    description: jf %q "JSON Formatted"
+    asset: jf-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -23711,6 +23711,24 @@ packages:
         no_asset: true
   - type: github_release
     repo_owner: sayanarijit
+    repo_name: jf
+    description: jf %q "JSON Formatted"
+    asset: jf-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+  - type: github_release
+    repo_owner: sayanarijit
     repo_name: xplr
     description: A hackable, minimal, fast TUI file explorer
     asset: xplr-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[sayanarijit/jf](https://github.com/sayanarijit/jf): jf %q "JSON Formatted"

```console
$ aqua g -i sayanarijit/jf
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ jf --help
USAGE

  jf [OPTION]... [--] TEMPLATE [VALUE]... [NAME=VALUE]... [NAME@FILE]...

OPTIONS

  -              alias for `-f -`, i.e. read template from stdin
  --             stop parsing CLI options
  -r, --raw      print the raw rendered value without formatting
  -p, --pretty   pretty print the JSON formatted output
  -y, --yaml     print the output as YAML instead of JSON
  -h, --help     print this help message
  -v, --version  print the version number
  -f, --file     treat the template argument as a file to read from

TEMPLATE

  Template should render into valid YAML. It can contain the following placeholders:

  `%%`                                    a literal `%` character
  `%s`                `%q`                read positional argument
  `%-s`               `%-q`               read stdin
  `%(NAME)s`          `%(NAME)q`          read named value from argument
  `%(NAME=DEFAULT)s`  `%(NAME=DEFAULT)q`  placeholder with default value
  `%(NAME@FILE)s`     `%(NAME@FILE)q`     read default value from file path
  `%(NAME@-)s`        `%(NAME@-)q`        read default value from stdin
  `%(NAME?)s`         `%(NAME?)q`         nullable placeholder that defaults to null
  `%(NAME)?s`         `%(NAME)?q`         optional placeholder that defaults to blank
  `%*s`               `%*q`               expand positional args as array items
  `%*-s`              `%*-q`              expand stdin as array items
  `%**s`              `%**q`              expand positional args as key value pairs
  `%**-s`             `%**-q`             expand stdin as key value pairs
  `%(NAME)*s`         `%(NAME)*q`         expand named args as array items
  `%(NAME)**s`        `%(NAME)**q`        expand named args as key value pairs

  Use placeholders with suffix `q` for safely quoted JSON string and `s` for JSON values
  other than string.

RULES

  * Pass values for positional placeholders in the same order as in the template.
  * Pass values for named placeholders using `NAME=VALUE` syntax.
  * Pass values for named array items using `NAME=ITEM_N` syntax.
  * Pass values for named key value pairs using `NAME=KEY_N NAME=VALUE_N` syntax.
  * Pass values to stdin following the order and separate them with null byte (`\0`).
  * Use `NAME@FILE` syntax to read from file where FILE can be `-` for stdin.
  * Do not pass positional values after named values.
  * To allow merging arrays and objects via expansion, trailing comma after `s` and `q`,
    if any, will be auto removed if no value is passed for the expandable placeholder.

EXAMPLES

  - Run: jf %s 1
  - Out: 1

  - Run: jf %q 1
  - Out: "1"

  - Run: jf '{%**q}' one 1 two 2 three 3
  - Out: {"one":"1","two":"2","three":"3"}

  - Run: seq 1 3 | xargs printf '%s\0' | jf '[%*-s]'
  - Out: [1,2,3]

  - Run: jf "{%q: %(value=default)q, %(bar)**q}" foo value=bar bar=biz bar=baz
  - Out: {"foo":"bar","biz":"baz"}

  - Run: jf "{str or bool: %(str)?q %(bool)?s, nullable: %(nullable?)q}" str=true
  - Out: {"str or bool":"true","nullable":null}

  - Run: jf '{1: %s, two: %q, 3: %(3)s, four: %(four=4)q, "%%": %(pct?)q}' 1 2 3=3
  - Out: {"1":1,"two":"2","3":3,"four":"4","%":null}

SHELL ALIASES

  You can set the following aliases in your shell:

  - alias str='jf %q'
  - alias arr='jf "[%*s]"'
  - alias obj='jf "{%**s}"'

  Then you can use them like this:

  - Run: str 1
  - Out: "1"

  - Run: arr 1 2 3
  - Out: [1,2,3]

  - Run: obj one 1 two 2 three 3
  - Out: {"one":1,"two":2,"three":3}

  - Run: obj 1 2 3 $(arr 4 $(str 5))
  - Out: {"1":2,"3":[4,"5"]}
```