### PR TITLE
feat: add jirutka/tty-copy

### DIFF
--- a/pkgs/jirutka/tty-copy/pkg.yaml
+++ b/pkgs/jirutka/tty-copy/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: jirutka/tty-copy@v0.2.2
+  - name: jirutka/tty-copy
+    version: v0.2.0

--- a/pkgs/jirutka/tty-copy/registry.yaml
+++ b/pkgs/jirutka/tty-copy/registry.yaml
@@ -1,0 +1,36 @@
+packages:
+  - type: github_release
+    repo_owner: jirutka
+    repo_name: tty-copy
+    description: Copy content to system clipboard via TTY and terminal using ANSI OSC52 sequence
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: tty-copy.{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: tty-copy.{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -20346,6 +20346,41 @@ packages:
       - darwin
       - amd64
     rosetta2: true
+  - type: github_release
+    repo_owner: jirutka
+    repo_name: tty-copy
+    description: Copy content to system clipboard via TTY and terminal using ANSI OSC52 sequence
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: tty-copy.{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: tty-copy.{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
   - type: go_install
     repo_owner: jmattheis
     repo_name: goverter


### PR DESCRIPTION
[jirutka/tty-copy](https://github.com/jirutka/tty-copy): Copy content to system clipboard via TTY and terminal using ANSI OSC52 sequence

```console
$ aqua g -i jirutka/tty-copy
```

## How to confirm if this package works well

Command and output

```console
$ tty-copy --help
```