### PR TITLE
fix(denoland/deno): Support linux/arm64

### DIFF
--- a/pkgs/denoland/deno/pkg.yaml
+++ b/pkgs/denoland/deno/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
   - name: denoland/deno@v1.40.4
+  - name: denoland/deno
+    version: v1.40.2
+  - name: denoland/deno
+    version: v1.5.4
+  - name: denoland/deno
+    version: v0.38.0
+  - name: denoland/deno
+    version: v0.35.0
+  - name: denoland/deno
+    version: v0.1.0

--- a/pkgs/denoland/deno/registry.yaml
+++ b/pkgs/denoland/deno/registry.yaml
@@ -2,14 +2,44 @@ packages:
   - type: github_release
     repo_owner: denoland
     repo_name: deno
-    asset: deno-{{.Arch}}-{{.OS}}.zip
-    supported_envs:
-      - darwin
-      - amd64
     description: A modern runtime for JavaScript and TypeScript
-    replacements:
-      darwin: apple-darwin
-      linux: unknown-linux-gnu
-      windows: pc-windows-msvc
-      arm64: aarch64
-      amd64: x86_64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.5.4")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.40.2")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc

--- a/pkgs/denoland/deno/registry.yaml
+++ b/pkgs/denoland/deno/registry.yaml
@@ -5,6 +5,70 @@ packages:
     description: A modern runtime for JavaScript and TypeScript
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: deno
+            src: deno_{{.OS}}_{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: deno
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.35.0")
+        asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: deno
+            src: deno_{{.OS}}_{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: deno
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.38.0")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: gz
+            asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            files:
+              - name: deno
+                src: deno_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.5.4")
         asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -25,10 +89,13 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - darwin
           - windows
@@ -43,3 +110,7 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -12214,6 +12214,70 @@ packages:
     description: A modern runtime for JavaScript and TypeScript
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: deno
+            src: deno_{{.OS}}_{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: deno
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.35.0")
+        asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: deno
+            src: deno_{{.OS}}_{{.Arch}}
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: deno
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.38.0")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: gz
+            asset: deno_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            files:
+              - name: deno
+                src: deno_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.5.4")
         asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -12234,10 +12298,13 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - darwin
           - windows
@@ -12252,6 +12319,10 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
   - type: github_release
     repo_owner: derailed
     repo_name: k9s

--- a/registry.yaml
+++ b/registry.yaml
@@ -12211,17 +12211,47 @@ packages:
   - type: github_release
     repo_owner: denoland
     repo_name: deno
-    asset: deno-{{.Arch}}-{{.OS}}.zip
-    supported_envs:
-      - darwin
-      - amd64
     description: A modern runtime for JavaScript and TypeScript
-    replacements:
-      darwin: apple-darwin
-      linux: unknown-linux-gnu
-      windows: pc-windows-msvc
-      arm64: aarch64
-      amd64: x86_64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.5.4")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.40.2")
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: deno-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
   - type: github_release
     repo_owner: derailed
     repo_name: k9s


### PR DESCRIPTION
Since v1.40.4 deno supports `linux/arm64` natively.

https://github.com/denoland/deno