### PR TITLE
fix(scripts): `cmdx s <package>` not working with podman

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -15,7 +15,13 @@ if [ -n "$token" ]; then
 	envs="-e GITHUB_TOKEN=$token"
 fi
 
+# https://github.com/aquaproj/aqua-registry/issues/20289
+opts=""
+if [ "$(uname)" = Linux ] && docker version | grep -q Podman; then
+	opts="--privileged"
+fi
+
 # shellcheck disable=SC2086
-docker run -d --name "$container_name" \
+docker run $opts -d --name "$container_name" \
 	-v "$PWD:/aqua-registry" $envs aquaproj/aqua-registry \
 	tail -f /dev/null


### PR DESCRIPTION
The `aqua-registry` image doesn't work well with podman on Fedora unless it's run with `--privileged` option.

Fix #20289