### PR TITLE
feat(fujiwara/lamux): scaffold fujiwara/lamux

### DIFF
--- a/pkgs/fujiwara/lamux/pkg.yaml
+++ b/pkgs/fujiwara/lamux/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiwara/lamux@v0.0.2

--- a/pkgs/fujiwara/lamux/registry.yaml
+++ b/pkgs/fujiwara/lamux/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: fujiwara
+    repo_name: lamux
+    description: Lamux is a HTTP multiplexer for AWS Lambda Function aliases
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lamux_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -18741,6 +18741,19 @@ packages:
           - darwin
   - type: github_release
     repo_owner: fujiwara
+    repo_name: lamux
+    description: Lamux is a HTTP multiplexer for AWS Lambda Function aliases
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lamux_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: fujiwara
     repo_name: riex
     asset: riex_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: AWS RI expiration detector


### PR DESCRIPTION
[fujiwara/lamux](https://github.com/fujiwara/lamux): Lamux is a HTTP multiplexer for AWS Lambda Function aliases

```console
$ aqua g -i fujiwara/lamux
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@2312833685fd:/workspace# lamux --help
Usage: lamux --function-name=STRING --domain-suffix=STRING [flags]

Flags:
  -h, --help                    Show context-sensitive help.
      --port=8080               Port to listen on ($LAMUX_PORT)
      --function-name=STRING    Name of the Lambda function to proxy ($LAMUX_FUNCTION_NAME)
      --domain-suffix=STRING    Domain suffix to accept requests for ($LAMUX_DOMAIN_SUFFIX)
      --upstream-timeout=30s    Timeout for upstream requests ($LAMUX_UPSTREAM_TIMEOUT)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/fujiwara/lamux/blob/main/README.md