### PR TITLE
feat: add Qovery/Replibyte

### DIFF
--- a/pkgs/Qovery/Replibyte/pkg.yaml
+++ b/pkgs/Qovery/Replibyte/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: Qovery/Replibyte@v0.10.0
+  - name: Qovery/Replibyte
+    version: v0.4.3
+  - name: Qovery/Replibyte
+    version: v0.4.2
+  - name: Qovery/Replibyte
+    version: v0.4.1
+  - name: Qovery/Replibyte
+    version: v0.1.8

--- a/pkgs/Qovery/Replibyte/registry.yaml
+++ b/pkgs/Qovery/Replibyte/registry.yaml
@@ -1,0 +1,127 @@
+packages:
+  - type: github_release
+    repo_owner: Qovery
+    repo_name: Replibyte
+    description: Seed your development database with real data
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.8")
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.4.1")
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.4.2"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+            src: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            checksum:
+              type: github_release
+              asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.sha256sum
+              algorithm: sha256
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.4.3"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+            src: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-gnu
+        supported_envs:
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            checksum:
+              type: github_release
+              asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}.sha256sum
+              algorithm: sha256
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256

--- a/pkgs/Qovery/Replibyte/registry.yaml
+++ b/pkgs/Qovery/Replibyte/registry.yaml
@@ -45,7 +45,7 @@ packages:
           windows: pc-windows-gnu
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
         checksum:
           type: github_release
           asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum

--- a/registry.yaml
+++ b/registry.yaml
@@ -2174,7 +2174,7 @@ packages:
           windows: pc-windows-gnu
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
         checksum:
           type: github_release
           asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum

--- a/registry.yaml
+++ b/registry.yaml
@@ -2129,6 +2129,132 @@ packages:
       asset: helmsman_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: Qovery
+    repo_name: Replibyte
+    description: Seed your development database with real data
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.8")
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.4.1")
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.4.2"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+            src: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            checksum:
+              type: github_release
+              asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.sha256sum
+              algorithm: sha256
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+      - version_constraint: Version == "v0.4.3"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+            src: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-gnu
+        supported_envs:
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}.sha256sum
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: replibyte
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            checksum:
+              type: github_release
+              asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.exe.{{.Format}}.sha256sum
+              algorithm: sha256
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: replibyte_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
+          algorithm: sha256
+  - type: github_release
     repo_owner: Rigellute
     repo_name: spotify-tui
     asset: spotify-tui-{{.OS}}.tar.gz


### PR DESCRIPTION
[Qovery/Replibyte](https://github.com/Qovery/Replibyte): Seed your development database with real data

```console
$ aqua g -i Qovery/Replibyte
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ replibyte --help
replibyte 0.10.0
Replibyte is a tool to seed your databases with your production data while keeping sensitive data
safe, just pass `-h`

USAGE:
    replibyte [OPTIONS] --config <configuration file> <SUBCOMMAND>

OPTIONS:
    -c, --config <configuration file>    Replibyte configuration file
    -h, --help                           Print help information
    -n, --no-telemetry                   disable telemetry
    -V, --version                        Print version information

SUBCOMMANDS:
    dump           all dump commands
    help           Print this message or the help of the given subcommand(s)
    source         all source commands
    transformer    all transformer commands

```