### PR TITLE
feat: add mashiike/redshift-credentials

### DIFF
--- a/pkgs/mashiike/redshift-credentials/pkg.yaml
+++ b/pkgs/mashiike/redshift-credentials/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: mashiike/redshift-credentials@v0.3.4
+  - name: mashiike/redshift-credentials
+    version: v0.3.3

--- a/pkgs/mashiike/redshift-credentials/registry.yaml
+++ b/pkgs/mashiike/redshift-credentials/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: mashiike
+    repo_name: redshift-credentials
+    description: a command line tool for Amazon Redshift temporary authorization with AWS IAM
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.3")
+        asset: redshift-credentials_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: redshift-credentials_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: redshift-credentials_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -27476,6 +27476,26 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: mashiike
+    repo_name: redshift-credentials
+    description: a command line tool for Amazon Redshift temporary authorization with AWS IAM
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.3")
+        asset: redshift-credentials_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: redshift-credentials_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: redshift-credentials_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: mashiike
     repo_name: stefunny
     description: stefunny is a deployment tool for AWS StepFunctions state machine and the accompanying AWS EventBridge rule
     asset: stefunny_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[mashiike/redshift-credentials](https://github.com/mashiike/redshift-credentials): a command line tool for Amazon Redshift temporary authorization with AWS IAM

```console
$ aqua g -i mashiike/redshift-credentials
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

ex: version-check
```console
$ aqua exec -- redshift-credentials --version
flag provided but not defined: -version
redshift-credentials is a command-like tool for Amazon Redshift temporary authorization
version: v0.3.4

usage: redshift-credentials [options] [-- user command]

  -cluster string
        redshift provisioned cluster identifier
  -db-name string
        redshift database name
  -db-user string
        redshift database user name (provisioned only)
  -duration-seconds int
        number of seconds until the returned temporary password expires (900 ~ 3600)
  -endpoint string
        redshift endpoint url
  -log-level string
        redshift-credentials log level (default "info")
  -output string
        Specifies the output format of the credential when not driven in wrapper mode. If not specified, the output is formatted for environment variable settings. [env|json|yaml] (default "env")
  -prefix REDSHIFT_
        Prefixes environment variable names when writing to environment variables (e.g., REDSHIFT_) (default "REDSHIFT_")
  -workgroup string
        redshift serverless workgroup name
```

ex: connect Redshift Serverless dev database

```
 $ aqua exec redshift-credentials --prefix PG -- psql dev
```

Reference

- https://techblog.kayac.com/dbt-actions-awsvpc
If this PR is imported, all the tools required to connect from Githuh Actions to Redshift used in the above article will be able to be managed with aqua.
