### PR TITLE
feat(Songmu/ecschedule): support windows

### DIFF
--- a/pkgs/Songmu/ecschedule/pkg.yaml
+++ b/pkgs/Songmu/ecschedule/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: Songmu/ecschedule@v0.12.0
   - name: Songmu/ecschedule
+    version: v0.11.4
+  - name: Songmu/ecschedule
     version: v0.6.3
   - name: Songmu/ecschedule
     version: v0.5.1

--- a/pkgs/Songmu/ecschedule/registry.yaml
+++ b/pkgs/Songmu/ecschedule/registry.yaml
@@ -8,18 +8,26 @@ packages:
     supported_envs:
       - darwin
       - linux
+      - windows
     files:
       - name: ecschedule
         src: ecschedule_{{.Version}}_{{.OS}}_{{.Arch}}/ecschedule
     overrides:
       - goos: darwin
         format: zip
+      - goos: windows
+        format: zip
     checksum:
       type: github_release
       asset: SHA256SUMS
       algorithm: sha256
-    version_constraint: semver(">= 0.7.0")
+    version_constraint: semver(">= 0.12.0")
     version_overrides:
+      # windows wasn't supported
+      - version_constraint: semver(">= 0.7.0")
+        supported_envs:
+          - darwin
+          - linux
       # darwin/amd64 wasn't supported
       - version_constraint: semver("= 0.5.1")
         checksum:
@@ -31,6 +39,9 @@ packages:
       - version_constraint: semver(">= 0.3.2")
         checksum:
           enabled: false
+        supported_envs:
+          - darwin
+          - linux
       # arm64 wasn't supported
       - version_constraint: "true"
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -3413,18 +3413,26 @@ packages:
     supported_envs:
       - darwin
       - linux
+      - windows
     files:
       - name: ecschedule
         src: ecschedule_{{.Version}}_{{.OS}}_{{.Arch}}/ecschedule
     overrides:
       - goos: darwin
         format: zip
+      - goos: windows
+        format: zip
     checksum:
       type: github_release
       asset: SHA256SUMS
       algorithm: sha256
-    version_constraint: semver(">= 0.7.0")
+    version_constraint: semver(">= 0.12.0")
     version_overrides:
+      # windows wasn't supported
+      - version_constraint: semver(">= 0.7.0")
+        supported_envs:
+          - darwin
+          - linux
       # darwin/amd64 wasn't supported
       - version_constraint: semver("= 0.5.1")
         checksum:
@@ -3436,6 +3444,9 @@ packages:
       - version_constraint: semver(">= 0.3.2")
         checksum:
           enabled: false
+        supported_envs:
+          - darwin
+          - linux
       # arm64 wasn't supported
       - version_constraint: "true"
         supported_envs:


### PR DESCRIPTION
[Songmu/ecschedule](https://github.com/Songmu/ecschedule) has started to distribute Windows binaries from version 0.12.0. (See: [Release v0.12.0 · Songmu/ecschedule](https://github.com/Songmu/ecschedule/releases/tag/v0.12.0) ) I propose a change to make it possible to install version 0.12.0 or later on Windows, even via aqua.

The changes in this PR are as follows

- Include windows in `supported_envs` for v0.12.0 and later
- Add `v0.11.4` to pkg.yaml so that v0.7.0 through v0.11.4 can be tested.
- Added `semver(">= 0.3.2")` to `supported_envs` to explicitly exclude windows support.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
