### PR TITLE
feat: add Canop/dysk

### DIFF
--- a/pkgs/Canop/dysk/pkg.yaml
+++ b/pkgs/Canop/dysk/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Canop/dysk@v2.8.2

--- a/pkgs/Canop/dysk/registry.yaml
+++ b/pkgs/Canop/dysk/registry.yaml
@@ -3,15 +3,17 @@ packages:
     repo_owner: Canop
     repo_name: dysk
     description: A linux utility to get information on filesystems, like df but better
-    link: https://dystroy.org/dysk/
-    asset: dysk_{{trimV .Version}}.{{.Format}}
-    format: zip
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      linux: unknown-linux-gnu
-    supported_envs:
-      - linux
-    files:
-      - name: dysk
-        src: build/{{.Arch}}-{{.OS}}/dysk
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dysk_{{trimV .Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: dysk
+            src: build/{{.Arch}}-{{.OS}}/dysk
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux

--- a/pkgs/Canop/dysk/registry.yaml
+++ b/pkgs/Canop/dysk/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: Canop
+    repo_name: dysk
+    description: A linux utility to get information on filesystems, like df but better
+    link: https://dystroy.org/dysk/
+    asset: dysk_{{trimV .Version}}.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      linux: unknown-linux-gnu
+    supported_envs:
+      - linux
+    files:
+      - name: dysk
+        src: build/{{.Arch}}-{{.OS}}/dysk

--- a/registry.yaml
+++ b/registry.yaml
@@ -893,6 +893,22 @@ packages:
     repo_name: mgo
     description: Build and bundle multiple GOAMD64 variants in a single executable
   - type: github_release
+    repo_owner: Canop
+    repo_name: dysk
+    description: A linux utility to get information on filesystems, like df but better
+    link: https://dystroy.org/dysk/
+    asset: dysk_{{trimV .Version}}.{{.Format}}
+    format: zip
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      linux: unknown-linux-gnu
+    supported_envs:
+      - linux
+    files:
+      - name: dysk
+        src: build/{{.Arch}}-{{.OS}}/dysk
+  - type: github_release
     repo_owner: Cian911
     repo_name: switchboard
     asset: switchboard_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -896,18 +896,20 @@ packages:
     repo_owner: Canop
     repo_name: dysk
     description: A linux utility to get information on filesystems, like df but better
-    link: https://dystroy.org/dysk/
-    asset: dysk_{{trimV .Version}}.{{.Format}}
-    format: zip
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      linux: unknown-linux-gnu
-    supported_envs:
-      - linux
-    files:
-      - name: dysk
-        src: build/{{.Arch}}-{{.OS}}/dysk
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dysk_{{trimV .Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: dysk
+            src: build/{{.Arch}}-{{.OS}}/dysk
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
   - type: github_release
     repo_owner: Cian911
     repo_name: switchboard


### PR DESCRIPTION
[Canop/dysk](https://github.com/Canop/dysk): A linux utility to get information on filesystems, like df but better

```console
$ aqua g -i Canop/dysk
```

## How to confirm if this package works well

Command and output

```console
$ dysk --help
```

Reference

- https://dystroy.org/dysk/install