### PR TITLE
feat(g-plane/pnpm-shell-completion): scaffold g-plane/pnpm-shell-completion

### DIFF
--- a/pkgs/g-plane/pnpm-shell-completion/pkg.yaml
+++ b/pkgs/g-plane/pnpm-shell-completion/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: g-plane/pnpm-shell-completion@v0.5.4
+  - name: g-plane/pnpm-shell-completion
+    version: v0.3.0
+  - name: g-plane/pnpm-shell-completion
+    version: v0.2.0

--- a/pkgs/g-plane/pnpm-shell-completion/registry.yaml
+++ b/pkgs/g-plane/pnpm-shell-completion/registry.yaml
@@ -1,0 +1,60 @@
+packages:
+  - type: github_release
+    repo_owner: g-plane
+    repo_name: pnpm-shell-completion
+    description: Complete your pnpm command fastly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.3.0"
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: pnpm-shell-completion_pwsh_{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/g-plane/pnpm-shell-completion/registry.yaml
+++ b/pkgs/g-plane/pnpm-shell-completion/registry.yaml
@@ -2,7 +2,23 @@ packages:
   - type: github_release
     repo_owner: g-plane
     repo_name: pnpm-shell-completion
-    description: Complete your pnpm command fastly
+    description: |
+      Complete your pnpm command fastly
+
+      ## Set up
+
+      You need to execute a script within the running shell's process.
+      For details, please see the document.
+
+      https://github.com/g-plane/pnpm-shell-completion#installation
+
+      Zsh:
+
+      ```sh
+      local plugin_path_dir=$(dirname $(aqua which pnpm-shell-completion))
+      local plugin_path="${plugin_path_dir}/pnpm-shell-completion.plugin.zsh"
+      source $plugin_path
+      ```
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -19790,7 +19790,23 @@ packages:
   - type: github_release
     repo_owner: g-plane
     repo_name: pnpm-shell-completion
-    description: Complete your pnpm command fastly
+    description: |
+      Complete your pnpm command fastly
+
+      ## Set up
+
+      You need to execute a script within the running shell's process.
+      For details, please see the document.
+
+      https://github.com/g-plane/pnpm-shell-completion#installation
+
+      Zsh:
+
+      ```sh
+      local plugin_path_dir=$(dirname $(aqua which pnpm-shell-completion))
+      local plugin_path="${plugin_path_dir}/pnpm-shell-completion.plugin.zsh"
+      source $plugin_path
+      ```
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -19788,6 +19788,65 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: g-plane
+    repo_name: pnpm-shell-completion
+    description: Complete your pnpm command fastly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.3.0"
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: pnpm-shell-completion_{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: pnpm-shell-completion_pwsh_{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: gabeduke
     repo_name: kubectl-iexec
     description: Kubectl plugin to interactively exec into a pod


### PR DESCRIPTION
[pnpm-shell-completion](https://github.com/g-plane/pnpm-shell-completion): a shell plugin designed to enhance the command-line experience with [pnpm](https://pnpm.io/) by providing tab-completion features. 

This shell plugin calls a Rust-based executable to provide completion functionality. Managing shell plugins is outside the scope of aqua. However, since the executable to be used may vary depending on the environment, it is convenient to be able to install it with aqua.


## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->


## How to confirm if this package works well

```zsh
# Any repository that uses pnpm will do.
$ git clone https://github.com/pnpm/pnpm.git

$ cd pnpm

# This simulates a call from script.
# https://github.com/g-plane/pnpm-shell-completion/blob/main/pnpm-shell-completion.plugin.zsh
$ FEATURE=scripts pnpm-shell-completion
test-pkgs-main
make-lcov
pretest
prepare
watch
compile
compile-only
preinstall
remove-temp-dir
test-main
update-manifests
meta-updater
make-release-description
dev-setup
test-branch
spellcheck
lint:meta
bump
test-pkgs-branch
changeset
lint:ts
copy-artifacts
lint
release
```