### PR TITLE
feat: add kettle11/devserver

### DIFF
--- a/pkgs/kettle11/devserver/pkg.yaml
+++ b/pkgs/kettle11/devserver/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kettle11/devserver@v0.4.3

--- a/pkgs/kettle11/devserver/registry.yaml
+++ b/pkgs/kettle11/devserver/registry.yaml
@@ -1,0 +1,30 @@
+packages:
+  - type: github_release
+    repo_owner: kettle11
+    repo_name: devserver
+    description: A simple HTTPS server for local development. Implemented in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: devserver-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: devserver-{{.Arch}}-{{.OS}}.sha512
+          algorithm: sha512

--- a/pkgs/kettle11/devserver/registry.yaml
+++ b/pkgs/kettle11/devserver/registry.yaml
@@ -10,13 +10,11 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -18475,6 +18475,35 @@ packages:
     description: A Command-line statistics tool to compare the GitHub repositories
     path: github.com/anqiansong/github-compare
   - type: github_release
+    repo_owner: kettle11
+    repo_name: devserver
+    description: A simple HTTPS server for local development. Implemented in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: devserver-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: devserver-{{.Arch}}-{{.OS}}.sha512
+          algorithm: sha512
+  - type: github_release
     repo_owner: kevincobain2000
     repo_name: gobrew
     asset: gobrew-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -18485,13 +18485,11 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc


### PR DESCRIPTION
#18103 [kettle11/devserver](https://github.com/kettle11/devserver): HTTPS server for local development. Implemented in Rust

```console
$ aqua g -i kettle11/devserver
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cat index.html
Hello World
$ devserver &
[1] 4756
$
Serving [/home/test/aqua-registry/test/] at [ https://localhost:8080 ] or [ http://localhost:8080 ]
Automatic reloading is enabled!
Stop with Ctrl+C

$ curl localhost:8080
Hello World
<script>
    // This code is inserted by devserver to enable reloading.
    const socket = new WebSocket("ws://" + window.location.hostname + ":8129");
    socket.addEventListener('open', function (event) { console.log("Reloading enabled!"); });
    socket.addEventListener('message', function (event) { location.reload(); });
$
```

If files such as configuration file are needed, please share them.

none.

Reference

- https://github.com/kettle11/devserver/releases