### PR TITLE
feat: add guumaster/hostctl

### DIFF
--- a/pkgs/guumaster/hostctl/pkg.yaml
+++ b/pkgs/guumaster/hostctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: guumaster/hostctl@v1.1.4

--- a/pkgs/guumaster/hostctl/registry.yaml
+++ b/pkgs/guumaster/hostctl/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: guumaster
+    repo_name: hostctl
+    description: Your dev tool to manage /etc/hosts like a pro
+    asset: hostctl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: 64-bit
+      darwin: macOS
+    checksum:
+      type: github_release
+      asset: hostctl_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -20325,6 +20325,22 @@ packages:
       asset: asciigraph_{{trimV .Version}}_sha512-checksums.txt
       algorithm: sha512
   - type: github_release
+    repo_owner: guumaster
+    repo_name: hostctl
+    description: Your dev tool to manage /etc/hosts like a pro
+    asset: hostctl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: 64-bit
+      darwin: macOS
+    checksum:
+      type: github_release
+      asset: hostctl_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip
+  - type: github_release
     repo_owner: hadolint
     repo_name: hadolint
     supported_envs:


### PR DESCRIPTION
[guumaster/hostctl](https://github.com/guumaster/hostctl): Your dev tool to manage /etc/hosts like a pro

```console
$ aqua g -i guumaster/hostctl
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ hostctl -h

hostctl is a CLI tool to manage your hosts file with ease.
You can have multiple profiles, enable/disable exactly what
you need each time with a simple interface.

Usage:
  hostctl [command]

Available Commands:
  add         Add content to a profile in your hosts file.
  backup      Creates a backup copy of your hosts file
  disable     Disable a profile from your hosts file.
  enable      Enable a profile on your hosts file.
  help        Help about any command
  list        Shows a detailed list of profiles on your hosts file.
  remove      Remove a profile from your hosts file.
  replace     Replace content to a profile in your hosts file.
  restore     Restore hosts file content from a backup file.
  status      Shows a list of profile names and statuses on your hosts file.
  sync        Sync some system IPs with a profile.
  toggle      Change status of a profile on your hosts file.

Flags:
  -c, --column strings     Column names to show on lists. comma separated
  -h, --help               help for hostctl
      --host-file string   Hosts file path (default "/etc/hosts")
      --no-color           force colorless output
  -o, --out string         Output type (table|raw|markdown|json) (default "table")
  -q, --quiet              Run command without output
      --raw                Output without borders (same as -o raw)
  -v, --version            version for hostctl

Use "hostctl [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/guumaster/hostctl/blob/v1.1.4/README.md