### PR TITLE
feat: add self-actuated/actuated-cli

### DIFF
--- a/pkgs/self-actuated/actuated-cli/pkg.yaml
+++ b/pkgs/self-actuated/actuated-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: self-actuated/actuated-cli@v0.1.8

--- a/pkgs/self-actuated/actuated-cli/registry.yaml
+++ b/pkgs/self-actuated/actuated-cli/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: self-actuated
+    repo_name: actuated-cli
+    description: CLI for actuated
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: actuated-cli
+        format: raw
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: actuated-cli-{{.OS}}
+          - goos: darwin
+            goarch: arm64
+            asset: actuated-cli-{{.OS}}-{{.Arch}}
+          - goos: linux
+            goarch: amd64
+            asset: actuated-cli
+        supported_envs:
+          - darwin
+          - amd64

--- a/pkgs/self-actuated/actuated-cli/registry.yaml
+++ b/pkgs/self-actuated/actuated-cli/registry.yaml
@@ -15,9 +15,6 @@ packages:
           - goos: darwin
             goarch: arm64
             asset: actuated-cli-{{.OS}}-{{.Arch}}
-          - goos: linux
-            goarch: amd64
-            asset: actuated-cli
         supported_envs:
           - darwin
           - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -25714,6 +25714,28 @@ packages:
     search_words:
       - kafka
   - type: github_release
+    repo_owner: self-actuated
+    repo_name: actuated-cli
+    description: CLI for actuated
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: actuated-cli
+        format: raw
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: actuated-cli-{{.OS}}
+          - goos: darwin
+            goarch: arm64
+            asset: actuated-cli-{{.OS}}-{{.Arch}}
+          - goos: linux
+            goarch: amd64
+            asset: actuated-cli
+        supported_envs:
+          - darwin
+          - amd64
+  - type: github_release
     repo_owner: sethvargo
     repo_name: ratchet
     description: A tool for securing CI/CD workflows with version pinning

--- a/registry.yaml
+++ b/registry.yaml
@@ -25729,9 +25729,6 @@ packages:
           - goos: darwin
             goarch: arm64
             asset: actuated-cli-{{.OS}}-{{.Arch}}
-          - goos: linux
-            goarch: amd64
-            asset: actuated-cli
         supported_envs:
           - darwin
           - amd64


### PR DESCRIPTION
[self-actuated/actuated-cli](https://github.com/self-actuated/actuated-cli): CLI for actuated

```console
$ aqua g -i self-actuated/actuated-cli
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ actuated-cli
The actuated-cli is for customers and operators to query
the status of jobs and servers.

Run "actuated-cli auth" to get a Personal Access Token from GitHub

See the project README on GitHub for more:

https://github.com/self-actuated/actuated-cli

Usage:
  actuated-cli [command]

Available Commands:
  agent-logs  Fetch logs from the agent's systemd service
  auth        Authenticate to GitHub to obtain a token and save it to $HOME/.actuated/PAT
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  jobs        List jobs in the build queue
  logs        Fetch logs from VMs
  repair      Schedule additional VMs to repair the build queue
  restart     Forcibly restart the agent by killing it or reboot the machine.
  runners     List runners for an organisation
  ssh         List and connect to SSH sessions
  upgrade     Upgrade an agent's kernel and root filesystem
  version     Print the version

Flags:
  -h, --help                 help for actuated-cli
      --staff                Execute the command as an actuated staff member
  -t, --token string         File to read for Personal Access Token (default "$HOME/.actuated/PAT")
      --token-value string   Personal Access Token

Use "actuated-cli [command] --help" for more information about a command.
```

Reference

- https://github.com/self-actuated/actuated-cli/blob/master/README.md
