### PR TITLE
fix(golang/tools/guru): guru was deleted at v0.20.0

### DIFF
--- a/pkgs/golang/tools/guru/registry.yaml
+++ b/pkgs/golang/tools/guru/registry.yaml
@@ -8,5 +8,8 @@ packages:
     link: https://pkg.go.dev/golang.org/x/tools/cmd/guru
     version_source: github_tag
     version_filter: not (Version startsWith "gopls/")
-    files:
-      - name: guru
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 0.20.0")
+        error_message: guru was deleted https://github.com/golang/go/issues/65880
+      - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -18793,8 +18793,11 @@ packages:
     link: https://pkg.go.dev/golang.org/x/tools/cmd/guru
     version_source: github_tag
     version_filter: not (Version startsWith "gopls/")
-    files:
-      - name: guru
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 0.20.0")
+        error_message: guru was deleted https://github.com/golang/go/issues/65880
+      - version_constraint: "true"
   - type: go_install
     name: golang/tools/stringer
     path: golang.org/x/tools/cmd/stringer


### PR DESCRIPTION
- https://github.com/golang/tools/commit/1f580da07881ed47f85cf39907a0b5c8e0d649b7
- https://github.com/golang/go/issues/65880

> RIP guru, Go's LSP server before LSP was invented.

Close #21617