### PR TITLE
fix(golang/vuln/govulncheck): change version_source to github_tag

### DIFF
--- a/pkgs/golang/vuln/govulncheck/registry.yaml
+++ b/pkgs/golang/vuln/govulncheck/registry.yaml
@@ -6,5 +6,6 @@ packages:
     repo_name: vuln
     description: Go Vulnerability Management
     link: https://go.dev/security/vuln/
+    version_source: github_tag
     files:
       - name: govulncheck

--- a/registry.yaml
+++ b/registry.yaml
@@ -16731,6 +16731,7 @@ packages:
     repo_name: vuln
     description: Go Vulnerability Management
     link: https://go.dev/security/vuln/
+    version_source: github_tag
     files:
       - name: govulncheck
   - type: github_release


### PR DESCRIPTION
This fixes the bug that `aqua g golang/vuln/govulncheck` can't get versions.