### PR TITLE
feat: add vmware/govmomi/govc

### DIFF
--- a/pkgs/vmware/govmomi/govc/pkg.yaml
+++ b/pkgs/vmware/govmomi/govc/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: vmware/govmomi/govc@v0.35.0
+  - name: vmware/govmomi/govc
+    version: v0.27.4
+  - name: vmware/govmomi/govc
+    version: v0.25.0
+  - name: vmware/govmomi/govc
+    version: v0.24.0
+  - name: vmware/govmomi/govc
+    version: v0.18.0
+  - name: vmware/govmomi/govc
+    version: v0.17.1
+  - name: vmware/govmomi/govc
+    version: v0.9.0

--- a/pkgs/vmware/govmomi/govc/registry.yaml
+++ b/pkgs/vmware/govmomi/govc/registry.yaml
@@ -1,0 +1,135 @@
+packages:
+  - name: vmware/govmomi/govc
+    type: github_release
+    repo_owner: vmware
+    repo_name: govmomi
+    description: a vSphere CLI built on top of govmomi
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.17.1")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.18.0"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: govc_{{trimV .Version}}_checksums.txt
+          algorithm: sha1
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+            files:
+            - name: govc
+              src: govc.exe
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.0")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.25.0"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+        - name: govc
+          src: govc
+      - version_constraint: semver("<= 0.27.4")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+        - name: govc
+          src: govc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+        - name: govc
+          src: govc
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/vmware/govmomi/govc/registry.yaml
+++ b/pkgs/vmware/govmomi/govc/registry.yaml
@@ -15,8 +15,8 @@ packages:
           - goos: windows
             asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         supported_envs:
           - darwin
           - windows
@@ -27,8 +27,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             format: zip
@@ -51,11 +51,11 @@ packages:
             format: zip
             asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
             files:
-            - name: govc
-              src: govc.exe
+              - name: govc
+                src: govc.exe
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         supported_envs:
           - darwin
           - windows
@@ -66,8 +66,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             format: zip
@@ -92,9 +92,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        files:
-        - name: govc
-          src: govc
       - version_constraint: semver("<= 0.27.4")
         asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -109,9 +106,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        files:
-        - name: govc
-          src: govc
         overrides:
           - goos: windows
             format: zip
@@ -127,9 +121,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        files:
-        - name: govc
-          src: govc
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -37427,6 +37427,140 @@ packages:
       type: github_release
       asset: CHECKSUM
       algorithm: sha256
+  - name: vmware/govmomi/govc
+    type: github_release
+    repo_owner: vmware
+    repo_name: govmomi
+    description: a vSphere CLI built on top of govmomi
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.17.1")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.18.0"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: govc_{{trimV .Version}}_checksums.txt
+          algorithm: sha1
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+            files:
+            - name: govc
+              src: govc.exe
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.0")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+        - name: govc
+          src: govc_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            format: zip
+            asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.25.0"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+        - name: govc
+          src: govc
+      - version_constraint: semver("<= 0.27.4")
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+        - name: govc
+          src: govc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        files:
+        - name: govc
+          src: govc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: volta-cli
     repo_name: volta

--- a/registry.yaml
+++ b/registry.yaml
@@ -37443,8 +37443,8 @@ packages:
           - goos: windows
             asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         supported_envs:
           - darwin
           - windows
@@ -37455,8 +37455,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             format: zip
@@ -37479,11 +37479,11 @@ packages:
             format: zip
             asset: govc_{{.OS}}_{{.Arch}}.exe.{{.Format}}
             files:
-            - name: govc
-              src: govc.exe
+              - name: govc
+                src: govc.exe
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         supported_envs:
           - darwin
           - windows
@@ -37494,8 +37494,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-        - name: govc
-          src: govc_{{.OS}}_{{.Arch}}
+          - name: govc
+            src: govc_{{.OS}}_{{.Arch}}
         overrides:
           - goos: windows
             format: zip
@@ -37520,9 +37520,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        files:
-        - name: govc
-          src: govc
       - version_constraint: semver("<= 0.27.4")
         asset: govc_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -37537,9 +37534,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        files:
-        - name: govc
-          src: govc
         overrides:
           - goos: windows
             format: zip
@@ -37555,9 +37549,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        files:
-        - name: govc
-          src: govc
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
[vmware/govmomi/govc](https://github.com/vmware/govmomi/tree/main/govc): a vSphere CLI built on top of govmomi

```console
$ aqua g -i vmware/govmomi/govc
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ govc version
govc 0.35.0
```

Reference

- [USAGE](https://github.com/vmware/govmomi/blob/main/govc/USAGE.md)
