### PR TITLE
fix(CAFxX/mgo): remove supported_envs

### DIFF
--- a/pkgs/CAFxX/mgo/registry.yaml
+++ b/pkgs/CAFxX/mgo/registry.yaml
@@ -3,5 +3,3 @@ packages:
     repo_owner: CAFxX
     repo_name: mgo
     description: Build and bundle multiple GOAMD64 variants in a single executable
-    supported_envs:
-      - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -603,8 +603,6 @@ packages:
     repo_owner: CAFxX
     repo_name: mgo
     description: Build and bundle multiple GOAMD64 variants in a single executable
-    supported_envs:
-      - linux/amd64
   - type: github_release
     repo_owner: Cian911
     repo_name: switchboard


### PR DESCRIPTION
Follow up https://github.com/aquaproj/aqua-registry/pull/18161 .

I changed my mind.
Basically, supported_envs is used for CI.
In case of this package, the installation itself succeeds without supported_envs. So we remove supported_envs.