### PR TITLE
feat: add keidarcy/e1s

### DIFF
--- a/pkgs/keidarcy/e1s/pkg.yaml
+++ b/pkgs/keidarcy/e1s/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: keidarcy/e1s@v1.0.9

--- a/pkgs/keidarcy/e1s/registry.yaml
+++ b/pkgs/keidarcy/e1s/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: keidarcy
+    repo_name: e1s
+    description: E1S - Easily Manage AWS ECS Resources in Terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: e1s_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        overrides:
+          - goos: darwin
+            asset: e1s_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        checksum:
+          type: github_release
+          asset: e1s_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/pkgs/keidarcy/e1s/registry.yaml
+++ b/pkgs/keidarcy/e1s/registry.yaml
@@ -8,7 +8,6 @@ packages:
       - version_constraint: "true"
         asset: e1s_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         overrides:
           - goos: darwin
             asset: e1s_{{trimV .Version}}_{{.OS}}_all.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -19214,6 +19214,23 @@ packages:
       - version_constraint: semver("< 0.0.4")
         overrides: *kdash_rs_overrides_1
   - type: github_release
+    repo_owner: keidarcy
+    repo_name: e1s
+    description: E1S - Easily Manage AWS ECS Resources in Terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: e1s_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        overrides:
+          - goos: darwin
+            asset: e1s_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        checksum:
+          type: github_release
+          asset: e1s_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: keilerkonzept
     repo_name: terraform-module-versions
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"

--- a/registry.yaml
+++ b/registry.yaml
@@ -19222,7 +19222,6 @@ packages:
       - version_constraint: "true"
         asset: e1s_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         overrides:
           - goos: darwin
             asset: e1s_{{trimV .Version}}_{{.OS}}_all.{{.Format}}


### PR DESCRIPTION
[keidarcy/e1s](https://github.com/keidarcy/e1s): E1S - Easily Manage AWS ECS Resources in Terminal

note: I had some problems following the contributing guide:

* I faced the GitHub API rate limit, so I exported a token as `AQUA_GITHUB_TOKEN`. However, since the container is already created and not removed automatically, the token was not picked up until I removed the container. This took me a while to figure out, consider adding this to the documentation.
* I needed to edit some of the generated files, but since they are created by the Docker container (as root I think/). I cannot edit them unless I run `chown $USER -R pkgs` in the repository.
* when running  `cmdx new <package name>`, the `gh` cli expects `GITHUB_TOKEN`, while I exported `AQUA_GITHUB_TOKEN` so it did not complete. Consider adding the exporting of the `GITHUB_TOKEN` as a prerequisite since it is needed to complete the workflow and removing the `AQUA_GITHUB_TOKEN` option.
* After setting the `GITHUB_TOKEN` I got the following error: `X No default remote repository has been set for this directory. please run "gh repo set-default" to select a default remote repository.` I do not know what this means, at this point I created this PR manually.

