### PR TITLE
feat: add docker/buildx

### DIFF
--- a/pkgs/docker/buildx/pkg.yaml
+++ b/pkgs/docker/buildx/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: docker/buildx@v0.12.1
+  - name: docker/buildx
+    version: v0.5.1
+  - name: docker/buildx
+    version: v0.5.0-rc1

--- a/pkgs/docker/buildx/pkg.yaml
+++ b/pkgs/docker/buildx/pkg.yaml
@@ -1,6 +1,10 @@
 packages:
   - name: docker/buildx@v0.12.1
   - name: docker/buildx
+    version: v0.10.0-rc1
+  - name: docker/buildx
+    version: v0.6.3
+  - name: docker/buildx
     version: v0.5.1
   - name: docker/buildx
     version: v0.5.0-rc1

--- a/pkgs/docker/buildx/registry.yaml
+++ b/pkgs/docker/buildx/registry.yaml
@@ -2,12 +2,10 @@ packages:
   - type: github_release
     repo_owner: docker
     repo_name: buildx
-    asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
-    format: raw
     description: Docker CLI plugin for extended build capabilities with BuildKit
-    version_constraint: "false"
     files:
       - name: docker-cli-plugin-docker-buildx
+    version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.5.0-rc1")
         asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
@@ -15,5 +13,31 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
       - version_constraint: semver("<= 0.5.1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
         windows_arm_emulation: true
+      - version_constraint: semver("<= 0.6.3")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: semver("<= 0.10.0-rc1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            checksum:
+              enabled: false # https://github.com/docker/buildx/issues/945
       - version_constraint: "true"
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            checksum:
+              enabled: false # https://github.com/docker/buildx/issues/945

--- a/pkgs/docker/buildx/registry.yaml
+++ b/pkgs/docker/buildx/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: docker
+    repo_name: buildx
+    asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+    format: raw
+    description: Docker CLI plugin for extended build capabilities with BuildKit
+    version_constraint: "false"
+    files:
+      - name: docker-cli-plugin-docker-buildx
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0-rc1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.5.1")
+        windows_arm_emulation: true
+      - version_constraint: "true"

--- a/pkgs/docker/compose/pkg.yaml
+++ b/pkgs/docker/compose/pkg.yaml
@@ -2,3 +2,31 @@ packages:
   - name: docker/compose@v2.24.0
   - name: docker/compose
     version: v2.10.0
+  - name: docker/compose
+    version: v2.9.0
+  - name: docker/compose
+    version: v2.4.1
+  - name: docker/compose
+    version: v2.0.0
+  - name: docker/compose
+    version: v2.0.0-rc.3
+  - name: docker/compose
+    version: 1.29.2
+  - name: docker/compose
+    version: 1.25.0
+  - name: docker/compose
+    version: 1.17.1
+  - name: docker/compose
+    version: 1.8.0-rc2
+  - name: docker/compose
+    version: 1.8.0-rc1
+  - name: docker/compose
+    version: 1.6.0-rc2
+  - name: docker/compose
+    version: 1.6.0-rc1
+  - name: docker/compose
+    version: 1.4.2
+  - name: docker/compose
+    version: 1.0.1
+  - name: docker/compose
+    version: 0.5.2

--- a/pkgs/docker/compose/pkg.yaml
+++ b/pkgs/docker/compose/pkg.yaml
@@ -5,25 +5,13 @@ packages:
   - name: docker/compose
     version: v2.9.0
   - name: docker/compose
-    version: v2.4.1
-  - name: docker/compose
     version: v2.0.0
   - name: docker/compose
     version: v2.0.0-rc.3
   - name: docker/compose
     version: 1.29.2
   - name: docker/compose
-    version: 1.25.0
-  - name: docker/compose
     version: 1.17.1
-  - name: docker/compose
-    version: 1.8.0-rc2
-  - name: docker/compose
-    version: 1.8.0-rc1
-  - name: docker/compose
-    version: 1.6.0-rc2
-  - name: docker/compose
-    version: 1.6.0-rc1
   - name: docker/compose
     version: 1.4.2
   - name: docker/compose

--- a/pkgs/docker/compose/pkg.yaml
+++ b/pkgs/docker/compose/pkg.yaml
@@ -2,5 +2,3 @@ packages:
   - name: docker/compose@v2.24.0
   - name: docker/compose
     version: v2.10.0
-  - name: docker/compose
-    version: v2.9.0

--- a/pkgs/docker/compose/registry.yaml
+++ b/pkgs/docker/compose/registry.yaml
@@ -36,62 +36,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.6.0-rc1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.6.0-rc2"
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.8.0-rc1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.8.0-rc2"
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 1.17.1")
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
@@ -106,33 +50,11 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.25.0")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
       - version_constraint: semver("<= 1.29.2")
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        overrides:
-          - goos: darwin
-            format: tgz
-            asset: docker-compose-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -154,21 +76,6 @@ packages:
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-      - version_constraint: semver("<= 2.4.1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        overrides:
-          - goos: windows
-            replacements:
-              arm64: arm64
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"

--- a/pkgs/docker/compose/registry.yaml
+++ b/pkgs/docker/compose/registry.yaml
@@ -2,23 +2,209 @@ packages:
   - type: github_release
     repo_owner: docker
     repo_name: compose
-    asset: docker-compose-{{.OS}}-{{.Arch}}
-    format: raw
     description: Define and run multi-container applications with Docker
     files:
       - name: docker-cli-plugin-docker-compose
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-    version_constraint: semver(">= 2.10.1")
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 2.10.0")
+      - version_constraint: semver("<= 0.5.2")
+        asset: "{{.OS}}"
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.1")
+        asset: fig-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.4.2")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.6.0-rc1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.6.0-rc2"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.8.0-rc1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.8.0-rc2"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.17.1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.25.0")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 1.29.2")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            format: tgz
+            asset: docker-compose-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v2.0.0-rc.3"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: Version == "v2.0.0"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 2.4.1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 2.9.0")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v2.10.0"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
       - version_constraint: "true"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/docker/compose/registry.yaml
+++ b/pkgs/docker/compose/registry.yaml
@@ -10,10 +10,6 @@ packages:
     replacements:
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     version_constraint: semver(">= 2.10.1")
     checksum:
       type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -12218,26 +12218,212 @@ packages:
   - type: github_release
     repo_owner: docker
     repo_name: compose
-    asset: docker-compose-{{.OS}}-{{.Arch}}
-    format: raw
     description: Define and run multi-container applications with Docker
     files:
       - name: docker-cli-plugin-docker-compose
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-    version_constraint: semver(">= 2.10.1")
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 2.10.0")
+      - version_constraint: semver("<= 0.5.2")
+        asset: "{{.OS}}"
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.1")
+        asset: fig-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.4.2")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.6.0-rc1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.6.0-rc2"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.8.0-rc1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.8.0-rc2"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.17.1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.25.0")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 1.29.2")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            format: tgz
+            asset: docker-compose-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v2.0.0-rc.3"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: Version == "v2.0.0"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 2.4.1")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 2.9.0")
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v2.10.0"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
       - version_constraint: "true"
