### PR TITLE
feat: add Crocmagnon/fatcontext

### DIFF
--- a/pkgs/Crocmagnon/fatcontext/pkg.yaml
+++ b/pkgs/Crocmagnon/fatcontext/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Crocmagnon/fatcontext@v0.2.2

--- a/pkgs/Crocmagnon/fatcontext/registry.yaml
+++ b/pkgs/Crocmagnon/fatcontext/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: Crocmagnon
+    repo_name: fatcontext
+    description: detects nested contexts in loops
+    version_constraint: "false"
+    version_overrides:
+      # foreshadow is used instead of fatcontext
+      - version_constraint: semver("<= 0.1.3")
+        no_asset: true
+      - version_constraint: "true"
+        asset: fatcontext_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: fatcontext_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -1156,6 +1156,30 @@ packages:
           - linux
           - amd64
   - type: github_release
+    repo_owner: Crocmagnon
+    repo_name: fatcontext
+    description: detects nested contexts in loops
+    version_constraint: "false"
+    version_overrides:
+      # foreshadow is used instead of fatcontext
+      - version_constraint: semver("<= 0.1.3")
+        no_asset: true
+      - version_constraint: "true"
+        asset: fatcontext_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: fatcontext_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     asset: cyclonedx-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
[Crocmagnon/fatcontext](https://github.com/Crocmagnon/fatcontext): detects nested contexts in loops

```console
$ aqua g -i Crocmagnon/fatcontext
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@4507e701ac22:/workspace# fatcontext
fatcontext: detects nested contexts in loops

Usage: fatcontext [-flag] [package]


Flags:
  -V    print version and exit
  -all
        no effect (deprecated)
  -c int
        display offending line with this many lines of context (default -1)
  -cpuprofile string
        write CPU profile to this file
  -debug string
        debug flags, any subset of "fpstv"
  -fix
        apply all suggested fixes
  -flags
        print analyzer flags in JSON
  -json
        emit JSON output
  -memprofile string
        write memory profile to this file
  -source
        no effect (deprecated)
  -tags string
        no effect (deprecated)
  -test
        indicates whether test files should be analyzed, too (default true)
  -trace string
        write trace log to this file
  -v    no effect (deprecated)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/Crocmagnon/fatcontext/blob/master/README.md
