### PR TITLE
feat: add weaviate/weaviate

### DIFF
--- a/pkgs/weaviate/weaviate/pkg.yaml
+++ b/pkgs/weaviate/weaviate/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: weaviate/weaviate@v1.26.1
+  - name: weaviate/weaviate
+    version: v1.22.1
+  - name: weaviate/weaviate
+    version: v1.22.0
+  - name: weaviate/weaviate
+    version: v1.20.6
+  - name: weaviate/weaviate
+    version: v1.19.13
+  - name: weaviate/weaviate
+    version: v1.19.12
+  - name: weaviate/weaviate
+    version: v1.19.5
+  - name: weaviate/weaviate
+    version: v1.18.5

--- a/pkgs/weaviate/weaviate/registry.yaml
+++ b/pkgs/weaviate/weaviate/registry.yaml
@@ -1,0 +1,110 @@
+packages:
+  - type: github_release
+    repo_owner: weaviate
+    repo_name: weaviate
+    description: Weaviate is an open-source vector database that stores both objects and vectors, allowing for the combination of vector search with structured filtering with the fault tolerance and scalability of a cloud-native database​
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.18.0-rc.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.18.5")
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: Version == "v1.18.6"
+        no_asset: true
+      - version_constraint: semver("<= 1.19.5")
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: semver("<= 1.19.12")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v1.19.13"
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: semver("<= 1.20.6")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.22.0")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: Version == "v1.22.1"
+        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/weaviate/weaviate/registry.yaml
+++ b/pkgs/weaviate/weaviate/registry.yaml
@@ -8,19 +8,19 @@ packages:
       - version_constraint: semver("<= 1.18.0-rc.0") || Version == "v1.18.6"
         no_asset: true
       - version_constraint: Version == "v1.22.1"
-        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
+            format: zip
           - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            format: zip
       - version_constraint: semver("<= 1.19.5") || Version == "v1.19.13"
         asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -31,31 +31,31 @@ packages:
         supported_envs:
           - linux
       - version_constraint: semver("<= 1.20.6")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+            format: zip
         supported_envs:
           - linux
           - darwin
       - version_constraint: "true"
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+            format: zip
           - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            format: zip

--- a/pkgs/weaviate/weaviate/registry.yaml
+++ b/pkgs/weaviate/weaviate/registry.yaml
@@ -5,30 +5,10 @@ packages:
     description: Weaviate is an open-source vector database that stores both objects and vectors, allowing for the combination of vector search with structured filtering with the fault tolerance and scalability of a cloud-native database​
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.18.0-rc.0")
+      - version_constraint: semver("<= 1.18.0-rc.0") || Version == "v1.18.6"
         no_asset: true
-      - version_constraint: semver("<= 1.18.5")
-        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        supported_envs:
-          - linux
-      - version_constraint: Version == "v1.18.6"
-        no_asset: true
-      - version_constraint: semver("<= 1.19.5")
-        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        supported_envs:
-          - linux
-      - version_constraint: semver("<= 1.19.12")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+      - version_constraint: Version == "v1.22.1"
+        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
         format: zip
         rosetta2: true
         checksum:
@@ -39,10 +19,9 @@ packages:
           - goos: linux
             format: tar.gz
             asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version == "v1.19.13"
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 1.19.5") || Version == "v1.19.13"
         asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -66,34 +45,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 1.22.0")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: Version == "v1.22.1"
-        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
-        format: zip
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
       - version_constraint: "true"
         asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -45029,19 +45029,19 @@ packages:
       - version_constraint: semver("<= 1.18.0-rc.0") || Version == "v1.18.6"
         no_asset: true
       - version_constraint: Version == "v1.22.1"
-        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
+            format: zip
           - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            format: zip
       - version_constraint: semver("<= 1.19.5") || Version == "v1.19.13"
         asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -45052,34 +45052,34 @@ packages:
         supported_envs:
           - linux
       - version_constraint: semver("<= 1.20.6")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+            format: zip
         supported_envs:
           - linux
           - darwin
       - version_constraint: "true"
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
         checksum:
           type: github_release
           asset: "{{.Asset}}.md5"
           algorithm: md5
         overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+            format: zip
           - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            format: zip
   - type: github_release
     repo_owner: webdevops
     repo_name: go-crond

--- a/registry.yaml
+++ b/registry.yaml
@@ -45021,6 +45021,115 @@ packages:
         version_prefix: cli-
         rosetta2: true
   - type: github_release
+    repo_owner: weaviate
+    repo_name: weaviate
+    description: Weaviate is an open-source vector database that stores both objects and vectors, allowing for the combination of vector search with structured filtering with the fault tolerance and scalability of a cloud-native database​
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.18.0-rc.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.18.5")
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: Version == "v1.18.6"
+        no_asset: true
+      - version_constraint: semver("<= 1.19.5")
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: semver("<= 1.19.12")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v1.19.13"
+        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+      - version_constraint: semver("<= 1.20.6")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.22.0")
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: Version == "v1.22.1"
+        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+  - type: github_release
     repo_owner: webdevops
     repo_name: go-crond
     description: Cron daemon written in golang (for eg. usage in docker images)

