### PR TITLE
fix(git-town/git-town): follow up changes of git-town v10.0.3

### DIFF
--- a/pkgs/git-town/git-town/pkg.yaml
+++ b/pkgs/git-town/git-town/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
-  - name: git-town/git-town@v10.0.2
+  - name: git-town/git-town@v10.0.3
   - name: git-town/git-town
-    version: v7.4.0
+    version: v10.0.2
+  - name: git-town/git-town
+    version: v7.6.0
   - name: git-town/git-town
     version: v7.3.0

--- a/pkgs/git-town/git-town/registry.yaml
+++ b/pkgs/git-town/git-town/registry.yaml
@@ -2,32 +2,54 @@ packages:
   - type: github_release
     repo_owner: git-town
     repo_name: git-town
-    asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    description: Generic, high-level Git workflow support
-    replacements:
-      darwin: macos
-      amd64: intel_64
-      arm64: arm_64
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 7.7.0")
+    description: Git workflow automation to keep branches in sync and reduce merge conflicts
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 7.4.0")
-        # In v7.7.0, darwin/arm64 was supported
-        rosetta2: true
-      - version_constraint: "true"
-        # In v7.4.0, linux/arm64 was supported and asset name formats were changed
-        rosetta2: true
-        replacements: {}
+      - version_constraint: semver("<= 3.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 7.3.0")
         asset: git-town-{{.OS}}-{{.Arch}}
         format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
-        overrides: []
+      - version_constraint: semver("<= 7.6.0")
+        asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          amd64: intel_64
+          arm64: arm_64
+      - version_constraint: semver("<= 10.0.2")
+        asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          amd64: intel_64
+          arm64: arm_64
+      - version_constraint: "true"
+        asset: git-town_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          arm64: arm_64
+          amd64: intel_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -12449,35 +12449,57 @@ packages:
   - type: github_release
     repo_owner: git-town
     repo_name: git-town
-    asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    description: Generic, high-level Git workflow support
-    replacements:
-      darwin: macos
-      amd64: intel_64
-      arm64: arm_64
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 7.7.0")
+    description: Git workflow automation to keep branches in sync and reduce merge conflicts
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 7.4.0")
-        # In v7.7.0, darwin/arm64 was supported
-        rosetta2: true
-      - version_constraint: "true"
-        # In v7.4.0, linux/arm64 was supported and asset name formats were changed
-        rosetta2: true
-        replacements: {}
+      - version_constraint: semver("<= 3.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 7.3.0")
         asset: git-town-{{.OS}}-{{.Arch}}
         format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
-        overrides: []
+      - version_constraint: semver("<= 7.6.0")
+        asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          amd64: intel_64
+          arm64: arm_64
+      - version_constraint: semver("<= 10.0.2")
+        asset: git-town_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          amd64: intel_64
+          arm64: arm_64
+      - version_constraint: "true"
+        asset: git-town_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          darwin: macos
+          arm64: arm_64
+          amd64: intel_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: github-release
     repo_name: github-release


### PR DESCRIPTION
Asset names were changed.

- https://github.com/git-town/git-town/commit/f5ceb27b45e26af6c91c66af351f0cf726908179
- https://github.com/git-town/git-town/pull/2670