### PR TITLE
fix(derailed/popeye): follow up changes of popeye v0.21.0

### DIFF
--- a/pkgs/derailed/popeye/pkg.yaml
+++ b/pkgs/derailed/popeye/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: derailed/popeye@v0.20.5
+  - name: derailed/popeye@v0.21.0
+  - name: derailed/popeye
+    version: v0.20.5
   - name: derailed/popeye
     version: v0.11.1
   - name: derailed/popeye

--- a/pkgs/derailed/popeye/registry.yaml
+++ b/pkgs/derailed/popeye/registry.yaml
@@ -58,13 +58,20 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.20.5")
         asset: popeye_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: popeye_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -13314,13 +13314,20 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.20.5")
         asset: popeye_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: popeye_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
Close #20751

Asset names were changed.

https://github.com/derailed/popeye/commit/8832a9e6cf6fb232df9e994806349c2dfa4cc6df