### PR TITLE
fix(junegunn/fzf): follow up changes of fzf v0.54.2

### DIFF
--- a/pkgs/junegunn/fzf/pkg.yaml
+++ b/pkgs/junegunn/fzf/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: junegunn/fzf@v0.54.1
+  - name: junegunn/fzf@v0.54.2
+  - name: junegunn/fzf
+    version: v0.54.1
   - name: junegunn/fzf
     version: 0.53.0
   - name: junegunn/fzf

--- a/pkgs/junegunn/fzf/registry.yaml
+++ b/pkgs/junegunn/fzf/registry.yaml
@@ -52,7 +52,7 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.54.1")
         asset: fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         checksum:
@@ -62,3 +62,13 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+      - version_constraint: "true"
+        asset: fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: fzf_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -25720,7 +25720,7 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.54.1")
         asset: fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         checksum:
@@ -25730,6 +25730,16 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
+      - version_constraint: "true"
+        asset: fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: fzf_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - name: junegunn/fzf/fzf-tmux
     type: github_content
     repo_owner: junegunn


### PR DESCRIPTION
Close #25302

https://github.com/junegunn/fzf/releases/tag/v0.54.2

> Updated GoReleaser to 2.1.0 to simplify notarization of macOS binaries
> macOS archives will be in tar.gz format instead of zip format since we no longer notarize the zip files but binaries
