### PR TITLE
chore: stop connecting to a container when test fails

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,7 @@ for os in linux darwin; do
 		docker exec "$container_name" bash -c "rm aqua-checksums.json 2>/dev/null || :"
 		if ! docker exec "$container_name" env AQUA_GOOS="$os" AQUA_GOARCH="$arch" aqua i; then
 			echo "[ERROR] Build failed $os/$arch" >&2
-			docker exec -ti "$container_name" env AQUA_GOOS="$os" AQUA_GOARCH="$arch" bash
+			echo "        If you want to look into the container, please run 'cmdx con $os $arch'" >&2
 			exit 1
 		fi
 	done


### PR DESCRIPTION
In most cases we don't need to connect to a container.