### PR TITLE
feat: add kattouf/ProgressLine

### DIFF
--- a/pkgs/kattouf/ProgressLine/pkg.yaml
+++ b/pkgs/kattouf/ProgressLine/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kattouf/ProgressLine@0.2.1

--- a/pkgs/kattouf/ProgressLine/registry.yaml
+++ b/pkgs/kattouf/ProgressLine/registry.yaml
@@ -1,0 +1,25 @@
+packages:
+  - type: github_release
+    repo_owner: kattouf
+    repo_name: ProgressLine
+    description: Track commands progress in a compact one-line format
+    files:
+      - name: progressline
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: progressline-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: progressline-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/kattouf/ProgressLine/registry.yaml
+++ b/pkgs/kattouf/ProgressLine/registry.yaml
@@ -12,14 +12,12 @@ packages:
         format: zip
         replacements:
           amd64: x86_64
-          darwin: apple
+          darwin: apple-macosx
           linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               arm64: aarch64
-          - goos: darwin
-            asset: progressline-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -26174,6 +26174,30 @@ packages:
     repo_name: terrafmt
     description: Format terraform blocks embedded in files
   - type: github_release
+    repo_owner: kattouf
+    repo_name: ProgressLine
+    description: Track commands progress in a compact one-line format
+    files:
+      - name: progressline
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: progressline-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: progressline-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: kayac
     repo_name: ecspresso
     asset: ecspresso_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -26186,14 +26186,12 @@ packages:
         format: zip
         replacements:
           amd64: x86_64
-          darwin: apple
+          darwin: apple-macosx
           linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               arm64: aarch64
-          - goos: darwin
-            asset: progressline-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
[kattouf/ProgressLine](https://github.com/kattouf/ProgressLine): Track commands progress in a compact one-line format

```console
$ aqua g -i kattouf/ProgressLine
```

Close #25076