### PR TITLE
feat: add imsnif/bandwhich

### DIFF
--- a/pkgs/imsnif/bandwhich/pkg.yaml
+++ b/pkgs/imsnif/bandwhich/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: imsnif/bandwhich@v0.21.1
+  - name: imsnif/bandwhich
+    version: 0.20.0
+  - name: imsnif/bandwhich
+    version: 0.5.1
+  - name: imsnif/bandwhich
+    version: 0.3.2

--- a/pkgs/imsnif/bandwhich/registry.yaml
+++ b/pkgs/imsnif/bandwhich/registry.yaml
@@ -1,0 +1,47 @@
+packages:
+  - type: github_release
+    repo_owner: imsnif
+    repo_name: bandwhich
+    description: Terminal bandwidth utilization tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.2")
+        asset: what
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.5.1")
+        asset: what-v{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: what
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.20.0")
+        asset: bandwhich-v{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: bandwhich-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15303,6 +15303,52 @@ packages:
       asset: rover_{{trimV .Version}}_SHA256SUMS
       algorithm: sha256
   - type: github_release
+    repo_owner: imsnif
+    repo_name: bandwhich
+    description: Terminal bandwidth utilization tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.2")
+        asset: what
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.5.1")
+        asset: what-v{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: what
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.20.0")
+        asset: bandwhich-v{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: bandwhich-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: imuxin
     repo_name: kubectl-watch
     description: A kubectl plugin to provide a pretty delta change view of being watched kubernetes resources


### PR DESCRIPTION
[imsnif/bandwhich](https://github.com/imsnif/bandwhich): Terminal bandwidth utilization tool

```console
$ aqua g -i imsnif/bandwhich
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ bandwhich --help
Usage: bandwhich [OPTIONS]

Options:
  -i, --interface <INTERFACE>    The network interface to listen on, eg. eth0
  -r, --raw                      Machine friendlier output
  -n, --no-resolve               Do not attempt to resolve IPs to their hostnames
  -s, --show-dns                 Show DNS queries
  -d, --dns-server <DNS_SERVER>  A dns server ip to use instead of the system default
      --log-to <LOG_TO>          Enable logging to a file
  -v, --verbose...               More output per occurrence
  -q, --quiet...                 Less output per occurrence
  -p, --processes                Show processes table only
  -c, --connections              Show connections table only
  -a, --addresses                Show remote addresses table only
  -t, --total-utilization        Show total (cumulative) usages
  -h, --help                     Print help
  -V, --version                  Print version
```

Please note that the binary was renamed from `what` to `bandwhich` in 0.6.0: https://github.com/imsnif/bandwhich/releases/tag/0.6.0
