### PR TITLE
feat: add kyoh86/richgo

### DIFF
--- a/pkgs/kyoh86/richgo/pkg.yaml
+++ b/pkgs/kyoh86/richgo/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
   - name: kyoh86/richgo@v0.3.12
+  - name: kyoh86/richgo
+    version: v0.3.10
+  - name: kyoh86/richgo
+    version: v0.3.8
+  - name: kyoh86/richgo
+    version: v0.3.6

--- a/pkgs/kyoh86/richgo/registry.yaml
+++ b/pkgs/kyoh86/richgo/registry.yaml
@@ -3,11 +3,49 @@ packages:
     repo_owner: kyoh86
     repo_name: richgo
     description: Enrich `go test` outputs with text decorations
-    supported_envs:
-      - darwin
-      - linux
-    asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: richgo_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 0.3.6")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.8")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.10")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -19352,14 +19352,52 @@ packages:
     repo_owner: kyoh86
     repo_name: richgo
     description: Enrich `go test` outputs with text decorations
-    supported_envs:
-      - darwin
-      - linux
-    asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: richgo_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 0.3.6")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.8")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.10")
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: richgo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: richgo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: kyoshidajp
     repo_name: ghkw


### PR DESCRIPTION
[kyoh86/richgo](https://github.com/kyoh86/richgo): Enrich `go test` outputs with text decorations

```console
$ aqua g -i kyoh86/richgo
```

Close #17444