### PR TITLE
feat: add livesense-inc/go-simple-http-redirector

### DIFF
--- a/pkgs/livesense-inc/go-simple-http-redirector/pkg.yaml
+++ b/pkgs/livesense-inc/go-simple-http-redirector/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: livesense-inc/go-simple-http-redirector@v0.1.0

--- a/pkgs/livesense-inc/go-simple-http-redirector/registry.yaml
+++ b/pkgs/livesense-inc/go-simple-http-redirector/registry.yaml
@@ -3,6 +3,8 @@ packages:
     repo_owner: livesense-inc
     repo_name: go-simple-http-redirector
     description: Redirect HTTP requests to specific URI
+    files:
+      - name: redirector
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/livesense-inc/go-simple-http-redirector/registry.yaml
+++ b/pkgs/livesense-inc/go-simple-http-redirector/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - type: github_release
+    repo_owner: livesense-inc
+    repo_name: go-simple-http-redirector
+    description: Redirect HTTP requests to specific URI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: redirector-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: redirector_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+        files:
+          - name: redirector

--- a/registry.yaml
+++ b/registry.yaml
@@ -25305,6 +25305,24 @@ packages:
       asset: s3get_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: livesense-inc
+    repo_name: go-simple-http-redirector
+    description: Redirect HTTP requests to specific URI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: redirector-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: redirector_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+        files:
+          - name: redirector
+  - type: github_release
     repo_owner: liweiyi88
     repo_name: gosnakego
     description: A snake game written in Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -25308,6 +25308,8 @@ packages:
     repo_owner: livesense-inc
     repo_name: go-simple-http-redirector
     description: Redirect HTTP requests to specific URI
+    files:
+      - name: redirector
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
[livesense-inc/go-simple-http-redirector](https://github.com/livesense-inc/go-simple-http-redirector): Redirect HTTP requests to specific URI

```console
$ aqua g -i livesense-inc/go-simple-http-redirector
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@11bad657ee7b:/workspace# redirector --help
{"time":"2024-03-14T08:50:52.474083762Z","level":"INFO","msg":"maxprocs: Leaving GOMAXPROCS=24: CPU quota undefined"}
Usage of redirector:
  -csv string
        Redirect list CSV file path
  -loglevel string
        Log level (debug, info, warn, error) (default "info")
  -port int
        Listening TCP port number (default 8080)
  -version
        Show version
```

Reference

- https://github.com/livesense-inc/go-simple-http-redirector/blob/main/README.md
