### PR TITLE
feat(jubako/arx): scaffold jubako/arx

### DIFF
--- a/pkgs/jubako/arx/pkg.yaml
+++ b/pkgs/jubako/arx/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jubako/arx@0.2.1

--- a/pkgs/jubako/arx/registry.yaml
+++ b/pkgs/jubako/arx/registry.yaml
@@ -10,6 +10,9 @@ packages:
       - version_constraint: "true"
         asset: arx-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: arx
+            src: arx-{{.Version}}-{{.OS}}/arx
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -21,6 +24,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: arx
+                src: arx-{{.Version}}-{{.OS}}/arx.exe
+            checksum:
+              type: github_release
+              file_format: regexp
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              pattern:
+                checksum: ^(\b[A-Fa-f0-9]{64}\b)
         supported_envs:
           - darwin
           - windows

--- a/pkgs/jubako/arx/registry.yaml
+++ b/pkgs/jubako/arx/registry.yaml
@@ -24,9 +24,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: arx
-                src: arx-{{.Version}}-{{.OS}}/arx.exe
             checksum:
               type: github_release
               file_format: regexp

--- a/pkgs/jubako/arx/registry.yaml
+++ b/pkgs/jubako/arx/registry.yaml
@@ -1,0 +1,27 @@
+packages:
+  - type: github_release
+    repo_owner: jubako
+    repo_name: arx
+    description: Store files and directory in an archive. Like tar, but faster and with direct random access
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: arx-{{.Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -25542,9 +25542,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: arx
-                src: arx-{{.Version}}-{{.OS}}/arx.exe
             checksum:
               type: github_release
               file_format: regexp

--- a/registry.yaml
+++ b/registry.yaml
@@ -25528,6 +25528,9 @@ packages:
       - version_constraint: "true"
         asset: arx-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: arx
+            src: arx-{{.Version}}-{{.OS}}/arx
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -25539,6 +25542,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: arx
+                src: arx-{{.Version}}-{{.OS}}/arx.exe
+            checksum:
+              type: github_release
+              file_format: regexp
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              pattern:
+                checksum: ^(\b[A-Fa-f0-9]{64}\b)
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -25518,6 +25518,32 @@ packages:
       - darwin
     rosetta2: true
   - type: github_release
+    repo_owner: jubako
+    repo_name: arx
+    description: Store files and directory in an archive. Like tar, but faster and with direct random access
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: arx-{{.Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: juicedata
     repo_name: juicefs
     asset: juicefs-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz


### PR DESCRIPTION
[jubako/arx](https://github.com/jubako/arx): Store files and directory in an archive. Like tar, but faster and with direct random access

```console
$ aqua g -i jubako/arx
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## System Prerequisites

I don't know if you want to distribute tools which have a system dependency.
This one have the lib "libfuse2" as dependencies as we can see when we launch it first time : 
```console 
$ arx
arx: error while loading shared libraries: libfuse.so.2: cannot open shared object file: No such file or directory
```
This can be fixed with "libfuse2" installed : 
```console
$ sudo apt-get install -y libfuse2
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ arx                     
A file archive based on Jubako container.

Usage: arx [OPTIONS] [COMMAND]

Commands:
  create   Create an archive
  list     List the content in an archive
  dump     Print the content of an entry in the archive
  extract  Extract the content of an archive
  mount    Mount an archive in a directory
  help     Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Set verbose level. Can be specify several times to augment verbose level
  -h, --help        Print help
  -V, --version     Print version

Advanced:
      --generate-man-page [<GENERATE_MAN_PAGE>]
          [possible values: , create, list, dump, extract, mount]
      --generate-complete <GENERATE_COMPLETE>
          [possible values: bash, elvish, fish, powershell, zsh]


$ arx --version
arx 0.2.1
```

