### PR TITLE
feat: add astral-sh/ruff

### DIFF
--- a/pkgs/astral-sh/ruff/pkg.yaml
+++ b/pkgs/astral-sh/ruff/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: astral-sh/ruff@v0.1.2

--- a/pkgs/astral-sh/ruff/registry.yaml
+++ b/pkgs/astral-sh/ruff/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: astral-sh
+    repo_name: ruff
+    description: An extremely fast Python linter and code formatter, written in Rust
+    asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -4651,6 +4651,25 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: astral-sh
+    repo_name: ruff
+    description: An extremely fast Python linter and code formatter, written in Rust
+    asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256
+  - type: github_release
     repo_owner: auth0
     repo_name: auth0-cli
     asset: auth0-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[astral-sh/ruff](https://github.com/astral-sh/ruff): An extremely fast Python linter and code formatter, written in Rust

```console
$ aqua g -i astral-sh/ruff
```