### PR TITLE
feat: add hrmsk66/terraformify

### DIFF
--- a/pkgs/hrmsk66/terraformify/pkg.yaml
+++ b/pkgs/hrmsk66/terraformify/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: hrmsk66/terraformify@v0.6.1

--- a/pkgs/hrmsk66/terraformify/registry.yaml
+++ b/pkgs/hrmsk66/terraformify/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: hrmsk66
+    repo_name: terraformify
+    description: An experimental CLI that generates Terraform files for managing existing Fastly services
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: terraformify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+          - name: terraformify
+            src: terraformify_{{.OS}}_{{.Arch}}/terraformify

--- a/registry.yaml
+++ b/registry.yaml
@@ -14475,6 +14475,28 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: hrmsk66
+    repo_name: terraformify
+    description: An experimental CLI that generates Terraform files for managing existing Fastly services
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: terraformify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+          - name: terraformify
+            src: terraformify_{{.OS}}_{{.Arch}}/terraformify
+  - type: github_release
     repo_owner: iann0036
     repo_name: iamlive
     asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[hrmsk66/terraformify](https://github.com/hrmsk66/terraformify): An experimental CLI that generates Terraform files for managing existing Fastly services

```console
$ aqua g -i hrmsk66/terraformify
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ terraformify --help
A CLI that generates TF files to manage existing Fastly services with Terraform

Usage:
  terraformify [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  service
  version     Display version information for terraformify

Flags:
  -k, --api-key string       Fastly API token (or via FASTLY_API_KEY)
  -h, --help                 help for terraformify
  -s, --skip-edit-state      Skip editing terraform.tfstate and leave it untouched (Note: Diffs will be detected on terraform plan/apply)
  -d, --working-dir string   Terraform working directory (default ".")
  -y, --yes                  Answer yes automatically to all Yes/No confirmations

Use "terraformify [command] --help" for more information about a command.
```


Reference

- https://github.com/hrmsk66/terraformify/blob/main/README.md