### PR TITLE
feat: add playwright-community/playwright-go

### DIFF
--- a/pkgs/playwright-community/playwright-go/pkg.yaml
+++ b/pkgs/playwright-community/playwright-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: playwright-community/playwright-go@v0.4201.1

--- a/pkgs/playwright-community/playwright-go/registry.yaml
+++ b/pkgs/playwright-community/playwright-go/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: go_install
+    repo_owner: playwright-community
+    repo_name: playwright-go
+    description: Playwright for Go a browser automation library to control Chromium, Firefox and WebKit with a single API
+    files:
+      - name: playwright
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        path: github.com/playwright-community/playwright-go/cmd/playwright

--- a/registry.yaml
+++ b/registry.yaml
@@ -32788,6 +32788,16 @@ packages:
       type: github_release
       asset: pscale_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - type: go_install
+    repo_owner: playwright-community
+    repo_name: playwright-go
+    description: Playwright for Go a browser automation library to control Chromium, Firefox and WebKit with a single API
+    files:
+      - name: playwright
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        path: github.com/playwright-community/playwright-go/cmd/playwright
   - type: github_release
     repo_owner: plexsystems
     repo_name: sinker


### PR DESCRIPTION
[playwright-community/playwright-go](https://github.com/playwright-community/playwright-go): Playwright for Go a browser automation library to control Chromium, Firefox and WebKit with a single API

```console
$ aqua g -i playwright-community/playwright-go
```

Close #22582