### PR TITLE
feat: add Songmu/make2help

### DIFF
--- a/pkgs/Songmu/make2help/pkg.yaml
+++ b/pkgs/Songmu/make2help/pkg.yaml
@@ -3,10 +3,4 @@ packages:
   - name: Songmu/make2help
     version: v0.2.0
   - name: Songmu/make2help
-    version: v0.1.1
-  - name: Songmu/make2help
-    version: v0.1.0
-  - name: Songmu/make2help
-    version: v0.0.2
-  - name: Songmu/make2help
     version: v0.0.1

--- a/pkgs/Songmu/make2help/pkg.yaml
+++ b/pkgs/Songmu/make2help/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: Songmu/make2help@v0.2.1
+  - name: Songmu/make2help
+    version: v0.2.0
+  - name: Songmu/make2help
+    version: v0.1.1
+  - name: Songmu/make2help
+    version: v0.1.0
+  - name: Songmu/make2help
+    version: v0.0.2
+  - name: Songmu/make2help
+    version: v0.0.1

--- a/pkgs/Songmu/make2help/registry.yaml
+++ b/pkgs/Songmu/make2help/registry.yaml
@@ -9,6 +9,9 @@ packages:
         asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz
@@ -20,6 +23,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz
@@ -30,6 +36,9 @@ packages:
       - version_constraint: "true"
         asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz

--- a/pkgs/Songmu/make2help/registry.yaml
+++ b/pkgs/Songmu/make2help/registry.yaml
@@ -1,0 +1,34 @@
+packages:
+  - type: github_release
+    repo_owner: Songmu
+    repo_name: make2help
+    description: Utility for self-documented Makefile
+    asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    version_constraint: semver(">= 0.2.1")
+    format: zip
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      algorithm: sha256
+    supported_envs:
+      - darwin
+      - linux
+      - windows
+    files:
+      - name: make2help
+        src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
+    overrides:
+      - goos: linux
+        format: tar.gz
+    version_overrides:
+      - version_constraint: semver(">= 0.1.0")
+        rosetta2: true
+        supported_envs:
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 0.0.1")
+        rosetta2: true
+        supported_envs:
+          - darwin/amd64
+          - linux/amd64

--- a/pkgs/Songmu/make2help/registry.yaml
+++ b/pkgs/Songmu/make2help/registry.yaml
@@ -3,32 +3,33 @@ packages:
     repo_owner: Songmu
     repo_name: make2help
     description: Utility for self-documented Makefile
-    asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    version_constraint: semver(">= 0.2.1")
-    format: zip
-    checksum:
-      type: github_release
-      asset: SHA256SUMS
-      algorithm: sha256
-    supported_envs:
-      - darwin
-      - linux
-      - windows
-    files:
-      - name: make2help
-        src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
-    overrides:
-      - goos: linux
-        format: tar.gz
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.1.0")
+      - version_constraint: semver("<= 0.0.1")
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
         rosetta2: true
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
-          - darwin/amd64
           - linux/amd64
-          - windows/amd64
-      - version_constraint: semver(">= 0.0.1")
+          - darwin
+      - version_constraint: semver("<= 0.2.0")
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
         rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
-          - darwin/amd64
-          - linux/amd64
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -2961,6 +2961,39 @@ packages:
         format: tar.gz
   - type: github_release
     repo_owner: Songmu
+    repo_name: make2help
+    description: Utility for self-documented Makefile
+    asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    version_constraint: semver(">= 0.2.1")
+    format: zip
+    checksum:
+      type: github_release
+      asset: SHA256SUMS
+      algorithm: sha256
+    supported_envs:
+      - darwin
+      - linux
+      - windows
+    files:
+      - name: make2help
+        src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
+    overrides:
+      - goos: linux
+        format: tar.gz
+    version_overrides:
+      - version_constraint: semver(">= 0.1.0")
+        rosetta2: true
+        supported_envs:
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 0.0.1")
+        rosetta2: true
+        supported_envs:
+          - darwin/amd64
+          - linux/amd64
+  - type: github_release
+    repo_owner: Songmu
     repo_name: maltmill
     asset: maltmill_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -2963,35 +2963,36 @@ packages:
     repo_owner: Songmu
     repo_name: make2help
     description: Utility for self-documented Makefile
-    asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    version_constraint: semver(">= 0.2.1")
-    format: zip
-    checksum:
-      type: github_release
-      asset: SHA256SUMS
-      algorithm: sha256
-    supported_envs:
-      - darwin
-      - linux
-      - windows
-    files:
-      - name: make2help
-        src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
-    overrides:
-      - goos: linux
-        format: tar.gz
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.1.0")
+      - version_constraint: semver("<= 0.0.1")
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
         rosetta2: true
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
-          - darwin/amd64
           - linux/amd64
-          - windows/amd64
-      - version_constraint: semver(">= 0.0.1")
+          - darwin
+      - version_constraint: semver("<= 0.2.0")
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
         rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
-          - darwin/amd64
-          - linux/amd64
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
   - type: github_release
     repo_owner: Songmu
     repo_name: maltmill

--- a/registry.yaml
+++ b/registry.yaml
@@ -2969,6 +2969,9 @@ packages:
         asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz
@@ -2980,6 +2983,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz
@@ -2990,6 +2996,9 @@ packages:
       - version_constraint: "true"
         asset: make2help_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: make2help
+            src: make2help_{{.Version}}_{{.OS}}_{{.Arch}}/make2help
         overrides:
           - goos: linux
             format: tar.gz


### PR DESCRIPTION
[Songmu/make2help](https://github.com/Songmu/make2help): Utility for self-documented Makefile

```console
$ aqua g -i Songmu/make2help
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Makefile example:
```make
.DEFAULT_GOAL := help

## Run tests
test: deps
    go test ./...

## Install dependencies
deps:
    go get -d -v ./...

## Show help
help:
    @make2help $(MAKEFILE_LIST)

.PHONY: test deps help
```

Command and output

```console
$ make
deps:              Install dependencies
help:              Show help
test:              Run tests
$ make2help
deps:              Install dependencies
help:              Show help
test:              Run tests
```

Reference

- https://github.com/Songmu/make2help
