### PR TITLE
feat: add Getdeck/getdeck

### DIFF
--- a/pkgs/Getdeck/getdeck/pkg.yaml
+++ b/pkgs/Getdeck/getdeck/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Getdeck/getdeck@0.11.1
+  - name: Getdeck/getdeck
+    version: 0.7.1
+  - name: Getdeck/getdeck
+    version: 0.6.0

--- a/pkgs/Getdeck/getdeck/registry.yaml
+++ b/pkgs/Getdeck/getdeck/registry.yaml
@@ -17,7 +17,6 @@ packages:
       - version_constraint: semver("<= 0.7.1")
         asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-        rosetta2: true
         overrides:
           - goos: darwin
             asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
@@ -29,7 +28,6 @@ packages:
       - version_constraint: "true"
         asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin

--- a/pkgs/Getdeck/getdeck/registry.yaml
+++ b/pkgs/Getdeck/getdeck/registry.yaml
@@ -1,0 +1,48 @@
+packages:
+  - type: github_release
+    repo_owner: Getdeck
+    repo_name: getdeck
+    description: A CLI that creates reproducible Kubernetes environments for development and testing
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.6.0")
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux/amd64
+        files:
+          - name: deck
+      - version_constraint: semver("<= 0.7.1")
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        overrides:
+          - goos: darwin
+            asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+        files:
+          - name: deck
+      - version_constraint: "true"
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            replacements:
+              amd64: x86_64
+            files:
+              - name: deck
+                src: dist/deck
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: deck

--- a/registry.yaml
+++ b/registry.yaml
@@ -995,6 +995,53 @@ packages:
     asset: mkcert-{{.Version}}-{{.OS}}-{{.Arch}}
     description: A simple zero-config tool to make locally trusted development certificates with any names you'd like
   - type: github_release
+    repo_owner: Getdeck
+    repo_name: getdeck
+    description: A CLI that creates reproducible Kubernetes environments for development and testing
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.6.0")
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux/amd64
+        files:
+          - name: deck
+      - version_constraint: semver("<= 0.7.1")
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        overrides:
+          - goos: darwin
+            asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+        files:
+          - name: deck
+      - version_constraint: "true"
+        asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            replacements:
+              amd64: x86_64
+            files:
+              - name: deck
+                src: dist/deck
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        files:
+          - name: deck
+  - type: github_release
     repo_owner: GhostTroops
     repo_name: scan4all
     aliases:

--- a/registry.yaml
+++ b/registry.yaml
@@ -1012,7 +1012,6 @@ packages:
       - version_constraint: semver("<= 0.7.1")
         asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-        rosetta2: true
         overrides:
           - goos: darwin
             asset: deck-{{.Version}}-{{.OS}}-universal.{{.Format}}
@@ -1024,7 +1023,6 @@ packages:
       - version_constraint: "true"
         asset: deck-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-        rosetta2: true
         windows_arm_emulation: true
         overrides:
           - goos: darwin


### PR DESCRIPTION
[Getdeck/getdeck](https://github.com/Getdeck/getdeck): A CLI that creates reproducible Kubernetes environments for development and testing

```console
$ aqua g -i Getdeck/getdeck
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ deck --help
usage: deck [-h] [-d] {list,get,remove,stop,version,hosts,telemetry} ...

The Deck CLI. For more help please visit: https://getdeck.dev

positional arguments:
  {list,get,remove,stop,version,hosts,telemetry}
                        the action to be performed

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           add debug output
```