### PR TITLE
feat: add martinvonz/jj

### DIFF
--- a/pkgs/martinvonz/jj/pkg.yaml
+++ b/pkgs/martinvonz/jj/pkg.yaml
@@ -5,6 +5,4 @@ packages:
   - name: martinvonz/jj
     version: v0.4.0
   - name: martinvonz/jj
-    version: v0.3.1
-  - name: martinvonz/jj
     version: v0.3.0

--- a/pkgs/martinvonz/jj/pkg.yaml
+++ b/pkgs/martinvonz/jj/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: martinvonz/jj@v0.14.0
+  - name: martinvonz/jj
+    version: v0.13.0
+  - name: martinvonz/jj
+    version: v0.4.0
+  - name: martinvonz/jj
+    version: v0.3.1
+  - name: martinvonz/jj
+    version: v0.3.0

--- a/pkgs/martinvonz/jj/registry.yaml
+++ b/pkgs/martinvonz/jj/registry.yaml
@@ -15,7 +15,7 @@ packages:
           windows: pc-windows-gnu
         checksum:
           type: github_release
-          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.tar.gz.sha256sum
+          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
           algorithm: sha256
         overrides:
           - goos: linux
@@ -24,14 +24,7 @@ packages:
           - linux/amd64
           - windows/amd64
       - version_constraint: Version == "v0.3.1"
-        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          windows: pc-windows-gnu
-        supported_envs:
-          - windows/amd64
+        no_asset: true
       - version_constraint: semver("<= 0.4.0")
         asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/martinvonz/jj/registry.yaml
+++ b/pkgs/martinvonz/jj/registry.yaml
@@ -1,0 +1,89 @@
+packages:
+  - type: github_release
+    repo_owner: martinvonz
+    repo_name: jj
+    description: A Git-compatible VCS that is both simple and powerful
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.tar.gz.sha256sum
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.3.1"
+        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-gnu
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.5.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.13.0")
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -24411,7 +24411,7 @@ packages:
           windows: pc-windows-gnu
         checksum:
           type: github_release
-          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.tar.gz.sha256sum
+          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}.sha256sum
           algorithm: sha256
         overrides:
           - goos: linux
@@ -24420,14 +24420,7 @@ packages:
           - linux/amd64
           - windows/amd64
       - version_constraint: Version == "v0.3.1"
-        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          windows: pc-windows-gnu
-        supported_envs:
-          - windows/amd64
+        no_asset: true
       - version_constraint: semver("<= 0.4.0")
         asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -24395,6 +24395,94 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+  - type: github_release
+    repo_owner: martinvonz
+    repo_name: jj
+    description: A Git-compatible VCS that is both simple and powerful
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.tar.gz.sha256sum
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.3.1"
+        asset: jj_{{.Version}}_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-gnu
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.5.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.13.0")
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
   - type: go_install
     repo_owner: marwan-at-work
     repo_name: mod


### PR DESCRIPTION
[martinvonz/jj](https://github.com/martinvonz/jj): A Git-compatible VCS that is both simple and powerful

```console
$ aqua g -i martinvonz/jj
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ jj --help

Jujutsu (An experimental VCS)

To get started, see the tutorial at
https://github.com/martinvonz/jj/blob/main/docs/tutorial.md.

Usage: jj [OPTIONS] <COMMAND>

Commands:
  abandon    Abandon a revision
  backout    Apply the reverse of a revision on top of another revision
  branch     Manage branches
  cat        Print contents of a file in a revision
  chmod      Sets or removes the executable bit for paths in the repo
  commit     Update the description and create a new change on top [aliases: ci]
  config     Manage config options
  describe   Update the change description or other metadata [aliases: desc]
  diff       Compare file contents between two commits
  diffedit   Touch up the content changes in a revision with a diff editor
  duplicate  Create a new change with the same content as an existing one
  edit       Edit a commit in the working copy
  files      List files in a revision
  git        Commands for working with the underlying Git repo
  init       Create a new repo in the given directory
  interdiff  Compare the changes of two commits
  log        Show commit history
  move       Move changes from one revision into another
  new        Create a new, empty change and (by default) edit it in the working
                 copy
  next       Move the current working copy commit to the next child revision in the
                 repository.
  obslog     Show how a change has evolved
  operation  Commands for working with the operation log [aliases: op]
  prev       Move the working copy commit to the parent of the current revision.
  rebase     Move revisions to different parent(s)
  resolve    Resolve a conflicted file with an external merge tool
  restore    Restore paths from another revision
  root       Show the current workspace root directory
  show       Show commit description and changes in a revision
  sparse     Manage which paths from the working-copy commit are present in the
                 working copy
  split      Split a revision in two
  squash     Move changes from a revision into its parent [aliases: amend]
  status     Show high-level repo status [aliases: st]
  tag        Manage tags
  util       Infrequently used commands such as for generating shell completions
  undo       Undo an operation (shortcut for `jj op undo`)
  unsquash   Move changes from a revision's parent into the revision [aliases:
                 unamend]
  untrack    Stop tracking specified paths in the working copy
  version    Display version information
  workspace  Commands for working with workspaces
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Global Options:
  -R, --repository <REPOSITORY>
          Path to repository to operate on
          
          By default, Jujutsu searches for the closest .jj/ directory in an ancestor of
          the current working directory.

      --ignore-working-copy
          Don't snapshot the working copy, and don't update it
          
          By default, Jujutsu snapshots the working copy at the beginning of every
          command. The working copy is also updated at the end of the command, if the
          command modified the working-copy commit (`@`). If you want to avoid
          snapshotting the working copy and instead see a possibly stale working copy
          commit, you can use `--ignore-working-copy`. This may be useful e.g. in a
          command prompt, especially if you have another process that commits the
          working copy.
          
          Loading the repository is at a specific operation with `--at-operation`
          implies `--ignore-working-copy`.

      --at-operation <AT_OPERATION>
          Operation to load the repo at
          
          Operation to load the repo at. By default, Jujutsu loads the repo at the most
          recent operation. You can use `--at-op=<operation ID>` to see what the repo
          looked like at an earlier operation. For example `jj --at-op=<operation ID>
          st` will show you what `jj st` would have shown you when the given operation
          had just finished.
          
          Use `jj op log` to find the operation ID you want. Any unambiguous prefix of
          the operation ID is enough.
          
          When loading the repo at an earlier operation, the working copy will be
          ignored, as if `--ignore-working-copy` had been specified.
          
          It is possible to run mutating commands when loading the repo at an earlier
          operation. Doing that is equivalent to having run concurrent commands
          starting at the earlier operation. There's rarely a reason to do that, but it
          is possible.
          
          [default: @]
          [aliases: at-op]

  -v, --verbose
          Enable verbose logging

      --color <WHEN>
          When to colorize output (always, never, auto)

      --no-pager
          Disable the pager

      --config-toml <TOML>
          Additional configuration options (can be repeated)
```

If files such as configuration file are needed, please share them.

- Configuration file is not required

Reference

- https://github.com/martinvonz/jj
