### PR TITLE
feat: add rustsec/rustsec/cargo-audit

### DIFF
--- a/pkgs/rustsec/rustsec/cargo-audit/pkg.yaml
+++ b/pkgs/rustsec/rustsec/cargo-audit/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: rustsec/rustsec/cargo-audit@cargo-audit/v0.20.0
+  - name: rustsec/rustsec/cargo-audit
+    version: cargo-audit/v0.17.0

--- a/pkgs/rustsec/rustsec/cargo-audit/registry.yaml
+++ b/pkgs/rustsec/rustsec/cargo-audit/registry.yaml
@@ -1,0 +1,59 @@
+packages:
+  - name: rustsec/rustsec/cargo-audit
+    type: github_release
+    repo_owner: rustsec
+    repo_name: rustsec
+    version_prefix: cargo-audit/v
+    description: Audit your dependencies for crates
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.17.0")
+        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cargo-audit
+            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.17.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cargo-audit
+            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/pkgs/rustsec/rustsec/cargo-audit/registry.yaml
+++ b/pkgs/rustsec/rustsec/cargo-audit/registry.yaml
@@ -7,30 +7,6 @@ packages:
     description: Audit your dependencies for crates
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.17.0")
-        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
-        format: tgz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: cargo-audit
-            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
       - version_constraint: Version == "0.17.1"
         no_asset: true
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -35361,6 +35361,64 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - name: rustsec/rustsec/cargo-audit
+    type: github_release
+    repo_owner: rustsec
+    repo_name: rustsec
+    version_prefix: cargo-audit/v
+    description: Audit your dependencies for crates
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.17.0")
+        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cargo-audit
+            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.17.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cargo-audit
+            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: rustwasm
     repo_name: wasm-pack

--- a/registry.yaml
+++ b/registry.yaml
@@ -35369,30 +35369,6 @@ packages:
     description: Audit your dependencies for crates
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.17.0")
-        asset: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}.{{.Format}}
-        format: tgz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: cargo-audit
-            src: cargo-audit-{{.Arch}}-{{.OS}}-v{{.SemVer}}/cargo-audit
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
       - version_constraint: Version == "0.17.1"
         no_asset: true
       - version_constraint: "true"


### PR DESCRIPTION
[rustsec/rustsec/cargo-audit](https://github.com/rustsec/rustsec): Audit your dependencies for crates.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

It seems releases (and prebuilt assets) are missing for some tags: https://github.com/rustsec/rustsec/releases, https://github.com/rustsec/rustsec/tags, https://crates.io/crates/cargo-audit/versions
Should I add a fallback with `type: cargo`? Is it possible to achieve that?
