### PR TITLE
feat: add Mikescher/better-docker-ps

### DIFF
--- a/pkgs/Mikescher/better-docker-ps/pkg.yaml
+++ b/pkgs/Mikescher/better-docker-ps/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Mikescher/better-docker-ps@v1.11
+  - name: Mikescher/better-docker-ps
+    version: v1.5
+  - name: Mikescher/better-docker-ps
+    version: v1.0

--- a/pkgs/Mikescher/better-docker-ps/registry.yaml
+++ b/pkgs/Mikescher/better-docker-ps/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: Mikescher
+    repo_name: better-docker-ps
+    description: Because `docker ps` is annoying and does not fit my monitor/terminal width
+    asset: dops_{{.OS}}-{{.Arch}}
+    format: raw
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: dops
+    rosetta2: true
+    version_constraint: semver(">= 1.5")
+    version_overrides:
+      - version_constraint: semver("< 1.5")
+        asset: dops
+        supported_envs:
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -1396,6 +1396,26 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: Mikescher
+    repo_name: better-docker-ps
+    description: Because `docker ps` is annoying and does not fit my monitor/terminal width
+    asset: dops_{{.OS}}-{{.Arch}}
+    format: raw
+    replacements:
+      darwin: macos
+    supported_envs:
+      - linux
+      - darwin
+    files:
+      - name: dops
+    rosetta2: true
+    version_constraint: semver(">= 1.5")
+    version_overrides:
+      - version_constraint: semver("< 1.5")
+        asset: dops
+        supported_envs:
+          - linux/amd64
+  - type: github_release
     repo_owner: MordechaiHadad
     repo_name: bob
     asset: bob-{{.OS}}-{{.Arch}}.zip


### PR DESCRIPTION
[Mikescher/better-docker-ps](https://github.com/Mikescher/better-docker-ps): Because `docker ps` is annoying and does not fit my monitor/terminal width

```console
$ aqua g -i Mikescher/better-docker-ps
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ dops --help
better-docker-ps

Usage:
  dops [OPTIONS]                     List docker container

Options (default):
  -h, --help                         Show this screen.
  --version                          Show version.
  --all , -a                         Show all containers (default shows just running)
  --filter <ftr>, -f <ftr>           Filter output based on conditions provided
  --format <fmt>                     Pretty-print containers using a Go template
  --last , -n                        Show n last created containers (includes all states)
  --latest , -l                      Show the latest created container (includes all states)
  --no-trunc                         Don't truncate output (eg ContainerIDs, Sha256 Image references, commandline)
  --quiet , -q                       Only display container IDs
  --size , -s                        Display total file sizes

Options (extra | do not exist in `docker ps`):
  --silent                           Do not print any output
  --timezone                         Specify the timezone for date outputs
  --color <true|false>               Enable/Disable terminal color output
  --no-color                         Disable terminal color output
  --socket <filepath>                Specify the docker socket location (Default: /var/run/docker.sock)
  --timeformat <go-time-fmt>         Specify the datetime output format (golang syntax)
  --no-header                        Do not print the table header
  --simple-header                    Do not print the lines under the header
  --format <fmt>                     You can specify multiple formats and the first one that fits your terminal widt will be used
  --watch <interval>                 Automatically refresh output periodically (interval is optional, default: 2s)

Available --format keys (default):
  {{.ID}}                            Container ID
  {{.Image}}                         Image ID
  {{.Command}}                       Quoted command
  {{.CreatedAt}}                     Time when the container was created.
  {{.RunningFor}}                    Elapsed time since the container was started.
  {{.Ports}}                         Published ports. ([!] differs from docker CLI, these are only the published ports)
  {{.State}}                         Container status
  {{.Status}}                        Container status with details
  {{.Size}}                          Container disk size.
  {{.Names}}                         Container names.
  {{.Labels}}                        All labels assigned to the container.
  {{.Label}}                         [!] Unsupported
  {{.Mounts}}                        Names of the volumes mounted in this container.
  {{.Networks}}                      Names of the networks attached to this container.

Available --format keys (extra | do not exist in `docker ps`):
  {{.ImageName}                      Image ID (without tag and registry)
  {{.ImageTag}, {{.Tag}              Image Tag
  {{.ImageRegistry}, {{.Registry}    Image Registry
  {{.ShortCommand}                   Command without arguments
  {{.LabelKeys}                      All labels assigned to the container (keys only)
  {{.ShortPublishedPorts}}           Published ports, shorter output than {{.Ports}}
  {{.LongPublishedPorts}}            Published ports, full output with IP
  {{.ExposedPorts}}                  Exposed ports
  {{.NotPublishedPorts}}             Exposed but not published ports
  {{.PublishedPorts}}                Published ports
  {{.PublicPorts}}                   Only the public part of published ports
  {{.IP}                             Internal IP Address
```