### PR TITLE
feat: add gruntwork-io/boilerplate

### DIFF
--- a/pkgs/gruntwork-io/boilerplate/pkg.yaml
+++ b/pkgs/gruntwork-io/boilerplate/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: gruntwork-io/boilerplate@v0.5.9
+  - name: gruntwork-io/boilerplate
+    version: v0.4.2

--- a/pkgs/gruntwork-io/boilerplate/registry.yaml
+++ b/pkgs/gruntwork-io/boilerplate/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: gruntwork-io
+    repo_name: boilerplate
+    description: A tool for generating files and folders ("boilerplate") from a set of templates
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.2")
+        asset: boilerplate_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: boilerplate_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -17024,6 +17024,25 @@ packages:
       - name: protoc-gen-go-grpc
   - type: github_release
     repo_owner: gruntwork-io
+    repo_name: boilerplate
+    description: A tool for generating files and folders ("boilerplate") from a set of templates
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.2")
+        asset: boilerplate_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: boilerplate_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+  - type: github_release
+    repo_owner: gruntwork-io
     repo_name: kubergrunt
     description: Kubergrunt is a standalone go binary with a collection of commands to fill in the gaps between Terraform, Helm, and Kubectl
     supported_envs:


### PR DESCRIPTION
[gruntwork-io/boilerplate](https://github.com/gruntwork-io/boilerplate): A tool for generating files and folders ("boilerplate") from a set of templates

```console
$ aqua g -i gruntwork-io/boilerplate
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ boilerplate --help
Usage: boilerplate [OPTIONS]

A tool for generating files and folders (\"boilerplate\") from a set of templates. Examples:

Generate a project in ~/output from the templates in ~/templates:

    boilerplate --template-url ~/templates --output-folder ~/output

Generate a project in ~/output from the templates in ~/templates, using variables passed in via the command line:

    boilerplate --template-url ~/templates --output-folder ~/output --var "Title=Boilerplate" --var "ShowLogo=false"

Generate a project in ~/output from the templates in ~/templates, using variables read from a file:

    boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.yml

Generate a project in ~/output from the templates in this repo's include example dir, using variables read from a file:

  boilerplate --template-url
  "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master"
  --output-folder ~/output --var-file vars.yml


Options:

   --template-url URL                     Generate the project from the templates in URL. This can be a local path, or a go-getter
                                          compatible URL for remote templates (e.g.,
                                          `git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master`).
   --output-folder FOLDER                 Create the output files and folders in FOLDER.
   --non-interactive                      Do not prompt for input variables. All variables must be set via --var and --var-file
                                          options instead. (default: false)
   --var NAME=VALUE [ --var NAME=VALUE ]  Use NAME=VALUE to set variable NAME to VALUE. May be specified more than
                                          once.
   --var-file FILE [ --var-file FILE ]    Load variable values from the YAML file FILE. May be specified more than
                                          once.
   --missing-key-action ACTION            What ACTION to take if a template looks up a variable that is not defined. Must be
                                          one of: [invalid zero error]. Default: error.
   --missing-config-action ACTION         What ACTION to take if a the template folder does not contain a boilerplate.yml
                                          file. Must be one of: [exit ignore]. Default: exit.
   --disable-hooks                        If this flag is set, no hooks will execute. (default: false)
   --disable-shell                        If this flag is set, no shell helpers will execute. They will instead return the text
                                          'replace-me'. (default: false)
   --help, -h                             show help
   --version, -v                          print the version
```


Reference

- https://github.com/gruntwork-io/boilerplate/blob/master/README.md