### PR TITLE
fix: remove duplicate dagu-dev/dagu alias

### DIFF
--- a/pkgs/dagu-dev/dagu/registry.yaml
+++ b/pkgs/dagu-dev/dagu/registry.yaml
@@ -4,7 +4,6 @@ packages:
     repo_name: dagu
     aliases:
       - name: yohamta/dagu
-      - name: dagu-dev/dagu
       - name: hotaruswarm/dagu
     description: Yet another cron alternative with a Web UI, but with much more capabilities. It aims to solve greater problems
     asset: dagu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -13984,7 +13984,6 @@ packages:
     repo_name: dagu
     aliases:
       - name: yohamta/dagu
-      - name: dagu-dev/dagu
       - name: hotaruswarm/dagu
     description: Yet another cron alternative with a Web UI, but with much more capabilities. It aims to solve greater problems
     asset: dagu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

The following warning was output with `AQUA_LOG_LEVEL=debug`. This PR fixes that.
```
DEBU[0000] ignore a package alias in the registry because the alias is duplicate  aqua_version=2.27.3 env=linux/amd64 exe_name=aqua-registry package_name= program=aqua registry_name=standard registry_package_alias="&{dagu-dev/dagu}" registry_package_name=dagu-dev/dagu
```
