### PR TITLE
feat: add CAFxX/mgo

### DIFF
--- a/pkgs/CAFxX/mgo/pkg.yaml
+++ b/pkgs/CAFxX/mgo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: CAFxX/mgo@v0.2.12

--- a/pkgs/CAFxX/mgo/registry.yaml
+++ b/pkgs/CAFxX/mgo/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - type: go_install
+    repo_owner: CAFxX
+    repo_name: mgo
+    description: Build and bundle multiple GOAMD64 variants in a single executable
+    supported_envs:
+      - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -599,6 +599,12 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+  - type: go_install
+    repo_owner: CAFxX
+    repo_name: mgo
+    description: Build and bundle multiple GOAMD64 variants in a single executable
+    supported_envs:
+      - linux/amd64
   - type: github_release
     repo_owner: Cian911
     repo_name: switchboard


### PR DESCRIPTION
[CAFxX/mgo](https://github.com/CAFxX/mgo): Build and bundle multiple GOAMD64 variants in a single executable