### PR TITLE
fix: rename the package `fujiwara/aws-sdk-client-go` to `fujiwara/awslim`

### DIFF
--- a/pkgs/fujiwara/aws-sdk-client-go/pkg.yaml
+++ b/pkgs/fujiwara/aws-sdk-client-go/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: fujiwara/aws-sdk-client-go@v0.0.14
-  - name: fujiwara/aws-sdk-client-go
-    version: v0.0.7

--- a/pkgs/fujiwara/awslim/pkg.yaml
+++ b/pkgs/fujiwara/awslim/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: fujiwara/awslim@v0.1.0
+  - name: fujiwara/awslim
+    version: v0.0.14
+  - name: fujiwara/awslim
+    version: v0.0.7

--- a/pkgs/fujiwara/awslim/registry.yaml
+++ b/pkgs/fujiwara/awslim/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
     repo_owner: fujiwara
-    repo_name: aws-sdk-client-go
+    repo_name: awslim
+    aliases:
+      - name: aws-sdk-client-go
     description: A simplified alternative to the AWS CLI for limited use cases
     version_constraint: "false"
     version_overrides:
@@ -14,8 +16,22 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux
-      - version_constraint: "true"
+        files:
+          - name: aws-sdk-client-go
+      - version_constraint: semver("<= 0.0.14")
         asset: aws-sdk-client-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+        files:
+          - name: aws-sdk-client-go
+      - version_constraint: "true"
+        asset: awslim_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release

--- a/pkgs/fujiwara/awslim/registry.yaml
+++ b/pkgs/fujiwara/awslim/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: fujiwara
     repo_name: awslim
     aliases:
-      - name: aws-sdk-client-go
+      - name: fujiwara/aws-sdk-client-go
     description: A simplified alternative to the AWS CLI for limited use cases
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -18465,7 +18465,9 @@ packages:
           - darwin
   - type: github_release
     repo_owner: fujiwara
-    repo_name: aws-sdk-client-go
+    repo_name: awslim
+    aliases:
+      - name: aws-sdk-client-go
     description: A simplified alternative to the AWS CLI for limited use cases
     version_constraint: "false"
     version_overrides:
@@ -18478,8 +18480,22 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux
-      - version_constraint: "true"
+        files:
+          - name: aws-sdk-client-go
+      - version_constraint: semver("<= 0.0.14")
         asset: aws-sdk-client-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+        files:
+          - name: aws-sdk-client-go
+      - version_constraint: "true"
+        asset: awslim_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -18467,7 +18467,7 @@ packages:
     repo_owner: fujiwara
     repo_name: awslim
     aliases:
-      - name: aws-sdk-client-go
+      - name: fujiwara/aws-sdk-client-go
     description: A simplified alternative to the AWS CLI for limited use cases
     version_constraint: "false"
     version_overrides:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

renamed to fujiwara/awslim from fujiwara/aws-sdk-client-go.

follow up: https://x.com/fujiwara/status/1793839566283264315 (Japanese)