--- a/registry.yaml
+++ b/registry.yaml
@@ -45026,30 +45026,10 @@ packages:
     description: Weaviate is an open-source vector database that stores both objects and vectors, allowing for the combination of vector search with structured filtering with the fault tolerance and scalability of a cloud-native database​
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.18.0-rc.0")
+      - version_constraint: semver("<= 1.18.0-rc.0") || Version == "v1.18.6"
         no_asset: true
-      - version_constraint: semver("<= 1.18.5")
-        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        supported_envs:
-          - linux
-      - version_constraint: Version == "v1.18.6"
-        no_asset: true
-      - version_constraint: semver("<= 1.19.5")
-        asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        supported_envs:
-          - linux
-      - version_constraint: semver("<= 1.19.12")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
+      - version_constraint: Version == "v1.22.1"
+        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
         format: zip
         rosetta2: true
         checksum:
@@ -45060,10 +45040,9 @@ packages:
           - goos: linux
             format: tar.gz
             asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version == "v1.19.13"
+          - goos: windows
+            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 1.19.5") || Version == "v1.19.13"
         asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -45087,34 +45066,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 1.22.0")
-        asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
-        format: zip
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: Version == "v1.22.1"
-        asset: weaviate-v1.21.1-{{.OS}}-all.{{.Format}}
-        format: zip
-        rosetta2: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            asset: weaviate-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
       - version_constraint: "true"
         asset: weaviate-{{.Version}}-{{.OS}}-all.{{.Format}}
         format: zip


### PR DESCRIPTION
[weaviate/weaviate](https://github.com/weaviate/weaviate): Weaviate is an open-source vector database that stores both objects and vectors, allowing for the combination of vector search with structured filtering with the fault tolerance and scalability of a cloud-native database​

```console
$ aqua g -i weaviate/weaviate
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output (Run on Ubuntu 22.04)

```console
$ weaviate -h
Usage:
  weaviate [OPTIONS]

Cloud-native, modular vector database

Application Options:
      --scheme=                    the listeners to enable, this can be repeated and defaults to the schemes in the swagger spec
      --cleanup-timeout=           grace period for which to wait before killing idle connections (default: 10s)
      --graceful-timeout=          grace period for which to wait before shutting down the server (default: 15s)
      --max-header-size=           controls the maximum number of bytes the server will read parsing the request header's keys and values,
                                   including the request line. It does not limit the size of the request body. (default: 1MiB)
      --socket-path=               the unix socket to listen on (default: /var/run/weaviate.sock)
      --host=                      the IP to listen on (default: localhost) [$HOST]
      --port=                      the port to listen on for insecure connections, defaults to a random value [$PORT]
      --listen-limit=              limit the number of outstanding requests
      --keep-alive=                sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing
                                   laptop mid-download) (default: 3m)
      --read-timeout=              maximum duration before timing out read of the request (default: 30s)
      --write-timeout=             maximum duration before timing out write of the response (default: 60s)
      --tls-host=                  the IP to listen on for tls, when not specified it's the same as --host [$TLS_HOST]
      --tls-port=                  the port to listen on for secure connections, defaults to a random value [$TLS_PORT]
      --tls-certificate=           the certificate to use for secure connections [$TLS_CERTIFICATE]
      --tls-key=                   the private key to use for secure connections [$TLS_PRIVATE_KEY]
      --tls-ca=                    the certificate authority file to be used with mutual tls auth [$TLS_CA_CERTIFICATE]
      --tls-listen-limit=          limit the number of outstanding requests
      --tls-keep-alive=            sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing
                                   laptop mid-download)
      --tls-read-timeout=          maximum duration before timing out read of the request
      --tls-write-timeout=         maximum duration before timing out write of the response

Connector, raft & MQTT config:
      --config-file=               path to config file (default: ./weaviate.conf.json)
      --raft-port=                 the port used by Raft for inter-node communication
      --raft-internal-rpc-port=    the port used for internal RPCs within the cluster
      --raft-rpc-message-max-size= maximum internal raft grpc message size in bytes, defaults to 1073741824
      --raft-join=                 a comma-separated list of server addresses to join on startup. Each element needs to be in the form
                                   NODE_NAME[:NODE_PORT]. If NODE_PORT is not present, raft-internal-rpc-port default value will be used
                                   instead
      --raft-bootstrap-timeout=    the duration for which the raft bootstrap procedure will wait for each node in raft-join to be reachable
      --raft-bootstrap-expect=     specifies the number of server nodes to wait for before bootstrapping the cluster
      --raft-heartbeat-timeout=    raft heartbeat timeout
      --raft-election-timeout=     raft election timeout
      --raft-snap-threshold=       number of outstanding log entries before performing a snapshot
      --raft-snap-interval=        controls how often raft checks if it should perform a snapshot
      --raft-metadata-only-voters  configures the voters to store metadata exclusively, without storing any other data

Help Options:
  -h, --help                       Show this help message
```

If files such as configuration file are needed, please share them.

Reference

- https://weaviate.io/developers/weaviate
