### PR TITLE
feat: add int128/cronjob-runner

### DIFF
--- a/pkgs/int128/cronjob-runner/pkg.yaml
+++ b/pkgs/int128/cronjob-runner/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: int128/cronjob-runner@v0.2.0

--- a/pkgs/int128/cronjob-runner/registry.yaml
+++ b/pkgs/int128/cronjob-runner/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: int128
+    repo_name: cronjob-runner
+    description: A command to run one-shot job from CronJob template and tail container logs in Kubernetes
+    asset: cronjob-runner_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -14571,6 +14571,19 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: int128
+    repo_name: cronjob-runner
+    description: A command to run one-shot job from CronJob template and tail container logs in Kubernetes
+    asset: cronjob-runner_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: zip
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256
+  - type: github_release
+    repo_owner: int128
     repo_name: ghcp
     asset: ghcp_{{.OS}}_amd64.zip
     description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API


### PR DESCRIPTION
[int128/cronjob-runner](https://github.com/int128/cronjob-runner): A command to run one-shot job from CronJob template and tail container logs in Kubernetes

```console
$ aqua g -i int128/cronjob-runner
```