### PR TITLE
chore: fix the symbolic link to aqua-proxy when connecting to the container

### DIFF
--- a/scripts/connect.sh
+++ b/scripts/connect.sh
@@ -14,4 +14,9 @@ if [ "$OS" = windows ]; then
 	container=aqua-registry-windows
 fi
 echo "[INFO] Connecting to the container $container ($OS/$ARCH)" >&2
+
+# Workaround to fix the symbolic link to aqua-proxy
+# https://github.com/aquaproj/aqua-registry/pull/17896#issuecomment-1837703289
+docker exec "$container" env AQUA_GOOS="$OS" AQUA_GOARCH="$ARCH" aqua i -l
+
 docker exec -ti "$container" env AQUA_GOOS="$OS" AQUA_GOARCH="$ARCH" bash


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/pull/17896#issuecomment-1837703289

I confirmed the change fixes the issue.

Before

```console
$ cmdx con                     
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/arm64)
root@2249e5ad7f3b:/workspace# github-nippou --help
bash: /root/aquaproj-aqua/bin/github-nippou: cannot execute binary file: Exec format error
```

After

```console
$ cmdx con               
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/arm64)
root@2249e5ad7f3b:/workspace# github-nippou --help
Print today's your GitHub activity for issues and pull requests

Usage:
  github-nippou [flags]
  github-nippou [command]

Available Commands:
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command
  init          Initialize github-nippou settings
  list          Print today's your GitHub activity for issues and pull requests
  open-settings Open settings url with web browser
  version       Print version

Flags:
  -d, --debug               Debug mode
  -h, --help                help for github-nippou
  -s, --since-date string   Retrieves GitHub user_events since the date (default "20231204")
  -u, --until-date string   Retrieves GitHub user_events until the date (default "20231204")

Use "github-nippou [command] --help" for more information about a command.
```