### PR TITLE
fix(aquasecurity/chain-bench): follow up changes of chain-bench v0.1.8

### DIFF
--- a/pkgs/aquasecurity/chain-bench/pkg.yaml
+++ b/pkgs/aquasecurity/chain-bench/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: aquasecurity/chain-bench@v0.1.7
+  - name: aquasecurity/chain-bench@v0.1.8
+  - name: aquasecurity/chain-bench
+    version: v0.0.1

--- a/pkgs/aquasecurity/chain-bench/registry.yaml
+++ b/pkgs/aquasecurity/chain-bench/registry.yaml
@@ -2,8 +2,9 @@ packages:
   - type: github_release
     repo_owner: aquasecurity
     repo_name: chain-bench
-    asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: An open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark
+    asset: chain-bench_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
     replacements:
       amd64: 64bit
       arm64: ARM64
@@ -16,3 +17,7 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.1.8")
+    version_overrides:
+      - version_constraint: semver("< 0.1.8")
+        asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -3902,8 +3902,9 @@ packages:
   - type: github_release
     repo_owner: aquasecurity
     repo_name: chain-bench
-    asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: An open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark
+    asset: chain-bench_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
     replacements:
       amd64: 64bit
       arm64: ARM64
@@ -3916,6 +3917,10 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: semver(">= 0.1.8")
+    version_overrides:
+      - version_constraint: semver("< 0.1.8")
+        asset: chain-bench_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
   - type: github_release
     repo_owner: aquasecurity
     repo_name: kube-bench


### PR DESCRIPTION
Asset names were changed.

- https://github.com/aquasecurity/chain-bench/pull/128
- https://github.com/aquasecurity/chain-bench/commit/31e45b551402a3dc368bb86feeb0f95fdc71ea0e