### PR TITLE
fix(extrawurst/gitui): follow up changes of gitui v0.26.1

### DIFF
--- a/pkgs/extrawurst/gitui/pkg.yaml
+++ b/pkgs/extrawurst/gitui/pkg.yaml
@@ -1,2 +1,34 @@
 packages:
-  - name: extrawurst/gitui@v0.25.2
+  - name: extrawurst/gitui@v0.26.1
+  - name: extrawurst/gitui
+    version: v0.26.0
+  - name: extrawurst/gitui
+    version: v0.25.2
+  - name: extrawurst/gitui
+    version: v0.21.0
+  - name: extrawurst/gitui
+    version: v0.20.0
+  - name: extrawurst/gitui
+    version: v0.19.0
+  - name: extrawurst/gitui
+    version: v0.12.0-rc1
+  - name: extrawurst/gitui
+    version: v0.11.0
+  - name: extrawurst/gitui
+    version: v0.11.0-rc1
+  - name: extrawurst/gitui
+    version: v0.10.1
+  - name: extrawurst/gitui
+    version: v0.10.0
+  - name: extrawurst/gitui
+    version: v0.9.1
+  - name: extrawurst/gitui
+    version: v0.9.0
+  - name: extrawurst/gitui
+    version: v0.8.1
+  - name: extrawurst/gitui
+    version: v0.1.11
+  - name: extrawurst/gitui
+    version: v0.1.8
+  - name: extrawurst/gitui
+    version: v0.1.7

--- a/pkgs/extrawurst/gitui/registry.yaml
+++ b/pkgs/extrawurst/gitui/registry.yaml
@@ -2,14 +2,231 @@ packages:
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui
-    rosetta2: true
-    asset: gitui-{{.OS}}.tar.gz
-    supported_envs:
-      - windows
-      - darwin
-      - linux/amd64
-    description: Blazing fast terminal-ui for git written in rust
-    replacements:
-      darwin: mac
-      linux: linux-musl
-      windows: win
+    description: Blazing  fast terminal-ui for git written in rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.7")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v0.1.8"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.11")
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.9.0"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.9.1"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.10.0"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v0.10.1"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.11.0-rc1"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.11.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.12.0-rc1"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.19.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.20.0"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.21.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.25.2")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: gitui-{{.OS}}-arm.{{.Format}}
+          - goos: linux
+            goarch: arm64
+            asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version == "v0.26.0"
+        asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -16608,17 +16608,234 @@ packages:
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui
-    rosetta2: true
-    asset: gitui-{{.OS}}.tar.gz
-    supported_envs:
-      - windows
-      - darwin
-      - linux/amd64
-    description: Blazing fast terminal-ui for git written in rust
-    replacements:
-      darwin: mac
-      linux: linux-musl
-      windows: win
+    description: Blazing  fast terminal-ui for git written in rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.7")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v0.1.8"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.11")
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.9.0"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.9.1"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.10.0"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v0.10.1"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.11.0-rc1"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.11.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.12.0-rc1"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.19.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.20.0"
+        asset: gitui-{{.OS}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.21.0")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-musl.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.25.2")
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: gitui-{{.OS}}-arm.{{.Format}}
+          - goos: linux
+            goarch: arm64
+            asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version == "v0.26.0"
+        asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: gitui-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: gitui-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: mac
+          windows: win
+        overrides:
+          - goos: linux
+            asset: gitui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
   - type: github_release
     repo_owner: eza-community
     repo_name: eza


### PR DESCRIPTION
https://github.com/extrawurst/gitui/releases/tag/v0.26.1

> clarify x86_64 linux binary in artifact names: gitui-linux-x86_64.tar.gz (formerly known as musl) (https://github.com/extrawurst/gitui/issues/2148)