### PR TITLE
feat: add Macchina-CLI/macchina

### DIFF
--- a/pkgs/Macchina-CLI/macchina/pkg.yaml
+++ b/pkgs/Macchina-CLI/macchina/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Macchina-CLI/macchina@v6.1.8
+  - name: Macchina-CLI/macchina
+    version: v0.8.1
+  - name: Macchina-CLI/macchina
+    version: v0.6.0

--- a/pkgs/Macchina-CLI/macchina/registry.yaml
+++ b/pkgs/Macchina-CLI/macchina/registry.yaml
@@ -1,0 +1,39 @@
+packages:
+  - type: github_release
+    repo_owner: Macchina-CLI
+    repo_name: macchina
+    description: A system information frontend with an emphasis on performance
+    asset: macchina-{{.OS}}-{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 4.0.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.8.1")
+        asset: macchina-{{.OS}}
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: macchina-{{.OS}}-{{.Arch}}
+            replacements:
+              arm64: aarch64
+        replacements:
+          darwin: macos
+      - version_constraint: semver("< 0.8.1")
+        asset: macchina-{{.OS}}
+        overrides: []
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1298,6 +1298,44 @@ packages:
     files:
       - name: deno
   - type: github_release
+    repo_owner: Macchina-CLI
+    repo_name: macchina
+    description: A system information frontend with an emphasis on performance
+    asset: macchina-{{.OS}}-{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          arm64: aarch64
+    replacements:
+      amd64: x86_64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    rosetta2: true
+    version_constraint: semver(">= 4.0.0")
+    version_overrides:
+      - version_constraint: semver(">= 0.8.1")
+        asset: macchina-{{.OS}}
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: macchina-{{.OS}}-{{.Arch}}
+            replacements:
+              arm64: aarch64
+        replacements:
+          darwin: macos
+      - version_constraint: semver("< 0.8.1")
+        asset: macchina-{{.OS}}
+        overrides: []
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - amd64
+  - type: github_release
     repo_owner: Madh93
     repo_name: tpm
     description: A package manager for Terraform providers


### PR DESCRIPTION
[Macchina-CLI/macchina](https://github.com/Macchina-CLI/macchina): A system information frontend with an emphasis on performance

```console
$ aqua g -i Macchina-CLI/macchina
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ macchina --help
Usage: macchina-linux-aarch64 [OPTIONS]

Options:
  -v, --version                Prints version information
  -o, --show <SHOW>            Displays only the specified readouts
  -d, --doctor                 Checks the system for failures
  -U, --long-uptime            Lengthens uptime output
  -S, --long-shell             Lengthens shell output
  -K, --long-kernel            Lengthens kernel output
  -C, --physical-cores         Toggles between logical and physical cores
  -s, --current-shell          Toggles between the current shell and the default one
  -t, --theme <THEME>          Specify the name of the theme
  -l, --list-themes            Lists all available themes: built-in and custom
  -c, --config <CONFIG>        Specify a custom path for the configuration file
      --ascii-artists          Lists the original artists of the ASCII art used by macchina
  -i, --interface <INTERFACE>  Specify the network interface for the LocalIP readout
  -h, --help                   Print help information
```