### PR TITLE
fix(mashiike/prepalert): follow up changes of prepalert v1.0.2

### DIFF
--- a/pkgs/mashiike/prepalert/pkg.yaml
+++ b/pkgs/mashiike/prepalert/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: mashiike/prepalert@v1.0.1
+  - name: mashiike/prepalert@v1.0.2
+  - name: mashiike/prepalert
+    version: v1.0.1
+  - name: mashiike/prepalert
+    version: v0.2.0

--- a/pkgs/mashiike/prepalert/registry.yaml
+++ b/pkgs/mashiike/prepalert/registry.yaml
@@ -3,9 +3,28 @@ packages:
     repo_owner: mashiike
     repo_name: prepalert
     description: Toil reduction tool to prepare before responding to Mackerel alerts
-    asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.1"
+        no_asset: true
+      - version_constraint: semver("<= 1.0.1")
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: prepalert_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -27096,12 +27096,31 @@ packages:
     repo_owner: mashiike
     repo_name: prepalert
     description: Toil reduction tool to prepare before responding to Mackerel alerts
-    asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.1"
+        no_asset: true
+      - version_constraint: semver("<= 1.0.1")
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: prepalert_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: prepalert_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: mashiike
     repo_name: stefunny


### PR DESCRIPTION
A checksum file was renamed.

https://github.com/mashiike/prepalert/commit/493b8aee55e11719cfffda35cdf55030441514c8

Close #21822