### PR TITLE
feat: add catenacyber/perfsprint

### DIFF
--- a/pkgs/catenacyber/perfsprint/pkg.yaml
+++ b/pkgs/catenacyber/perfsprint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: catenacyber/perfsprint@v0.6.0

--- a/pkgs/catenacyber/perfsprint/registry.yaml
+++ b/pkgs/catenacyber/perfsprint/registry.yaml
@@ -1,0 +1,5 @@
+packages:
+  - type: go_install
+    repo_owner: catenacyber
+    repo_name: perfsprint
+    description: Golang linter to use strconv

--- a/registry.yaml
+++ b/registry.yaml
@@ -8721,6 +8721,10 @@ packages:
     overrides:
       - goos: windows
         format: zip
+  - type: go_install
+    repo_owner: catenacyber
+    repo_name: perfsprint
+    description: Golang linter to use strconv
   - type: github_release
     repo_owner: cbroglie
     repo_name: mustache


### PR DESCRIPTION
[catenacyber/perfsprint](https://github.com/catenacyber/perfsprint): Golang linter to use strconv

```console
$ aqua g -i catenacyber/perfsprint
```
