### PR TITLE
feat: add apache/maven-mvnd

### DIFF
--- a/pkgs/apache/maven-mvnd/pkg.yaml
+++ b/pkgs/apache/maven-mvnd/pkg.yaml
@@ -6,13 +6,13 @@ packages:
     version: 1.0-m6
   - name: apache/maven-mvnd
     version: 1.0.0-m4
-  - name: apache/maven-mvnd
-    version: 0.8.1
-  - name: apache/maven-mvnd
-    version: 0.7.1
-  - name: apache/maven-mvnd
-    version: 0.0.8
   # https://github.com/aquaproj/aqua-registry/pull/20468#issuecomment-1973173615
+  # - name: apache/maven-mvnd
+  #   version: 0.8.1
+  # - name: apache/maven-mvnd
+  #   version: 0.7.1
+  # - name: apache/maven-mvnd
+  #   version: 0.0.8
   # - name: apache/maven-mvnd
   #   version: 0.0.2
   - name: apache/maven-mvnd

--- a/pkgs/apache/maven-mvnd/pkg.yaml
+++ b/pkgs/apache/maven-mvnd/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: apache/maven-mvnd@1.0-m8

--- a/pkgs/apache/maven-mvnd/pkg.yaml
+++ b/pkgs/apache/maven-mvnd/pkg.yaml
@@ -12,7 +12,8 @@ packages:
     version: 0.7.1
   - name: apache/maven-mvnd
     version: 0.0.8
-  - name: apache/maven-mvnd
-    version: 0.0.2
+  # https://github.com/aquaproj/aqua-registry/pull/20468#issuecomment-1973173615
+  # - name: apache/maven-mvnd
+  #   version: 0.0.2
   - name: apache/maven-mvnd
     version: 0.0.1

--- a/pkgs/apache/maven-mvnd/pkg.yaml
+++ b/pkgs/apache/maven-mvnd/pkg.yaml
@@ -1,2 +1,18 @@
 packages:
   - name: apache/maven-mvnd@1.0-m8
+  - name: apache/maven-mvnd
+    version: 1.0-m7
+  - name: apache/maven-mvnd
+    version: 1.0-m6
+  - name: apache/maven-mvnd
+    version: 1.0.0-m4
+  - name: apache/maven-mvnd
+    version: 0.8.1
+  - name: apache/maven-mvnd
+    version: 0.7.1
+  - name: apache/maven-mvnd
+    version: 0.0.8
+  - name: apache/maven-mvnd
+    version: 0.0.2
+  - name: apache/maven-mvnd
+    version: 0.0.1

--- a/pkgs/apache/maven-mvnd/registry.yaml
+++ b/pkgs/apache/maven-mvnd/registry.yaml
@@ -3,15 +3,95 @@ packages:
     repo_owner: apache
     repo_name: maven-mvnd
     description: Apache Maven Daemon
-    asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
     files:
       - name: mvnd
-        src: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}/bin/mvnd
-    version_constraint: semver(">= 1.0.0-m6")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "1.0-m6"
+      - version_constraint: semver("<= 0.0.1")
+        asset: mvnd-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
         windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.0.2"
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.8")
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.7.1")
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.1")
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.0-m4")
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m6"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:
@@ -19,8 +99,13 @@ packages:
           - windows
           - amd64
       - version_constraint: Version == "1.0-m7"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         windows_arm_emulation: true
         complete_windows_ext: false
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -32,7 +117,12 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:

--- a/pkgs/apache/maven-mvnd/registry.yaml
+++ b/pkgs/apache/maven-mvnd/registry.yaml
@@ -1,0 +1,41 @@
+packages:
+  - type: github_release
+    repo_owner: apache
+    repo_name: maven-mvnd
+    description: Apache Maven Daemon
+    asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: mvnd
+        src: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}/bin/mvnd
+    version_constraint: semver(">= 1.0.0-m6")
+    version_overrides:
+      - version_constraint: Version == "1.0-m6"
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m7"
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5422,6 +5422,46 @@ packages:
           - amd64
         rosetta2: true
   - type: github_release
+    repo_owner: apache
+    repo_name: maven-mvnd
+    description: Apache Maven Daemon
+    asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: mvnd
+        src: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}/bin/mvnd
+    version_constraint: semver(">= 1.0.0-m6")
+    version_overrides:
+      - version_constraint: Version == "1.0-m6"
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m7"
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: aporia-ai
     repo_name: kubesurvival
     asset: KubeSurvival_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -5425,15 +5425,95 @@ packages:
     repo_owner: apache
     repo_name: maven-mvnd
     description: Apache Maven Daemon
-    asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
     files:
       - name: mvnd
-        src: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}/bin/mvnd
-    version_constraint: semver(">= 1.0.0-m6")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "1.0-m6"
+      - version_constraint: semver("<= 0.0.1")
+        asset: mvnd-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
         windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.0.2"
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.8")
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.7.1")
+        asset: mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.1")
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.0-m4")
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m6"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:
@@ -5441,8 +5521,13 @@ packages:
           - windows
           - amd64
       - version_constraint: Version == "1.0-m7"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         windows_arm_emulation: true
         complete_windows_ext: false
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -5454,7 +5539,12 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:


### PR DESCRIPTION
[apache/maven-mvnd](https://github.com/apache/maven-mvnd): Apache Maven Daemon

```console
aqua g -i apache/maven-mvnd
```

To test (requires Java and Maven to be installed):
```console
$ mvnd --version
Apache Maven Daemon (mvnd) 1.0-m8 linux-amd64 native client (0f4bdb6df5e74453d8d558d292789da4e66a7933)
Terminal: org.jline.terminal.impl.PosixSysTerminal with pty org.jline.terminal.impl.jansi.linux.LinuxNativePty
Apache Maven 3.9.5 (57804ffe001d7215b5e7bcb531cf83df38f93546)
Maven home: /home/tasato/.local/share/aquaproj-aqua/pkgs/github_release/github.com/apache/maven-mvnd/1.0-m8/maven-mvnd-1.0-m8-m39-linux-amd64.tar.gz/maven-mvnd-1.0-m8-m39-linux-amd64/mvn
Java version: 17.0.9, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.9.0.9-3.fc39.x86_64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.7.5-200.fc39.x86_64", arch: "amd64", family: "unix"
```