### PR TITLE
feat: add traviswt/gke-auth-plugin

### DIFF
--- a/pkgs/traviswt/gke-auth-plugin/pkg.yaml
+++ b/pkgs/traviswt/gke-auth-plugin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: traviswt/gke-auth-plugin@0.1.1

--- a/pkgs/traviswt/gke-auth-plugin/registry.yaml
+++ b/pkgs/traviswt/gke-auth-plugin/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: traviswt
+    repo_name: gke-auth-plugin
+    description: A GKE standalone auth plugin, with no dependencies on gcloud cli and python
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gke-auth-plugin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -30729,6 +30729,27 @@ packages:
       - darwin
       - linux
   - type: github_release
+    repo_owner: traviswt
+    repo_name: gke-auth-plugin
+    description: A GKE standalone auth plugin, with no dependencies on gcloud cli and python
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gke-auth-plugin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: tree-sitter
     repo_name: tree-sitter
     description: An incremental parsing system for programming tools


### PR DESCRIPTION
[traviswt/gke-auth-plugin](https://github.com/traviswt/gke-auth-plugin): A GKE standalone auth plugin, with no dependencies on gcloud cli and python

```console
$ aqua g -i traviswt/gke-auth-plugin
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ gke-auth-plugin --help
GKE Authentication Plugin

Usage:
  gke-auth-plugin [flags]
  gke-auth-plugin [command]

Available Commands:
  help        Help about any command
  version     prints the version of this plugin

Flags:
  -h, --help   help for gke-auth-plugin

Use "gke-auth-plugin [command] --help" for more information about a command.
```

Reference

- https://github.com/traviswt/gke-auth-plugin/blob/main/README.md