### PR TITLE
feat: add zaghaghi/openapi-tui

### DIFF
--- a/pkgs/zaghaghi/openapi-tui/pkg.yaml
+++ b/pkgs/zaghaghi/openapi-tui/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: zaghaghi/openapi-tui@0.6.1
+  - name: zaghaghi/openapi-tui
+    version: 0.6.0
+  - name: zaghaghi/openapi-tui
+    version: 0.5.0

--- a/pkgs/zaghaghi/openapi-tui/registry.yaml
+++ b/pkgs/zaghaghi/openapi-tui/registry.yaml
@@ -29,7 +29,7 @@ packages:
           algorithm: sha256
         supported_envs:
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: "true"
         asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/zaghaghi/openapi-tui/registry.yaml
+++ b/pkgs/zaghaghi/openapi-tui/registry.yaml
@@ -1,0 +1,43 @@
+packages:
+  - type: github_release
+    repo_owner: zaghaghi
+    repo_name: openapi-tui
+    description: Terminal UI to list, browse and run APIs defined with openapi spec
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0")
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256
+      - version_constraint: Version == "0.6.0"
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -39579,7 +39579,7 @@ packages:
           algorithm: sha256
         supported_envs:
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: "true"
         asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -39542,6 +39542,48 @@ packages:
       type: github_release
       asset: multiple.intoto.jsonl
   - type: github_release
+    repo_owner: zaghaghi
+    repo_name: openapi-tui
+    description: Terminal UI to list, browse and run APIs defined with openapi spec
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0")
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256
+      - version_constraint: Version == "0.6.0"
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: openapi-tui-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
+          algorithm: sha256
+  - type: github_release
     repo_owner: zaquestion
     repo_name: lab
     rosetta2: true


### PR DESCRIPTION
[zaghaghi/openapi-tui](https://github.com/zaghaghi/openapi-tui): Terminal UI to list, browse and run APIs defined with openapi spec

```console
$ aqua g -i zaghaghi/openapi-tui
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ openapi-tui -h
This TUI allows you to list and browse APIs described by the openapi specification.

Usage: openapi-tui --input <PATH>

Options:
  -i, --input <PATH>  Input file or url, in json or yaml format with openapi specification
  -h, --help          Print help
  -V, --version       Print version
```
