### PR TITLE
feat: add rajatjindal/kubectl-whoami

### DIFF
--- a/pkgs/rajatjindal/kubectl-whoami/pkg.yaml
+++ b/pkgs/rajatjindal/kubectl-whoami/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: rajatjindal/kubectl-whoami@v0.0.46
+  - name: rajatjindal/kubectl-whoami
+    version: v0.0.45
+  - name: rajatjindal/kubectl-whoami
+    version: v0.0.42
+  - name: rajatjindal/kubectl-whoami
+    version: v0.0.41
+  - name: rajatjindal/kubectl-whoami
+    version: v0.0.18
+  - name: rajatjindal/kubectl-whoami
+    version: v0.0.6

--- a/pkgs/rajatjindal/kubectl-whoami/registry.yaml
+++ b/pkgs/rajatjindal/kubectl-whoami/registry.yaml
@@ -1,0 +1,68 @@
+packages:
+  - type: github_release
+    repo_owner: rajatjindal
+    repo_name: kubectl-whoami
+    description: This plugin gets the subject name using the effective kubeconfig
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.6")
+        asset: "{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}"
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.0.16")
+        no_asset: true
+      - version_constraint: semver("<= 0.0.18")
+        asset: kubectl-whoami_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.19"
+        no_asset: true
+      - version_constraint: semver("<= 0.0.41")
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.42"
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.45")
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -26486,6 +26486,73 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
   - type: github_release
+    repo_owner: rajatjindal
+    repo_name: kubectl-whoami
+    description: This plugin gets the subject name using the effective kubeconfig
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.6")
+        asset: "{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}"
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.0.16")
+        no_asset: true
+      - version_constraint: semver("<= 0.0.18")
+        asset: kubectl-whoami_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.19"
+        no_asset: true
+      - version_constraint: semver("<= 0.0.41")
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.42"
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.45")
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kubectl-whoami_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kubectl-whoami_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: rancher
     repo_name: cli
     description: Rancher CLI


### PR DESCRIPTION
[rajatjindal/kubectl-whoami](https://github.com/rajatjindal/kubectl-whoami): This plugin gets the subject name using the effective kubeconfig

```console
$ aqua g -i rajatjindal/kubectl-whoami
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@51821587141d:/workspace# kubectl-whoami --help
find out the subject for the current context of kubeconfig

Usage:
  whoami [flags]

Flags:
      --all                            Prints information about user, groups and ARN
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/root/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --disable-compression            If true, opt-out of response compression for all requests to the server
  -h, --help                           help for whoami
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --version                        prints version of plugin
```

Reference

- https://github.com/rajatjindal/kubectl-whoami/blob/main/README.md
