### PR TITLE
feat: add masutaka/github-nippou

### DIFF
--- a/pkgs/masutaka/github-nippou/pkg.yaml
+++ b/pkgs/masutaka/github-nippou/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: masutaka/github-nippou@v4.2.11
+  - name: masutaka/github-nippou
+    version: v4.2.9
+  - name: masutaka/github-nippou
+    version: v4.1.11

--- a/pkgs/masutaka/github-nippou/registry.yaml
+++ b/pkgs/masutaka/github-nippou/registry.yaml
@@ -1,0 +1,34 @@
+packages:
+  - type: github_release
+    repo_owner: masutaka
+    repo_name: github-nippou
+    description: Print today's your GitHub activity for issues and pull requests
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.2.0")
+        no_asset: true
+      - version_constraint: semver("<= 4.1.11")
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 4.2.9")
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: github-nippou_{{.Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -20646,6 +20646,39 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: masutaka
+    repo_name: github-nippou
+    description: Print today's your GitHub activity for issues and pull requests
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.2.0")
+        no_asset: true
+      - version_constraint: semver("<= 4.1.11")
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 4.2.9")
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: github-nippou_{{.Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: mathew-fleisch
     repo_name: bashbot
     description: A slack-bot written in golang for infrastructure/devops teams


### PR DESCRIPTION
[masutaka/github-nippou](https://github.com/masutaka/github-nippou): Print today's your GitHub activity for issues and pull requests

```console
$ aqua g -i masutaka/github-nippou
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ github-nippou --help
Print today's your GitHub activity for issues and pull requests

Usage:
  github-nippou [flags]
  github-nippou [command]

Available Commands:
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command
  init          Initialize github-nippou settings
  list          Print today's your GitHub activity for issues and pull requests
  open-settings Open settings url with web browser
  version       Print version

Flags:
  -d, --debug               Debug mode
  -h, --help                help for github-nippou
  -s, --since-date string   Retrieves GitHub user_events since the date (default "20231204")
  -u, --until-date string   Retrieves GitHub user_events until the date (default "20231204")

Use "github-nippou [command] --help" for more information about a command.

```

Reference

- https://github.com/masutaka/github-nippou/blob/main/README.md
