### PR TITLE
feat: add bazelbuild/bazelisk

### DIFF
--- a/pkgs/bazelbuild/bazelisk/pkg.yaml
+++ b/pkgs/bazelbuild/bazelisk/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: bazelbuild/bazelisk@v1.19.0
+  - name: bazelbuild/bazelisk
+    version: v1.8.1
+  - name: bazelbuild/bazelisk
+    version: v1.6.1
+  - name: bazelbuild/bazelisk
+    version: v1.5.0
+  - name: bazelbuild/bazelisk
+    version: v0.0.5

--- a/pkgs/bazelbuild/bazelisk/registry.yaml
+++ b/pkgs/bazelbuild/bazelisk/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: bazelbuild
+    repo_name: bazelisk
+    description: A user-friendly launcher for Bazel
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v0.0.6"
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 1.6.1")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v1.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.8.1")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: "true"
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5582,6 +5582,53 @@ packages:
       - name: bats
         src: bats-core-{{trimV .Version}}/bin/bats
   - type: github_release
+    repo_owner: bazelbuild
+    repo_name: bazelisk
+    description: A user-friendly launcher for Bazel
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v0.0.6"
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver("<= 1.6.1")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: Version == "v1.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.8.1")
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
+      - version_constraint: "true"
+        asset: bazelisk-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+  - type: github_release
     repo_owner: bcicen
     repo_name: ctop
     description: Top-like interface for container metrics


### PR DESCRIPTION
[bazelbuild/bazelisk](https://github.com/bazelbuild/bazelisk): A user-friendly launcher for Bazel

```console
$ aqua g -i bazelbuild/bazelisk
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ bazelisk
2023/11/20 16:27:36 Downloading https://releases.bazel.build/6.4.0/release/bazel-6.4.0-linux-x86_64...
Downloading: 52 MB out of 52 MB (100%) 
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a WORKSPACE file).
                                                           [bazel release 6.4.0]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  mod                 Queries the Bzlmod external dependency graph
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.

Getting more help:
  bazel help <command>
                   Prints help and options for <command>.
  bazel help startup_options
                   Options for the JVM hosting bazel.
  bazel help target-syntax
                   Explains the syntax for specifying targets.
  bazel help info-keys
                   Displays a list of keys used by the info command
```

If files such as configuration file are needed, please share them.

```
```

Reference

-
