### PR TITLE
feat: add charmbracelet/freeze

### DIFF
--- a/pkgs/charmbracelet/freeze/pkg.yaml
+++ b/pkgs/charmbracelet/freeze/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: charmbracelet/freeze@v0.1.4

--- a/pkgs/charmbracelet/freeze/registry.yaml
+++ b/pkgs/charmbracelet/freeze/registry.yaml
@@ -1,0 +1,37 @@
+packages:
+  - type: github_release
+    repo_owner: charmbracelet
+    repo_name: freeze
+    description: Generate images of code and terminal output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: freeze_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: freeze
+            src: "{{.AssetWithoutExt}}/freeze"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/charmbracelet/meta/\\.github/workflows/goreleaser\\.yml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/charmbracelet/freeze/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/charmbracelet/freeze/releases/download/{{.Version}}/checksums.txt.pem
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -10356,6 +10356,42 @@ packages:
       - version_constraint: "true"
   - type: github_release
     repo_owner: charmbracelet
+    repo_name: freeze
+    description: Generate images of code and terminal output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: freeze_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        files:
+          - name: freeze
+            src: "{{.AssetWithoutExt}}/freeze"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/charmbracelet/meta/\\.github/workflows/goreleaser\\.yml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/charmbracelet/freeze/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/charmbracelet/freeze/releases/download/{{.Version}}/checksums.txt.pem
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: charmbracelet
     repo_name: glow
     description: Render markdown on the CLI, with pizzazz
     asset: glow_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
Close #21293

[charmbracelet/freeze](https://github.com/charmbracelet/freeze): Generate images of code and terminal output

```console
$ aqua g -i charmbracelet/freeze
```