### PR TITLE
fix(catenacyber/perfsprint): get versions from GitHub Tags

### DIFF
--- a/pkgs/catenacyber/perfsprint/registry.yaml
+++ b/pkgs/catenacyber/perfsprint/registry.yaml
@@ -3,3 +3,4 @@ packages:
     repo_owner: catenacyber
     repo_name: perfsprint
     description: Golang linter to use strconv
+    version_source: github_tag

--- a/registry.yaml
+++ b/registry.yaml
@@ -8725,6 +8725,7 @@ packages:
     repo_owner: catenacyber
     repo_name: perfsprint
     description: Golang linter to use strconv
+    version_source: github_tag
   - type: github_release
     repo_owner: cbroglie
     repo_name: mustache


### PR DESCRIPTION
- https://github.com/aquaproj/aqua-registry/pull/19777