### PR TITLE
feat: add go-delve/delve

### DIFF
--- a/pkgs/go-delve/delve/pkg.yaml
+++ b/pkgs/go-delve/delve/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-delve/delve@v1.21.2

--- a/pkgs/go-delve/delve/registry.yaml
+++ b/pkgs/go-delve/delve/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: go_install
+    repo_owner: go-delve
+    repo_name: delve
+    description: Delve is a debugger for the Go programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        path: github.com/go-delve/delve/cmd/dlv
+        files:
+          - name: dlv

--- a/registry.yaml
+++ b/registry.yaml
@@ -13319,6 +13319,16 @@ packages:
         rosetta2: true
         checksum:
           enabled: false
+  - type: go_install
+    repo_owner: go-delve
+    repo_name: delve
+    description: Delve is a debugger for the Go programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        path: github.com/go-delve/delve/cmd/dlv
+        files:
+          - name: dlv
   - type: github_release
     repo_owner: go-gost
     repo_name: gost


### PR DESCRIPTION
[go-delve/delve](https://github.com/go-delve/delve): Delve is a debugger for the Go programming language

```console
$ aqua g -i go-delve/delve
```