### PR TITLE
feat: add fukubaka0825/tffmtmd

### DIFF
--- a/pkgs/fukubaka0825/tffmtmd/pkg.yaml
+++ b/pkgs/fukubaka0825/tffmtmd/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fukubaka0825/tffmtmd@v0.0.9

--- a/pkgs/fukubaka0825/tffmtmd/registry.yaml
+++ b/pkgs/fukubaka0825/tffmtmd/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: github_release
+    repo_owner: fukubaka0825
+    repo_name: tffmtmd
+    description: tffmtmd formats HCL source code block in Markdown. detects fenced code & formats code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tffmtmd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: tffmtmd_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -15639,6 +15639,25 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: fukubaka0825
+    repo_name: tffmtmd
+    description: tffmtmd formats HCL source code block in Markdown. detects fenced code & formats code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tffmtmd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: tffmtmd_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: fullstorydev
     repo_name: grpcui
     asset: grpcui_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[fukubaka0825/tffmtmd](https://github.com/fukubaka0825/tffmtmd): tffmtmd formats HCL source code block in Markdown. detects fenced code & formats code

```console
$ aqua g -i fukubaka0825/tffmtmd
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@527310bf78a9:/workspace# tffmtmd --help
Usage: tffmtmd [options...] filePath

tffmtmd is a command line tool to format HCL code in Markdown.

OPTIONS:
  --replace value, -r value  replace HCL code with formated code
  --write value, -w value    write result to file instead of stdout
  --help, -h              prints out help
```


Reference

- Blog (JP)
	- https://qiita.com/fukubaka0825/items/641be849eff3409636c3
- README
	- https://github.com/fukubaka0825/tffmtmd/blob/master/README.md
