### PR TITLE
fix(GoogleContainerTools/container-structure-test): follow up changes of container-structure-test v1.17.0

### DIFF
--- a/pkgs/GoogleContainerTools/container-structure-test/pkg.yaml
+++ b/pkgs/GoogleContainerTools/container-structure-test/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: GoogleContainerTools/container-structure-test@v1.16.0
+  - name: GoogleContainerTools/container-structure-test@v1.17.0
+  - name: GoogleContainerTools/container-structure-test
+    version: v1.16.0

--- a/pkgs/GoogleContainerTools/container-structure-test/registry.yaml
+++ b/pkgs/GoogleContainerTools/container-structure-test/registry.yaml
@@ -1,14 +1,30 @@
 packages:
-  - type: http
+  - type: github_release
     repo_owner: GoogleContainerTools
     repo_name: container-structure-test
-    rosetta2: true
-    url: https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}
     description: validate the structure of your container images
-    files:
-      - name: container-structure-test
-        src: container-structure-test-{{.OS}}-{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.16.0")
+        type: http
+        rosetta2: true
+        url: https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}
+        files:
+          - name: container-structure-test
+            src: container-structure-test-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+      # v1.17.0 https://github.com/GoogleContainerTools/container-structure-test/releases/tag/v1.17.0
+      # > Important
+      # > Releases are no longer published to GCS, use the github release asset to access the binary.
+      - version_constraint: "true"
+        type: github_release
+        asset: container-structure-test-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -1496,19 +1496,35 @@ packages:
     files:
       - name: container-diff
         src: container-diff-{{.OS}}-amd64
-  - type: http
+  - type: github_release
     repo_owner: GoogleContainerTools
     repo_name: container-structure-test
-    rosetta2: true
-    url: https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}
     description: validate the structure of your container images
-    files:
-      - name: container-structure-test
-        src: container-structure-test-{{.OS}}-{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.16.0")
+        type: http
+        rosetta2: true
+        url: https://storage.googleapis.com/container-structure-test/{{.Version}}/container-structure-test-{{.OS}}-{{.Arch}}
+        files:
+          - name: container-structure-test
+            src: container-structure-test-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+      # v1.17.0 https://github.com/GoogleContainerTools/container-structure-test/releases/tag/v1.17.0
+      # > Important
+      # > Releases are no longer published to GCS, use the github release asset to access the binary.
+      - version_constraint: "true"
+        type: github_release
+        asset: container-structure-test-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - type: http
     repo_owner: GoogleContainerTools
     repo_name: skaffold


### PR DESCRIPTION
https://github.com/GoogleContainerTools/container-structure-test/releases/tag/v1.17.0

> Important
> Releases are no longer published to GCS, use the github release asset to access the binary.

Close #20634