### PR TITLE
feat: add anordal/shellharden

### DIFF
--- a/pkgs/anordal/shellharden/pkg.yaml
+++ b/pkgs/anordal/shellharden/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: anordal/shellharden@v4.3.1
+  - name: anordal/shellharden
+    version: 4.3.0

--- a/pkgs/anordal/shellharden/registry.yaml
+++ b/pkgs/anordal/shellharden/registry.yaml
@@ -1,0 +1,33 @@
+packages:
+  - type: github_release
+    repo_owner: anordal
+    repo_name: shellharden
+    aliases:
+      # The registry had registered this name when this tool was first registered.
+      # https://github.com/aquaproj/aqua-registry/pull/13784
+      - name: crates.io/shellharden
+    description: The corrective bash syntax highlighter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 4.3.0")
+        type: cargo
+        crate: shellharden
+      - version_constraint: "true"
+        asset: shellharden-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: shellharden-{{.Arch}}-{{.OS}}.sha512
+          algorithm: sha512
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64

--- a/pkgs/crates.io/shellharden/pkg.yaml
+++ b/pkgs/crates.io/shellharden/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: crates.io/shellharden@4.3.1

--- a/pkgs/crates.io/shellharden/registry.yaml
+++ b/pkgs/crates.io/shellharden/registry.yaml
@@ -1,7 +1,0 @@
-packages:
-  - name: crates.io/shellharden
-    type: cargo
-    repo_owner: anordal
-    repo_name: shellharden
-    description: The corrective bash syntax highlighter
-    crate: shellharden

--- a/registry.yaml
+++ b/registry.yaml
@@ -5351,6 +5351,38 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: anordal
+    repo_name: shellharden
+    aliases:
+      # The registry had registered this name when this tool was first registered.
+      # https://github.com/aquaproj/aqua-registry/pull/13784
+      - name: crates.io/shellharden
+    description: The corrective bash syntax highlighter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 4.3.0")
+        type: cargo
+        crate: shellharden
+      - version_constraint: "true"
+        asset: shellharden-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: shellharden-{{.Arch}}-{{.OS}}.sha512
+          algorithm: sha512
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm64
+  - type: github_release
     repo_owner: antham
     repo_name: gommit
     description: Enforce git message commit consistency
@@ -12281,12 +12313,6 @@ packages:
     repo_name: gitu
     description: A TUI Git client inspired by Magit
     crate: gitu
-  - name: crates.io/shellharden
-    type: cargo
-    repo_owner: anordal
-    repo_name: shellharden
-    description: The corrective bash syntax highlighter
-    crate: shellharden
   - name: crates.io/skim
     type: cargo
     repo_owner: lotabout


### PR DESCRIPTION
[crates.io/shellharden](https://crates.io/crates/shellharden): The corrective bash syntax highlighter

```console
$ aqua g -i anordal/shellharden
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please
describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ echo '${a}' | shellharden --replace ''
"$a"
```

If files such as configuration file are needed, please share them.

None

Reference

- add shellharden of crate type #13784
- https://github.com/anordal/shellharden/releasesd