### PR TITLE
feat: add AGWA/git-crypt

### DIFF
--- a/pkgs/AGWA/git-crypt/pkg.yaml
+++ b/pkgs/AGWA/git-crypt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: AGWA/git-crypt@0.7.0

--- a/pkgs/AGWA/git-crypt/registry.yaml
+++ b/pkgs/AGWA/git-crypt/registry.yaml
@@ -16,4 +16,4 @@ packages:
             asset: git-crypt-{{.Version}}-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows

--- a/pkgs/AGWA/git-crypt/registry.yaml
+++ b/pkgs/AGWA/git-crypt/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: AGWA
+    repo_name: git-crypt
+    description: Transparent file encryption in git
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-crypt-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            asset: git-crypt-{{.Version}}-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -163,7 +163,7 @@ packages:
             asset: git-crypt-{{.Version}}-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
   - type: github_release
     repo_owner: Aloxaf
     repo_name: silicon

--- a/registry.yaml
+++ b/registry.yaml
@@ -147,6 +147,24 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: AGWA
+    repo_name: git-crypt
+    description: Transparent file encryption in git
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-crypt-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            asset: git-crypt-{{.Version}}-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+  - type: github_release
     repo_owner: Aloxaf
     repo_name: silicon
     description: Create beautiful image of your source code


### PR DESCRIPTION
[AGWA/git-crypt](https://github.com/AGWA/git-crypt): Transparent file encryption in git

```console
$ aqua g -i AGWA/git-crypt
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ git-crypt --help
Usage: git-crypt COMMAND [ARGS ...]

Common commands:
  init                 generate a key and prepare repo to use git-crypt
  status               display which files are encrypted
  lock                 de-configure git-crypt and re-encrypt files in work tree

GPG commands:
  add-gpg-user USERID  add the user with the given GPG user ID as a collaborator
  unlock               decrypt this repo using the in-repo GPG-encrypted key

Symmetric key commands:
  export-key FILE      export this repo's symmetric key to the given file
  unlock KEYFILE       decrypt this repo using the given symmetric key

Legacy commands:
  init KEYFILE         alias for 'unlock KEYFILE'
  keygen KEYFILE       generate a git-crypt key in the given file
  migrate-key OLD NEW  migrate the legacy key file OLD to the new format in NEW

See 'git-crypt help COMMAND' for more information on a specific command.
```

If files such as configuration file are needed, please share them.

```
```

Reference

- https://www.agwa.name/projects/git-crypt/
