### PR TITLE
fix(atuinsh/atuin): use musl builds instead of gnu when available

### DIFF
--- a/pkgs/atuinsh/atuin/pkg.yaml
+++ b/pkgs/atuinsh/atuin/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: atuinsh/atuin@v17.1.0
   - name: atuinsh/atuin
+    version: v13.0.1
+  - name: atuinsh/atuin
     version: v0.6.4
   - name: atuinsh/atuin
     version: v0.6.3

--- a/pkgs/atuinsh/atuin/pkg.yaml
+++ b/pkgs/atuinsh/atuin/pkg.yaml
@@ -1,8 +1,10 @@
 packages:
   - name: atuinsh/atuin@v17.1.0
   - name: atuinsh/atuin
-    version: v13.0.1
+    version: v15.0.0
   - name: atuinsh/atuin
-    version: v0.6.4
+    version: v14.0.1
+  - name: atuinsh/atuin
+    version: v13.0.1
   - name: atuinsh/atuin
     version: v0.6.3

--- a/pkgs/atuinsh/atuin/registry.yaml
+++ b/pkgs/atuinsh/atuin/registry.yaml
@@ -18,8 +18,13 @@ packages:
       - linux/amd64
       - darwin
     rosetta2: true
-    version_constraint: semver(">= 0.6.4")
+    version_constraint: semver(">= 14.0.0")
     version_overrides:
+      - version_constraint: semver("< 14.0.0")
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
       - version_constraint: semver("< 0.6.4")
         overrides:
           - goos: linux

--- a/pkgs/atuinsh/atuin/registry.yaml
+++ b/pkgs/atuinsh/atuin/registry.yaml
@@ -20,11 +20,6 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 14.0.0")
     version_overrides:
-      - version_constraint: semver("< 14.0.0")
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
       - version_constraint: semver("< 0.6.4")
         overrides:
           - goos: linux
@@ -33,3 +28,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 14.0.0")
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu

--- a/pkgs/atuinsh/atuin/registry.yaml
+++ b/pkgs/atuinsh/atuin/registry.yaml
@@ -10,7 +10,7 @@ packages:
     replacements:
       amd64: x86_64
       darwin: apple-darwin
-      linux: unknown-linux-gnu
+      linux: unknown-linux-musl
     files:
       - name: atuin
         src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin

--- a/pkgs/atuinsh/atuin/registry.yaml
+++ b/pkgs/atuinsh/atuin/registry.yaml
@@ -2,34 +2,89 @@ packages:
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin
-    aliases:
-      - name: ellie/atuin
     description: Magical shell history
-    asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-    files:
-      - name: atuin
-        src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
-    supported_envs:
-      - linux/amd64
-      - darwin
-    rosetta2: true
-    version_constraint: semver(">= 14.0.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 0.6.4")
+      - version_constraint: semver("<= 0.6.3")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
         overrides:
           - goos: linux
             replacements:
               arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("< 14.0.0")
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 13.0.1")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 14.0.1")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v15.0.0"
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        rosetta2: true # asset for darwin/arm64 is unavailable
+        format: tar.gz
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          linux: unknown-linux-musl
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux/amd64 # linux/arm64 is unavailable
+          - darwin
+      - version_constraint: "true"
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -5767,11 +5767,6 @@ packages:
     rosetta2: true
     version_constraint: semver(">= 14.0.0")
     version_overrides:
-      - version_constraint: semver("< 14.0.0")
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
       - version_constraint: semver("< 0.6.4")
         overrides:
           - goos: linux
@@ -5780,6 +5775,11 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 14.0.0")
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
   - type: github_release
     repo_owner: auth0
     repo_name: auth0-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -5757,7 +5757,7 @@ packages:
     replacements:
       amd64: x86_64
       darwin: apple-darwin
-      linux: unknown-linux-gnu
+      linux: unknown-linux-musl
     files:
       - name: atuin
         src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
@@ -5765,8 +5765,13 @@ packages:
       - linux/amd64
       - darwin
     rosetta2: true
-    version_constraint: semver(">= 0.6.4")
+    version_constraint: semver(">= 14.0.0")
     version_overrides:
+      - version_constraint: semver("< 14.0.0")
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
       - version_constraint: semver("< 0.6.4")
         overrides:
           - goos: linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -5749,37 +5749,92 @@ packages:
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin
-    aliases:
-      - name: ellie/atuin
     description: Magical shell history
-    asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-    files:
-      - name: atuin
-        src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
-    supported_envs:
-      - linux/amd64
-      - darwin
-    rosetta2: true
-    version_constraint: semver(">= 14.0.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 0.6.4")
+      - version_constraint: semver("<= 0.6.3")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
         overrides:
           - goos: linux
             replacements:
               arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("< 14.0.0")
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 13.0.1")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 14.0.1")
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v15.0.0"
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        rosetta2: true # asset for darwin/arm64 is unavailable
+        format: tar.gz
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        replacements:
+          linux: unknown-linux-musl
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux/amd64 # linux/arm64 is unavailable
+          - darwin
+      - version_constraint: "true"
+        asset: atuin-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: atuin
+            src: atuin-{{.Version}}-{{.Arch}}-{{.OS}}/atuin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: auth0
     repo_name: auth0-cli


### PR DESCRIPTION
This PR replaces the gnu build of `atuinsh/atuin` on Linux with the musl build, in order to follow the [Aqua Registry Style Guide](https://aquaproj.github.io/docs/develop-registry/registry-style-guide/#consideration-about-rust)'s recommendations on gnu vs musl. musl Linux builds are only available for atuin starting in [release v14.0.0](https://github.com/atuinsh/atuin/releases/tag/v14.0.0); in [v13.0.1](https://github.com/atuinsh/atuin/releases/tag/v13.0.1) and earlier, only gnu Linux builds were available. Thus, this PR changes the atuin package's `registry.yaml` file so that aqua downloads the musl Linux build for v14.0.0 and above, but still downloads the gnu Linux build for v13.0.1 and below.

I'm not sure what level of testing is needed for this PR, but I tested out this change in an Alpine Linux [Distrobox container](https://github.com/89luca89/distrobox) and it resolved a glibc-vs.-musl error I had previously been getting from Aqua when trying to run atuin in that container; with this change, atuin v14.0.0 and above run properly without that error.