### PR TITLE
feat: add iamhsa/pkenv

### DIFF
--- a/pkgs/iamhsa/pkenv/pkg.yaml
+++ b/pkgs/iamhsa/pkenv/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: iamhsa/pkenv@0.5.3

--- a/pkgs/iamhsa/pkenv/registry.yaml
+++ b/pkgs/iamhsa/pkenv/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_archive
+    repo_owner: iamhsa
+    repo_name: pkenv
+    description: Packer version manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        files:
+          - name: pkenv
+            src: pkenv-{{trimV .Version}}/bin/pkenv
+          - name: packer
+            src: pkenv-{{trimV .Version}}/bin/packer

--- a/registry.yaml
+++ b/registry.yaml
@@ -18662,6 +18662,18 @@ packages:
         files:
           - name: terraformify
             src: terraformify_{{.OS}}_{{.Arch}}/terraformify
+  - type: github_archive
+    repo_owner: iamhsa
+    repo_name: pkenv
+    description: Packer version manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        files:
+          - name: pkenv
+            src: pkenv-{{trimV .Version}}/bin/pkenv
+          - name: packer
+            src: pkenv-{{trimV .Version}}/bin/packer
   - type: github_release
     repo_owner: iann0036
     repo_name: iamlive


### PR DESCRIPTION
[iamhsa/pkenv](https://github.com/iamhsa/pkenv): Packer version manager

```console
$ aqua g -i iamhsa/pkenv
```

## ⚠️ Note

If you install Packer with pkenv managed by aqua, the directory where Packer is installed is different by pkenv version.
For example, if you install Packer with pkenv 0.5.0 and upgrade pkenv to 0.5.3, you need to install Packer again.

Install Packer 1.10.1 with pkenv 0.5.0.

```console
$ aqua which -v pkenv
0.5.0

$ pkenv install 1.10.1
$ pkenv list          
* 1.10.1 (set by /Users/shunsukesuzuki/.local/share/aquaproj-aqua/pkgs/github_archive/github.com/iamhsa/pkenv/0.5.0/pkenv-0.5.0/version)
```

Upgrade pkenv to 0.5.3.

```console
$ aqua up pkenv@0.5.3
INFO[0000] updating a package                            aqua_version=2.23.1 env=darwin/arm64 new_version=0.5.3 old_version=0.5.0 package_name=iamhsa/pkenv program=aqua

$ aqua which -v pkenv 
0.5.3
```

Then Packer installed with pkenv 0.5.0 is unavailable.

```console
$ pkenv list
pkenv: pkenv-list: [ERROR] No versions available. Please install one with: pkenv install
```

pkenv seems not to be maintained actively.
The last release is about [three years ago](https://github.com/iamhsa/pkenv/releases/tag/0.5.3), so I think there is no problem at the moment.

## 💡 You can install Packer with aqua too

JFYI

```sh
aqua g -i hashicorp/packer
```