### PR TITLE
feat: add stripe/stripe-cli

### DIFF
--- a/pkgs/stripe/stripe-cli/pkg.yaml
+++ b/pkgs/stripe/stripe-cli/pkg.yaml
@@ -1,0 +1,26 @@
+packages:
+  - name: stripe/stripe-cli@v1.19.5
+  - name: stripe/stripe-cli
+    version: v1.13.2
+  - name: stripe/stripe-cli
+    version: v1.13.1
+  - name: stripe/stripe-cli
+    version: v1.12.3
+  - name: stripe/stripe-cli
+    version: v1.7.7
+  - name: stripe/stripe-cli
+    version: v1.7.6
+  - name: stripe/stripe-cli
+    version: v1.7.5
+  - name: stripe/stripe-cli
+    version: v1.7.4
+  - name: stripe/stripe-cli
+    version: v1.7.2
+  - name: stripe/stripe-cli
+    version: v1.7.1
+  - name: stripe/stripe-cli
+    version: v1.5.10
+  - name: stripe/stripe-cli
+    version: v1.5.9
+  - name: stripe/stripe-cli
+    version: v0.8.2

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -1,0 +1,254 @@
+packages:
+  - type: github_release
+    repo_owner: stripe
+    repo_name: stripe-cli
+    description: A command-line tool for Stripe
+    files:
+      - name: stripe
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.2")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.5.9")
+        asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.5.10"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.7.1")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.7.4")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.5"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v1.7.6"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.7"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 1.12.3")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.1")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.13.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: tar.gz
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -7,41 +7,6 @@ packages:
       - name: stripe
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.8.2")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac-os
-        checksum:
-          type: github_release
-          asset: stripe-checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.5.9")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac-os
-        checksum:
-          type: github_release
-          asset: stripe-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.5.10"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -66,50 +31,10 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.7.1")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.7.2"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.7.4")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -179,6 +104,59 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
+      - version_constraint: Version == "v1.13.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: tar.gz
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: semver("<= 0.8.2")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac-os
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.5.9")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac-os
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.12.3")
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -199,40 +177,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.13.1")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.13.2"
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: tar.gz
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
       - version_constraint: "true"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -27,23 +27,20 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 1.5.9")
-        asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
           asset: stripe-checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
           - windows

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -14,14 +14,11 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
           asset: stripe-checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
           - windows

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -142,7 +142,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
       - version_constraint: Version == "v1.7.6"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -178,7 +178,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 1.12.3")
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -232,7 +232,7 @@ packages:
             asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: "true"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/stripe/stripe-cli/registry.yaml
+++ b/pkgs/stripe/stripe-cli/registry.yaml
@@ -55,14 +55,17 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
-          asset: stripe-checksums.txt
+          asset: stripe-{{.OS}}-checksums.txt
           algorithm: sha256
         overrides:
           - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+            checksum:
+              type: github_release
+              asset: stripe-checksums.txt
+              algorithm: sha256
           - goos: windows
             format: zip
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -38896,41 +38896,6 @@ packages:
       - name: stripe
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.8.2")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac-os
-        checksum:
-          type: github_release
-          asset: stripe-checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.5.9")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac-os
-        checksum:
-          type: github_release
-          asset: stripe-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.5.10"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -38955,50 +38920,10 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.7.1")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.7.2"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.7.4")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -39068,6 +38993,59 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
+      - version_constraint: Version == "v1.13.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: tar.gz
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: semver("<= 0.8.2")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac-os
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.5.9")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac-os
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.12.3")
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -39088,40 +39066,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 1.13.1")
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.13.2"
-        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: stripe-{{.OS}}-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: tar.gz
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
       - version_constraint: "true"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -39031,7 +39031,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
       - version_constraint: Version == "v1.7.6"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -39067,7 +39067,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 1.12.3")
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -39121,7 +39121,7 @@ packages:
             asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: "true"
         asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -38903,14 +38903,11 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
           asset: stripe-checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -38944,14 +38944,17 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
-          asset: stripe-checksums.txt
+          asset: stripe-{{.OS}}-checksums.txt
           algorithm: sha256
         overrides:
           - goos: darwin
-            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+            checksum:
+              type: github_release
+              asset: stripe-checksums.txt
+              algorithm: sha256
           - goos: windows
             format: zip
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -38916,23 +38916,20 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 1.5.9")
-        asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: mac
+          darwin: mac-os
         checksum:
           type: github_release
           asset: stripe-checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -38889,6 +38889,259 @@ packages:
     description: A swiss army knife CLI tool for interacting with Kafka, RabbitMQ and other messaging systems
     format: raw
   - type: github_release
+    repo_owner: stripe
+    repo_name: stripe-cli
+    description: A command-line tool for Stripe
+    files:
+      - name: stripe
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.2")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.5.9")
+        asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.5.10"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.7.1")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.7.4")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.5"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v1.7.6"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.7.7"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 1.12.3")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.1")
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.13.2"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: tar.gz
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: stripe_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: stripe-{{.OS}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: stripe_{{trimV .Version}}_{{.OS}}-os_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: sue445
     repo_name: plant_erd
     asset: plant_erd_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[stripe/stripe-cli](https://github.com/stripe/stripe-cli): A command-line tool for Stripe

```console
$ aqua g -i stripe/stripe-cli
```

Close #23241