### PR TITLE
fix(redpanda-data/connect): follow up changes of redpanda-connect v4.28.0

### DIFF
--- a/pkgs/redpanda-data/connect/pkg.yaml
+++ b/pkgs/redpanda-data/connect/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: redpanda-data/connect@v4.27.0
+  - name: redpanda-data/connect@v4.28.0
+  - name: redpanda-data/connect
+    version: v4.27.0
   - name: redpanda-data/connect
     version: v3.54.1
   - name: redpanda-data/connect

--- a/pkgs/redpanda-data/connect/registry.yaml
+++ b/pkgs/redpanda-data/connect/registry.yaml
@@ -7,6 +7,7 @@ packages:
       - name: benthosdev/benthos
     description: Fancy stream processing made operationally mundane
     files:
+      # At v4.28.0, the binary is renamed from benthos to redpanda-connect
       - name: benthos
       - name: redpanda-connect
     version_constraint: "false"

--- a/pkgs/redpanda-data/connect/registry.yaml
+++ b/pkgs/redpanda-data/connect/registry.yaml
@@ -8,6 +8,7 @@ packages:
     description: Fancy stream processing made operationally mundane
     files:
       - name: benthos
+      - name: redpanda-connect
     version_constraint: "false"
     version_overrides:
       # v0.10.7 and v0.11.1 doesn't work
@@ -18,6 +19,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         supported_envs:
           - darwin
           - windows
@@ -27,6 +30,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
@@ -40,6 +45,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
@@ -48,14 +55,27 @@ packages:
         asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: benthos
+        checksum:
+          type: github_release
+          asset: benthos_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 4.27.0")
+        asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
           algorithm: sha256
       - version_constraint: "true"
-        asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: redpanda-connect_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: redpanda-connect
         checksum:
           type: github_release
-          asset: benthos_{{trimV .Version}}_checksums.txt
+          asset: redpanda-connect_{{trimV .Version}}_checksums.txt
           algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -34923,6 +34923,7 @@ packages:
       - name: benthosdev/benthos
     description: Fancy stream processing made operationally mundane
     files:
+      # At v4.28.0, the binary is renamed from benthos to redpanda-connect
       - name: benthos
       - name: redpanda-connect
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -34924,6 +34924,7 @@ packages:
     description: Fancy stream processing made operationally mundane
     files:
       - name: benthos
+      - name: redpanda-connect
     version_constraint: "false"
     version_overrides:
       # v0.10.7 and v0.11.1 doesn't work
@@ -34934,6 +34935,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         supported_envs:
           - darwin
           - windows
@@ -34943,6 +34946,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
@@ -34956,6 +34961,8 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
@@ -34964,16 +34971,29 @@ packages:
         asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: benthos
+        checksum:
+          type: github_release
+          asset: benthos_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 4.27.0")
+        asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: benthos
         checksum:
           type: github_release
           asset: benthos_{{trimV .Version}}_checksums.txt
           algorithm: sha256
       - version_constraint: "true"
-        asset: benthos_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: redpanda-connect_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: redpanda-connect
         checksum:
           type: github_release
-          asset: benthos_{{trimV .Version}}_checksums.txt
+          asset: redpanda-connect_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - name: regclient/regclient/regbot
     type: github_release


### PR DESCRIPTION
Close #23471

The command name was changed.

https://github.com/redpanda-data/connect/releases/tag/v4.28.0

> The repository has been moved to redpanda-data/connect and no longer contains the core Benthos engine, which is now broken out into redpanda-data/benthos.

https://github.com/redpanda-data/benthos