### PR TITLE
feat: add turbot/flowpipe

### DIFF
--- a/pkgs/turbot/flowpipe/pkg.yaml
+++ b/pkgs/turbot/flowpipe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: turbot/flowpipe@v0.2.0-rc.2

--- a/pkgs/turbot/flowpipe/registry.yaml
+++ b/pkgs/turbot/flowpipe/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: turbot
+    repo_name: flowpipe
+    description: Flowpipe is a cloud scripting engine. Automation and workflow to connect your clouds to the people, systems and data that matters
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: flowpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -33100,6 +33100,22 @@ packages:
       - version_constraint: "true"
   - type: github_release
     repo_owner: turbot
+    repo_name: flowpipe
+    description: Flowpipe is a cloud scripting engine. Automation and workflow to connect your clouds to the people, systems and data that matters
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: flowpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: turbot
     repo_name: steampipe
     asset: steampipe_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
Close #18973

[turbot/flowpipe](https://github.com/turbot/flowpipe): Flowpipe is a cloud scripting engine. Automation and workflow to connect your clouds to the people, systems and data that matters

```console
$ aqua g -i turbot/flowpipe
```