### PR TITLE
fix(authzed/zed): use gnu binary instead of musl binary

### DIFF
--- a/pkgs/authzed/zed/registry.yaml
+++ b/pkgs/authzed/zed/registry.yaml
@@ -24,5 +24,9 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          # NOTE:
+          # musl version exists for linux,
+          # but it is dynamically linked to musl libc
+          # and therefore doesn't work on glibc systems
           - goos: linux
-            asset: zed_{{trimV .Version}}_{{.OS}}_{{.Arch}}_musl.{{.Format}}
+            asset: zed_{{trimV .Version}}_{{.OS}}_{{.Arch}}_gnu.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -7978,8 +7978,12 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          # NOTE:
+          # musl version exists for linux,
+          # but it is dynamically linked to musl libc
+          # and therefore doesn't work on glibc systems
           - goos: linux
-            asset: zed_{{trimV .Version}}_{{.OS}}_{{.Arch}}_musl.{{.Format}}
+            asset: zed_{{trimV .Version}}_{{.OS}}_{{.Arch}}_gnu.{{.Format}}
   - type: github_release
     repo_owner: aws-cloudformation
     repo_name: rain


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

I assumed the musl binary is statically linked to the musl-libc, but actually it wasn't.

```shell
$ file zed # musl one
zed: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, Go BuildID=2ZbIHM7fm_qH0A8vNnmy/3pvpNm9dxBuIrnpvFeyZ/d5OtyK0byW5GnoJlQSZB/WgTLlKM2bIKVe4KKwICX, stripped
$ file zed # gnu one
zed: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=x-yaIcruAVZ84yYrQQxk/3pvpNm9dxBuIrnpvFeyZ/d5OtyK0byW5GnoJlQSZB/272joxCFNtIqpuIdGMXo, stripped
$ file exa # for reference musl version of exa
exa: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=6389d0843e1c09a2f29de132cd49d3fe5d1c0b48, stripped
```
musl-libc doesn't exist on glibc systems and therefore doesn't work. This PR swaps the registry.yaml to use glibc binaries so that it works with glibc systems (It would not work anymore on musl systems though).

refs #23375
