### PR TITLE
feat: add sigoden/aichat

### DIFF
--- a/pkgs/sigoden/aichat/pkg.yaml
+++ b/pkgs/sigoden/aichat/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: sigoden/aichat@v0.12.0
+  - name: sigoden/aichat
+    version: v0.8.0

--- a/pkgs/sigoden/aichat/registry.yaml
+++ b/pkgs/sigoden/aichat/registry.yaml
@@ -1,0 +1,34 @@
+packages:
+  - type: github_release
+    repo_owner: sigoden
+    repo_name: aichat
+    description: Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        asset: aichat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: aichat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -29190,6 +29190,39 @@ packages:
       asset: sigi_{{.Version}}_{{.Arch}}-{{.OS}}.tar.gz.sha256sum
       algorithm: sha256
   - type: github_release
+    repo_owner: sigoden
+    repo_name: aichat
+    description: Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        asset: aichat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: aichat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+  - type: github_release
     repo_owner: sigstore
     repo_name: cosign
     format: raw


### PR DESCRIPTION
[sigoden/aichat](https://github.com/sigoden/aichat): Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal

```console
$ aqua g -i sigoden/aichat
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ aichat --help
Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal.

Usage: aichat [OPTIONS] [TEXT]...

Arguments:
  [TEXT]...  Input text

Options:
  -m, --model <MODEL>        Choose a LLM model
  -r, --role <ROLE>          Choose a role
  -s, --session [<SESSION>]  Create or reuse a session
  -f, --file <FILE>...       Attach files to the message to be sent
  -H, --no-highlight         Disable syntax highlighting
  -S, --no-stream            No stream output
  -w, --wrap <WRAP>          Specify the text-wrapping mode (no, auto, <max-width>)
      --light-theme          Use light theme
      --dry-run              Run in dry run mode
      --info                 Print related information
      --list-models          List all available models
      --list-roles           List all available roles
      --list-sessions        List all available sessions
  -h, --help                 Print help
  -V, --version              Print version
```