### PR TITLE
feat: add cloudposse/slack-notifier

### DIFF
--- a/pkgs/cloudposse/slack-notifier/pkg.yaml
+++ b/pkgs/cloudposse/slack-notifier/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: cloudposse/slack-notifier@0.10.0
+  - name: cloudposse/slack-notifier
+    version: 0.8.0
+  - name: cloudposse/slack-notifier
+    version: 0.5.1
+  - name: cloudposse/slack-notifier
+    version: 0.5.0
+  - name: cloudposse/slack-notifier
+    version: 0.4.0

--- a/pkgs/cloudposse/slack-notifier/registry.yaml
+++ b/pkgs/cloudposse/slack-notifier/registry.yaml
@@ -40,6 +40,9 @@ packages:
       - version_constraint: "true"
         asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: slack-notifier
+            src: slack-notifier_v{{.Version}}
         checksum:
           type: github_release
           asset: slack-notifier_{{.Version}}_SHA256SUMS

--- a/pkgs/cloudposse/slack-notifier/registry.yaml
+++ b/pkgs/cloudposse/slack-notifier/registry.yaml
@@ -1,0 +1,46 @@
+packages:
+  - type: github_release
+    repo_owner: cloudposse
+    repo_name: slack-notifier
+    description: Command line utility to send messages with attachments to Slack channels via Incoming Webhooks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: slack-notifier_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.5.0"
+        asset: slack-notifier_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "0.5.1"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.7.0")
+        no_asset: true
+      - version_constraint: Version == "0.8.0"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -12859,6 +12859,51 @@ packages:
           asset: atmos_{{trimV .Version}}_SHA256SUMS
           algorithm: sha256
   - type: github_release
+    repo_owner: cloudposse
+    repo_name: slack-notifier
+    description: Command line utility to send messages with attachments to Slack channels via Incoming Webhooks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: slack-notifier_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.5.0"
+        asset: slack-notifier_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "0.5.1"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.7.0")
+        no_asset: true
+      - version_constraint: Version == "0.8.0"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: slack-notifier_{{.Version}}_SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: cloudquery
     repo_name: cloudquery
     description: The open source high performance data integration platform built for developers

--- a/registry.yaml
+++ b/registry.yaml
@@ -12899,6 +12899,9 @@ packages:
       - version_constraint: "true"
         asset: slack-notifier_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: slack-notifier
+            src: slack-notifier_v{{.Version}}
         checksum:
           type: github_release
           asset: slack-notifier_{{.Version}}_SHA256SUMS


### PR DESCRIPTION
[cloudposse/slack-notifier](https://github.com/cloudposse/slack-notifier): Command line utility to send messages with attachments to Slack channels via Incoming Webhooks

```console
$ aqua g -i cloudposse/slack-notifier
```