### PR TITLE
feat: add loft-sh/devpod

### DIFF
--- a/pkgs/loft-sh/devpod/pkg.yaml
+++ b/pkgs/loft-sh/devpod/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: loft-sh/devpod@v0.4.2

--- a/pkgs/loft-sh/devpod/pkg.yaml
+++ b/pkgs/loft-sh/devpod/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: loft-sh/devpod@v0.4.2
+  - name: loft-sh/devpod
+    version: v0.0.3

--- a/pkgs/loft-sh/devpod/registry.yaml
+++ b/pkgs/loft-sh/devpod/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: loft-sh
+    repo_name: devpod
+    description: "Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: devpod-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - darwin
+          - windows

--- a/pkgs/loft-sh/devpod/registry.yaml
+++ b/pkgs/loft-sh/devpod/registry.yaml
@@ -5,6 +5,14 @@ packages:
     description: "Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+        asset: devpod-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
       - version_constraint: "true"
         asset: devpod-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -23236,6 +23236,14 @@ packages:
     description: "Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+        asset: devpod-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
       - version_constraint: "true"
         asset: devpod-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -23232,6 +23232,20 @@ packages:
           enabled: false
   - type: github_release
     repo_owner: loft-sh
+    repo_name: devpod
+    description: "Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: devpod-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - darwin
+          - windows
+  - type: github_release
+    repo_owner: loft-sh
     repo_name: vcluster
     description: vcluster - Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster. It's cheaper than creating separate full-blown clusters and it offers better multi-tenancy and isolation than regular namespaces
     asset: vcluster-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
[loft-sh/devpod](https://github.com/loft-sh/devpod): Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker.

```console
$ aqua g -i loft-sh/devpod
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ devpod --help
DevPod

Usage:
  devpod [command]

Available Commands:
  build       Builds a workspace
  completion  Generate the autocompletion script for the specified shell
  context     DevPod Context commands
  delete      Deletes an existing workspace
  help        Help about any command
  ide         DevPod IDE commands
  list        Lists existing workspaces
  logs-daemon Prints the daemon logs on the machine
  machine     DevPod Machine commands
  pro         DevPod Pro commands
  provider    DevPod Provider commands
  ssh         Starts a new ssh session to a workspace
  status      Shows the status of a workspace
  stop        Stops an existing workspace
  up          Starts a new workspace
  use         Use DevPod resources
  version     Prints the version

Flags:
      --context string       The context to use
      --debug                Prints the stack trace if an error occurs
      --devpod-home string   If defined will override the default devpod home. You can also use DEVPOD_HOME to set this
  -h, --help                 help for devpod
      --log-output string    The log format to use. Can be either plain, raw or json (default "plain")
      --provider string      The provider to use. Needs to be configured for the selected context.
      --silent               Run in silent mode and prevents any devpod log output except panics & fatals

Use "devpod [command] --help" for more information about a command.
```