### PR TITLE
feat: add gabeduke/kubectl-iexec

### DIFF
--- a/pkgs/gabeduke/kubectl-iexec/pkg.yaml
+++ b/pkgs/gabeduke/kubectl-iexec/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: gabeduke/kubectl-iexec@1.19.14
+  - name: gabeduke/kubectl-iexec
+    version: 1.19.12
+  - name: gabeduke/kubectl-iexec
+    version: 1.19.11
+  - name: gabeduke/kubectl-iexec
+    version: v1.18.0
+  - name: gabeduke/kubectl-iexec
+    version: v1.8.0
+  - name: gabeduke/kubectl-iexec
+    version: v1.6.1
+  - name: gabeduke/kubectl-iexec
+    version: 1.4.0
+  - name: gabeduke/kubectl-iexec
+    version: 1.2.0

--- a/pkgs/gabeduke/kubectl-iexec/registry.yaml
+++ b/pkgs/gabeduke/kubectl-iexec/registry.yaml
@@ -1,0 +1,121 @@
+packages:
+  - type: github_release
+    repo_owner: gabeduke
+    repo_name: kubectl-iexec
+    description: Kubectl plugin to interactively exec into a pod
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.4.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "1.5.0-alpha1"
+        no_asset: true
+      - version_constraint: Version == "v1.6.1"
+        asset: kubectl-iexec_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.8.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.18.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.19.11")
+        asset: kubectl-iexec_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "1.19.12"
+        asset: kubectl-iexec_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/gabeduke/kubectl-iexec/registry.yaml
+++ b/pkgs/gabeduke/kubectl-iexec/registry.yaml
@@ -104,9 +104,7 @@ packages:
           linux: Linux
           windows: Windows
         checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
+          enabled: false # Disable as the checksum file is broken
       - version_constraint: "true"
         asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -17751,6 +17751,126 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: gabeduke
+    repo_name: kubectl-iexec
+    description: Kubectl plugin to interactively exec into a pod
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.4.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "1.5.0-alpha1"
+        no_asset: true
+      - version_constraint: Version == "v1.6.1"
+        asset: kubectl-iexec_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.8.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.18.0")
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.19.11")
+        asset: kubectl-iexec_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "1.19.12"
+        asset: kubectl-iexec_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: gabrie30
     repo_name: ghorg
     description: Quickly clone an entire org/users repositories into one directory - Supports GitHub, GitLab, Bitbucket, and more

--- a/registry.yaml
+++ b/registry.yaml
@@ -17855,9 +17855,7 @@ packages:
           linux: Linux
           windows: Windows
         checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
+          enabled: false # Disable as the checksum file is broken
       - version_constraint: "true"
         asset: kubectl-iexec_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[gabeduke/kubectl-iexec](https://github.com/gabeduke/kubectl-iexec): Kubectl plugin to interactively exec into a pod

```console
$ aqua g -i gabeduke/kubectl-iexec
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ kubectl-iexec
root@306e5e9a61a5:/workspace# kubectl-iexec
Error: unable to get namespace: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
Usage:
  iexec [pod filter] [remote command(s)] [flags]

Examples:

        # select from all pods in the namespace then run: 'kubectl exec sh'
        kubectl iexec

        # select from all pods matching [busybox] then run: 'kubectl exec [pod_name] /bin/sh'
        kubectl iexec busybox

        # select from all pods matching [busybox] then run: 'kubectl exec [pod_name] cat /etc/hosts'
        kubectl iexec busybox cat /etc/hosts

        # select from all pods matching [multi_container_pod]
        # then select from all containers in pod matching [second_container]
        # then run: 'kubectl exec [pod_name] [container_name] /bin/sh'
        kubectl iexec multi_container_pod -c second_container


Flags:
  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/root/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
  -c, --container string               Container to search
      --context string                 The name of the kubeconfig context to use
      --disable-compression            If true, opt-out of response compression for all requests to the server
  -h, --help                           help for iexec
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
      --log-level string               log level (trace|debug|info|warn|error|fatal|panic)
  -x, --naked                          Decolorize output
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
  -v, --vim-mode                       Vim Mode enabled
```

If files such as configuration file are needed, please share them.

Reference

- README.md
    - https://github.com/gabeduke/kubectl-iexec/blob/main/README.md
