### PR TITLE
fix(scripts): use user from host when running docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,21 @@
 FROM golang:1.22.3-bookworm@sha256:c2caf8c1c462dfa1cb58a7e8eb3e942d4013a90f42ad4ed2ac2517b37ed4bb8c
-WORKDIR /workspace
-ENV AQUA_ROOT_DIR=/root/aquaproj-aqua
-ENV AQUA_LOG_COLOR=always
-ENV AQUA_POLICY_CONFIG=/workspace/aqua-policy.yaml
-ENV PATH=$AQUA_ROOT_DIR/bin:/root/.cargo/bin:$PATH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
   apt-get update && \
   apt-get install --no-install-recommends -y tree && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+ARG USERNAME=root
+ARG GROUPNAME=root
+ARG HOME=/root
+RUN (id -u $USERNAME || useradd -m $USERNAME) && \
+  (getent group $GROUPNAME || groupadd $GROUPNAME)
+USER $USERNAME
+WORKDIR $HOME
+ENV AQUA_ROOT_DIR=$HOME/aquaproj-aqua
+ENV AQUA_LOG_COLOR=always
+ENV AQUA_POLICY_CONFIG=$HOME/aqua-policy.yaml
+ENV PATH=$AQUA_ROOT_DIR/bin:$HOME/.cargo/bin:$PATH
 RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0.0/aqua-installer
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "8299de6c19a8ff6b2cc6ac69669cf9e12a96cece385658310aea4f4646a5496d  aqua-installer" | sha256sum -c
@@ -17,3 +23,4 @@ RUN chmod +x aqua-installer
 RUN ./aqua-installer -v v2.27.3
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml
+WORKDIR /workspace

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -2,7 +2,12 @@
 
 set -eu
 
+opts=""
+if [ "$(uname)" = Linux ]; then
+	opts="--build-arg USERNAME=$(id -u -n) --build-arg GROUPNAME=$(id -g -n) --build-arg HOME=/home/$(id -u -n)"
+fi
+
 cp aqua-policy.yaml docker
-docker build -t aquaproj/aqua-registry docker
+docker build -t aquaproj/aqua-registry $opts docker
 mkdir -p .build
 cp docker/Dockerfile .build

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,6 +21,10 @@ if [ "$(uname)" = Linux ] && docker version | grep -q Podman; then
 	opts="--privileged"
 fi
 
+if [ "$(uname)" = Linux ]; then
+	opts+=" -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"
+fi
+
 # shellcheck disable=SC2086
 docker run $opts -d --name "$container_name" \
 	-v "$PWD:/aqua-registry" $envs aquaproj/aqua-registry \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,7 +22,7 @@ if [ "$(uname)" = Linux ] && docker version | grep -q Podman; then
 fi
 
 if [ "$(uname)" = Linux ]; then
-	opts+=" -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"
+	opts+=" -u $(id -u -n):$(id -g -n) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro"
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

This PR makes the scripts to run with the user that is running the docker command.
I'm not sure if this works for others.

fixes #22716
