### PR TITLE
feat: add lasiar/canonicalheader

### DIFF
--- a/pkgs/lasiar/canonicalheader/pkg.yaml
+++ b/pkgs/lasiar/canonicalheader/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: lasiar/canonicalheader@v1.0.6

--- a/pkgs/lasiar/canonicalheader/registry.yaml
+++ b/pkgs/lasiar/canonicalheader/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: lasiar
+    repo_name: canonicalheader
+    description: Golang linter checking the canonicality of the http header
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: canonicalheader_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: canonicalheader_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -26953,6 +26953,27 @@ packages:
         asset: kyverno_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         rosetta2: true
   - type: github_release
+    repo_owner: lasiar
+    repo_name: canonicalheader
+    description: Golang linter checking the canonicality of the http header
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: canonicalheader_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: canonicalheader_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: lc
     repo_name: gau
     description: Fetch known URLs from AlienVault's Open Threat Exchange, the Wayback Machine, and Common Crawl


### PR DESCRIPTION
[lasiar/canonicalheader](https://github.com/lasiar/canonicalheader): Golang linter checking the canonicality of the http header

```console
$ aqua g -i lasiar/canonicalheader
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@8fb53d00dc15:/workspace# canonicalheader
canonicalheader: canonicalheader checks whether net/http.Header uses canonical header

Usage: canonicalheader [-flag] [package]


Flags:
  -V    print version and exit
  -all
        no effect (deprecated)
  -c int
        display offending line with this many lines of context (default -1)
  -cpuprofile string
        write CPU profile to this file
  -debug string
        debug flags, any subset of "fpstv"
  -fix
        apply all suggested fixes
  -flags
        print analyzer flags in JSON
  -json
        emit JSON output
  -memprofile string
        write memory profile to this file
  -source
        no effect (deprecated)
  -tags string
        no effect (deprecated)
  -test
        indicates whether test files should be analyzed, too (default true)
  -trace string
        write trace log to this file
  -v    no effect (deprecated)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/lasiar/canonicalheader/blob/main/README.md