### PR TITLE
feat: add xeol-io/xeol

### DIFF
--- a/pkgs/xeol-io/xeol/pkg.yaml
+++ b/pkgs/xeol-io/xeol/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: xeol-io/xeol@v0.9.5
+  - name: xeol-io/xeol
+    version: v0.1.0

--- a/pkgs/xeol-io/xeol/registry.yaml
+++ b/pkgs/xeol-io/xeol/registry.yaml
@@ -1,0 +1,24 @@
+packages:
+  - type: github_release
+    repo_owner: xeol-io
+    repo_name: xeol
+    description: A scanner for end-of-life (EOL) software in container images, filesystems, and SBOMs
+    asset: xeol_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: xeol_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.5")
+    # Verify with SLSA didn't work well
+    # > Verified signature against tlog entry index 44906341 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a658e74e86e03e7aedcca39eebddebf59310b4d9c463b037951109186d73a5681
+    # > Verifying artifact /var/folders/lk/bw_hsbdd72l9ckd0tz61xz2m0000gn/T/176337015: FAILED: verifying tag: invalid ref: "": unexpected ref type: ""
+    version_overrides:
+      - version_constraint: semver("< 0.9.5")
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -29303,6 +29303,31 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: xeol-io
+    repo_name: xeol
+    description: A scanner for end-of-life (EOL) software in container images, filesystems, and SBOMs
+    asset: xeol_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: xeol_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    version_constraint: semver(">= 0.9.5")
+    slsa_provenance:
+      type: github_release
+      asset: multiple.intoto.jsonl
+    version_overrides:
+      - version_constraint: semver("< 0.9.5")
+        slsa_provenance:
+          enabled: false
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+  - type: github_release
     repo_owner: xiecat
     repo_name: fofax
     description: "fofaX is a command line query tool based on the API of https://fofa.so/, simple is the best"

--- a/registry.yaml
+++ b/registry.yaml
@@ -29316,13 +29316,11 @@ packages:
       asset: xeol_{{trimV .Version}}_checksums.txt
       algorithm: sha256
     version_constraint: semver(">= 0.9.5")
-    slsa_provenance:
-      type: github_release
-      asset: multiple.intoto.jsonl
+    # Verify with SLSA didn't work well
+    # > Verified signature against tlog entry index 44906341 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77a658e74e86e03e7aedcca39eebddebf59310b4d9c463b037951109186d73a5681
+    # > Verifying artifact /var/folders/lk/bw_hsbdd72l9ckd0tz61xz2m0000gn/T/176337015: FAILED: verifying tag: invalid ref: "": unexpected ref type: ""
     version_overrides:
       - version_constraint: semver("< 0.9.5")
-        slsa_provenance:
-          enabled: false
         supported_envs:
           - darwin
           - linux


### PR DESCRIPTION
#16755 #16756 [xeol-io/xeol](https://github.com/xeol-io/xeol): A scanner for end-of-life (EOL) software in container images, filesystems, and SBOMs

```console
$ aqua g -i xeol-io/xeol
```

Close #16755