### PR TITLE
feat: add cloudentity/oauth2c

### DIFF
--- a/pkgs/cloudentity/oauth2c/pkg.yaml
+++ b/pkgs/cloudentity/oauth2c/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudentity/oauth2c@v1.12.0

--- a/pkgs/cloudentity/oauth2c/registry.yaml
+++ b/pkgs/cloudentity/oauth2c/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: cloudentity
+    repo_name: oauth2c
+    description: User-friendly OAuth2 CLI
+    asset: oauth2c_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -7039,6 +7039,21 @@ packages:
       - goarch: arm64
         asset: ch-remote-static-aarch64
   - type: github_release
+    repo_owner: cloudentity
+    repo_name: oauth2c
+    description: User-friendly OAuth2 CLI
+    asset: oauth2c_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     name: cloudflare/cfssl/cfssl
     aliases:
       - name: cloudflare/cfssl


### PR DESCRIPTION
[cloudentity/oauth2c](https://github.com/cloudentity/oauth2c): User-friendly OAuth2 CLI

```console
$ aqua g -i cloudentity/oauth2c
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ oauth2c --help
User-friendly command-line for OAuth2

Usage:
  oauthc [issuer url] [flags]
  oauthc [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  docs        Open docs page in browser
  help        Help about any command
  version     Display version

Flags:
      --acr-values strings          ACR values
      --actor-token string          acting party token
      --actor-token-type string     acting party token type
      --assertion string            claims for jwt bearer assertion
      --audience strings            requested audience
      --auth-method string          token endpoint authentication method
      --browser-timeout duration    browser timeout (default 10m0s)
      --claims string               use claims
      --client-id string            client identifier
      --client-secret string        client secret
      --dpop                        use DPoP
      --encrypted-request-object    pass request parameters as encrypted jwt
      --encryption-key string       path or url to encryption key in jwks format
      --grant-type string           grant type
  -h, --help                        help for oauthc
      --http-timeout duration       http client timeout (default 1m0s)
      --id-token-hint string        id token hint
      --idp-hint string             identity provider hint
      --insecure                    allow insecure connections
      --login-hint string           user identifier hint
      --no-prompt                   disable prompt
      --par                         enable pushed authorization requests (PAR)
      --password string             resource owner password credentials grant flow password
      --pkce                        enable proof key for code exchange (PKCE)
      --rar string                  use rich authorization request (RAR)
      --redirect-url string         client redirect url (default "http://localhost:9876/callback")
      --refresh-token string        refresh token
      --request-object              pass request parameters as jwt
      --response-mode string        response mode
      --response-types strings      response type
      --scopes strings              requested scopes
      --signing-key string          path or url to signing key in jwks format
  -s, --silent                      silent mode
      --subject-token string        third party token
      --subject-token-type string   third party token type
      --tls-cert string             path to tls cert pem file
      --tls-key string              path to tls key pem file
      --tls-root-ca string          path to tls root ca pem file
      --username string             resource owner password credentials grant flow username

Use "oauthc [command] --help" for more information about a command.
```