### PR TITLE
feat: add ouch-org/ouch

### DIFF
--- a/pkgs/ouch-org/ouch/pkg.yaml
+++ b/pkgs/ouch-org/ouch/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: ouch-org/ouch@0.4.2
+  - name: ouch-org/ouch
+    version: 0.4.0
+  - name: ouch-org/ouch
+    version: 0.3.0
+  - name: ouch-org/ouch
+    version: 0.2.0
+  - name: ouch-org/ouch
+    version: 0.1.6
+  - name: ouch-org/ouch
+    version: 0.1.5
+  - name: ouch-org/ouch
+    version: 0.1.4

--- a/pkgs/ouch-org/ouch/registry.yaml
+++ b/pkgs/ouch-org/ouch/registry.yaml
@@ -55,6 +55,7 @@ packages:
           - amd64
       - version_constraint: semver(">= 0.2.0")
         asset: ouch-{{.Arch}}-{{.OS}}
+        complete_windows_ext: false
         format: raw
         overrides:
           - goos: linux

--- a/pkgs/ouch-org/ouch/registry.yaml
+++ b/pkgs/ouch-org/ouch/registry.yaml
@@ -1,0 +1,103 @@
+packages:
+  - type: github_release
+    repo_owner: ouch-org
+    repo_name: ouch
+    description: Painless compression and decompression in the terminal
+    asset: ouch-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: ouch
+        src: ouch-{{.Arch}}-{{.OS}}/ouch
+    supported_envs:
+      - linux
+      - windows
+      - amd64
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    rosetta2: true
+    version_constraint: semver(">= 0.4.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.4.0")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.3.0")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.2.0")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.6")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.5")
+        asset: ouch-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.OS}}-x86-64-musl
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("< 0.1.5")
+        asset: ouch-{{.OS}}
+        format: raw
+        overrides:
+          - goos: windows
+            asset: ouch
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+          - windows/amd64

--- a/pkgs/ouch-org/ouch/registry.yaml
+++ b/pkgs/ouch-org/ouch/registry.yaml
@@ -53,7 +53,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.2.0")
+      - version_constraint: Version == "0.2.0"
         asset: ouch-{{.Arch}}-{{.OS}}
         complete_windows_ext: false
         format: raw
@@ -67,7 +67,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.1.6")
+      - version_constraint: Version == "0.1.6"
         asset: ouch-{{.Arch}}-{{.OS}}
         format: raw
         overrides:
@@ -80,7 +80,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.1.5")
+      - version_constraint: Version == "0.1.5"
         asset: ouch-{{.OS}}
         format: raw
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -22089,7 +22089,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.2.0")
+      - version_constraint: Version == "0.2.0"
         asset: ouch-{{.Arch}}-{{.OS}}
         complete_windows_ext: false
         format: raw
@@ -22103,7 +22103,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.1.6")
+      - version_constraint: Version == "0.1.6"
         asset: ouch-{{.Arch}}-{{.OS}}
         format: raw
         overrides:
@@ -22116,7 +22116,7 @@ packages:
         supported_envs:
           - darwin
           - amd64
-      - version_constraint: semver(">= 0.1.5")
+      - version_constraint: Version == "0.1.5"
         asset: ouch-{{.OS}}
         format: raw
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -22036,6 +22036,108 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: ouch-org
+    repo_name: ouch
+    description: Painless compression and decompression in the terminal
+    asset: ouch-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: ouch
+        src: ouch-{{.Arch}}-{{.OS}}/ouch
+    supported_envs:
+      - linux
+      - windows
+      - amd64
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    rosetta2: true
+    version_constraint: semver(">= 0.4.2")
+    version_overrides:
+      - version_constraint: semver(">= 0.4.0")
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: semver(">= 0.3.0")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.2.0")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.6")
+        asset: ouch-{{.Arch}}-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.Arch}}-{{.OS}}-musl
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 0.1.5")
+        asset: ouch-{{.OS}}
+        format: raw
+        overrides:
+          - goos: linux
+            asset: ouch-{{.OS}}-x86-64-musl
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("< 0.1.5")
+        asset: ouch-{{.OS}}
+        format: raw
+        overrides:
+          - goos: windows
+            asset: ouch
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+          - windows/amd64
+  - type: github_release
     repo_owner: out-of-cheese-error
     repo_name: the-way
     description: A code snippets manager for your terminal

--- a/registry.yaml
+++ b/registry.yaml
@@ -22091,6 +22091,7 @@ packages:
           - amd64
       - version_constraint: semver(">= 0.2.0")
         asset: ouch-{{.Arch}}-{{.OS}}
+        complete_windows_ext: false
         format: raw
         overrides:
           - goos: linux


### PR DESCRIPTION
[ouch-org/ouch](https://github.com/ouch-org/ouch): Painless compression and decompression in the terminal

```console
$ aqua g -i ouch-org/ouch
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ ouch --help
A command-line utility for easily compressing and decompressing files and directories.

Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz, zst.

Repository: https://github.com/ouch-org/ouch

Usage: ouch [OPTIONS] <COMMAND>

Commands:
  compress    Compress one or more files into one output file [aliases: c]
  decompress  Decompresses one or more files, optionally into another folder [aliases: d]
  list        List contents of an archive [aliases: l, ls]
  help        Print this message or the help of the given subcommand(s)

Options:
  -y, --yes
          Skip [Y/n] questions positively

  -n, --no
          Skip [Y/n] questions negatively

  -A, --accessible
          Activate accessibility mode, reducing visual noise

          [env: ACCESSIBLE=]

  -H, --hidden
          Ignores hidden files

  -q, --quiet
          Silences output

  -g, --gitignore
          Ignores files matched by git's ignore files

  -f, --format <FORMAT>
          Specify the format of the archive

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```