### PR TITLE
fix(kubeshark/kubeshark): follow up changes of kubeshark v51.0.0

### DIFF
--- a/pkgs/kubeshark/kubeshark/pkg.yaml
+++ b/pkgs/kubeshark/kubeshark/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: kubeshark/kubeshark@50.4
+  - name: kubeshark/kubeshark@v51.0.0
+  - name: kubeshark/kubeshark
+    version: "50.4"
   - name: kubeshark/kubeshark
     version: "37.0"
   - name: kubeshark/kubeshark

--- a/pkgs/kubeshark/kubeshark/registry.yaml
+++ b/pkgs/kubeshark/kubeshark/registry.yaml
@@ -6,11 +6,11 @@ packages:
       # Repository was transferred at 37.0
       - name: up9inc/mizu
     description: The API traffic analyzer for Kubernetes providing real-time K8s protocol-level visibility, capturing and monitoring all traffic and payloads going in, out and across containers, pods, nodes and clusters.. Think TCPDump and Wireshark re-invented for Kubernetes
-    asset: kubeshark_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    asset: kubeshark_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     checksum:
       type: github_release
-      asset: kubeshark_{{.Version}}_checksums.txt
+      asset: kubeshark_{{trimV .Version}}_checksums.txt
       algorithm: sha256
     version_constraint: semver(">= 38.0")
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -17750,11 +17750,11 @@ packages:
       # Repository was transferred at 37.0
       - name: up9inc/mizu
     description: The API traffic analyzer for Kubernetes providing real-time K8s protocol-level visibility, capturing and monitoring all traffic and payloads going in, out and across containers, pods, nodes and clusters.. Think TCPDump and Wireshark re-invented for Kubernetes
-    asset: kubeshark_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    asset: kubeshark_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     checksum:
       type: github_release
-      asset: kubeshark_{{.Version}}_checksums.txt
+      asset: kubeshark_{{trimV .Version}}_checksums.txt
       algorithm: sha256
     version_constraint: semver(">= 38.0")
     version_overrides:


### PR DESCRIPTION
https://github.com/kubeshark/kubeshark/releases/tag/v51.0.0

> Version tag correlation across docker images, helm chart and CLI release:
> Choose whether to use the latest release or a past release using a single version tag (e.g. v51.0.0)