### PR TITLE
chore: fix the task scaffold

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,7 +8,6 @@ registries:
     type: local
     path: registry.yaml
 packages:
-  - import: aqua-local.yaml
-  - name: aquaproj/registry-tool@v0.2.0
+  - name: aquaproj/registry-tool@v0.2.2
   - name: rhysd/actionlint@v1.6.26
   - name: suzuki-shunsuke/cmdx@v1.7.4

--- a/aqua/dev.yaml
+++ b/aqua/dev.yaml
@@ -1,9 +1,0 @@
----
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-registries:
-  - name: standard
-    type: local
-    path: ../registry.yaml
-packages:
-  - import: ../pkgs/cli/cli/pkg.yaml

--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -17,11 +17,17 @@ tasks:
         short: r
         type: bool
         usage: Recreate the container
+      - name: cmd
+        type: string
+        usage: A list of commands joined with commas ','
+      - name: limit
+        type: string
+        usage: The maximum number of versions
     script: |
       if [ "{{.recreate}}" = true ]; then
         cmdx rm
       fi
-      bash scripts/scaffold.sh "{{.package}}"
+      bash scripts/scaffold.sh "{{.package}}" "{{.cmd}}" "{{.limit}}"
     args:
       - name: package
         usage: a package name. e.g. `cli/cli`

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -3,6 +3,8 @@
 set -euxo pipefail
 
 pkg=$1
+cmd=$2
+limit=$3
 
 bash scripts/start.sh
 
@@ -12,6 +14,16 @@ fi
 
 docker exec -ti -w /aqua-registry aqua-registry aqua policy allow
 docker exec -ti -w /aqua-registry aqua-registry aqua i -l
-docker exec -ti -w /aqua-registry aqua-registry aqua-registry scaffold "$pkg"
+
+opts=""
+if [ -n "$cmd" ]; then
+  opts="-cmd $cmd"
+fi
+if [ -n "$limit" ]; then
+  opts="$opts -limit $limit"
+fi
+
+# shellcheck disable=SC2086
+docker exec -ti -w /aqua-registry aqua-registry aqua-registry scaffold $opts "$pkg"
 
 cmdx t "$pkg"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,3 +18,5 @@ for os in linux darwin windows; do
 		fi
 	done
 done
+
+aqua-registry gr


### PR DESCRIPTION
- Remove aqua-local.yaml
  - We run tests in the container, so `aqua-local.yaml` gets unnecessary
- Update registry-tool
- Remove an unused file `aqua/dev.yaml`
- scaffold: Support command line options `-limit` and `-cmd`
- test: Update registry.yaml after all tests succeed