+        asset: docker-compose-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - type: github_release
     repo_owner: docker
     repo_name: hub-tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -12106,6 +12106,24 @@ packages:
           - amd64
         checksum:
           enabled: false
+  - type: github_release
+    repo_owner: docker
+    repo_name: buildx
+    asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+    format: raw
+    description: Docker CLI plugin for extended build capabilities with BuildKit
+    version_constraint: "false"
+    files:
+      - name: docker-cli-plugin-docker-buildx
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0-rc1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.5.1")
+        windows_arm_emulation: true
+      - version_constraint: "true"
   - type: http
     repo_owner: docker
     repo_name: cli
@@ -12208,10 +12226,6 @@ packages:
     replacements:
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
     version_constraint: semver(">= 2.10.1")
     checksum:
       type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -12252,62 +12252,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.6.0-rc1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.6.0-rc2"
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.8.0-rc1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.8.0-rc2"
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 1.17.1")
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
@@ -12322,33 +12266,11 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.25.0")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
       - version_constraint: semver("<= 1.29.2")
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        overrides:
-          - goos: darwin
-            format: tgz
-            asset: docker-compose-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -12370,21 +12292,6 @@ packages:
         asset: docker-compose-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-      - version_constraint: semver("<= 2.4.1")
-        asset: docker-compose-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        overrides:
-          - goos: windows
-            replacements:
-              arm64: arm64
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12109,12 +12109,10 @@ packages:
   - type: github_release
     repo_owner: docker
     repo_name: buildx
-    asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
-    format: raw
     description: Docker CLI plugin for extended build capabilities with BuildKit
-    version_constraint: "false"
     files:
       - name: docker-cli-plugin-docker-buildx
+    version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.5.0-rc1")
         asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
@@ -12122,8 +12120,34 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
       - version_constraint: semver("<= 0.5.1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
         windows_arm_emulation: true
+      - version_constraint: semver("<= 0.6.3")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: semver("<= 0.10.0-rc1")
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            checksum:
+              enabled: false # https://github.com/docker/buildx/issues/945
       - version_constraint: "true"
+        asset: buildx-{{.Version}}.{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            checksum:
+              enabled: false # https://github.com/docker/buildx/issues/945
   - type: http
     repo_owner: docker
     repo_name: cli


### PR DESCRIPTION
[docker/buildx](https://github.com/docker/buildx): Docker CLI plugin for extended build capabilities with BuildKit

Heavily based on the PR here: https://github.com/aquaproj/aqua-registry/pull/4819/files

Also removed OS restrictions from `docker/compose` since Windows binaries are included in releases.

