### PR TITLE
feat: add ysugimoto/vintage

### DIFF
--- a/pkgs/ysugimoto/vintage/pkg.yaml
+++ b/pkgs/ysugimoto/vintage/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ysugimoto/vintage@v0.1.0

--- a/pkgs/ysugimoto/vintage/registry.yaml
+++ b/pkgs/ysugimoto/vintage/registry.yaml
@@ -1,0 +1,10 @@
+packages:
+  - type: github_release
+    repo_owner: ysugimoto
+    repo_name: vintage
+    description: VCL Transpiler for Edge Runtime
+    asset: vintage-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -29060,6 +29060,15 @@ packages:
         format: raw
         rosetta2: true
   - type: github_release
+    repo_owner: ysugimoto
+    repo_name: vintage
+    description: VCL Transpiler for Edge Runtime
+    asset: vintage-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+  - type: github_release
     repo_owner: yudai
     repo_name: gotty
     asset: gotty_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[ysugimoto/vintage](https://github.com/ysugimoto/vintage): VCL Transpiler for Edge Runtime

```console
$ aqua g -i ysugimoto/vintage
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ vintage --help
=====================================================
  _    ___       __
 | |  / (_)___  / /_____ _____ ____ 
 | | / / / __ \/ __/ __ `/ __ `/ _ \
 | |/ / / / / / /_/ /_/ / /_/ /  __/
 |___/_/_/ /_/\__/\__,_/\__, /\___/ 
                       /____/       VCL into a Edge
=====================================================

Usage:
    vintage [flags] [entry vcl file]

Flags:
    -I, --include_path : Add include path
    -h, --help         : Show this help
    -o, --output       : Specify output filename
    -t, --target       : Specify transpile target
    -p, --package      : Specify package name

Simple tranpilation example:
    vintage -o vintage.go -p main /path/to/vcl/main.vcl
```

Reference

- README
	- https://github.com/ysugimoto/vintage/blob/main/README.md
