### PR TITLE
feat: add afnanenayet/diffsitter

### DIFF
--- a/pkgs/afnanenayet/diffsitter/pkg.yaml
+++ b/pkgs/afnanenayet/diffsitter/pkg.yaml
@@ -1,0 +1,30 @@
+packages:
+  - name: afnanenayet/diffsitter@v0.8.1
+  - name: afnanenayet/diffsitter
+    version: v0.7.3
+  - name: afnanenayet/diffsitter
+    version: v0.7.2
+  - name: afnanenayet/diffsitter
+    version: v0.7.1
+  - name: afnanenayet/diffsitter
+    version: v0.6.6
+  - name: afnanenayet/diffsitter
+    version: v0.6.5
+  - name: afnanenayet/diffsitter
+    version: v0.6.4
+  - name: afnanenayet/diffsitter
+    version: v0.3.0
+  - name: afnanenayet/diffsitter
+    version: v0.3.0-1
+  - name: afnanenayet/diffsitter
+    version: v0.2.0
+  - name: afnanenayet/diffsitter
+    version: v0.2.0-3
+  - name: afnanenayet/diffsitter
+    version: v0.2.0-2
+  - name: afnanenayet/diffsitter
+    version: v0.1.6
+  - name: afnanenayet/diffsitter
+    version: v0.1.3
+  - name: afnanenayet/diffsitter
+    version: v0.1.1

--- a/pkgs/afnanenayet/diffsitter/registry.yaml
+++ b/pkgs/afnanenayet/diffsitter/registry.yaml
@@ -1,0 +1,323 @@
+packages:
+  - type: github_release
+    repo_owner: afnanenayet
+    repo_name: diffsitter
+    description: A tree-sitter based AST difftool to get meaningful semantic diffs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        asset: diffsitter-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.3")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: diffsitter
+            src: target/release/diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.5"
+        no_asset: true
+      - version_constraint: Version == "v0.1.6"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.0-2")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.2.0-3"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+            checksum:
+              enabled: false
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: diffsitter-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.3.0-1"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+            checksum:
+              enabled: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.3.0"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.6.4")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/git-diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.6.5"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.6.6"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 0.7.1")
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.7.2"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.7.3"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: diffsitter-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -4138,6 +4138,328 @@ packages:
       asset: jsondiff_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: afnanenayet
+    repo_name: diffsitter
+    description: A tree-sitter based AST difftool to get meaningful semantic diffs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        asset: diffsitter-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.3")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: diffsitter
+            src: target/release/diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.5"
+        no_asset: true
+      - version_constraint: Version == "v0.1.6"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.0-2")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.2.0-3"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+            checksum:
+              enabled: false
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: diffsitter-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.3.0-1"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: diffsitter
+            checksum:
+              enabled: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.3.0"
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.6.4")
+        asset: diffsitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.OS}}-{{.Arch}}/git-diffsitter
+        overrides:
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.6.5"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.6.6"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 0.7.1")
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.7.2"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+          - name: git-diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/git-diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.7.3"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: diffsitter
+            src: diffsitter-{{.Arch}}-{{.OS}}/diffsitter
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            checksum:
+              enabled: false
+            files:
+              - name: diffsitter
+              - name: git-diffsitter
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: diffsitter-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: diffsitter-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+  - type: github_release
     repo_owner: ahmetb
     repo_name: kubectl-tree
     asset: kubectl-tree_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[afnanenayet/diffsitter](https://github.com/afnanenayet/diffsitter): A tree-sitter based AST difftool to get meaningful semantic diffs

```console
$ aqua g -i afnanenayet/diffsitter
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ diffsitter --help
An AST based difftool for meaningful diffs

Usage: diffsitter [OPTIONS] [OLD] [NEW] [COMMAND]

Commands:
  list                 List the languages that this program was compiled for
  dump-default-config  Dump the default config to stdout
  gen-completion       Generate shell completion scripts for diffsitter
  help                 Print this message or the help of the given subcommand(s)

Arguments:
  [OLD]
          The first file to compare against

          Text that is in this file but is not in the new file is considered a deletion

  [NEW]
          The file that the old file is compared against

          Text that is in this file but is not in the old file is considered an addition

Options:
  -d, --debug
          Print debug output

          This will print debug logs at the trace level. This is useful for debugging and bug reports should contain debug logging info.

  -t, --file-type <FILE_TYPE>
          Manually set the file type for the given files

          This will dictate which parser is used with the difftool. You can list all of the valid file type strings with `diffsitter --cmd list`

  -c, --config <CONFIG>
          Use the config provided at the given path

          By default, diffsitter attempts to find the config at `$XDG_CONFIG_HOME/diffsitter.json5`. On Windows the app will look in the standard config path.

      --color <COLOR_OUTPUT>
          Set the color output policy. Valid values are: "auto", "on", "off".

          "auto" will automatically detect whether colors should be applied by trying to determine whether the process is outputting to a TTY. "on" will enable output and "off" will
          disable color output regardless of whether the process detects a TTY.

          [default: auto]

  -n, --no-config
          Ignore any config files and use the default config

          This will cause the app to ignore any configs and all config values will use the their default settings.

  -r, --renderer <RENDERER>
          Specify which renderer tag to use.

          If no option is supplied then this will fall back to the default renderer.

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

```