### PR TITLE
feat: add denoland/deno/denort

### DIFF
--- a/pkgs/denoland/deno/denort/pkg.yaml
+++ b/pkgs/denoland/deno/denort/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: denoland/deno/denort@v1.40.5

--- a/pkgs/denoland/deno/denort/registry.yaml
+++ b/pkgs/denoland/deno/denort/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - name: denoland/deno/denort
+    type: github_release
+    repo_owner: denoland
+    repo_name: deno
+    description: A slim version of deno without tooling, used as the default for deno compile
+    asset: denort-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: zip
+    windows_arm_emulation: true
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
+    files:
+      - name: denort
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -12323,6 +12323,26 @@ packages:
           - goos: windows
             replacements:
               arm64: arm64
+  - name: denoland/deno/denort
+    type: github_release
+    repo_owner: denoland
+    repo_name: deno
+    description: A slim version of deno without tooling, used as the default for deno compile
+    asset: denort-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: zip
+    windows_arm_emulation: true
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
+    files:
+      - name: denort
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
   - type: github_release
     repo_owner: derailed
     repo_name: k9s


### PR DESCRIPTION
[denoland/deno/denort](https://github.com/denoland/deno): A slim version of deno without tooling, used as the default for deno compile

### Test

```console
$ denort
error: No archive found.
```
