### PR TITLE
feat: add abhinav/doc2go

### DIFF
--- a/pkgs/abhinav/doc2go/pkg.yaml
+++ b/pkgs/abhinav/doc2go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: abhinav/doc2go@v0.6.0

--- a/pkgs/abhinav/doc2go/registry.yaml
+++ b/pkgs/abhinav/doc2go/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: abhinav
+    repo_name: doc2go
+    description: Your Go project's documentation, to-go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: doc2go-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -3812,6 +3812,19 @@ packages:
       asset: sttr_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: abhinav
+    repo_name: doc2go
+    description: Your Go project's documentation, to-go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: doc2go-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: abice
     repo_name: go-enum
     description: An enum generator for go


### PR DESCRIPTION
[abhinav/doc2go](https://github.com/abhinav/doc2go): Your Go project's documentation, to-go

```console
$ aqua g -i abhinav/doc2go
```