### PR TITLE
feat: add awslabs/soci-snapshotter

### DIFF
--- a/pkgs/awslabs/soci-snapshotter/pkg.yaml
+++ b/pkgs/awslabs/soci-snapshotter/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: awslabs/soci-snapshotter@v0.5.0
+  - name: awslabs/soci-snapshotter
+    version: v0.4.0
+  - name: awslabs/soci-snapshotter
+    version: v0.3.0
+  - name: awslabs/soci-snapshotter
+    version: v0.1.0

--- a/pkgs/awslabs/soci-snapshotter/registry.yaml
+++ b/pkgs/awslabs/soci-snapshotter/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - type: github_release
+    repo_owner: awslabs
+    repo_name: soci-snapshotter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        files:
+          - name: soci
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}-static.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        files:
+          - name: soci
+        supported_envs:
+          - linux

--- a/pkgs/awslabs/soci-snapshotter/registry.yaml
+++ b/pkgs/awslabs/soci-snapshotter/registry.yaml
@@ -3,6 +3,9 @@ packages:
     repo_owner: awslabs
     repo_name: soci-snapshotter
     version_constraint: "false"
+    files:
+      - name: soci
+      - name: soci-snapshotter-grpc
     version_overrides:
       - version_constraint: semver("<= 0.1.0")
         asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -13,6 +16,7 @@ packages:
           algorithm: sha256
         files:
           - name: soci
+          - name: soci-snapshotter-grpc
         supported_envs:
           - linux
       - version_constraint: "true"
@@ -24,5 +28,6 @@ packages:
           algorithm: sha256
         files:
           - name: soci
+          - name: soci-snapshotter-grpc
         supported_envs:
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -7567,6 +7567,9 @@ packages:
     repo_owner: awslabs
     repo_name: soci-snapshotter
     version_constraint: "false"
+    files:
+      - name: soci
+      - name: soci-snapshotter-grpc
     version_overrides:
       - version_constraint: semver("<= 0.1.0")
         asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -7577,6 +7580,7 @@ packages:
           algorithm: sha256
         files:
           - name: soci
+          - name: soci-snapshotter-grpc
         supported_envs:
           - linux
       - version_constraint: "true"
@@ -7588,6 +7592,7 @@ packages:
           algorithm: sha256
         files:
           - name: soci
+          - name: soci-snapshotter-grpc
         supported_envs:
           - linux
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -7565,6 +7565,33 @@ packages:
         src: bin/mount-s3
   - type: github_release
     repo_owner: awslabs
+    repo_name: soci-snapshotter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        files:
+          - name: soci
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: soci-snapshotter-{{trimV .Version}}-{{.OS}}-{{.Arch}}-static.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        files:
+          - name: soci
+        supported_envs:
+          - linux
+  - type: github_release
+    repo_owner: awslabs
     repo_name: ssosync
     asset: ssosync_{{.OS}}_{{.Arch}}.{{.Format}}
     description: Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda


### PR DESCRIPTION
[awslabs/soci-snapshotter](https://github.com/awslabs/soci-snapshotter): 

```console
$ aqua g -i awslabs/soci-snapshotter
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@088f7dcc5a1d:/workspace# soci
NAME:
   soci - A new cli application

USAGE:
   soci [global options] command [command options] [arguments...]

VERSION:
   v0.5.0.m 77f218d0b11c88d17a832ad7456dbd2165d19c86.m

COMMANDS:
   index       manage indices
   ztoc        manage ztocs
   create      create SOCI index
   push        push SOCI artifacts to a registry
   rebuild-db  rebuild the artifacts database. You should use this command after "rpull" so that indices/ztocs can be discovered by commands like "soci index list", and after "index rm" when using the containerd content store so that deleted orphaned zTOCs will be forgotten
   help, h     Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --address value, -a value    address for containerd's GRPC server (default: "/run/containerd/containerd.sock") [$CONTAINERD_ADDRESS]
   --namespace value, -n value  namespace to use with commands (default: "default") [$CONTAINERD_NAMESPACE]
   --timeout value              timeout for commands (default: 0s)
   --debug                      enable debug output
   --content-store value        use a specific content store (soci or containerd) (default: "soci")
   --help, -h                   show help
   --version, -v                print the version
```

Reference

- Install
	- https://github.com/awslabs/soci-snapshotter/blob/main/docs/build.md#dependencies
- README
	- https://github.com/awslabs/soci-snapshotter/blob/main/README.md
