### PR TITLE
feat: add crates.io/pueue

### DIFF
--- a/pkgs/crates.io/pueue/pkg.yaml
+++ b/pkgs/crates.io/pueue/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/pueue@3.4.0

--- a/pkgs/crates.io/pueue/registry.yaml
+++ b/pkgs/crates.io/pueue/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/pueue
+    type: cargo
+    repo_owner: nukesor
+    repo_name: pueue
+    description: A cli tool for managing long running shell commands.
+    crate: pueue

--- a/registry.yaml
+++ b/registry.yaml
@@ -13017,6 +13017,12 @@ packages:
     repo_name: gitu
     description: A TUI Git client inspired by Magit
     crate: gitu
+  - name: crates.io/pueue
+    type: cargo
+    repo_owner: nukesor
+    repo_name: pueue
+    description: A cli tool for managing long running shell commands.
+    crate: pueue
   - name: crates.io/skim
     type: cargo
     repo_owner: lotabout


### PR DESCRIPTION
[crates.io/pueue](https://crates.io/crates/pueue): A cli tool for managing long running shell commands.

```console
$ aqua g -i crates.io/pueue
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ 
```

If files such as configuration file are needed, please share them.

```
```

Reference

-
