### PR TITLE
feat: add rustic-rs/rustic

### DIFF
--- a/pkgs/rustic-rs/rustic/pkg.yaml
+++ b/pkgs/rustic-rs/rustic/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: rustic-rs/rustic@v0.6.1
+  - name: rustic-rs/rustic
+    version: v0.5.4
+  - name: rustic-rs/rustic
+    version: v0.4.4
+  - name: rustic-rs/rustic
+    version: v0.3.0
+  - name: rustic-rs/rustic
+    version: v0.2.2
+  - name: rustic-rs/rustic
+    version: v0.2.0-rc1

--- a/pkgs/rustic-rs/rustic/registry.yaml
+++ b/pkgs/rustic-rs/rustic/registry.yaml
@@ -1,0 +1,129 @@
+packages:
+  - type: github_release
+    repo_owner: rustic-rs
+    repo_name: rustic
+    description: rustic - fast, encrypted, and deduplicated backups powered by Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0-rc1")
+        asset: rustic_{{trimV .Version}}_{{.Arch}}_64-{{.OS}}.{{.Format}}
+        format: bz2
+        files:
+          - name: rustic
+            src: rustic_0.2.0-rc1_x64_64-unknown-linux-musl
+        replacements:
+          amd64: x64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.2.2")
+        asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: rustic
+            src: rustic-rs
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.0")
+        asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: rustic
+            src: rustic-rs
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.5.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.6.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/rustic-rs/rustic/registry.yaml
+++ b/pkgs/rustic-rs/rustic/registry.yaml
@@ -98,9 +98,6 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
-          - goos: windows
-            replacements:
-              arm64: arm64
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -27984,6 +27984,134 @@ packages:
       - name: rust-analyzer
         src: rust-analyzer-{{.Arch}}-{{.OS}}
   - type: github_release
+    repo_owner: rustic-rs
+    repo_name: rustic
+    description: rustic - fast, encrypted, and deduplicated backups powered by Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0-rc1")
+        asset: rustic_{{trimV .Version}}_{{.Arch}}_64-{{.OS}}.{{.Format}}
+        format: bz2
+        files:
+          - name: rustic
+            src: rustic_0.2.0-rc1_x64_64-unknown-linux-musl
+        replacements:
+          amd64: x64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.2.2")
+        asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: rustic
+            src: rustic-rs
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.0")
+        asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        files:
+          - name: rustic
+            src: rustic-rs
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.5.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.6.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: rustwasm
     repo_name: wasm-pack
     description: your favorite rust -> wasm workflow tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -28082,9 +28082,6 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
-          - goos: windows
-            replacements:
-              arm64: arm64
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
[rustic-rs/rustic](https://github.com/rustic-rs/rustic): rustic - fast, encrypted, and deduplicated backups powered by Rust

```console
$ aqua g -i rustic-rs/rustic
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ rustic --help
rustic - fast, encrypted, deduplicated backups powered by Rust

Usage: rustic [OPTIONS] <COMMAND>

Commands:
  backup       Backup to the repository
  cat          Show raw data of repository files and blobs
  config       Change the repository configuration
  completions  Generate shell completions
  check        Check the repository
  copy         Copy snapshots to other repositories. Note: The target repositories must be given in the config file!
  diff         Compare two snapshots/paths Note that the exclude options only apply for comparison with a local path
  dump         dump the contents of a file in a snapshot to stdout
  forget       Remove snapshots from the repository
  init         Initialize a new repository
  key          Manage keys
  list         List repository files
  ls           List file contents of a snapshot
  merge        Merge snapshots
  snapshots    Show a detailed overview of the snapshots within the repository
  show-config  Show the configuration which has been read from the config file(s)
  self-update  Update to the latest rustic release
  prune        Remove unused data or repack repository pack files
  restore      Restore a snapshot/path
  repair       Repair a snapshot/path
  repoinfo     Show general information about the repository
  tag          Change tags of snapshots
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Global options:
  -P, --use-profile <PROFILE>
          Config profile to use. This parses the file `<PROFILE>.toml` in the config directory. [default: "rustic"]

          [env: RUSTIC_USE_PROFILE=]

  -n, --dry-run
          Only show what would be done without modifying anything. Does not affect read-only commands

          [env: RUSTIC_DRY_RUN=]

      --log-level <LOG_LEVEL>
          Use this log level [default: info]

          [env: RUSTIC_LOG_LEVEL=]

      --log-file <LOGFILE>
          Write log messages to the given file instead of printing them.

          # Note

          Warnings and errors are still additionally printed unless they are ignored by `--log-level`

          [env: RUSTIC_LOG_FILE=]

      --no-progress
          Don't show any progress bar

          [env: RUSTIC_NO_PROGRESS=]

      --progress-interval <DURATION>
          Interval to update progress bars

          [env: RUSTIC_PROGRESS_INTERVAL=]

Repository options:
  -r, --repository <REPOSITORY>
          Repository to use

          [env: RUSTIC_REPOSITORY=]

      --repo-hot <REPO_HOT>
          Repository to use as hot storage

          [env: RUSTIC_REPO_HOT=]

      --password <PASSWORD>
          Password of the repository

          # Warning

          Using --password can reveal the password in the process list!

          [env: RUSTIC_PASSWORD=]

  -p, --password-file <PASSWORD_FILE>
          File to read the password from

          [env: RUSTIC_PASSWORD_FILE=]

      --password-command <PASSWORD_COMMAND>
          Command to read the password from. Password is read from stdout

          [env: RUSTIC_PASSWORD_COMMAND=]

      --no-cache
          Don't use a cache

          [env: RUSTIC_NO_CACHE=]

      --cache-dir <CACHE_DIR>
          Use this dir as cache dir instead of the standard cache dir

          [env: RUSTIC_CACHE_DIR=]

      --warm-up
          Warm up needed data pack files by only requesting them without processing

      --warm-up-command <WARM_UP_COMMAND>
          Warm up needed data pack files by running the command with %id replaced by pack id

      --warm-up-wait <DURATION>
          Duration (e.g. 10m) to wait after warm up

Snapshot filter options:
      --filter-host <HOSTNAME>
          Hostname to filter (can be specified multiple times)

      --filter-label <LABEL>
          Label to filter (can be specified multiple times)

      --filter-paths <PATH[,PATH,..]>
          Path list to filter (can be specified multiple times)

      --filter-tags <TAG[,TAG,..]>
          Tag list to filter (can be specified multiple times)

      --filter-fn <FUNC>
          Function to filter snapshots
```
