### PR TITLE
chore: commit scaffolded code

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,7 +8,7 @@ registries:
     type: local
     path: registry.yaml
 packages:
-  - name: aquaproj/registry-tool@v0.2.5
+  - name: aquaproj/registry-tool@v0.3.0-1
   - name: rhysd/actionlint@v1.7.0
   - name: suzuki-shunsuke/cmdx@v1.7.4
   - name: jqlang/jq@jq-1.7.1

--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -22,9 +22,13 @@ tasks:
       - name: cmd
         type: string
         usage: A list of commands joined with commas ','
+        script_envs:
+          - CMD
       - name: limit
         type: string
         usage: The maximum number of versions
+        script_envs:
+          - LIMIT
     shell:
       - "bash"
       - "-c"
@@ -33,15 +37,21 @@ tasks:
       if [ "{{.recreate}}" = true ]; then
         cmdx rm
       fi
+      bash scripts/checkout.sh "$PACKAGE"
+      bash scripts/check_gpgsign.sh
+      bash scripts/check_diff.sh
       bash scripts/start.sh
-      bash scripts/scaffold.sh "{{.package}}" "{{.cmd}}" "{{.limit}}"
-      bash scripts/test.sh "{{.package}}"
+      bash scripts/scaffold.sh "$PACKAGE" "$CMD" "$LIMIT"
+      bash scripts/commit.sh "$PACKAGE"
+      bash scripts/test.sh "$PACKAGE"
       bash scripts/start.sh aqua-registry-windows
-      bash scripts/test-windows.sh "{{.package}}"
+      bash scripts/test-windows.sh "$PACKAGE"
     args:
       - name: package
         usage: a package name. e.g. `cli/cli`
         required: true
+        script_envs:
+          - PACKAGE
 
   - name: test
     short: t

--- a/scripts/check_diff.sh
+++ b/scripts/check_diff.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if ! git diff --quiet pkgs; then
+    echo "[ERROR] The directory pkgs has changes" >&2
+    git diff --name-only --exit-code pkgs
+fi
+
+if ! git diff --cached --quiet pkgs; then
+    echo "[ERROR] The directory pkgs has changes" >&2
+    git diff --cached --name-only --exit-code pkgs
+fi
+
+if [ -n "$(git ls-files --others --exclude-standard pkgs)" ]; then
+    echo "[ERROR] The directory pkgs has changes" >&2
+    git ls-files --others --exclude-standard pkgs
+    exit 1
+fi

--- a/scripts/check_gpgsign.sh
+++ b/scripts/check_gpgsign.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ "$(git config commit.gpgSign)" != true ]; then
+    echo "[ERROR] This repository requires commit signing, so please configure it." >&2
+    echo "        https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md" >&2
+    exit 1
+fi

--- a/scripts/checkout.sh
+++ b/scripts/checkout.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu
+
+pkg=$1
+branch=feat/$pkg
+
+if git show-ref --quiet "refs/heads/$branch"; then
+    git checkout "$branch"
+    exit 0
+fi
+
+temp_remote="temp-remote-$(date +%Y%m%d%H%M%S)"
+
+git remote add "$temp_remote" https://github.com/aquaproj/aqua-registry
+git fetch "$temp_remote" main
+git checkout -b "feat/$pkg" "$temp_remote/main"
+git remote remove "$temp_remote"

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu
+
+pkg=$1
+
+git add registry.yaml pkgs/$pkg/pkg.yaml pkgs/$pkg/registry.yaml
+git commit -m "feat($pkg): scaffold $pkg"


### PR DESCRIPTION
This pull request updates how `cmdx s` and `cmdx new` work.
We receive pull requests from contributors.
We provide the automation tool and we expect contributors to use the tool properly.
We expect developers to scaffold code and fix bugs step by step.
But the current problem is we can't see how contributors generate and fix code.

Maybe contributors don't use `cmdx s`. Or maybe contributors fix generated code wrongly.
We can't see how contributors fix generated code.
Even if CI passes, maybe the fix is wrong.
For example, contributors can delete versions from pkg.yaml instead of fixing registry.yaml.

To solve the issue, this pull request updates how `cmdx s` and `cmdx new` work.
`cmdx s` creates a feature branch from [the upstream's main branch](https://github.com/aquaproj/aqua-registry/tree/main) and scaffold code by `cmdx s` and commit generated code.
`cmdx new` doesn't create a feature branch anymore because `cmdx s` creates it.

1. `cmdx s` always checkout the latest main branch, which prevents us from using old scripts
1. `cmdx s` checks if commit signing is enabled, so we can notice commit signing before creating commits
1. `cmdx s` commits generated code, so we can distinguish generated code and changes
1. `cmdx s` creates a commit, so we can notice if contributors don't use `cmdx s`

- https://github.com/aquaproj/aquaproj.github.io/pull/976