### PR TITLE
feat: add fujiwara/s3mover

### DIFF
--- a/pkgs/fujiwara/s3mover/pkg.yaml
+++ b/pkgs/fujiwara/s3mover/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiwara/s3mover@v0.0.3

--- a/pkgs/fujiwara/s3mover/registry.yaml
+++ b/pkgs/fujiwara/s3mover/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: fujiwara
+    repo_name: s3mover
+    description: s3mover is an agent for moving local files to Amazon S3
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: s3mover_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18753,6 +18753,19 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: fujiwara
+    repo_name: s3mover
+    description: s3mover is an agent for moving local files to Amazon S3
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: s3mover_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: fujiwara
     repo_name: tfstate-lookup
     description: Lookup resource attributes in tfstate
     asset: tfstate-lookup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[fujiwara/s3mover](https://github.com/fujiwara/s3mover): s3mover is an agent for moving local files to Amazon S3

```console
$ aqua g -i fujiwara/s3mover
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@2312833685fd:/workspace# s3mover --help
Usage of s3mover:
  -bucket string
        S3 bucket name
  -debug
        debug mode
  -gzip
        gzip compress
  -gzip-level int
        gzip compress level (1-9) (default 6)
  -parallels int
        max parallels (default 1)
  -port int
        stats server port (default 9898)
  -prefix string
        S3 key prefix
  -src string
        source directory
  -time-format string
        time format (default "2006/01/02/15")
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/fujiwara/s3mover/blob/main/README.md
