### PR TITLE
chore(hadolint/hadolint): re-scaffold hadolint/hadolint to include checksum

### DIFF
--- a/pkgs/hadolint/hadolint/pkg.yaml
+++ b/pkgs/hadolint/hadolint/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: hadolint/hadolint@v2.12.1-beta
+  - name: hadolint/hadolint@v2.12.0
   - name: hadolint/hadolint
     version: v2.10.0
   - name: hadolint/hadolint

--- a/pkgs/hadolint/hadolint/pkg.yaml
+++ b/pkgs/hadolint/hadolint/pkg.yaml
@@ -1,4 +1,12 @@
 packages:
-  - name: hadolint/hadolint@v2.12.0
+  - name: hadolint/hadolint@v2.12.1-beta
   - name: hadolint/hadolint
-    version: v2.9.0
+    version: v2.10.0
+  - name: hadolint/hadolint
+    version: v2.9.3
+  - name: hadolint/hadolint
+    version: v2.7.0
+  - name: hadolint/hadolint
+    version: v2.6.1
+  - name: hadolint/hadolint
+    version: v1.2.2

--- a/pkgs/hadolint/hadolint/registry.yaml
+++ b/pkgs/hadolint/hadolint/registry.yaml
@@ -2,21 +2,80 @@ packages:
   - type: github_release
     repo_owner: hadolint
     repo_name: hadolint
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
-    asset: hadolint-{{.OS}}-{{.Arch}}
-    format: raw
     description: Dockerfile linter, validate inline bash, written in Haskell
-    replacements:
-      amd64: x86_64
-      linux: Linux
-      darwin: Darwin
-    version_constraint: semver(">= 2.10.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: hadolint_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 2.6.1")
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.7.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.9.3")
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.10.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: "true"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/hadolint/hadolint/registry.yaml
+++ b/pkgs/hadolint/hadolint/registry.yaml
@@ -5,31 +5,6 @@ packages:
     description: Dockerfile linter, validate inline bash, written in Haskell
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0")
-        no_asset: true
-      - version_constraint: semver("<= 1.2.2")
-        asset: hadolint_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 2.6.1")
-        asset: hadolint-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v2.7.0"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
@@ -41,6 +16,17 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: hadolint_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 2.9.3")
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -22606,24 +22606,83 @@ packages:
   - type: github_release
     repo_owner: hadolint
     repo_name: hadolint
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
-    asset: hadolint-{{.OS}}-{{.Arch}}
-    format: raw
     description: Dockerfile linter, validate inline bash, written in Haskell
-    replacements:
-      amd64: x86_64
-      linux: Linux
-      darwin: Darwin
-    version_constraint: semver(">= 2.10.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: hadolint_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 2.6.1")
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.7.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.9.3")
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.10.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+      - version_constraint: "true"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - type: github_release
     repo_owner: hairyhenderson
     repo_name: gomplate

--- a/registry.yaml
+++ b/registry.yaml
@@ -22609,31 +22609,6 @@ packages:
     description: Dockerfile linter, validate inline bash, written in Haskell
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0")
-        no_asset: true
-      - version_constraint: semver("<= 1.2.2")
-        asset: hadolint_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 2.6.1")
-        asset: hadolint-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v2.7.0"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
@@ -22645,6 +22620,17 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.2")
+        asset: hadolint_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 2.9.3")
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Re-ran `cmdx s hadolint/hadolint` to include `checksum` which is added since hadolint@2.10.0.
