### PR TITLE
feat: add handlename/let-rds-sleep

### DIFF
--- a/pkgs/handlename/let-rds-sleep/pkg.yaml
+++ b/pkgs/handlename/let-rds-sleep/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: handlename/let-rds-sleep@v0.3.0
+  - name: handlename/let-rds-sleep
+    version: v0.1.2

--- a/pkgs/handlename/let-rds-sleep/registry.yaml
+++ b/pkgs/handlename/let-rds-sleep/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: handlename
     repo_name: let-rds-sleep
+    description: Keep sleeping AWS RDS/Aurora Cluster
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.2")

--- a/pkgs/handlename/let-rds-sleep/registry.yaml
+++ b/pkgs/handlename/let-rds-sleep/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: handlename
+    repo_name: let-rds-sleep
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.2")
+        asset: let-rds-sleep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: let-rds-sleep_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: let-rds-sleep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: let-rds-sleep_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -21951,6 +21951,28 @@ packages:
       algorithm: sha512
   - type: github_release
     repo_owner: handlename
+    repo_name: let-rds-sleep
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.2")
+        asset: let-rds-sleep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: let-rds-sleep_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: let-rds-sleep_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: let-rds-sleep_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: handlename
     repo_name: ssmwrap
     description: Exec command with environment variables loaded from AWS SSM
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -21952,6 +21952,7 @@ packages:
   - type: github_release
     repo_owner: handlename
     repo_name: let-rds-sleep
+    description: Keep sleeping AWS RDS/Aurora Cluster
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.2")


### PR DESCRIPTION
[handlename/let-rds-sleep](https://github.com/handlename/let-rds-sleep): 

```console
$ aqua g -i handlename/let-rds-sleep
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@cc91e3172834:/workspace# let-rds-sleep -help
Usage of let-rds-sleep:
  -dryrun
        show process target only
  -exclude string
        TagName=Value,... If Tag exists exclude the resource
  -mode string
        STOP or START, only for oneshot mode
  -target string
        TagName=Value,... If no tags given, treat all of resources as target
  -version
        display version
```

If files such as configuration file are needed, please share them.

Reference

- README
	- https://github.com/handlename/let-rds-sleep#usage
