### PR TITLE
feat: add Melkeydev/go-blueprint

### DIFF
--- a/pkgs/Melkeydev/go-blueprint/pkg.yaml
+++ b/pkgs/Melkeydev/go-blueprint/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Melkeydev/go-blueprint@v0.2.9
+  - name: Melkeydev/go-blueprint
+    version: v0.2.5
+  - name: Melkeydev/go-blueprint
+    version: v0.2.4

--- a/pkgs/Melkeydev/go-blueprint/registry.yaml
+++ b/pkgs/Melkeydev/go-blueprint/registry.yaml
@@ -1,0 +1,30 @@
+packages:
+  - type: github_release
+    repo_owner: Melkeydev
+    repo_name: go-blueprint
+    description: Go-blueprint allows users to spin up a quick Go project using a popular framework
+    asset: go-blueprint-{{.OS}}_{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_constraint: semver(">= 0.2.5")
+    version_overrides:
+      - version_constraint: semver("< 0.2.5")
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86
+              arm64: arm
+        asset: go-blueprint-{{.Arch}}
+        supported_envs:
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -1354,6 +1354,35 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: Melkeydev
+    repo_name: go-blueprint
+    description: Go-blueprint allows users to spin up a quick Go project using a popular framework
+    asset: go-blueprint-{{.OS}}_{{.Arch}}
+    format: raw
+    overrides:
+      - goos: linux
+        replacements:
+          amd64: x86_64
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    version_constraint: semver(">= 0.2.5")
+    version_overrides:
+      - version_constraint: semver("< 0.2.5")
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86
+              arm64: arm
+        asset: go-blueprint-{{.Arch}}
+        supported_envs:
+          - linux
+  - type: github_release
     repo_owner: MiSawa
     repo_name: xq
     asset: xq-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz


### PR DESCRIPTION
[Melkeydev/go-blueprint](https://github.com/Melkeydev/go-blueprint): Go-blueprint allows users to spin up a quick Go project using a popular framework

```console
$ aqua g -i Melkeydev/go-blueprint
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ go-blueprint --help
Go Blueprint is a CLI tool that allows users to spin up a Go project with the corresponding structure seamlessly.
It also gives the option to integrate with one of the more popular Go frameworks!

Usage:
  go-blueprint [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  create      Create a Go project and don't worry about the structure
  help        Help about any command

Flags:
  -h, --help     help for go-blueprint
  -t, --toggle   Help message for toggle

Use "go-blueprint [command] --help" for more information about a command.
```