### PR TITLE
feat: add trunk-io/launcher

### DIFF
--- a/pkgs/trunk-io/launcher/pkg.yaml
+++ b/pkgs/trunk-io/launcher/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: trunk-io/launcher@1.2.7

--- a/pkgs/trunk-io/launcher/registry.yaml
+++ b/pkgs/trunk-io/launcher/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - name: trunk-io/launcher
+    # https://github.com/aquaproj/aqua-registry/issues/13989#issuecomment-1802981855
+    description: Trunk Launcher
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        type: http
+        url: https://trunk.io/releases/launcher/{{.Version}}/trunk
+        format: raw
+        complete_windows_ext: false
+        files:
+          - name: trunk

--- a/pkgs/trunk-io/launcher/registry.yaml
+++ b/pkgs/trunk-io/launcher/registry.yaml
@@ -1,5 +1,6 @@
 packages:
   - name: trunk-io/launcher
+    type: http
     # https://github.com/aquaproj/aqua-registry/issues/13989#issuecomment-1802981855
     description: Trunk Launcher
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -28639,6 +28639,7 @@ packages:
       asset: trufflehog_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - name: trunk-io/launcher
+    type: http
     # https://github.com/aquaproj/aqua-registry/issues/13989#issuecomment-1802981855
     description: Trunk Launcher
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -28638,6 +28638,18 @@ packages:
       type: github_release
       asset: trufflehog_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - name: trunk-io/launcher
+    # https://github.com/aquaproj/aqua-registry/issues/13989#issuecomment-1802981855
+    description: Trunk Launcher
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        type: http
+        url: https://trunk.io/releases/launcher/{{.Version}}/trunk
+        format: raw
+        complete_windows_ext: false
+        files:
+          - name: trunk
   - type: github_release
     repo_owner: tsenart
     repo_name: vegeta


### PR DESCRIPTION
[trunk-io/launcher](https://docs.trunk.io/reference/components#trunk-launcher): trunk launcher is a bash script that enables users to easily switch between multiple versions of trunk

```console
$ aqua g -i trunk-io/launcher
```

- https://github.com/aquaproj/aqua-registry/issues/13989