### PR TITLE
feat: add awslabs/eks-node-viewer

### DIFF
--- a/pkgs/awslabs/eks-node-viewer/pkg.yaml
+++ b/pkgs/awslabs/eks-node-viewer/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: awslabs/eks-node-viewer@v0.6.0
+  - name: awslabs/eks-node-viewer
+    version: v0.2.1

--- a/pkgs/awslabs/eks-node-viewer/registry.yaml
+++ b/pkgs/awslabs/eks-node-viewer/registry.yaml
@@ -1,0 +1,50 @@
+packages:
+  - type: github_release
+    repo_owner: awslabs
+    repo_name: eks-node-viewer
+    description: EKS Node Viewer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.2.1")
+        asset: eks-node-viewer_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: eks-node-viewer_{{.OS}}_all
+          - goos: windows
+            format: zip
+            asset: eks-node-viewer_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: eks-node-viewer_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: eks-node-viewer_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: eks-node-viewer_{{.OS}}_all
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: eks-node-viewer_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256

--- a/pkgs/awslabs/eks-node-viewer/registry.yaml
+++ b/pkgs/awslabs/eks-node-viewer/registry.yaml
@@ -10,7 +10,6 @@ packages:
       - version_constraint: semver("<= 0.2.1")
         asset: eks-node-viewer_{{.OS}}_{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin
@@ -34,7 +33,6 @@ packages:
       - version_constraint: "true"
         asset: eks-node-viewer_{{.OS}}_{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -5383,6 +5383,55 @@ packages:
     version_overrides:
       - version_constraint: semver(">= 0.3.1")
         rosetta2: true
+  - type: github_release
+    repo_owner: awslabs
+    repo_name: eks-node-viewer
+    description: EKS Node Viewer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.2.1")
+        asset: eks-node-viewer_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: eks-node-viewer_{{.OS}}_all
+          - goos: windows
+            format: zip
+            asset: eks-node-viewer_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: eks-node-viewer_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: eks-node-viewer_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: eks-node-viewer_{{.OS}}_all
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: eks-node-viewer_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256
   - type: github_content
     repo_owner: awslabs
     repo_name: git-secrets

--- a/registry.yaml
+++ b/registry.yaml
@@ -5394,7 +5394,6 @@ packages:
       - version_constraint: semver("<= 0.2.1")
         asset: eks-node-viewer_{{.OS}}_{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin
@@ -5418,7 +5417,6 @@ packages:
       - version_constraint: "true"
         asset: eks-node-viewer_{{.OS}}_{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin


### PR DESCRIPTION
[awslabs/eks-node-viewer](https://github.com/awslabs/eks-node-viewer): EKS Node Viewer

```console
$ aqua g -i awslabs/eks-node-viewer
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ eks-node-viewer --help
Usage of eks-node-viewer_Linux_arm64:
  -attribution
        Show the Open Source Attribution
  -context string
        Name of the kubernetes context to use
  -disable-pricing
        Disable pricing lookups
  -extra-labels string
        A comma separated set of extra node labels to display
  -kubeconfig string
        Absolute path to the kubeconfig file (default "/root/.kube/config")
  -node-selector string
        Node label selector used to filter nodes, if empty all nodes are selected
  -node-sort string
        Sort order for the nodes, either 'creation' or a label name. The sort order defaults to ascending and can be controlled by appending =asc or =dsc to the value. (default "creation=dsc")
  -resources string
        List of comma separated resources to monitor (default "cpu")
  -style string
        Three color to use for styling 'good','ok' and 'bad' values. These are also used in the gradients displayed from bad -> good. (default "#04B575,#FFFF00,#FF0000")
  -v    Display eks-node-viewer version
  -version
        Display eks-node-viewer version
```


Reference

- https://github.com/awslabs/eks-node-viewer/blob/main/README.md