### PR TITLE
feat: add skeema/skeema

### DIFF
--- a/pkgs/skeema/skeema/pkg.yaml
+++ b/pkgs/skeema/skeema/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: skeema/skeema@v1.11.1
+  - name: skeema/skeema
+    version: v1.6.0
+  - name: skeema/skeema
+    version: v1.5.3
+  - name: skeema/skeema
+    version: v1.0.1
+  - name: skeema/skeema
+    version: v1.0.0

--- a/pkgs/skeema/skeema/registry.yaml
+++ b/pkgs/skeema/skeema/registry.yaml
@@ -1,0 +1,69 @@
+packages:
+  - type: github_release
+    repo_owner: skeema
+    repo_name: skeema
+    description: Declarative pure-SQL schema management for MySQL and MariaDB
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v1.0.1"
+        asset: skeema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: Mac
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.5.3")
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256
+      - version_constraint: Version == "v1.6.0"
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256

--- a/pkgs/skeema/skeema/registry.yaml
+++ b/pkgs/skeema/skeema/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: skeema
     repo_name: skeema
-    description: Declarative pure-SQL schema management for MySQL and MariaDB
+    description: Declarative pure-SQL schema management for MySQL and MariaDB (Community Edition)
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.0.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -30011,6 +30011,74 @@ packages:
       - name: yd
         src: yd_{{.Version}}_{{.OS}}_{{.Arch}}/yd
   - type: github_release
+    repo_owner: skeema
+    repo_name: skeema
+    description: Declarative pure-SQL schema management for MySQL and MariaDB
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v1.0.1"
+        asset: skeema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: Mac
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.5.3")
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256
+      - version_constraint: Version == "v1.6.0"
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: skeema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: skeema_checksums_{{trimV .Version}}.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: sl1pm4t
     repo_name: k2tf
     asset: k2tf_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -30013,7 +30013,7 @@ packages:
   - type: github_release
     repo_owner: skeema
     repo_name: skeema
-    description: Declarative pure-SQL schema management for MySQL and MariaDB
+    description: Declarative pure-SQL schema management for MySQL and MariaDB (Community Edition)
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.0.0")


### PR DESCRIPTION
[skeema/skeema](https://github.com/skeema/skeema): Declarative pure-SQL schema management for MySQL and MariaDB

```console
$ aqua g -i skeema/skeema
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ skeema --help
Usage:  skeema [<options>] <command>

Skeema is a declarative schema management system for MySQL and MariaDB. It allows you to export a database schema to the filesystem, and apply online schema
changes by modifying CREATE statements in .sql files.

Commands:
      add-environment  Add a new named environment to an existing host directory
      diff             Compare a DB instance's schemas to the filesystem
      format           Normalize format of filesystem representation of database objects
      help             Display usage information
      init             Save a DB instance's schemas to the filesystem
      lint             Check for problems in filesystem representation of database objects
      pull             Update the filesystem representation of schemas
      push             Alter objects on DBs to reflect the filesystem representation
      version          Display program version

Global Options:
  -o, --connect-options value  Comma-separated session options to set upon connecting to each database instance
      --debug                  Enable debug logging
  -?, --help[=value]           Display usage information for the specified command
  -H, --host-wrapper value     External bin to shell out to for host lookup; see manual for template vars
      --ignore-func value      Ignore functions that match regex
      --ignore-proc value      Ignore stored procedures that match regex
      --ignore-schema value    Ignore schemas that match regex
      --ignore-table value     Ignore tables that match regex
      --[skip-]my-cnf          Parse ~/.my.cnf for configuration (enabled by default; disable with --skip-my-cnf)
  -p, --password[=value]       Password for database user; omit value to prompt from TTY (default "$MYSQL_PWD")
      --ssl-mode value         Specify desired connection security SSL/TLS usage (valid values: "disabled", "preferred", "required")
  -u, --user value             Username to connect to database host (default "root")
      --version                Display program version

Complete documentation for this command suite is available online: https://www.skeema.io/docs/commands
```

Reference

- https://www.skeema.io/
