### PR TITLE
feat: add nvarner/typst-lsp

### DIFF
--- a/pkgs/nvarner/typst-lsp/pkg.yaml
+++ b/pkgs/nvarner/typst-lsp/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: nvarner/typst-lsp@v0.13.0
+  - name: nvarner/typst-lsp
+    version: v0.10.1
+  - name: nvarner/typst-lsp
+    version: v0.8.1
+  - name: nvarner/typst-lsp
+    version: v0.7.2
+  - name: nvarner/typst-lsp
+    version: v0.5.1
+  - name: nvarner/typst-lsp
+    version: v0.4.1

--- a/pkgs/nvarner/typst-lsp/registry.yaml
+++ b/pkgs/nvarner/typst-lsp/registry.yaml
@@ -5,23 +5,7 @@ packages:
     description: A brand-new language server for Typst, plus a VS Code extension
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.0")
-        no_asset: true
-      - version_constraint: semver("<= 0.4.1")
-        asset: typst-lsp-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x64
-          windows: win32
-      - version_constraint: Version == "v0.5.0"
-        no_asset: true
-      - version_constraint: Version == "v0.5.1"
-        asset: typst-lsp-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x64
-          windows: win32
-      - version_constraint: semver("<= 0.6.1")
+      - version_constraint: semver("<= 0.3.0") or Version in ["v0.5.0", "v0.6.0", "v0.6.1", "v0.8.0"]
         no_asset: true
       - version_constraint: semver("<= 0.7.2")
         asset: typst-lsp-{{.OS}}-{{.Arch}}
@@ -29,8 +13,6 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "v0.8.0"
-        no_asset: true
       - version_constraint: Version == "v0.8.1"
         asset: typst-lsp
         format: raw

--- a/pkgs/nvarner/typst-lsp/registry.yaml
+++ b/pkgs/nvarner/typst-lsp/registry.yaml
@@ -1,0 +1,49 @@
+packages:
+  - type: github_release
+    repo_owner: nvarner
+    repo_name: typst-lsp
+    description: A brand-new language server for Typst, plus a VS Code extension
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.4.1")
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: Version == "v0.5.0"
+        no_asset: true
+      - version_constraint: Version == "v0.5.1"
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: semver("<= 0.6.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.7.2")
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: Version == "v0.8.0"
+        no_asset: true
+      - version_constraint: Version == "v0.8.1"
+        asset: typst-lsp
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: "true"
+        asset: typst-lsp-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -32266,23 +32266,7 @@ packages:
     description: A brand-new language server for Typst, plus a VS Code extension
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.0")
-        no_asset: true
-      - version_constraint: semver("<= 0.4.1")
-        asset: typst-lsp-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x64
-          windows: win32
-      - version_constraint: Version == "v0.5.0"
-        no_asset: true
-      - version_constraint: Version == "v0.5.1"
-        asset: typst-lsp-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x64
-          windows: win32
-      - version_constraint: semver("<= 0.6.1")
+      - version_constraint: semver("<= 0.3.0") or Version in ["v0.5.0", "v0.6.0", "v0.6.1", "v0.8.0"]
         no_asset: true
       - version_constraint: semver("<= 0.7.2")
         asset: typst-lsp-{{.OS}}-{{.Arch}}
@@ -32290,8 +32274,6 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "v0.8.0"
-        no_asset: true
       - version_constraint: Version == "v0.8.1"
         asset: typst-lsp
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -32261,6 +32261,54 @@ packages:
         files:
           - name: nu
   - type: github_release
+    repo_owner: nvarner
+    repo_name: typst-lsp
+    description: A brand-new language server for Typst, plus a VS Code extension
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.4.1")
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: Version == "v0.5.0"
+        no_asset: true
+      - version_constraint: Version == "v0.5.1"
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: semver("<= 0.6.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.7.2")
+        asset: typst-lsp-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+      - version_constraint: Version == "v0.8.0"
+        no_asset: true
+      - version_constraint: Version == "v0.8.1"
+        asset: typst-lsp
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: "true"
+        asset: typst-lsp-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+  - type: github_release
     repo_owner: o2sh
     repo_name: onefetch
     asset: onefetch-{{.OS}}.tar.gz


### PR DESCRIPTION
[nvarner/typst-lsp](https://github.com/nvarner/typst-lsp): A brand-new language server for Typst, plus a VS Code extension

```console
$ aqua g -i nvarner/typst-lsp
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ typst-lsp --help
Usage: typst-lsp-aarch64-apple-darwin

Available options:
    -h, --help     Prints help information
    -V, --version  Prints version information
```