### PR TITLE
feat: add go-simpler/sloglint

### DIFF
--- a/pkgs/go-simpler/sloglint/pkg.yaml
+++ b/pkgs/go-simpler/sloglint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-simpler/sloglint@v0.7.1

--- a/pkgs/go-simpler/sloglint/registry.yaml
+++ b/pkgs/go-simpler/sloglint/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: go-simpler
+    repo_name: sloglint
+    description: Ensure consistent code style when using log/slog
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sloglint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -19906,6 +19906,27 @@ packages:
       - amd64
     asset: jira-{{.OS}}-{{.Arch}}
   - type: github_release
+    repo_owner: go-simpler
+    repo_name: sloglint
+    description: Ensure consistent code style when using log/slog
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sloglint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: go-swagger
     repo_name: go-swagger
     asset: swagger_{{.OS}}_{{.Arch}}


### PR DESCRIPTION
[go-simpler/sloglint](https://github.com/go-simpler/sloglint): Ensure consistent code style when using log/slog

```console
$ aqua g -i go-simpler/sloglint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ sloglint
root@ded5e3619dcf:/workspace# sloglint
sloglint: ensure consistent code style when using log/slog

Usage: sloglint [-flag] [package]


Flags:
  -V    print version and exit
  -all
        no effect (deprecated)
  -args-on-sep-lines value
        enforce putting arguments on separate lines
  -attr-only value
        enforce using attributes only (overrides -no-mixed-args, incompatible with -kv-only)
  -c int
        display offending line with this many lines of context (default -1)
  -context-only value
        enforce using methods that accept a context (all|scope)
  -cpuprofile string
        write CPU profile to this file
  -debug string
        debug flags, any subset of "fpstv"
  -fix
        apply all suggested fixes
  -flags
        print analyzer flags in JSON
  -forbidden-keys value
        enforce not using specific keys (comma-separated)
  -json
        emit JSON output
  -key-naming-case value
        enforce a single key naming convention (snake|kebab|camel|pascal)
  -kv-only value
        enforce using key-value pairs only (overrides -no-mixed-args, incompatible with -attr-only)
  -memprofile string
        write memory profile to this file
  -no-global value
        enforce not using global loggers (all|default)
  -no-mixed-args value
        enforce not mixing key-value pairs and attributes (default true)
  -no-raw-keys value
        enforce using constants instead of raw keys
  -source
        no effect (deprecated)
  -static-msg value
        enforce using static log messages
  -tags string
        no effect (deprecated)
  -test
        indicates whether test files should be analyzed, too (default true)
  -trace string
        write trace log to this file
  -v    no effect (deprecated)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/go-simpler/sloglint/blob/main/README.md
