### PR TITLE
feat: add mfridman/tparse

### DIFF
--- a/pkgs/mfridman/tparse/pkg.yaml
+++ b/pkgs/mfridman/tparse/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: mfridman/tparse@v0.13.1
+  - name: mfridman/tparse
+    version: v0.9.0
+  - name: mfridman/tparse
+    version: v0.8.2
+  - name: mfridman/tparse
+    version: v0.1.0

--- a/pkgs/mfridman/tparse/registry.yaml
+++ b/pkgs/mfridman/tparse/registry.yaml
@@ -1,0 +1,41 @@
+packages:
+  - type: github_release
+    repo_owner: mfridman
+    repo_name: tparse
+    description: CLI tool for summarizing go test output. Pipe friendly. CI/CD friendly
+    asset: tparse_{{.OS}}_{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.8.2")
+        asset: tparse_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.8.2")
+        asset: tparse_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -19301,6 +19301,46 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: mfridman
+    repo_name: tparse
+    description: CLI tool for summarizing go test output. Pipe friendly. CI/CD friendly
+    asset: tparse_{{.OS}}_{{.Arch}}
+    format: raw
+    replacements:
+      amd64: x86_64
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.8.2")
+        asset: tparse_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("< 0.8.2")
+        asset: tparse_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+  - type: github_release
     repo_owner: mgdm
     repo_name: htmlq
     asset: htmlq-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[mfridman/tparse](https://github.com/mfridman/tparse): CLI tool for summarizing go test output. Pipe friendly. CI/CD friendly

```console
$ aqua g -i mfridman/tparse
```