### PR TITLE
feat: add erebe/wstunnel

### DIFF
--- a/pkgs/erebe/wstunnel/pkg.yaml
+++ b/pkgs/erebe/wstunnel/pkg.yaml
@@ -1,0 +1,32 @@
+packages:
+  - name: erebe/wstunnel@v8.4.2
+  - name: erebe/wstunnel
+    version: v7.1.0
+  - name: erebe/wstunnel
+    version: v7.0.0-rc2
+  - name: erebe/wstunnel
+    version: v7.0-rc1
+  - name: erebe/wstunnel
+    version: v6.0
+  - name: erebe/wstunnel
+    version: v5.1
+  - name: erebe/wstunnel
+    version: v5.0
+  - name: erebe/wstunnel
+    version: v4.1
+  - name: erebe/wstunnel
+    version: v4.0
+  - name: erebe/wstunnel
+    version: v3.1
+  - name: erebe/wstunnel
+    version: v3.0
+  - name: erebe/wstunnel
+    version: v0.1.5
+  - name: erebe/wstunnel
+    version: "2.0"
+  - name: erebe/wstunnel
+    version: "1.2"
+  - name: erebe/wstunnel
+    version: "1.1"
+  - name: erebe/wstunnel
+    version: "1.0"

--- a/pkgs/erebe/wstunnel/registry.yaml
+++ b/pkgs/erebe/wstunnel/registry.yaml
@@ -10,24 +10,7 @@ packages:
         format: raw
         supported_envs:
           - linux/amd64
-      - version_constraint: Version == "1.1"
-        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            format: raw
-            asset: wstunnel_{{.OS}}_{{.Arch}}
-          - goos: windows
-            files:
-              - name: wstunnel
-                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "1.2"
+      - version_constraint: Version in ["1.1", "1.2"]
         asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true

--- a/pkgs/erebe/wstunnel/registry.yaml
+++ b/pkgs/erebe/wstunnel/registry.yaml
@@ -1,0 +1,255 @@
+packages:
+  - type: github_release
+    repo_owner: erebe
+    repo_name: wstunnel
+    description: Tunnel all your traffic over Websocket or HTTP2 - Bypass firewalls/DPI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.0"
+        asset: wstunnel
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "1.1"
+        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel_{{.OS}}_{{.Arch}}
+          - goos: windows
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "1.2"
+        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel_{{.OS}}_{{.Arch}}
+          - goos: windows
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "2.0"
+        asset: wstunnel_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: wstunnel-{{.OS}}
+          - goos: windows
+            format: zip
+            asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.5"
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v3.0"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: wstunnel-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v3.1"
+        asset: wstunnel-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: linux
+            goarch: arm64
+            asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+            files:
+              - name: wstunnel
+                src: wstunnel/wstunnel
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v4.0"
+        asset: wstunnel-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v4.1"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.Arch}}
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: wstunnel-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v5.0"
+        asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.OS}}-{{.Arch}}
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: wstunnel-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v5.1"
+        asset: wstunnel-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v6.0"
+        asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: Version == "v7.0-rc1"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v7.0.0-rc2"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 7.1.0")
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 8.4.2")
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -13441,6 +13441,260 @@ packages:
       asset: terratag_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: erebe
+    repo_name: wstunnel
+    description: Tunnel all your traffic over Websocket or HTTP2 - Bypass firewalls/DPI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.0"
+        asset: wstunnel
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "1.1"
+        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel_{{.OS}}_{{.Arch}}
+          - goos: windows
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "1.2"
+        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel_{{.OS}}_{{.Arch}}
+          - goos: windows
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "2.0"
+        asset: wstunnel_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: wstunnel-{{.OS}}
+          - goos: windows
+            format: zip
+            asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.5"
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v3.0"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: wstunnel-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v3.1"
+        asset: wstunnel-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: linux
+            goarch: arm64
+            asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+            files:
+              - name: wstunnel
+                src: wstunnel/wstunnel
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v4.0"
+        asset: wstunnel-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v4.1"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.Arch}}-{{.OS}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: wstunnel
+                src: wstunnel_{{.Arch}}
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: wstunnel-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v5.0"
+        asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: raw
+            asset: wstunnel-{{.OS}}-{{.Arch}}
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: wstunnel-{{.OS}}.{{.Format}}
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: Version == "v5.1"
+        asset: wstunnel-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v6.0"
+        asset: wstunnel-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: wstunnel-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: Version == "v7.0-rc1"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v7.0.0-rc2"
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 7.1.0")
+        asset: wstunnel-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 8.4.2")
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: wstunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: ericchiang
     repo_name: pup
     asset: pup_{{.Version}}_{{.OS}}_{{.Arch}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -13451,24 +13451,7 @@ packages:
         format: raw
         supported_envs:
           - linux/amd64
-      - version_constraint: Version == "1.1"
-        asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            format: raw
-            asset: wstunnel_{{.OS}}_{{.Arch}}
-          - goos: windows
-            files:
-              - name: wstunnel
-                src: wstunnel_{{.OS}}_{{.Arch}}/wstunnel
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "1.2"
+      - version_constraint: Version in ["1.1", "1.2"]
         asset: wstunnel_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true


### PR DESCRIPTION
[erebe/wstunnel](https://github.com/erebe/wstunnel): Tunnel all your traffic over Websocket or HTTP2 - Bypass firewalls/DPI

```console
$ aqua g -i erebe/wstunnel
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ wstunnel --help
Use the websockets protocol to tunnel {TCP,UDP} traffic
wsTunnelClient <---> wsTunnelServer <---> RemoteHost
Use secure connection (wss://) to bypass proxies

Usage: wstunnel [OPTIONS] <COMMAND>

Commands:
  client
  server
  help    Print this message or the help of the given subcommand(s)

Options:
      --no-color <NO_COLOR>      Disable color output in logs [env: NO_COLOR=]
      --nb-worker-threads <INT>  *WARNING* The flag does nothing, you need to set the env variable *WARNING*
                                 Control the number of threads that will be used.
                                 By default it is equal the number of cpus [env: TOKIO_WORKER_THREADS=]
  -h, --help                     Print help
  -V, --version                  Print version
```