### PR TITLE
feat: add gruntwork-io/git-xargs

### DIFF
--- a/pkgs/gruntwork-io/git-xargs/pkg.yaml
+++ b/pkgs/gruntwork-io/git-xargs/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: gruntwork-io/git-xargs@v0.1.11
+  - name: gruntwork-io/git-xargs
+    version: v0.1.6
+  - name: gruntwork-io/git-xargs
+    version: v0.0.1

--- a/pkgs/gruntwork-io/git-xargs/registry.yaml
+++ b/pkgs/gruntwork-io/git-xargs/registry.yaml
@@ -1,0 +1,35 @@
+packages:
+  - type: github_release
+    repo_owner: gruntwork-io
+    repo_name: git-xargs
+    description: git-xargs is a command-line tool (CLI) for making updates across multiple Github repositories with a single command
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.2"
+        no_asset: true
+      - version_constraint: semver("<= 0.1.6")
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.1.8")
+        no_asset: true
+      - version_constraint: "true"
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18629,6 +18629,40 @@ packages:
         windows_arm_emulation: true
   - type: github_release
     repo_owner: gruntwork-io
+    repo_name: git-xargs
+    description: git-xargs is a command-line tool (CLI) for making updates across multiple Github repositories with a single command
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.2"
+        no_asset: true
+      - version_constraint: semver("<= 0.1.6")
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.1.8")
+        no_asset: true
+      - version_constraint: "true"
+        asset: git-xargs_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
+    repo_owner: gruntwork-io
     repo_name: kubergrunt
     description: Kubergrunt is a standalone go binary with a collection of commands to fill in the gaps between Terraform, Helm, and Kubectl
     supported_envs:


### PR DESCRIPTION
[gruntwork-io/git-xargs](https://github.com/gruntwork-io/git-xargs): git-xargs is a command-line tool (CLI) for making updates across multiple Github repositories with a single command

```console
$ aqua g -i gruntwork-io/git-xargs
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@dc75c07e826f:/workspace# git-xargs --help
Usage: git-xargs_linux_arm64 [--loglevel] [--github-org] [--draft] [--dry-run] [--skip-pull-requests]
[--skip-archived-repos] [--repo] [--repos] [--branch-name] [--base-branch-name] [--commit-message]
[--pull-request-title] [--pull-request-description] [--reviewers] [--team-reviewers] [--seconds-between-prs]
[--max-pr-retries] [--seconds-to-wait-when-rate-limited] [--no-skip-ci] [--keep-cloned-repositories] [--help]
[--version] command [options] [args]

git-xargs is a command-line tool (CLI) for making updates across multiple Github repositories with a single command.

Commands:

   help, h  Shows a list of commands or help for one command
```

Reference

- https://github.com/gruntwork-io/git-xargs/blob/master/README.md
