### PR TITLE
fix: `cmdx new` errored with illegal option

### DIFF
--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -150,6 +150,9 @@ tasks:
       e.g.
 
       $ cmdx new cli/cli
+    shell:
+      - "bash"
+      - "-c"
     script: |
       set -euo pipefail
       bash scripts/check_diff_package.sh


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

The following error happened when running `cmdx new authzed/zed`.
```
sh: 1: set: Illegal option -o pipefail
exit status 2
```
This was happening because the script was executed with sh instead of bash.
This PR fixes that error by adding `task.shell: ['bash', '-c']`.