### PR TITLE
fix(BurntSushi/ripgrep): Use aarch64 binary after 14.0.0

### DIFF
--- a/pkgs/BurntSushi/ripgrep/registry.yaml
+++ b/pkgs/BurntSushi/ripgrep/registry.yaml
@@ -4,11 +4,11 @@ packages:
     repo_name: ripgrep
     asset: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: ripgrep recursively searches directories for a regex pattern while respecting your gitignore
-    rosetta2: true
     supported_envs:
       - darwin
       - amd64
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl
@@ -20,3 +20,11 @@ packages:
     files:
       - name: rg
         src: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rg
+    version_constraint: semver(">= 14")
+    version_overrides:
+      - version_constraint: semver("< 14")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: x86_64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -493,11 +493,11 @@ packages:
     repo_name: ripgrep
     asset: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: ripgrep recursively searches directories for a regex pattern while respecting your gitignore
-    rosetta2: true
     supported_envs:
       - darwin
       - amd64
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl
@@ -509,6 +509,14 @@ packages:
     files:
       - name: rg
         src: ripgrep-{{.Version}}-{{.Arch}}-{{.OS}}/rg
+    version_constraint: semver(">= 14")
+    version_overrides:
+      - version_constraint: semver("< 14")
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: x86_64
+        rosetta2: true
   - type: github_release
     repo_owner: BurntSushi
     repo_name: xsv


### PR DESCRIPTION
Currently aqua install x86_64 binary on M series Mac.

If run without Rosetta2, failed to execute.

I fix to install aarch64 binary when use after `ripgrep@14.0.0` on M series mac.

Ref: https://github.com/BurntSushi/ripgrep/releases