### PR TITLE
fix(LGUG2Z/komorebi): expose all executables

### DIFF
--- a/pkgs/LGUG2Z/komorebi/registry.yaml
+++ b/pkgs/LGUG2Z/komorebi/registry.yaml
@@ -7,6 +7,9 @@ packages:
     replacements:
       amd64: x86_64
       windows: pc-windows-msvc
+    files:
+      - name: komorebi
+      - name: komorebic
     supported_envs:
       - windows/amd64
     checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -1147,6 +1147,9 @@ packages:
     replacements:
       amd64: x86_64
       windows: pc-windows-msvc
+    files:
+      - name: komorebi
+      - name: komorebic
     supported_envs:
       - windows/amd64
     checksum:


### PR DESCRIPTION
The command `komorebic` is added.

> komorebic is a CLI that writes messages on komorebi's socket.

https://github.com/LGUG2Z/komorebi#description