### PR TITLE
feat: add ast-grep/ast-grep

### DIFF
--- a/pkgs/ast-grep/ast-grep/pkg.yaml
+++ b/pkgs/ast-grep/ast-grep/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: ast-grep/ast-grep@0.14.4
+  - name: ast-grep/ast-grep
+    version: 0.14.0
+  - name: ast-grep/ast-grep
+    version: 0.13.2
+  - name: ast-grep/ast-grep
+    version: 0.6.6

--- a/pkgs/ast-grep/ast-grep/registry.yaml
+++ b/pkgs/ast-grep/ast-grep/registry.yaml
@@ -1,0 +1,63 @@
+packages:
+  - type: github_release
+    repo_owner: ast-grep
+    repo_name: ast-grep
+    description: A CLI tool for code structural search, lint and rewriting. Written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.6")
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: semver("<= 0.13.2")
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: Version == "0.14.0"
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: "true"
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: sg
+            src: sg

--- a/registry.yaml
+++ b/registry.yaml
@@ -5154,6 +5154,68 @@ packages:
       asset: surf_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: ast-grep
+    repo_name: ast-grep
+    description: A CLI tool for code structural search, lint and rewriting. Written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.6")
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: semver("<= 0.13.2")
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: Version == "0.14.0"
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+        files:
+          - name: sg
+            src: sg
+      - version_constraint: "true"
+        asset: sg-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: sg
+            src: sg
+  - type: github_release
     repo_owner: astefanutti
     repo_name: kubebox
     asset: kubebox-{{.OS}}


### PR DESCRIPTION
[ast-grep/ast-grep](https://github.com/ast-grep/ast-grep): A CLI tool for code structural search, lint and rewriting. Written in Rust

```console
$ aqua g -i ast-grep/ast-grep
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ sg --help
Search and Rewrite code at large scale using AST pattern.
                    __
        ____ ______/ /_      ____ _________  ____
       / __ `/ ___/ __/_____/ __ `/ ___/ _ \/ __ \
      / /_/ (__  ) /_/_____/ /_/ / /  /  __/ /_/ /
      \__,_/____/\__/      \__, /_/   \___/ .___/
                          /____/         /_/


Usage: sg <COMMAND>

Commands:
  run          Run one time search or rewrite in command line. (default command)
  scan         Scan and rewrite code by configuration
  test         Test ast-grep rules
  new          Create new ast-grep project or items like rules/tests
  lsp          Start language server
  completions  Generate shell completion script
  docs         Generate rule docs for current configuration. (Not Implemented Yet)
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```