### PR TITLE
feat: add kluctl/kluctl

### DIFF
--- a/pkgs/kluctl/kluctl/pkg.yaml
+++ b/pkgs/kluctl/kluctl/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: kluctl/kluctl@v2.22.1
+  - name: kluctl/kluctl
+    version: v2.7.9
+  - name: kluctl/kluctl
+    version: v2.7.8
+  - name: kluctl/kluctl
+    version: v2.7.1
+  - name: kluctl/kluctl
+    version: v2.6.2

--- a/pkgs/kluctl/kluctl/registry.yaml
+++ b/pkgs/kluctl/kluctl/registry.yaml
@@ -1,0 +1,64 @@
+packages:
+  - type: github_release
+    repo_owner: kluctl
+    repo_name: kluctl
+    description: The missing glue to put together large Kubernetes deployments, composed of multiple smaller parts (Helm/Kustomize/...)  in a manageable and unified way
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.6.2")
+        asset: kluctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.7.1")
+        asset: kluctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 2.7.8")
+        asset: kluctl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v2.7.9"
+        asset: kluctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kluctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: kluctl_{{.Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18897,6 +18897,69 @@ packages:
       asset: youtubedr_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: kluctl
+    repo_name: kluctl
+    description: The missing glue to put together large Kubernetes deployments, composed of multiple smaller parts (Helm/Kustomize/...)  in a manageable and unified way
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.6.2")
+        asset: kluctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.7.1")
+        asset: kluctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 2.7.8")
+        asset: kluctl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v2.7.9"
+        asset: kluctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kluctl_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: kluctl_{{.Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: knadh
     repo_name: listmonk
     description: High performance, self-hosted, newsletter and mailing list manager with a modern dashboard. Single binary app


### PR DESCRIPTION
[kluctl/kluctl](https://github.com/kluctl/kluctl): The missing glue to put together large Kubernetes deployments, composed of multiple smaller parts (Helm/Kustomize/...)  in a manageable and unified way

```console
$ aqua g -i kluctl/kluctl
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kluctl --help
Usage: kluctl [flags]kluctl [command]

Deploy and manage complex deployments on Kubernetes
The missing glue to put together large Kubernetes deployments,
composed of multiple smaller parts (Helm/Kustomize/...) in a manageable and unified way.

Global arguments:
      --cpu-profile string       Enable CPU profiling and write the result to the given path
      --debug                    Enable debug logging
      --gops-agent               Start gops agent in the background
      --gops-agent-addr string   Specify the address:port to use for the gops agent (default "127.0.0.1:0")
      --no-color                 Disable colored output
      --no-update-check          Disable update check on startup

Commands:
  completion   Generate the autocompletion script for the specified shell
  controller   Kluctl controller sub-commands
  delete       Delete a target (or parts of it) from the corresponding cluster
  deploy       Deploys a target to the corresponding cluster
  diff         Perform a diff between the locally rendered target and the already deployed target
  gitops       GitOps sub-commands
  helm-pull    Recursively searches for 'helm-chart.yaml' files and pre-pulls the specified Helm charts
  helm-update  Recursively searches for 'helm-chart.yaml' files and checks for new available versions
  help         Help about any command
  list-images  Renders the target and outputs all images used via 'images.get_image(...)
  list-targets Outputs a yaml list with all targets
  oci          Oci sub-commands
  poke-images  Replace all images in target
  prune        Searches the target cluster for prunable objects and deletes them
  render       Renders all resources and configuration files
  seal         Seal secrets based on target's sealingConfig
  validate     Validates the already deployed deployment
  version      Print kluctl version
  webui        Kluctl Webui sub-commands

Use "kluctl [command] --help" for more information about a command.
```