### PR TITLE
feat: add `chainguard-dev/apko`

### DIFF
--- a/pkgs/chainguard-dev/apko/pkg.yaml
+++ b/pkgs/chainguard-dev/apko/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chainguard-dev/apko@v0.13.2

--- a/pkgs/chainguard-dev/apko/pkg.yaml
+++ b/pkgs/chainguard-dev/apko/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
-  - name: chainguard-dev/apko@v0.13.2
+  - name: chainguard-dev/apko@v0.13.3
+  - name: chainguard-dev/apko
+    version: v0.11.0
+  - name: chainguard-dev/apko
+    version: v0.6.1
+  - name: chainguard-dev/apko
+    version: v0.4.0

--- a/pkgs/chainguard-dev/apko/registry.yaml
+++ b/pkgs/chainguard-dev/apko/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    name: chainguard-dev/apko
+    repo_owner: chainguard-dev
+    repo_name: apko
+    description: Build OCI images from APK packages directly without Dockerfile
+    asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    format: tar.gz
+    files:
+      - name: apko
+        src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/386
+      - linux/amd64
+      - linux/arm64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/pkgs/chainguard-dev/apko/registry.yaml
+++ b/pkgs/chainguard-dev/apko/registry.yaml
@@ -7,6 +7,9 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.4.0")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         format: tar.gz
         supported_envs:
           - linux
@@ -17,6 +20,9 @@ packages:
       - version_constraint: semver("<= 0.6.1")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         supported_envs:
           - linux
         checksum:
@@ -26,6 +32,9 @@ packages:
       - version_constraint: semver("<= 0.11.0")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         supported_envs:
           - linux
           - darwin
@@ -35,6 +44,9 @@ packages:
           algorithm: sha256
       - version_constraint: "true"
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         format: tar.gz
         supported_envs:
           - linux

--- a/pkgs/chainguard-dev/apko/registry.yaml
+++ b/pkgs/chainguard-dev/apko/registry.yaml
@@ -1,21 +1,45 @@
 packages:
   - type: github_release
-    name: chainguard-dev/apko
     repo_owner: chainguard-dev
     repo_name: apko
     description: Build OCI images from APK packages directly without Dockerfile
-    asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    format: tar.gz
-    files:
-      - name: apko
-        src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
-    supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/386
-      - linux/amd64
-      - linux/arm64
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.6.1")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -8779,6 +8779,9 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.4.0")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         format: tar.gz
         supported_envs:
           - linux
@@ -8789,6 +8792,9 @@ packages:
       - version_constraint: semver("<= 0.6.1")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         supported_envs:
           - linux
         checksum:
@@ -8798,6 +8804,9 @@ packages:
       - version_constraint: semver("<= 0.11.0")
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         supported_envs:
           - linux
           - darwin
@@ -8807,6 +8816,9 @@ packages:
           algorithm: sha256
       - version_constraint: "true"
         asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: apko
+            src: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}/apko
         format: tar.gz
         supported_envs:
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -8772,6 +8772,50 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: chainguard-dev
+    repo_name: apko
+    description: Build OCI images from APK packages directly without Dockerfile
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.6.1")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0")
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: apko_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: chanzuckerberg
     repo_name: fogg
     description: Manage Infrastructure as Code with less pain


### PR DESCRIPTION
#19225 [chainguard-dev/apko](https://github.com/chainguard-dev/apko): Build OCI images from APK packages directly without Dockerfile

---

Add package `chainguard-dev/apko` to the `aqua-registry`