### PR TITLE
feat: add `chainguard-dev/melange`

### DIFF
--- a/pkgs/chainguard-dev/melange/pkg.yaml
+++ b/pkgs/chainguard-dev/melange/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: chainguard-dev/melange@v0.5.5
+  - name: chainguard-dev/melange@v0.5.6
+  - name: chainguard-dev/melange
+    version: v0.2.0

--- a/pkgs/chainguard-dev/melange/pkg.yaml
+++ b/pkgs/chainguard-dev/melange/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chainguard-dev/melange@v0.5.5

--- a/pkgs/chainguard-dev/melange/registry.yaml
+++ b/pkgs/chainguard-dev/melange/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    name: chainguard-dev/melange
+    repo_owner: chainguard-dev
+    repo_name: melange
+    description: build APKs from source code
+    asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: melange
+        src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/386
+      - linux/amd64
+      - linux/arm64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/pkgs/chainguard-dev/melange/registry.yaml
+++ b/pkgs/chainguard-dev/melange/registry.yaml
@@ -8,6 +8,9 @@ packages:
       - version_constraint: semver("<= 0.2.0")
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: melange
+            src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
         checksum:
@@ -17,6 +20,9 @@ packages:
       - version_constraint: "true"
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: melange
+            src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
           - darwin

--- a/pkgs/chainguard-dev/melange/registry.yaml
+++ b/pkgs/chainguard-dev/melange/registry.yaml
@@ -13,10 +13,24 @@ packages:
             src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
+        cosign:
+          cosign_experimental: true
+          opts:
+            - --signature
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.sig
+            - --certificate
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.crt
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            cosign_experimental: true
+            opts:
+              - --signature
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.crt
       - version_constraint: "true"
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -26,7 +40,21 @@ packages:
         supported_envs:
           - linux
           - darwin
+        cosign:
+          cosign_experimental: true
+          opts:
+            - --signature
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.sig
+            - --certificate
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.crt
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            cosign_experimental: true
+            opts:
+              - --signature
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.crt

--- a/pkgs/chainguard-dev/melange/registry.yaml
+++ b/pkgs/chainguard-dev/melange/registry.yaml
@@ -1,21 +1,26 @@
 packages:
   - type: github_release
-    name: chainguard-dev/melange
     repo_owner: chainguard-dev
     repo_name: melange
     description: build APKs from source code
-    asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: melange
-        src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
-    supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/386
-      - linux/amd64
-      - linux/arm64
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -8841,10 +8841,24 @@ packages:
             src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
+        cosign:
+          cosign_experimental: true
+          opts:
+            - --signature
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.sig
+            - --certificate
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.crt
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            cosign_experimental: true
+            opts:
+              - --signature
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.crt
       - version_constraint: "true"
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -8854,10 +8868,24 @@ packages:
         supported_envs:
           - linux
           - darwin
+        cosign:
+          cosign_experimental: true
+          opts:
+            - --signature
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.sig
+            - --certificate
+            - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}.crt
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            cosign_experimental: true
+            opts:
+              - --signature
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/chainguard-dev/melange/releases/download/{{.Version}}/checksums.txt.crt
   - type: github_release
     repo_owner: chanzuckerberg
     repo_name: fogg

--- a/registry.yaml
+++ b/registry.yaml
@@ -8828,6 +8828,31 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: chainguard-dev
+    repo_name: melange
+    description: build APKs from source code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: chanzuckerberg
     repo_name: fogg
     description: Manage Infrastructure as Code with less pain

--- a/registry.yaml
+++ b/registry.yaml
@@ -8836,6 +8836,9 @@ packages:
       - version_constraint: semver("<= 0.2.0")
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: melange
+            src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
         checksum:
@@ -8845,6 +8848,9 @@ packages:
       - version_constraint: "true"
         asset: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: melange
+            src: melange_{{trimV .Version}}_{{.OS}}_{{.Arch}}/melange
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
#19226 [chainguard-dev/melange](https://github.com/chainguard-dev/melange): build APKs from source code

---

add `chainguard-dev/melange` package to the `aqua-registry`