### PR TITLE
feat: Add abhinav/doc2go package to registry

### DIFF
--- a/pkgs/abhinav/doc2go/pkg.yaml
+++ b/pkgs/abhinav/doc2go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: abhinav/doc2go@v0.6.0

--- a/pkgs/abhinav/doc2go/registry.yaml
+++ b/pkgs/abhinav/doc2go/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: abhinav
+    repo_name: doc2go
+    description: doc2go is a command line tool that generates static HTML documentation from your Go code. It is a self-hosted static alternative to https://pkg.go.dev/ and https://godocs.io/.
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: doc2go-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -3812,6 +3812,19 @@ packages:
       asset: sttr_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: abhinav
+    repo_name: doc2go
+    description: doc2go is a command line tool that generates static HTML documentation from your Go code. It is a self-hosted static alternative to https://pkg.go.dev/ and https://godocs.io/.
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: doc2go-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: abice
     repo_name: go-enum
     description: An enum generator for go


### PR DESCRIPTION
`doc2go` is a tool that generates static HTML documentation from your Go code. It’s a simpler, self-hosted alternative to services like https://pkg.go.dev/ and https://godocs.io/.