### PR TITLE
feat: add microsoft/kiota

### DIFF
--- a/pkgs/microsoft/kiota/pkg.yaml
+++ b/pkgs/microsoft/kiota/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: microsoft/kiota@v1.10.1
+  - name: microsoft/kiota
+    version: v1.0.1

--- a/pkgs/microsoft/kiota/registry.yaml
+++ b/pkgs/microsoft/kiota/registry.yaml
@@ -1,0 +1,35 @@
+packages:
+  - type: github_release
+    repo_owner: microsoft
+    repo_name: kiota
+    description: OpenAPI based HTTP Client code generator
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.1")
+        asset: "{{.OS}}-{{.Arch}}.{{.Format}}"
+        files:
+          - name: kiota
+            src: "{{.OS}}-{{.Arch}}/kiota"
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: "{{.OS}}-{{.Arch}}.{{.Format}}"
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -23460,6 +23460,40 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: microsoft
+    repo_name: kiota
+    description: OpenAPI based HTTP Client code generator
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.1")
+        asset: "{{.OS}}-{{.Arch}}.{{.Format}}"
+        files:
+          - name: kiota
+            src: "{{.OS}}-{{.Arch}}/kiota"
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: "{{.OS}}-{{.Arch}}.{{.Format}}"
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
+    repo_owner: microsoft
     repo_name: ripgrep-prebuilt
     asset: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: Builds ripgrep on Azure Pipelines for multiple platforms and makes the binaries available as Github releases


### PR DESCRIPTION
[microsoft/kiota](https://github.com/microsoft/kiota): OpenAPI based HTTP Client code generator

```console
$ aqua g -i microsoft/kiota
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kiota -h
Description:

Usage:
  kiota [command] [options]

Options:
  --version       Show version information
  -?, -h, --help  Show help and usage information

Commands:
  generate             Generates a REST HTTP API client from an OpenAPI description file.
  search <searchTerm>  Searches for an OpenAPI description in multiple registries.
  download <key>       Downloads an OpenAPI description from multiple registries.
  show                 Displays the API tree in a given description.
  info                 Displays information about the languages supported by kiota and dependencies to add in your project.
  update               Updates existing clients under the target directory using their lock files.
  login                Logs in to the Kiota registries so search/download/show/generate commands can access private API definitions.
  logout               Logs out of Kiota registries.
  rpc                  WARNING EXPERIMENTAL: Starts a kiota as a JSON-RPC server.
```

Reference

- https://learn.microsoft.com/openapi/kiota/
