### PR TITLE
feat: add chaaz/versio

### DIFF
--- a/pkgs/chaaz/versio/pkg.yaml
+++ b/pkgs/chaaz/versio/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: chaaz/versio@v0.8.3
+  - name: chaaz/versio
+    version: v0.7.6
+  - name: chaaz/versio
+    version: v0.5.3
+  - name: chaaz/versio
+    version: v0.5.2
+  - name: chaaz/versio
+    version: v0.5.1
+  - name: chaaz/versio
+    version: v0.4.5

--- a/pkgs/chaaz/versio/registry.yaml
+++ b/pkgs/chaaz/versio/registry.yaml
@@ -1,0 +1,82 @@
+packages:
+  - type: github_release
+    repo_owner: chaaz
+    repo_name: versio
+    description: A version number manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.5")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.1")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.5.2"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            asset: versio.exe
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.5.3"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.7.6")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -9519,6 +9519,87 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: chaaz
+    repo_name: versio
+    description: A version number manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.5")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.1")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.5.2"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            asset: versio.exe
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.5.3"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-gnu
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.7.6")
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: versio__{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: chainguard-dev
     repo_name: apko
     description: Build OCI images from APK packages directly without Dockerfile


### PR DESCRIPTION
[chaaz/versio](https://github.com/chaaz/versio): A version number manager (especially intelligent when dealing with [monorepos](https://en.wikipedia.org/wiki/Monorepo)).

```console
$ aqua g -i chaaz/versio
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ versio --version
versio 0.8.3

$ versio --help
Versio is a tool to manage and publish project versions.

Usage: versio__x86_64-unknown-linux-gnu [OPTIONS] <COMMAND>

Commands:
  check     Check current config
  show      Show all versions
  get       Get one or more versions
  set       Set a version
  diff      View changes from previous
  files     Stream changed files
  plan      Find versions that need to change
  release   Change and commit version numbers
  changes   Print true changes
  init      Search for projects and write a config
  info      Print info about projects
  template  Output a changelog template
  schema    Output a JSON schema for the config file
  help      Print this message or the help of the given subcommand(s)

Options:
  -l, --vcs-level <VCS_LEVEL>          The VCS level [possible values: auto, max, none, local, remote, smart]
  -m, --vcs-level-min <VCS_LEVEL_MIN>  The minimum VCS level [possible values: none, local, remote, smart]
  -x, --vcs-level-max <VCS_LEVEL_MAX>  The maximum VCS level [possible values: none, local, remote, smart]
  -c, --no-current                     Ignore local repo changes
  -h, --help                           Print help
  -V, --version                        Print version
```

Reference

- [Use cases](https://github.com/chaaz/versio/blob/main/docs/use_cases.md)
