### PR TITLE
feat(bufbuild/buf): add support linux/arm64 architecture

### DIFF
--- a/pkgs/bufbuild/buf/pkg.yaml
+++ b/pkgs/bufbuild/buf/pkg.yaml
@@ -1,2 +1,14 @@
 packages:
   - name: bufbuild/buf@v1.29.0
+  - name: bufbuild/buf
+    version: v0.56.0
+  - name: bufbuild/buf
+    version: v0.53.0
+  - name: bufbuild/buf
+    version: v0.52.0
+  - name: bufbuild/buf
+    version: v0.51.1
+  - name: bufbuild/buf
+    version: v0.42.0
+  - name: bufbuild/buf
+    version: v0.41.0

--- a/pkgs/bufbuild/buf/pkg.yaml
+++ b/pkgs/bufbuild/buf/pkg.yaml
@@ -1,13 +1,7 @@
 packages:
   - name: bufbuild/buf@v1.29.0
   - name: bufbuild/buf
-    version: v0.56.0
-  - name: bufbuild/buf
     version: v0.53.0
-  - name: bufbuild/buf
-    version: v0.52.0
-  - name: bufbuild/buf
-    version: v0.51.1
   - name: bufbuild/buf
     version: v0.42.0
   - name: bufbuild/buf

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -6,13 +6,16 @@ packages:
     supported_envs:
       - windows
       - darwin
-      - linux/amd64
+      - linux
     asset: buf-{{.OS}}-{{.Arch}}.tar.gz
     overrides:
       - goos: windows
         asset: buf-Windows-{{.Arch}}.exe
         files:
           - name: buf
+      - goos: linux
+        replacements:
+          arm64: aarch64
     replacements:
       darwin: Darwin
       linux: Linux

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -3,12 +3,23 @@ packages:
     repo_owner: bufbuild
     repo_name: buf
     description: The best way of working with Protocol Buffers
+    files:
+      - name: buf
+      - name: protoc-gen-buf-breaking
+      - name: protoc-gen-buf-lint
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.41.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -23,6 +34,13 @@ packages:
       - version_constraint: Version == "v0.42.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -37,6 +55,13 @@ packages:
       - version_constraint: semver("<= 0.51.1")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -55,13 +80,20 @@ packages:
       - version_constraint: Version == "v0.52.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
           type: github_release
-          asset: sha256.txt.minisig
+          asset: sha256.txt
           algorithm: sha256
         overrides:
           - goos: linux
