### PR TITLE
Feat/eficode/wait for

### DIFF
--- a/pkgs/eficode/wait-for/pkg.yaml
+++ b/pkgs/eficode/wait-for/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/eficode/wait-for/pkg.yaml
+++ b/pkgs/eficode/wait-for/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: eficode/wait-for@v2.2.4

--- a/pkgs/eficode/wait-for/registry.yaml
+++ b/pkgs/eficode/wait-for/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: eficode
     repo_name: wait-for
     description: ./wait-for is a script to wait for another service to become available
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    asset: wait-for
+    supported_envs:
+      - linux
+      - darwin

--- a/pkgs/eficode/wait-for/registry.yaml
+++ b/pkgs/eficode/wait-for/registry.yaml
@@ -1,0 +1,9 @@
+packages:
+  - type: github_release
+    repo_owner: eficode
+    repo_name: wait-for
+    description: ./wait-for is a script to wait for another service to become available
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -17489,10 +17489,10 @@ packages:
     repo_owner: eficode
     repo_name: wait-for
     description: ./wait-for is a script to wait for another service to become available
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    asset: wait-for
+    supported_envs:
+      - linux
+      - darwin
   - type: github_content
     repo_owner: ekalinin
     repo_name: github-markdown-toc

--- a/registry.yaml
+++ b/registry.yaml
@@ -17485,6 +17485,14 @@ packages:
           - darwin
           - linux
           - amd64
+  - type: github_release
+    repo_owner: eficode
+    repo_name: wait-for
+    description: ./wait-for is a script to wait for another service to become available
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
   - type: github_content
     repo_owner: ekalinin
     repo_name: github-markdown-toc


### PR DESCRIPTION
[eficode/wait-for](https://github.com/eficode/wait-for): ./wait-for is a script to wait for another service to become available

```console
$ aqua g -i eficode/wait-for
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ which wait-for 
/home/yuma/.local/share/aquaproj-aqua/bin/wait-for
$ wait-for google.com:80 -- echo success
success
```

If files such as configuration file are needed, please share them.

Reference

-