### PR TITLE
fix: add slsa configs for ko-build/ko

### DIFF
--- a/pkgs/ko-build/ko/pkg.yaml
+++ b/pkgs/ko-build/ko/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: ko-build/ko@v0.15.2
+  - name: ko-build/ko
+    version: v0.12.0

--- a/pkgs/ko-build/ko/registry.yaml
+++ b/pkgs/ko-build/ko/registry.yaml
@@ -16,3 +16,11 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    slsa_provenance:
+      type: github_release
+      asset: multiple.intoto.jsonl
+    version_constraint: semver("> 0.12.0")
+    version_overrides:
+      - version_constraint: 'semver("<=0.12.0")'
+        slsa_provenance:
+          enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -25419,6 +25419,14 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    slsa_provenance:
+      type: github_release
+      asset: multiple.intoto.jsonl
+    version_constraint: semver("> 0.12.0")
+    version_overrides:
+      - version_constraint: 'semver("<=0.12.0")'
+        slsa_provenance:
+          enabled: false
   - type: github_release
     repo_owner: ko1nksm
     repo_name: getoptions


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

[v0.12.0](https://github.com/ko-build/ko/releases/tag/v0.12.0) also has `attestation.intoto.jsonl` but I wasn't able to make it work. I got the following error.

```
Verifying artifact /tmp/440275049: FAILED: invalid DSSE envelope payload: buildType is invalid: "https://github.com/slsa-framework/slsa-github-generator@v1" for builder ID "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml"

FAILED: SLSA verification failed: invalid DSSE envelope payload: buildType is invalid: "https://github.com/slsa-framework/slsa-github-generator@v1" for builder ID "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml"
```
I tried with the following config.
```yaml
      - version_constraint: 'semver("=0.12.0")'
        slsa_provenance:
          type: github_release
          asset: attestation.intoto.jsonl
          # repository was transferred from google to ko-build
          source_uri: github.com/google/ko
```
