### PR TITLE
feat: add crates.io/eza

### DIFF
--- a/pkgs/crates.io/eza/pkg.yaml
+++ b/pkgs/crates.io/eza/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/eza@0.17.3

--- a/pkgs/crates.io/eza/registry.yaml
+++ b/pkgs/crates.io/eza/registry.yaml
@@ -1,4 +1,6 @@
 packages:
+  # TODO: Merge this package with eza-community/eza
+  # https://github.com/aquaproj/aqua/issues/2649
   - name: crates.io/eza
     type: cargo
     repo_owner: eza-community

--- a/pkgs/crates.io/eza/registry.yaml
+++ b/pkgs/crates.io/eza/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/eza
+    type: cargo
+    repo_owner: eza-community
+    repo_name: eza
+    description: A modern replacement for ls
+    crate: eza

--- a/registry.yaml
+++ b/registry.yaml
@@ -10889,6 +10889,8 @@ packages:
     description: A new file manager
     link: https://dystroy.org/broot
     crate: broot
+  # TODO: Merge this package with eza-community/eza
+  # https://github.com/aquaproj/aqua/issues/2649
   - name: crates.io/eza
     type: cargo
     repo_owner: eza-community

--- a/registry.yaml
+++ b/registry.yaml
@@ -10889,6 +10889,12 @@ packages:
     description: A new file manager
     link: https://dystroy.org/broot
     crate: broot
+  - name: crates.io/eza
+    type: cargo
+    repo_owner: eza-community
+    repo_name: eza
+    description: A modern replacement for ls
+    crate: eza
   - name: crates.io/fw
     type: cargo
     repo_owner: brocode


### PR DESCRIPTION
[crates.io/eza](https://crates.io/crates/eza): A modern replacement for ls

```console
$ aqua g -i crates.io/eza
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ eza --help
Usage:
  eza [options] [files...]

META OPTIONS
  --help                     show list of command-line options
  -v, --version              show version of eza

DISPLAY OPTIONS
  -1, --oneline              display one entry per line
  -l, --long                 display extended file metadata as a table
  -G, --grid                 display entries as a grid (default)
  -x, --across               sort the grid across, rather than downwards
  -R, --recurse              recurse into directories
  -T, --tree                 recurse into directories as a tree
  -X, --dereference          dereference symbolic links when displaying information
  -F, --classify             display type indicator by file names
  --colo[u]r=WHEN            when to use terminal colours (always, auto, never)
  --colo[u]r-scale           highlight levels of 'field' distinctly(all, age, size)
  --colo[u]r-scale-mode      use gradient or fixed colors in --color-scale (fixed, gradient)
  --icons=WHEN               when to display icons (always, auto, never)
  --no-quotes                don't quote file names with spaces
  --hyperlink                display entries as hyperlinks
  -w, --width COLS           set screen width in columns


FILTERING AND SORTING OPTIONS
  -a, --all                  show hidden and 'dot' files. Use this twice to also
                             show the '.' and '..' directories
  -A, --almost-all           equivalent to --all; included for compatibility with `ls -A`
  -d, --list-dirs            list directories as files; don't list their contents
  -L, --level DEPTH          limit the depth of recursion
  -r, --reverse              reverse the sort order
  -s, --sort SORT_FIELD      which field to sort by
  --group-directories-first  list directories before other files
  -D, --only-dirs            list only directories
  -f, --only-files           list only files
  -I, --ignore-glob GLOBS    glob patterns (pipe-separated) of files to ignore
  --git-ignore               ignore files mentioned in '.gitignore'
  Valid sort fields:         name, Name, extension, Extension, size, type,
                             modified, accessed, created, inode, and none.
                             date, time, old, and new all refer to modified.

LONG VIEW OPTIONS
  -b, --binary               list file sizes with binary prefixes
  -B, --bytes                list file sizes in bytes, without any prefixes
  -g, --group                list each file's group
  --smart-group              only show group if it has a different name from owner
  -h, --header               add a header row to each column
  -H, --links                list each file's number of hard links
  -i, --inode                list each file's inode number
  -m, --modified             use the modified timestamp field
  -M, --mounts               show mount details (Linux and Mac only)
  -n, --numeric              list numeric user and group IDs
  -O, --flags                list file flags (Mac, BSD, and Windows only)
  -S, --blocksize            show size of allocated file system blocks
  -t, --time FIELD           which timestamp field to list (modified, accessed, created)
  -u, --accessed             use the accessed timestamp field
  -U, --created              use the created timestamp field
  --changed                  use the changed timestamp field
  --time-style               how to format timestamps (default, iso, long-iso,
                             full-iso, relative, or a custom style '+<FORMAT>'
                             like '+%Y-%m-%d %H:%M')
  --total-size               show the size of a directory as the size of all
                             files and directories inside (unix only)
  --no-permissions           suppress the permissions field
  -o, --octal-permissions    list each file's permission in octal format
  --no-filesize              suppress the filesize field
  --no-user                  suppress the user field
  --no-time                  suppress the time field
  --stdin                    read file names from stdin, one per line or other separator 
                             specified in environment
  --git                      list each file's Git status, if tracked or ignored
  --no-git                   suppress Git status (always overrides --git,
                             --git-repos, --git-repos-no-status)
  --git-repos                list root of git-tree status
  -@, --extended             list each file's extended attributes and sizes
  -Z, --context              list each file's security context

```

If files such as configuration file are needed, please share them.

- No configuration files are needed.

Reference

- [eza-community/eza: A modern, maintained replacement for ls](https://github.com/eza-community/eza)

Note:

Currently, eza seems like that didnt release binary for aarch64 darwin: https://github.com/eza-community/eza/releases/tag/v0.17.3
