### PR TITLE
feat: add graelo/pumas

### DIFF
--- a/pkgs/graelo/pumas/pkg.yaml
+++ b/pkgs/graelo/pumas/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: graelo/pumas@v0.1.2

--- a/pkgs/graelo/pumas/registry.yaml
+++ b/pkgs/graelo/pumas/registry.yaml
@@ -1,0 +1,18 @@
+packages:
+  - type: github_release
+    repo_owner: graelo
+    repo_name: pumas
+    description: Power Usage Monitor for Apple Silicon
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pumas-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: pumas
+            src: target/release/pumas
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15200,6 +15200,23 @@ packages:
     files:
       - name: gotify
   - type: github_release
+    repo_owner: graelo
+    repo_name: pumas
+    description: Power Usage Monitor for Apple Silicon
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pumas-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: pumas
+            src: target/release/pumas
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin/arm64
+  - type: github_release
     repo_owner: grafana
     repo_name: grafana-kiosk
     description: Kiosk Utility for Grafana


### PR DESCRIPTION
[graelo/pumas](https://github.com/graelo/pumas): Power Usage Monitor for Apple Silicon

```console
$ aqua g -i graelo/pumas
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ pumas --help
A power usage monitor for Apple Silicon.

Usage: pumas <COMMAND>

Commands:
  run                  Run the power usage monitor
  generate-completion  Print a shell completion script to stdout
  help                 Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```