### PR TITLE
feat: add EdJoPaTo/mqttui

### DIFF
--- a/pkgs/EdJoPaTo/mqttui/pkg.yaml
+++ b/pkgs/EdJoPaTo/mqttui/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: EdJoPaTo/mqttui@v0.19.0
+  - name: EdJoPaTo/mqttui
+    version: v0.16.2
+  - name: EdJoPaTo/mqttui
+    version: v0.12.0
+  - name: EdJoPaTo/mqttui
+    version: v0.11.0
+  - name: EdJoPaTo/mqttui
+    version: v0.10.0
+  - name: EdJoPaTo/mqttui
+    version: v0.4.0
+  - name: EdJoPaTo/mqttui
+    version: v0.1.0

--- a/pkgs/EdJoPaTo/mqttui/registry.yaml
+++ b/pkgs/EdJoPaTo/mqttui/registry.yaml
@@ -1,0 +1,113 @@
+packages:
+  - type: github_release
+    repo_owner: EdJoPaTo
+    repo_name: mqttui
+    description: Subscribe to a MQTT Topic or publish something quickly from the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: quick-mqtt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: mqttui
+            src: quick-mqtt
+      - version_constraint: semver("<= 0.4.0")
+        asset: mqtt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: mqttui
+            src: mqtt
+      - version_constraint: semver("<= 0.10.0")
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.11.0"
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.12.0")
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.16.2")
+        asset: mqttui-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: mqttui-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -766,6 +766,118 @@ packages:
           - name: clash
             src: clash-windows-{{.Arch}}.exe
   - type: github_release
+    repo_owner: EdJoPaTo
+    repo_name: mqttui
+    description: Subscribe to a MQTT Topic or publish something quickly from the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: quick-mqtt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: mqttui
+            src: quick-mqtt
+      - version_constraint: semver("<= 0.4.0")
+        asset: mqtt-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        files:
+          - name: mqttui
+            src: mqtt
+      - version_constraint: semver("<= 0.10.0")
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.11.0"
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.12.0")
+        asset: mqttui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.16.2")
+        asset: mqttui-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: mqttui-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+  - type: github_release
     repo_owner: EdenEast
     repo_name: repo
     asset: repo-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[EdJoPaTo/mqttui](https://github.com/EdJoPaTo/mqttui): Subscribe to a MQTT Topic or publish something quickly from the terminal

```console
$ aqua g -i EdJoPaTo/mqttui
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mqttui --help
Subscribe to a MQTT Topic or publish something quickly from the terminal

Usage: mqttui [OPTIONS] [TOPIC]... [COMMAND]

Commands:
  clean-retained
          Clean retained messages from the broker [aliases: c, clean]
  log
          Log values from subscribed topics to stdout [aliases: l]
  read-one
          Wait for the first message on the given topic(s) and return its payload to stdout [aliases: r, read]
  publish
          Publish a value quickly [aliases: p, pub]
  help
          Print this message or the help of the given subcommand(s)

Arguments:
  [TOPIC]...
          Topic to watch

          [env: MQTTUI_TOPIC=]
          [default: #]

Options:
  -b, --broker <URL>
          URL which represents how to connect to the MQTT broker.

          Examples: `mqtt://localhost` `mqtt://localhost:1883` `mqtts://localhost` `mqtts://localhost:8883` `ws://localhost/path`
          `ws://localhost:9001/path` `wss://localhost/path` `wss://localhost:9001/path`

          [env: MQTTUI_BROKER=]
          [default: mqtt://localhost]

  -u, --username <STRING>
          Username to access the mqtt broker.

          Anonymous access when not supplied.

          [env: MQTTUI_USERNAME=]

      --password <STRING>
          Password to access the mqtt broker.

          Consider using a connection with TLS to the broker. Otherwise the password will be transported in plaintext.

          Passing the password via command line is insecure as the password can be read from the history! You should pass it via environment
          variable.

          [env: MQTTUI_PASSWORD]

  -i, --client-id <STRING>
          Specify the client id to connect with

          [env: MQTTUI_CLIENTID=]

      --client-cert <FILEPATH>
          Path to the TLS client certificate file.

          Used together with --client-key to enable TLS client authentication. The file has to be a DER-encoded X.509 certificate serialized to PEM.

          [env: MQTTUI_CLIENT_CERTIFICATE=]

      --client-key <FILEPATH>
          Path to the TLS client private key.

          Used together with --client-cert to enable TLS client authentication. The file has to be a DER-encoded ASN.1 file in PKCS#8 form
          serialized to PEM.

          [env: MQTTUI_CLIENT_PRIVATE_KEY=]

      --insecure
          Allow insecure TLS connections

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```