### PR TITLE
feat: add qdrant/qdrant

### DIFF
--- a/pkgs/qdrant/qdrant/pkg.yaml
+++ b/pkgs/qdrant/qdrant/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: qdrant/qdrant@v1.6.1
+  - name: qdrant/qdrant
+    version: v1.3.0
+  - name: qdrant/qdrant
+    version: v1.2.2

--- a/pkgs/qdrant/qdrant/registry.yaml
+++ b/pkgs/qdrant/qdrant/registry.yaml
@@ -5,27 +5,8 @@ packages:
     description: High-performance, massive-scale Vector Database for the next generation of AI
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.1.3")
+      - version_constraint: semver("<= 1.1.3") || Version == "v1.3.1"
         no_asset: true
-      - version_constraint: semver("<= 1.2.2")
-        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.3.0"
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -39,9 +20,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "v1.3.1"
-        no_asset: true
+          - windows
       - version_constraint: "true"
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/qdrant/qdrant/registry.yaml
+++ b/pkgs/qdrant/qdrant/registry.yaml
@@ -1,0 +1,63 @@
+packages:
+  - type: github_release
+    repo_owner: qdrant
+    repo_name: qdrant
+    description: High-performance, massive-scale Vector Database for the next generation of AI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.3.0"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v1.3.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -35959,6 +35959,68 @@ packages:
             replacements:
               arm64: arm64
   - type: github_release
+    repo_owner: qdrant
+    repo_name: qdrant
+    description: High-performance, massive-scale Vector Database for the next generation of AI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.3.0"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v1.3.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: quarkslab
     repo_name: kdigger
     description: Kubernetes focused container assessment tool for penetration testing

--- a/registry.yaml
+++ b/registry.yaml
@@ -35964,27 +35964,8 @@ packages:
     description: High-performance, massive-scale Vector Database for the next generation of AI
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.1.3")
+      - version_constraint: semver("<= 1.1.3") || Version == "v1.3.1"
         no_asset: true
-      - version_constraint: semver("<= 1.2.2")
-        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.3.0"
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -35998,9 +35979,7 @@ packages:
             format: tar.gz
         supported_envs:
           - linux/amd64
-          - windows/amd64
-      - version_constraint: Version == "v1.3.1"
-        no_asset: true
+          - windows
       - version_constraint: "true"
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[qdrant/qdrant](https://github.com/qdrant/qdrant): High-performance, massive-scale Vector Database for the next generation of AI

```console
$ aqua g -i qdrant/qdrant
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output (Run on Ubuntu 22.04)

```console
$ qdrant -h
Qdrant (read: quadrant ) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage points - vectors with an additional payload

Usage: qdrant [OPTIONS]

Options:
      --bootstrap <URI>          Uri of the peer to bootstrap from in case of multi-peer deployment. If not specified - this peer will be considered as a first in a new deployment
      --uri <URI>                Uri of this peer. Other peers should be able to reach it by this uri
  -f, --force-snapshot           Force snapshot re-creation If provided - existing collections will be replaced with snapshots. Default is to not recreate from snapshots
      --snapshot <PATH:NAME>     List of paths to snapshot files. Format: <snapshot_file_path>:<target_collection_name>
      --storage-snapshot <PATH>  Path to snapshot of multiple collections. Format: <snapshot_file_path>
      --config-path <PATH>       Path to an alternative configuration file. Format: <config_file_path>
      --disable-telemetry        Disable telemetry sending to developers If provided - telemetry collection will be disabled. Read more: <https://qdrant.tech/documentation/guides/telemetry>
      --stacktrace               Run stacktrace collector. Used for debugging
  -h, --help                     Print help (see more with '--help')
  -V, --version                  Print version

```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/qdrant/qdrant/blob/master/QUICK_START.md
