### PR TITLE
feat: add oxc-project/oxc/oxlint

### DIFF
--- a/pkgs/oxc-project/oxc/oxlint/pkg.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: oxc-project/oxc/oxlint@oxlint_v0.0.20
+  - name: oxc-project/oxc/oxlint
+    version: oxlint_v0.0.3

--- a/pkgs/oxc-project/oxc/oxlint/registry.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/registry.yaml
@@ -1,0 +1,39 @@
+packages:
+  - type: github_release
+    name: oxc-project/oxc/oxlint
+    repo_owner: oxc-project
+    repo_name: oxc
+    description: The linter for oxc
+    version_constraint: "false"
+    version_filter: Version startsWith "oxlint_v"
+    version_overrides:
+      - version_constraint: semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))
+        asset: oxlint-{{.OS}}-{{.Arch}}
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: semverWithVersion("== 0.0.9", trimPrefix(Version, "oxlint_v"))
+        no_asset: true
+      - version_constraint: semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))
+        asset: oxlint-{{.OS}}-{{.Arch}}
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: "true"
+        asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x64
+          windows: win32

--- a/pkgs/oxc-project/oxc/oxlint/registry.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/registry.yaml
@@ -5,9 +5,9 @@ packages:
     repo_name: oxc
     description: The linter for oxc
     version_constraint: "false"
-    version_filter: Version startsWith "oxlint_v"
+    version_prefix: oxlint_v
     version_overrides:
-      - version_constraint: semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: semver("<= 0.0.8")
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -15,9 +15,9 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: semverWithVersion("== 0.0.9", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: Version == "oxlint_v0.0.9"
         no_asset: true
-      - version_constraint: semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: semver("<= 0.0.19")
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint

--- a/registry.yaml
+++ b/registry.yaml
@@ -24815,9 +24815,9 @@ packages:
     repo_name: oxc
     description: The linter for oxc
     version_constraint: "false"
-    version_filter: Version startsWith "oxlint_v"
+    version_prefix: oxlint_v
     version_overrides:
-      - version_constraint: semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: semver("<= 0.0.8")
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -24825,9 +24825,9 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: semverWithVersion("== 0.0.9", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: Version == "oxlint_v0.0.9"
         no_asset: true
-      - version_constraint: semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))
+      - version_constraint: semver("<= 0.0.19")
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint

--- a/registry.yaml
+++ b/registry.yaml
@@ -24810,6 +24810,44 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    name: oxc-project/oxc/oxlint
+    repo_owner: oxc-project
+    repo_name: oxc
+    description: The linter for oxc
+    version_constraint: "false"
+    version_filter: Version startsWith "oxlint_v"
+    version_overrides:
+      - version_constraint: semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))
+        asset: oxlint-{{.OS}}-{{.Arch}}
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: semverWithVersion("== 0.0.9", trimPrefix(Version, "oxlint_v"))
+        no_asset: true
+      - version_constraint: semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))
+        asset: oxlint-{{.OS}}-{{.Arch}}
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: "true"
+        asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: oxlint
+            src: oxlint-{{.OS}}-{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x64
+          windows: win32
+  - type: github_release
     repo_owner: ozankasikci
     repo_name: dockerfile-generator
     description: dfg - Generates dockerfiles based on various input channels


### PR DESCRIPTION
[oxc-project/oxc/oxlint](https://github.com/oxc-project/oxc): The linter for oxc

```console
$ aqua g -i oxc-project/oxc/oxlint
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ oxlint --help
Linter for the JavaScript Oxidation Compiler

Usage: oxlint-linux-arm64 [-A=NAME | -D=NAME]... [--fix] [PATH]...

Allowing / Denying Multiple Lints
  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`. ㅤ
  The default category is "-D correctness".
  Use "--rules" for rule names.
  Use "--help --help" for rule categories.
    -A, --allow=NAME          Allow the rule or category (suppress the lint)
    -D, --deny=NAME           Deny the rule or category (emit an error)

Enable Plugins
        --import-plugin       Enable the experimental import plugin and detect ESM problems
        --jest-plugin         Enable the Jest plugin and detect test problems
        --jsx-a11y-plugin     Enable the JSX-a11y plugin and detect accessibility problems

Fix Problems
        --fix                 Fix as many issues as possible. Only unfixed issues are reported in the
                              output

Ignore Files
        --ignore-path=PATH    Specify the file to use as your .eslintignore
        --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in .eslintignore)
        --no-ignore           Disables excluding of files from .eslintignore files, --ignore-path flags
                              and --ignore-pattern flags

Handle Warnings
        --quiet               Disable reporting on warnings, only errors are reported
        --deny-warnings       Ensure warnings produce a non-zero exit code
        --max-warnings=INT    Specify a warning threshold, which can be used to force exit with an error
                              status if there are too many warning-level rule violations in your project

Miscellaneous
        --timing              Display the execution time of each lint rule
                              [env:TIMING: not set]
        --rules               list all the rules that are currently registered
        --threads=INT         Number of threads to use. Set to 1 for using only 1 CPU core

Codeowners
        --codeowners-file=PATH  Path to CODEOWNERS file
        --codeowners=NAME     Code owner names, e.g. @Boshen

Available positional items:
    PATH                      Single file, single path or list of paths

Available options:
    -h, --help                Prints help information
```