### PR TITLE
fix(ariga/atlas): Remove windows

### DIFF
--- a/pkgs/ariga/atlas/pkg.yaml
+++ b/pkgs/ariga/atlas/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: ariga/atlas@v0.14.0
+  - name: ariga/atlas@v0.15.0
+  - name: ariga/atlas
+    version: v0.14.0

--- a/pkgs/ariga/atlas/registry.yaml
+++ b/pkgs/ariga/atlas/registry.yaml
@@ -8,16 +8,24 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - windows/amd64
     checksum:
       type: http
       url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
       file_format: raw
       algorithm: sha256
-    overrides:
-      - goos: windows
-        checksum:
-          type: http
-          url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
-          file_format: raw
-          algorithm: sha256
+    version_constraint: semver(">= 0.14.3")
+    # https://atlasgo.io/getting-started
+    # > As of version v0.14.3 we no longer provide a windows binary. Windows users are advised to use our [docker image](https://hub.docker.com/r/arigaio/atlas) or use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+    version_overrides:
+      - version_constraint: semver("< 0.14.3")
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+        overrides:
+          - goos: windows
+            checksum:
+              type: http
+              url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
+              file_format: raw
+              algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -4380,19 +4380,27 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - windows/amd64
     checksum:
       type: http
       url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
       file_format: raw
       algorithm: sha256
-    overrides:
-      - goos: windows
-        checksum:
-          type: http
-          url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
-          file_format: raw
-          algorithm: sha256
+    version_constraint: semver(">= 0.14.3")
+    # https://atlasgo.io/getting-started
+    # > As of version v0.14.3 we no longer provide a windows binary. Windows users are advised to use our [docker image](https://hub.docker.com/r/arigaio/atlas) or use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+    version_overrides:
+      - version_constraint: semver("< 0.14.3")
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+        overrides:
+          - goos: windows
+            checksum:
+              type: http
+              url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
+              file_format: raw
+              algorithm: sha256
   - type: github_release
     repo_owner: aristocratos
     repo_name: btop


### PR DESCRIPTION
https://atlasgo.io/getting-started

> As of version v0.14.3 we no longer provide a windows binary. Windows users are advised to use our [docker image](https://hub.docker.com/r/arigaio/atlas) or use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).