### PR TITLE
feat: add dustinblackman/oatmeal

### DIFF
--- a/pkgs/dustinblackman/oatmeal/pkg.yaml
+++ b/pkgs/dustinblackman/oatmeal/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dustinblackman/oatmeal@v0.5.5

--- a/pkgs/dustinblackman/oatmeal/registry.yaml
+++ b/pkgs/dustinblackman/oatmeal/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: dustinblackman
+    repo_name: oatmeal
+    description: Terminal UI to chat with large language models (LLM) using different model backends, and integrations with your favourite editors
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: oatmeal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -11307,6 +11307,22 @@ packages:
       asset: sha256sums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: dustinblackman
+    repo_name: oatmeal
+    description: Terminal UI to chat with large language models (LLM) using different model backends, and integrations with your favourite editors
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: oatmeal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: dutchcoders
     repo_name: cloudman
     description: Textual user interface to manage ec2 instances


### PR DESCRIPTION
[dustinblackman/oatmeal](https://github.com/dustinblackman/oatmeal): Terminal UI to chat with large language models (LLM) using different model backends, and integrations with your favourite editors

```console
$ aqua g -i dustinblackman/oatmeal
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ oatmeal --help
Terminal UI to chat with large language models (LLM) using different model backends, and direct integrations with your favourite editors!

Version: 0.5.4
Commit: 67f5df6

Usage: oatmeal [OPTIONS] [COMMAND]

Commands:
  chat         Start a new chat session
  completions  Generates shell completions
  sessions     Manage past chat sessions
  help         Print this message or the help of the given subcommand(s)

Options:
  -b, --backend <backend>            The initial backend hosting a model to connect to. [Possible values: ollama, openai] [env: OATMEAL_BACKEND=] [default: ollama]
  -m, --model <model>                The initial model on a backend to consume [env: OATMEAL_MODEL=] [default: llama2:latest]
  -e, --editor <editor>              The editor to integrate with. [Possible values: clipboard, neovim] [env: OATMEAL_EDITOR=] [default: clipboard]
  -t, --theme <theme>                Sets code syntax highlighting theme. [Possible values: base16-github, base16-monokai, base16-one-light, base16-onedark, base16-seti] [env: OATMEAL_THEME=] [default: base16-onedark]
      --theme-file <theme-file>      Absolute path to a TextMate tmTheme to use for code syntax highlighting [env: OATMEAL_THEME_FILE=]
      --openai-url <openai-url>      OpenAI API URL when using the OpenAI backend. Can be swapped to a compatiable proxy [env: OATMEAL_OPENAI_URL=] [default: https://api.openai.com]
      --openai-token <openai-token>  OpenAI API token when using the OpenAI backend [env: OATMEAL_OPENAI_TOKEN=]
  -h, --help                         Print help
  -V, --version                      Print version

CHAT COMMANDS:
  - /modellist (/ml) - Lists all available models from the backend.
  - /model (/model) [MODEL_NAME,MODEL_INDEX] - Sets the specified model as the active model. You can pass either the model name, or the index from /modellist
  - /append (/a) [CODE_BLOCK_NUMBER?] - Appends code blocks to an editor. See Code Actions for more details.
  - /replace (/r) [CODE_BLOCK_NUMBER?] - Replaces selections with code blocks in an editor. See Code Actions for more details.
  - /copy (/c) [CODE_BLOCK_NUMBER?] - Copies the entire chat history to your clipboard. When a CODE_BLOCK_NUMBER is used, only the specified copy blocks are copied to clipboard. See Code Actions for more details.
  - /quit /exit (/q) - Exit Oatmeal.
  - /help (/h) - Provides this help menu.

CHAT HOTKEYS:
  - Up arrow - Scroll up
  - Down arrow - Scroll down
  - CTRL+U - Page up
  - CTRL+D - Page down
  - CTRL+C - Interrupt waiting for prompt response if in progress, otherwise exit.
  - CTRL+R - Resubmit your last message to the backend.

CHAT CODE ACTIONS:
When working with models that provide code, and using an editor integration, Oatmeal has the capabilities to read selected code from an editor, and submit model provided code back in to an editor. Each code block provided by a model is indexed with a (NUMBER) at the beginning of the block to make it easily identifiable.

  - /append (/a) [CODE_BLOCK_NUMBER?] will append one-to-many model provided code blocks to the open file in your editor.
  - /replace (/r) [CODE_BLOCK_NUMBER?] - will replace selected code in your editor with one-to-many model provided code blocks.
  - /copy (/c) [CODE_BLOCK_NUMBER?] - will append one-to-many model provided code blocks to your clipboard, no matter the editor integration being used.

The CODE_BLOCK_NUMBER allows you to select several code blocks to send back to your editor at once. The parameter can be set as follows:
  - `1` - Selects the first code block
  - `1,3,5` - Selects code blocks 1, 3, and 5.
  - `2..5`- Selects an inclusive range of code blocks between 2 and 5.
  - None - Selects the last provided code block.
```