@@ -73,6 +105,13 @@ packages:
       - version_constraint: Version == "v0.53.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -91,6 +130,13 @@ packages:
       - version_constraint: semver("<= 0.56.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -98,7 +144,7 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: sha256.txt.minisig
+          asset: sha256.txt
           algorithm: sha256
         overrides:
           - goos: linux
@@ -110,6 +156,13 @@ packages:
       - version_constraint: "true"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -2,33 +2,127 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: buf
-    description: A new way of working with Protocol Buffers
-    supported_envs:
-      - windows
-      - darwin
-      - linux
-    asset: buf-{{.OS}}-{{.Arch}}.tar.gz
-    overrides:
-      - goos: windows
-        asset: buf-Windows-{{.Arch}}.exe
-        files:
-          - name: buf
-      - goos: linux
+    description: The best way of working with Protocol Buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.41.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
-          arm64: aarch64
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
-    files:
-      - name: buf
-        src: buf/bin/buf
-      - name: protoc-gen-buf-breaking
-        src: buf/bin/protoc-gen-buf-breaking
-      - name: protoc-gen-buf-lint
-        src: buf/bin/protoc-gen-buf-lint
-    checksum:
-      type: github_release
-      asset: sha256.txt
-      algorithm: sha256
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.42.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.51.1")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.52.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt.minisig
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.53.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.56.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sha256.txt.minisig
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: raw
+            asset: buf-{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: raw
+            asset: buf-{{.OS}}-{{.Arch}}

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -52,7 +52,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.51.1")
+      - version_constraint: semver("<= 0.53.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -77,82 +77,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v0.52.0"
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version == "v0.53.0"
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.56.0")
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: raw
-            asset: buf-{{.OS}}-{{.Arch}}
       - version_constraint: "true"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -8586,36 +8586,130 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: buf
-    description: A new way of working with Protocol Buffers
-    supported_envs:
-      - windows
-      - darwin
-      - linux
-    asset: buf-{{.OS}}-{{.Arch}}.tar.gz
-    overrides:
-      - goos: windows
-        asset: buf-Windows-{{.Arch}}.exe
-        files:
-          - name: buf
-      - goos: linux
+    description: The best way of working with Protocol Buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.41.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
-          arm64: aarch64
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
-    files:
-      - name: buf
-        src: buf/bin/buf
-      - name: protoc-gen-buf-breaking
-        src: buf/bin/protoc-gen-buf-breaking
-      - name: protoc-gen-buf-lint
-        src: buf/bin/protoc-gen-buf-lint
-    checksum:
-      type: github_release
-      asset: sha256.txt
-      algorithm: sha256
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.42.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.51.1")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.52.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt.minisig
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.53.0"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.56.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sha256.txt.minisig
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: raw
+            asset: buf-{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: raw
+            asset: buf-{{.OS}}-{{.Arch}}
   - type: go_install
     name: bufbuild/connect-go/protoc-gen-connect-go
     repo_owner: bufbuild

--- a/registry.yaml
+++ b/registry.yaml
@@ -8636,7 +8636,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.51.1")
+      - version_constraint: semver("<= 0.53.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -8661,82 +8661,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v0.52.0"
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version == "v0.53.0"
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.56.0")
-        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buf
-            src: buf/bin/buf
-          - name: protoc-gen-buf-breaking
-            src: buf/bin/protoc-gen-buf-breaking
-          - name: protoc-gen-buf-lint
-            src: buf/bin/protoc-gen-buf-lint
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: sha256.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: raw
-            asset: buf-{{.OS}}-{{.Arch}}
       - version_constraint: "true"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -8587,12 +8587,23 @@ packages:
     repo_owner: bufbuild
     repo_name: buf
     description: The best way of working with Protocol Buffers
+    files:
+      - name: buf
+      - name: protoc-gen-buf-breaking
+      - name: protoc-gen-buf-lint
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.41.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -8607,6 +8618,13 @@ packages:
       - version_constraint: Version == "v0.42.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -8621,6 +8639,13 @@ packages:
       - version_constraint: semver("<= 0.51.1")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -8639,13 +8664,20 @@ packages:
       - version_constraint: Version == "v0.52.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
           type: github_release
-          asset: sha256.txt.minisig
+          asset: sha256.txt
           algorithm: sha256
         overrides:
           - goos: linux
@@ -8657,6 +8689,13 @@ packages:
       - version_constraint: Version == "v0.53.0"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -8675,6 +8714,13 @@ packages:
       - version_constraint: semver("<= 0.56.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -8682,7 +8728,7 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: sha256.txt.minisig
+          asset: sha256.txt
           algorithm: sha256
         overrides:
           - goos: linux
@@ -8694,6 +8740,13 @@ packages:
       - version_constraint: "true"
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -8590,13 +8590,16 @@ packages:
     supported_envs:
       - windows
       - darwin
-      - linux/amd64
+      - linux
     asset: buf-{{.OS}}-{{.Arch}}.tar.gz
     overrides:
       - goos: windows
         asset: buf-Windows-{{.Arch}}.exe
         files:
           - name: buf
+      - goos: linux
+        replacements:
+          arm64: aarch64
     replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
I added support for the Linux/arm64 architecture because [bufbuild/buf](https://github.com/bufbuild/buf/releases) supports it.