### PR TITLE
feat: add Bearer/gon

### DIFF
--- a/pkgs/Bearer/gon/pkg.yaml
+++ b/pkgs/Bearer/gon/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Bearer/gon@v0.0.36

--- a/pkgs/Bearer/gon/registry.yaml
+++ b/pkgs/Bearer/gon/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: Bearer
+    repo_name: gon
+    description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.13")
+        no_asset: true
+      - version_constraint: "true"
+        asset: gon_{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin

--- a/pkgs/Bearer/gon/registry.yaml
+++ b/pkgs/Bearer/gon/registry.yaml
@@ -10,7 +10,6 @@ packages:
       - version_constraint: "true"
         asset: gon_{{.OS}}.{{.Format}}
         format: zip
-        rosetta2: true
         replacements:
           darwin: macos
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -354,7 +354,6 @@ packages:
       - version_constraint: "true"
         asset: gon_{{.OS}}.{{.Format}}
         format: zip
-        rosetta2: true
         replacements:
           darwin: macos
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -344,6 +344,22 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: Bearer
+    repo_name: gon
+    description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.13")
+        no_asset: true
+      - version_constraint: "true"
+        asset: gon_{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: BeryJu
     repo_name: korb
     description: Move Kubernetes PVCs between Storage Classes and Namespaces


### PR DESCRIPTION
[Bearer/gon](https://github.com/Bearer/gon): Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library

```console
$ aqua g -i Bearer/gon
```