### PR TITLE
feat: add michidk/vscli

### DIFF
--- a/pkgs/michidk/vscli/pkg.yaml
+++ b/pkgs/michidk/vscli/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: michidk/vscli@v0.1.10
+  - name: michidk/vscli
+    version: v0.1.7
+  - name: michidk/vscli
+    version: v0.1.6
+  - name: michidk/vscli
+    version: v0.1.5
+  - name: michidk/vscli
+    version: v0.1.2

--- a/pkgs/michidk/vscli/registry.yaml
+++ b/pkgs/michidk/vscli/registry.yaml
@@ -1,0 +1,71 @@
+packages:
+  - type: github_release
+    repo_owner: michidk
+    repo_name: vscli
+    description: A CLI tool to launch vscode projects, which supports devcontainers
+    asset: vscli-{{.Arch}}-{{.OS}}.{{.Format}}
+    files:
+      - name: vscli
+        src: vscli-{{.Arch}}-{{.OS}}/vscli
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 0.1.7")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.6")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver(">= 0.1.5")
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("< 0.1.5")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/michidk/vscli/registry.yaml
+++ b/pkgs/michidk/vscli/registry.yaml
@@ -22,11 +22,14 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 0.1.7")
     version_overrides:
-      - version_constraint: semver(">= 0.1.6")
+      - version_constraint: Version == "v0.1.6"
         format: zip
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl
@@ -39,7 +42,7 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-      - version_constraint: semver(">= 0.1.5")
+      - version_constraint: Version == "v0.1.5"
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl
@@ -48,6 +51,11 @@ packages:
           - linux/amd64
           - windows/amd64
         rosetta2: false
+        overrides:
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -57,6 +65,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl

--- a/registry.yaml
+++ b/registry.yaml
@@ -19553,11 +19553,14 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 0.1.7")
     version_overrides:
-      - version_constraint: semver(">= 0.1.6")
+      - version_constraint: Version == "v0.1.6"
         format: zip
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl
@@ -19570,7 +19573,7 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-      - version_constraint: semver(">= 0.1.5")
+      - version_constraint: Version == "v0.1.5"
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl
@@ -19579,6 +19582,11 @@ packages:
           - linux/amd64
           - windows/amd64
         rosetta2: false
+        overrides:
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -19588,6 +19596,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+          - goos: windows
+            checksum:
+              enabled: false
         replacements:
           amd64: x86_64
           linux: unknown-linux-musl

--- a/registry.yaml
+++ b/registry.yaml
@@ -19531,6 +19531,76 @@ packages:
         supported_envs:
           - linux/amd64
   - type: github_release
+    repo_owner: michidk
+    repo_name: vscli
+    description: A CLI tool to launch vscode projects, which supports devcontainers
+    asset: vscli-{{.Arch}}-{{.OS}}.{{.Format}}
+    files:
+      - name: vscli
+        src: vscli-{{.Arch}}-{{.OS}}/vscli
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 0.1.7")
+    version_overrides:
+      - version_constraint: semver(">= 0.1.6")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver(">= 0.1.5")
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("< 0.1.5")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        rosetta2: false
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+  - type: github_release
     repo_owner: microsoft
     repo_name: ripgrep-prebuilt
     asset: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[michidk/vscli](https://github.com/michidk/vscli): A CLI tool to launch vscode projects, which supports devcontainers

```console
$ aqua g -i michidk/vscli
```

Close https://github.com/aquaproj/aqua-registry/issues/16498