### PR TITLE
fix(astral-sh/ruff): follow up changes of ruff 0.5.0

### DIFF
--- a/pkgs/astral-sh/ruff/pkg.yaml
+++ b/pkgs/astral-sh/ruff/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: astral-sh/ruff@v0.4.10
+  - name: astral-sh/ruff@0.5.0
+  - name: astral-sh/ruff
+    version: v0.4.10
   - name: astral-sh/ruff
     version: v0.1.7

--- a/pkgs/astral-sh/ruff/registry.yaml
+++ b/pkgs/astral-sh/ruff/registry.yaml
@@ -48,6 +48,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/pkgs/astral-sh/ruff/registry.yaml
+++ b/pkgs/astral-sh/ruff/registry.yaml
@@ -23,9 +23,28 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.10")
         asset: ruff-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: ruff
+            src: "{{.AssetWithoutExt}}/ruff"
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -7905,6 +7905,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7880,9 +7880,28 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.10")
         asset: ruff-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: ruff
+            src: "{{.AssetWithoutExt}}/ruff"
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
Close #24368

https://github.com/astral-sh/ruff/releases/tag/0.5.0

> The released archives now include an extra level of nesting, which can be removed with --strip-components=1 when untarring.
> The release artifact's file name no longer includes the version tag. This enables users to install via /latest URLs on GitHub.