### PR TITLE
fix(k9s): Change the checksum pattern

### DIFF
--- a/pkgs/derailed/k9s/pkg.yaml
+++ b/pkgs/derailed/k9s/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
   - name: derailed/k9s@v0.31.7
+    checksum:
+      asset: "checksums.sha256"
   - name: derailed/k9s
     version: v0.27.4
   - name: derailed/k9s


### PR DESCRIPTION
Since the version v0.27.4 of k9s, the checksum file change from "checksum.txt" to "checksums.sha256".