### PR TITLE
feat: add mgechev/revive

### DIFF
--- a/pkgs/mgechev/revive/pkg.yaml
+++ b/pkgs/mgechev/revive/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: mgechev/revive@v1.3.7
+  - name: mgechev/revive
+    version: v1.3.2
+  - name: mgechev/revive
+    version: v1.2.2

--- a/pkgs/mgechev/revive/registry.yaml
+++ b/pkgs/mgechev/revive/registry.yaml
@@ -1,0 +1,41 @@
+packages:
+  - type: github_release
+    repo_owner: mgechev
+    repo_name: revive
+    description: ~6x faster, stricter, configurable, extensible, and beautiful drop-in replacement for golint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: revive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.3.2")
+        asset: revive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: revive_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -25136,6 +25136,46 @@ packages:
       - goos: windows
         format: zip
   - type: github_release
+    repo_owner: mgechev
+    repo_name: revive
+    description: ~6x faster, stricter, configurable, extensible, and beautiful drop-in replacement for golint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: revive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.3.2")
+        asset: revive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: revive_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: mgunyho
     repo_name: tere
     asset: tere-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[mgechev/revive](https://github.com/mgechev/revive): ~6x faster, stricter, configurable, extensible, and beautiful drop-in replacement for golint

```console
$ aqua g -i mgechev/revive
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```
root@b4c7bae260fa:/workspace# revive --help

 _ __ _____   _(_)__  _____
| '__/ _ \ \ / / \ \ / / _ \
| | |  __/\ V /| |\ V /  __/
|_|  \___| \_/ |_| \_/ \___|

Example:
  revive -config c.toml -formatter friendly -exclude a.go -exclude b.go ./...

Usage of revive:
  -config string
        path to the configuration TOML file, defaults to $XDG_CONFIG_HOME/revive.toml or $HOME/revive.toml, if present (i.e. -config myconf.toml)
  -exclude value
        list of globs which specify files to be excluded (i.e. -exclude foo/...)
  -formatter string
        formatter to be used for the output (i.e. -formatter stylish)
  -max_open_files int
        maximum number of open files at the same time
  -set_exit_status
        set exit status to 1 if any issues are found, overwrites errorCode and warningCode in config
  -version
        get revive version
```

Reference

- https://github.com/mgechev/revive/blob/master/README.md