### PR TITLE
feat: add fujiwara/iam-policy-finder

### DIFF
--- a/pkgs/fujiwara/iam-policy-finder/pkg.yaml
+++ b/pkgs/fujiwara/iam-policy-finder/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: fujiwara/iam-policy-finder@v0.0.1

--- a/pkgs/fujiwara/iam-policy-finder/registry.yaml
+++ b/pkgs/fujiwara/iam-policy-finder/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: fujiwara
+    repo_name: iam-policy-finder
+    description: iam-policy-finder is finder of AWS IAM Policies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: iam-policy-finder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -19286,6 +19286,19 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: fujiwara
+    repo_name: iam-policy-finder
+    description: iam-policy-finder is finder of AWS IAM Policies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: iam-policy-finder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: fujiwara
     repo_name: lambroll
     description: lambroll is a minimal deployment tool for AWS Lambda
     version_constraint: "false"


### PR DESCRIPTION
[fujiwara/iam-policy-finder](https://github.com/fujiwara/iam-policy-finder): iam-policy-finder is finder of AWS IAM Policies

```console
$ aqua g -i fujiwara/iam-policy-finder
```