### PR TITLE
feat: add rajatjindal/krew-release-bot

### DIFF
--- a/pkgs/rajatjindal/krew-release-bot/pkg.yaml
+++ b/pkgs/rajatjindal/krew-release-bot/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/rajatjindal/krew-release-bot/pkg.yaml
+++ b/pkgs/rajatjindal/krew-release-bot/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: rajatjindal/krew-release-bot@v0.0.46

--- a/pkgs/rajatjindal/krew-release-bot/registry.yaml
+++ b/pkgs/rajatjindal/krew-release-bot/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: rajatjindal
+    repo_name: krew-release-bot
+    description: bot to bump version of plugin in krew-index on new releases
+    asset: krew-release-bot_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: krew-release-bot_{{trimV .Version}}_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -26487,6 +26487,20 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: rajatjindal
+    repo_name: krew-release-bot
+    description: bot to bump version of plugin in krew-index on new releases
+    asset: krew-release-bot_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    supported_envs:
+      - linux/amd64
+      - darwin
+    rosetta2: true
+    checksum:
+      type: github_release
+      asset: krew-release-bot_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+  - type: github_release
+    repo_owner: rajatjindal
     repo_name: kubectl-whoami
     description: This plugin gets the subject name using the effective kubeconfig
     version_constraint: "false"


### PR DESCRIPTION
[rajatjindal/krew-release-bot](https://github.com/rajatjindal/krew-release-bot): bot to bump version of plugin in krew-index on new releases

```console
$ aqua g -i rajatjindal/krew-release-bot
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@10798bbd177d:/workspace# krew-release-bot --help
krew-release-bot is a Github Action for updating plugin manifests in Krew Index repo

Usage:
  krew-release-bot [command]

Available Commands:
  action      github action for updating plugin manifests in krew-index repo
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  template    template helps validate the krew index template file without going through github actions workflow

Flags:
  -h, --help   help for krew-release-bot

Use "krew-release-bot [command] --help" for more information about a command.
```

Reference

- https://github.com/rajatjindal/krew-release-bot
