### PR TITLE
feat: add crates.io/tailspin

### DIFF
--- a/pkgs/crates.io/tailspin/pkg.yaml
+++ b/pkgs/crates.io/tailspin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/tailspin@1.6.1

--- a/pkgs/crates.io/tailspin/registry.yaml
+++ b/pkgs/crates.io/tailspin/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/tailspin
+    type: cargo
+    repo_owner: bensadeh
+    repo_name: tailspin
+    description: A log file highlighter
+    crate: tailspin

--- a/registry.yaml
+++ b/registry.yaml
@@ -8286,6 +8286,12 @@ packages:
     crate: skim
     files:
       - name: sk
+  - name: crates.io/tailspin
+    type: cargo
+    repo_owner: bensadeh
+    repo_name: tailspin
+    description: A log file highlighter
+    crate: tailspin
   - type: github_release
     repo_owner: crazy-max
     repo_name: diun


### PR DESCRIPTION
[crates.io/tailspin](https://crates.io/crates/tailspin): A log file highlighter

```console
$ aqua g -i crates.io/tailspin
```

Close #16956

[cargo](https://doc.rust-lang.org/stable/cargo/) is required.