### PR TITLE
feat: add nabeken/go-github-apps

### DIFF
--- a/pkgs/nabeken/go-github-apps/pkg.yaml
+++ b/pkgs/nabeken/go-github-apps/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: nabeken/go-github-apps@v0.1.12
+  - name: nabeken/go-github-apps
+    version: v0.1.3
+  - name: nabeken/go-github-apps
+    version: v0.1.2
+  - name: nabeken/go-github-apps
+    version: v0.1.1

--- a/pkgs/nabeken/go-github-apps/registry.yaml
+++ b/pkgs/nabeken/go-github-apps/registry.yaml
@@ -1,0 +1,55 @@
+packages:
+  - type: github_release
+    repo_owner: nabeken
+    repo_name: go-github-apps
+    description: A tiny command-line utility to retrieve Github Apps Installation Token
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.1.1")
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.2"
+        asset: go-github-apps_0_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.3"
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -26411,6 +26411,60 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: nabeken
+    repo_name: go-github-apps
+    description: A tiny command-line utility to retrieve Github Apps Installation Token
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.1.1")
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.2"
+        asset: go-github-apps_0_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.3"
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: go-github-apps_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: naggie
     repo_name: dstask
     description: Git powered terminal-based todo manager -- markdown note page per task. Single binary


### PR DESCRIPTION
[nabeken/go-github-apps](https://github.com/nabeken/go-github-apps): A tiny command-line utility to retrieve Github Apps Installation Token

```console
$ aqua g -i nabeken/go-github-apps
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@60fbf8bab1e4:/workspace# go-github-apps --help
Usage of go-github-apps:
  -app-id int
        App ID
  -export
        show token as 'export GITHUB_TOKEN=...'
  -inst-id int
        Installation ID
  -show-insts
        show all of the installations for the app
  -url string
        specify the base URL for Github API, for use with Github Enterprise. Example: 'https://github.example.com/api/v3' (default "https://api.github.com")
  -version
        show version info

== Build Info ==
Version: 0.1.12
Commit: 5b22097dca0a7822f2404e5755f43183ff4b5c11
BuiltAt: 2023-12-07T13:11:19Z
```

If files such as configuration file are needed, please share them.

```
```

Reference

- README.md
	- https://github.com/nabeken/go-github-apps/blob/master/README.md
