### PR TITLE
feat: add manabusakai/tdtidy

### DIFF
--- a/pkgs/manabusakai/tdtidy/pkg.yaml
+++ b/pkgs/manabusakai/tdtidy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: manabusakai/tdtidy@v0.0.2

--- a/pkgs/manabusakai/tdtidy/registry.yaml
+++ b/pkgs/manabusakai/tdtidy/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: manabusakai
+    repo_name: tdtidy
+    description: A command line tool for managing ECS task definitions. `tdtidy` can deregister and delete old task definitions
+    asset: tdtidy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -19239,6 +19239,19 @@ packages:
           - amd64
         rosetta2: true
   - type: github_release
+    repo_owner: manabusakai
+    repo_name: tdtidy
+    description: A command line tool for managing ECS task definitions. `tdtidy` can deregister and delete old task definitions
+    asset: tdtidy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: mantil-io
     repo_name: mantil
     description: Build your AWS Lambda-based Go backends quicker than ever


### PR DESCRIPTION
[manabusakai/tdtidy](https://github.com/manabusakai/tdtidy): A command line tool for managing ECS task definitions. `tdtidy` can deregister and delete old task definitions

```console
$ aqua g -i manabusakai/tdtidy
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ tdtidy --help
Usage of tdtidy:
  -dry-run
        Turn on dry-run. List the target task definitions.
  -family-prefix string
        Family name of task definitions. If specified, filter by family name.
  -retention-period int
        Retention period for task definitions. Unit is number of days. The default value is zero.
```


Reference

- Blog (Japanese)
	- https://blog.manabusakai.com/2023/10/tdtidy/
- README
	- https://github.com/manabusakai/tdtidy/blob/main/README.md
