### PR TITLE
feat: add funbiscuit/spacedisplay-rs

### DIFF
--- a/pkgs/funbiscuit/spacedisplay-rs/pkg.yaml
+++ b/pkgs/funbiscuit/spacedisplay-rs/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: funbiscuit/spacedisplay-rs@v0.3.0
+  - name: funbiscuit/spacedisplay-rs
+    version: v0.2.0
+  - name: funbiscuit/spacedisplay-rs
+    version: v0.1.1

--- a/pkgs/funbiscuit/spacedisplay-rs/registry.yaml
+++ b/pkgs/funbiscuit/spacedisplay-rs/registry.yaml
@@ -1,0 +1,40 @@
+packages:
+  - type: github_release
+    repo_owner: funbiscuit
+    repo_name: spacedisplay-rs
+    description: Fast and lightweight tool to scan your disk space
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: spacedisplay-{{.Arch}}_{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: spacedisplay-{{.OS}}
+        replacements:
+          windows: win64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        files:
+          - name: spacedisplay
+            src: spacedisplay-rs
+      - version_constraint: "true"
+        asset: spacedisplay-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            asset: spacedisplay-{{.Arch}}_{{.OS}}
+        replacements:
+          darwin: macos
+          windows: win64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: spacedisplay
+            src: spacedisplay-rs

--- a/registry.yaml
+++ b/registry.yaml
@@ -12481,6 +12481,45 @@ packages:
       asset: grpcurl_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: funbiscuit
+    repo_name: spacedisplay-rs
+    description: Fast and lightweight tool to scan your disk space
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: spacedisplay-{{.Arch}}_{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: spacedisplay-{{.OS}}
+        replacements:
+          windows: win64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        files:
+          - name: spacedisplay
+            src: spacedisplay-rs
+      - version_constraint: "true"
+        asset: spacedisplay-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            asset: spacedisplay-{{.Arch}}_{{.OS}}
+        replacements:
+          darwin: macos
+          windows: win64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: spacedisplay
+            src: spacedisplay-rs
+  - type: github_release
     repo_owner: future-architect
     repo_name: tftarget
     description: tftarget is a CLI tool for Terraform ( plan | apply | destroy ) with target option. You can interactivity select resource to ( plan | apply | destroy )  with target option


### PR DESCRIPTION
[funbiscuit/spacedisplay-rs](https://github.com/funbiscuit/spacedisplay-rs): Fast and lightweight tool to scan your disk space

```console
$ aqua g -i funbiscuit/spacedisplay-rs
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ spacedisplay --help
Fast and lightweight tool to scan your disk space.


Usage: spacedisplay-macos [OPTIONS] [PATH]

Arguments:
  [PATH]  Path to directory to scan

Options:
      --no-ui                  Run without UI. Performs scan of specified path and prints results
  -s, --simple-graphics        Use simple graphics instead of unicode
  -t, --tick-rate <TICK_RATE>  Refresh rate of terminal UI [default: 200]
  -h, --help                   Print help
  -V, --version                Print version
```