### PR TITLE
feat: add undistro/marvin

### DIFF
--- a/pkgs/undistro/marvin/pkg.yaml
+++ b/pkgs/undistro/marvin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: undistro/marvin@v0.2.3

--- a/pkgs/undistro/marvin/registry.yaml
+++ b/pkgs/undistro/marvin/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: undistro
+    repo_name: marvin
+    description: Marvin is a CLI tool that scans a k8s cluster by performing CEL expressions to report potential issues, misconfigurations and vulnerabilities
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: marvin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -39937,6 +39937,27 @@ packages:
     files:
       - name: mockgen
   - type: github_release
+    repo_owner: undistro
+    repo_name: marvin
+    description: Marvin is a CLI tool that scans a k8s cluster by performing CEL expressions to report potential issues, misconfigurations and vulnerabilities
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: marvin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: updatecli
     repo_name: updatecli
     asset: updatecli_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[undistro/marvin](https://github.com/undistro/marvin): Marvin is a CLI tool that scans a k8s cluster by performing CEL expressions to report potential issues, misconfigurations and vulnerabilities

```console
$ aqua g -i undistro/marvin
```