### PR TITLE
feat: add moby/buildkit

### DIFF
--- a/pkgs/moby/buildkit/pkg.yaml
+++ b/pkgs/moby/buildkit/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: moby/buildkit@v0.13.1
+  - name: moby/buildkit
+    version: v0.11.0-rc2
+  - name: moby/buildkit
+    version: v0.8.3

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -5,11 +5,6 @@ packages:
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
     files:
       - name: buildctl
-      - name: buildkitd
-    overrides:
-      - goos: darwin
-        files:
-          - name: buildctl
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -20,26 +15,12 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
-        overrides:
-          - goos: linux
-            files:
-              - name: buildctl
-                src: bin/buildctl
-              - name: buildkitd
-                src: bin/buildkitd
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: buildctl
             src: bin/buildctl
-        overrides:
-          - goos: linux
-            files:
-              - name: buildctl
-                src: bin/buildctl
-              - name: buildkitd
-                src: bin/buildkitd
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -47,10 +28,3 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
-          - name: buildkitd
-            src: bin/buildkitd
-        overrides:
-          - goos: darwin
-            files:
-              - name: buildctl
-                src: bin/buildctl

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - type: github_release
+    repo_owner: moby
+    repo_name: buildkit
+    description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.3")
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: buildkit
+            src: bin/buildctl
+      - version_constraint: semver("<= 0.11.0-rc2")
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: buildkit
+            src: bin/buildctl
+      - version_constraint: "true"
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        files:
+          - name: buildkit
+            src: bin/buildctl

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -11,18 +11,18 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         complete_windows_ext: false
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -3,6 +3,13 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    files:
+      - name: buildctl
+      - name: buildkitd
+    overrides:
+      - goos: darwin
+        files:
+          - name: buildctl
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -13,12 +20,26 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
+        overrides:
+          - goos: linux
+            files:
+              - name: buildctl
+                src: bin/buildctl
+              - name: buildkitd
+                src: bin/buildkitd
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: buildctl
             src: bin/buildctl
+        overrides:
+          - goos: linux
+            files:
+              - name: buildctl
+                src: bin/buildctl
+              - name: buildkitd
+                src: bin/buildkitd
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -26,3 +47,10 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
+          - name: buildkitd
+            src: bin/buildkitd
+        overrides:
+          - goos: darwin
+            files:
+              - name: buildctl
+                src: bin/buildctl

--- a/registry.yaml
+++ b/registry.yaml
@@ -28016,6 +28016,33 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: moby
+    repo_name: buildkit
+    description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.3")
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: buildkit
+            src: bin/buildctl
+      - version_constraint: semver("<= 0.11.0-rc2")
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: buildkit
+            src: bin/buildctl
+      - version_constraint: "true"
+        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        files:
+          - name: buildkit
+            src: bin/buildctl
+  - type: github_release
     repo_owner: momaek
     repo_name: authy
     description: TOTP Alfred Workflow, Authy Aflred Workflow, Authy command line tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -28027,20 +28027,20 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         complete_windows_ext: false
         files:
-          - name: buildkit
+          - name: buildctl
             src: bin/buildctl
   - type: github_release
     repo_owner: momaek

--- a/registry.yaml
+++ b/registry.yaml
@@ -28021,11 +28021,6 @@ packages:
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
     files:
       - name: buildctl
-      - name: buildkitd
-    overrides:
-      - goos: darwin
-        files:
-          - name: buildctl
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -28036,26 +28031,12 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
-        overrides:
-          - goos: linux
-            files:
-              - name: buildctl
-                src: bin/buildctl
-              - name: buildkitd
-                src: bin/buildkitd
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: buildctl
             src: bin/buildctl
-        overrides:
-          - goos: linux
-            files:
-              - name: buildctl
-                src: bin/buildctl
-              - name: buildkitd
-                src: bin/buildkitd
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -28063,13 +28044,6 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
-          - name: buildkitd
-            src: bin/buildkitd
-        overrides:
-          - goos: darwin
-            files:
-              - name: buildctl
-                src: bin/buildctl
   - type: github_release
     repo_owner: momaek
     repo_name: authy

--- a/registry.yaml
+++ b/registry.yaml
@@ -28019,6 +28019,13 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    files:
+      - name: buildctl
+      - name: buildkitd
+    overrides:
+      - goos: darwin
+        files:
+          - name: buildctl
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -28029,12 +28036,26 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
+        overrides:
+          - goos: linux
+            files:
+              - name: buildctl
+                src: bin/buildctl
+              - name: buildkitd
+                src: bin/buildkitd
       - version_constraint: semver("<= 0.11.0-rc2")
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: buildctl
             src: bin/buildctl
+        overrides:
+          - goos: linux
+            files:
+              - name: buildctl
+                src: bin/buildctl
+              - name: buildkitd
+                src: bin/buildkitd
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -28042,6 +28063,13 @@ packages:
         files:
           - name: buildctl
             src: bin/buildctl
+          - name: buildkitd
+            src: bin/buildkitd
+        overrides:
+          - goos: darwin
+            files:
+              - name: buildctl
+                src: bin/buildctl
   - type: github_release
     repo_owner: momaek
     repo_name: authy


### PR DESCRIPTION
[moby/buildkit](https://github.com/moby/buildkit): concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit

```console
$ aqua g -i moby/buildkit
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@f5204bd5a9d4:/workspace# buildctl
NAME:
   buildctl - build utility

USAGE:
   buildctl [global options] command [command options] [arguments...]

VERSION:
   v0.13.1

COMMANDS:
   du               disk usage
   prune            clean up build cache
   prune-histories  clean up build histories
   build, b         build
   debug            debug utilities
   help, h          Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug                enable debug output in logs
   --addr value           buildkitd address (default: "unix:///run/buildkit/buildkitd.sock")
   --log-format value     log formatter: json or text (default: "text")
   --tlsservername value  buildkitd server name for certificate validation
   --tlscacert value      CA certificate for validation
   --tlscert value        client certificate
   --tlskey value         client key
   --tlsdir value         directory containing CA certificate, client certificate, and client key
   --timeout value        timeout backend connection after value seconds (default: 5)
   --wait                 block RPCs until the connection becomes available
   --help, -h             show help
   --version, -v          print the version
```

If files such as configuration file are needed, please share them.

```
```

Reference

- README
    - https://github.com/moby/buildkit#exploring-dockerfiles
