### PR TITLE
feat: add FalconForceTeam/FalconHound

### DIFF
--- a/pkgs/FalconForceTeam/FalconHound/pkg.yaml
+++ b/pkgs/FalconForceTeam/FalconHound/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: FalconForceTeam/FalconHound@v1.0.0

--- a/pkgs/FalconForceTeam/FalconHound/registry.yaml
+++ b/pkgs/FalconForceTeam/FalconHound/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: FalconForceTeam
+    repo_name: FalconHound
+    description: FalconHound is a blue team multi-tool. It allows you to utilize and enhance the power of BloodHound in a more automated fashion. It is designed to be used in conjunction with a SIEM or other log aggregation tool
+    asset: FalconHound_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    files:
+      - name: falconhound
+        src: FalconHound
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -764,6 +764,20 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: FalconForceTeam
+    repo_name: FalconHound
+    description: FalconHound is a blue team multi-tool. It allows you to utilize and enhance the power of BloodHound in a more automated fashion. It is designed to be used in conjunction with a SIEM or other log aggregation tool
+    asset: FalconHound_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    files:
+      - name: falconhound
+        src: FalconHound
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+  - type: github_release
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability


### PR DESCRIPTION
#16614 [FalconForceTeam/FalconHound](https://github.com/FalconForceTeam/FalconHound): FalconHound is a blue team multi-tool. It allows you to utilize and enhance the power of BloodHound in a more automated fashion. It is designed to be used in conjunction with a SIEM or other log aggregation tool

```console
$ aqua g -i FalconForceTeam/FalconHound
```