### PR TITLE
chore(cmdx): fix `cmdx remove` to be able to delete Docker container

### DIFF
--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -154,7 +154,7 @@ tasks:
 
       $ cmdx rm
     script: |
-      set -euxo pipefail
+      set -eux
       docker stop -t 1 aqua-registry
       docker rm aqua-registry
 


### PR DESCRIPTION
When the shell is not set, an error with `sh` will occur.

```console
$ cmdx remove
+ set -euxo pipefail
docker stop -t 1 aqua-registry
docker rm aqua-registry

sh: 1: set: Illegal option -o pipefail
exit status 2
```