### PR TITLE
feat: add bodaay/HuggingFaceModelDownloader

### DIFF
--- a/pkgs/bodaay/HuggingFaceModelDownloader/pkg.yaml
+++ b/pkgs/bodaay/HuggingFaceModelDownloader/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: bodaay/HuggingFaceModelDownloader@1.2.9
+  - name: bodaay/HuggingFaceModelDownloader
+    version: 1.0.0

--- a/pkgs/bodaay/HuggingFaceModelDownloader/registry.yaml
+++ b/pkgs/bodaay/HuggingFaceModelDownloader/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: bodaay
+    repo_name: HuggingFaceModelDownloader
+    description: Simple go utility to download HuggingFace Models and Datasets
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: hfdownloader_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: hfdownloader
+      - version_constraint: "true"
+        asset: hfdownloader_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        files:
+          - name: hfdownloader

--- a/registry.yaml
+++ b/registry.yaml
@@ -7775,6 +7775,25 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: bodaay
+    repo_name: HuggingFaceModelDownloader
+    description: Simple go utility to download HuggingFace Models and Datasets
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: hfdownloader_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: hfdownloader
+      - version_constraint: "true"
+        asset: hfdownloader_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        files:
+          - name: hfdownloader
+  - type: github_release
     repo_owner: bojand
     repo_name: ghz
     asset: ghz-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[bodaay/HuggingFaceModelDownloader](https://github.com/bodaay/HuggingFaceModelDownloader): Simple go utility to
 download HuggingFace Models and Datasets

```console
$ aqua g -i bodaay/HuggingFaceModelDownloader
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ hfdownloader --help
a Simple HuggingFace Models Downloader Utility
Version: 1.2.9
Running on: /root/aquaproj-aqua/pkgs/github_release/github.com/bodaay/HuggingFaceModelDownloader/1.2.9/hfdownloader_linux_arm64_1.2.9/hfdownloader_linux_arm64_1.2.9

Usage:
  hfdowloader [flags]

Flags:
  -m, --model string         Model/Dataset name (required if dataset not set)
                             You can supply filters for required LFS model files
                             ex:  ModelName:q4_0,q8_1
                             ex:  TheBloke/WizardLM-Uncensored-Falcon-7B-GGML:fp16
  -d, --dataset string       Model/Dataset name (required if model not set)
  -b, --branch string        ModModel/Datasetel branch (optional) (default "main")
  -s, --storage string       Storage path (optional) (default "Storage")
  -k, --skipSHA              Skip SHA256 Hash Check, sometimes you just need to download missing files without wasting time waiting (optional)
  -f, --appendFilterFolder   This will append the filter name to the folder, use it for GGML qunatizatized filterd download only (optional)
  -c, --concurrent int       Number of LFS concurrent connections (optional) (default 5)
  -t, --token string         HuggingFace Access Token, this can be automatically supplied by env variable 'HUGGING_FACE_HUB_TOKEN' or .env file, required for some Models/Datasets, you still need to manually accept agreement if model requires it (optional)
  -i, --install              Install the binary to the OS default bin folder, Unix-like operating systems only
  -p, --installPath string   install Path (optional) (default "/usr/local/bin/")
      --maxRetries int       Max number of retries (optional) (default 3)
      --retryInterval int    Retry interval in seconds (optional) (default 5)
  -h, --help                 help for hfdowloader
```