### PR TITLE
feat: add acheronfail/repgrep

### DIFF
--- a/pkgs/acheronfail/repgrep/pkg.yaml
+++ b/pkgs/acheronfail/repgrep/pkg.yaml
@@ -1,0 +1,26 @@
+packages:
+  - name: acheronfail/repgrep@v0.7.0
+  - name: acheronfail/repgrep
+    version: v0.4.8
+  - name: acheronfail/repgrep
+    version: v0.4.5
+  - name: acheronfail/repgrep
+    version: v0.4.3
+  - name: acheronfail/repgrep
+    version: v0.4.0
+  - name: acheronfail/repgrep
+    version: v0.2.0
+  - name: acheronfail/repgrep
+    version: v0.1.1
+  - name: acheronfail/repgrep
+    version: 0.9.0
+  - name: acheronfail/repgrep
+    version: 0.14.3
+  - name: acheronfail/repgrep
+    version: 0.10.6
+  - name: acheronfail/repgrep
+    version: 0.10.5
+  - name: acheronfail/repgrep
+    version: 0.10.4
+  - name: acheronfail/repgrep
+    version: 0.10.2

--- a/pkgs/acheronfail/repgrep/registry.yaml
+++ b/pkgs/acheronfail/repgrep/registry.yaml
@@ -1,0 +1,199 @@
+packages:
+  - type: github_release
+    repo_owner: acheronfail
+    repo_name: repgrep
+    description: An interactive replacer for ripgrep that makes it easy to find and replace across files on the command line
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.2.0"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.3")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("<= 0.4.5")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 0.4.7")
+        no_asset: true
+      - version_constraint: Version == "v0.4.8"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("<= 0.7.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v0.7.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.9.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "0.10.2"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: Version == "0.10.3"
+        no_asset: true
+      - version_constraint: Version == "0.10.4"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: Version == "0.10.5"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.10.6"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: "true"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -3597,6 +3597,204 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: acheronfail
+    repo_name: repgrep
+    description: An interactive replacer for ripgrep that makes it easy to find and replace across files on the command line
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.2.0"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.3")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("<= 0.4.5")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 0.4.7")
+        no_asset: true
+      - version_constraint: Version == "v0.4.8"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver("<= 0.7.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v0.7.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.9.0")
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "0.10.2"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: Version == "0.10.3"
+        no_asset: true
+      - version_constraint: Version == "0.10.4"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: Version == "0.10.5"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.10.6"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: "true"
+        asset: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: rgr
+            src: repgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rgr
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+  - type: github_release
     repo_owner: acorn-io
     repo_name: runtime
     aliases:


### PR DESCRIPTION
[acheronfail/repgrep](https://github.com/acheronfail/repgrep): An interactive replacer for ripgrep that makes it easy to find and replace across files on the command line

```console
$ aqua g -i acheronfail/repgrep
```
