### PR TITLE
feat: add redhat-developer/odo.

### DIFF
--- a/pkgs/redhat-developer/odo/pkg.yaml
+++ b/pkgs/redhat-developer/odo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: redhat-developer/odo@v3.15.0

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -2,8 +2,8 @@ packages:
   - type: http
     repo_owner: redhat-developer
     repo_name: odo
-    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
     description: A fast, and iterative CLI tool for container-based application development
+    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
     format: raw
     supported_envs:
       - darwin

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: redhat-developer
     repo_name: odo
     url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
-    description: A fast, and iterative CLI tool for container-based application development.
+    description: A fast, and iterative CLI tool for container-based application development
     format: raw
     supported_envs:
       - darwin

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -7,8 +7,7 @@ packages:
     format: raw
     supported_envs:
       - darwin
-      - linux/amd64
-      - linux/arm64
+      - linux
       - windows/amd64
     version_constraint: semver(">= 3.0.0")
     checksum:

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -9,7 +9,6 @@ packages:
       - darwin
       - linux
       - windows/amd64
-    version_constraint: semver(">= 3.0.0")
     checksum:
       type: http
       url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -16,7 +16,6 @@ packages:
       algorithm: sha256
     overrides:
       - goos: windows
-        url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe
         checksum:
           type: http
           url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+  - type: http
+    repo_owner: redhat-developer
+    repo_name: odo
+    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
+    description: A fast, and iterative CLI tool for container-based application development.
+    format: raw
+    supported_envs:
+      - darwin
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
+    version_constraint: semver(">= 3.0.0")
+    checksum:
+      type: http
+      url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256
+      file_format: raw
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe
+        checksum:
+          type: http
+          url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256
+          file_format: raw
+          algorithm: sha256

--- a/pkgs/redhat-developer/odo/registry.yaml
+++ b/pkgs/redhat-developer/odo/registry.yaml
@@ -12,12 +12,10 @@ packages:
     checksum:
       type: http
       url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256
-      file_format: raw
       algorithm: sha256
     overrides:
       - goos: windows
         checksum:
           type: http
           url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256
-          file_format: raw
           algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -23269,6 +23269,31 @@ packages:
     files:
       - name: aws-nuke
         src: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}
+  - type: http
+    repo_owner: redhat-developer
+    repo_name: odo
+    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
+    description: A fast, and iterative CLI tool for container-based application development.
+    format: raw
+    supported_envs:
+      - darwin
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
+    version_constraint: semver(">= 3.0.0")
+    checksum:
+      type: http
+      url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256
+      file_format: raw
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe
+        checksum:
+          type: http
+          url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256
+          file_format: raw
+          algorithm: sha256
   - name: regclient/regclient/regbot
     type: github_release
     repo_owner: regclient

--- a/registry.yaml
+++ b/registry.yaml
@@ -23279,7 +23279,6 @@ packages:
       - darwin
       - linux
       - windows/amd64
-    version_constraint: semver(">= 3.0.0")
     checksum:
       type: http
       url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -23272,8 +23272,8 @@ packages:
   - type: http
     repo_owner: redhat-developer
     repo_name: odo
-    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
     description: A fast, and iterative CLI tool for container-based application development
+    url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
     format: raw
     supported_envs:
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -23282,14 +23282,12 @@ packages:
     checksum:
       type: http
       url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.sha256
-      file_format: raw
       algorithm: sha256
     overrides:
       - goos: windows
         checksum:
           type: http
           url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256
-          file_format: raw
           algorithm: sha256
   - name: regclient/regclient/regbot
     type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -23277,8 +23277,7 @@ packages:
     format: raw
     supported_envs:
       - darwin
-      - linux/amd64
-      - linux/arm64
+      - linux
       - windows/amd64
     version_constraint: semver(">= 3.0.0")
     checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -23273,7 +23273,7 @@ packages:
     repo_owner: redhat-developer
     repo_name: odo
     url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}
-    description: A fast, and iterative CLI tool for container-based application development.
+    description: A fast, and iterative CLI tool for container-based application development
     format: raw
     supported_envs:
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -23286,7 +23286,6 @@ packages:
       algorithm: sha256
     overrides:
       - goos: windows
-        url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe
         checksum:
           type: http
           url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256


### PR DESCRIPTION
[redhat-developer/odo](https://github.com/redhat-developer/odo): odo - Developer-focused CLI for fast & iterative container-based application development on Podman and Kubernetes. Implementation of the open Devfile standard

https://odo.dev/docs/overview/installation/

---

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
