### PR TITLE
feat: add fe3dback/go-arch-lint

### DIFF
--- a/pkgs/fe3dback/go-arch-lint/pkg.yaml
+++ b/pkgs/fe3dback/go-arch-lint/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: fe3dback/go-arch-lint@v1.11.2
+  - name: fe3dback/go-arch-lint
+    version: v1.7.3
+  - name: fe3dback/go-arch-lint
+    version: v1.6.1

--- a/pkgs/fe3dback/go-arch-lint/registry.yaml
+++ b/pkgs/fe3dback/go-arch-lint/registry.yaml
@@ -1,0 +1,51 @@
+packages:
+  - type: github_release
+    repo_owner: fe3dback
+    repo_name: go-arch-lint
+    description: GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file. Useful for hexagonal / onion / ddd / mvc and other architectural patterns. Tool can by used in your CI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.1")
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.7.3")
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.7.5")
+        no_asset: true
+      - version_constraint: "true"
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -16554,6 +16554,56 @@ packages:
       asset: frp_sha256_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: fe3dback
+    repo_name: go-arch-lint
+    description: GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file. Useful for hexagonal / onion / ddd / mvc and other architectural patterns. Tool can by used in your CI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.1")
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.7.3")
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.7.5")
+        no_asset: true
+      - version_constraint: "true"
+        asset: go-arch-lint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: ffuf
     repo_name: ffuf
     description: Fast web fuzzer written in Go


### PR DESCRIPTION
[fe3dback/go-arch-lint](https://github.com/fe3dback/go-arch-lint): GoLang architecture linter (checker) tool. Will check all project import path and compare with arch rules defined in yml file. Useful for hexagonal / onion / ddd / mvc and other architectural patterns. Tool can by used in your CI

```console
$ aqua g -i fe3dback/go-arch-lint
```