### PR TITLE
fix: add cosign configs for caddyserver/caddy

### DIFF
--- a/pkgs/caddyserver/caddy/pkg.yaml
+++ b/pkgs/caddyserver/caddy/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: caddyserver/caddy@v2.8.4
+  - name: caddyserver/caddy
+    version: v2.5.2

--- a/pkgs/caddyserver/caddy/registry.yaml
+++ b/pkgs/caddyserver/caddy/registry.yaml
@@ -2,15 +2,40 @@ packages:
   - type: github_release
     repo_owner: caddyserver
     repo_name: caddy
-    asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: Fast, multi-platform web server with automatic HTTPS
-    replacements:
-      darwin: mac
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: caddy_{{trimV .Version}}_checksums.txt
-      algorithm: sha512
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.5.2")
+        asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: caddy_{{trimV .Version}}_checksums.txt
+          algorithm: sha512
+      - version_constraint: "true"
+        asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: caddy_{{trimV .Version}}_checksums.txt
+          algorithm: sha512
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/caddyserver/caddy/\\.github/workflows/release\\.yml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/caddyserver/caddy/releases/download/v{{trimV .Version}}/caddy_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/caddyserver/caddy/releases/download/v{{trimV .Version}}/caddy_{{trimV .Version}}_checksums.txt.pem

--- a/registry.yaml
+++ b/registry.yaml
@@ -10832,18 +10832,43 @@ packages:
   - type: github_release
     repo_owner: caddyserver
     repo_name: caddy
-    asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: Fast, multi-platform web server with automatic HTTPS
-    replacements:
-      darwin: mac
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: caddy_{{trimV .Version}}_checksums.txt
-      algorithm: sha512
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.5.2")
+        asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: caddy_{{trimV .Version}}_checksums.txt
+          algorithm: sha512
+      - version_constraint: "true"
+        asset: caddy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: caddy_{{trimV .Version}}_checksums.txt
+          algorithm: sha512
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/caddyserver/caddy/\\.github/workflows/release\\.yml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/caddyserver/caddy/releases/download/v{{trimV .Version}}/caddy_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/caddyserver/caddy/releases/download/v{{trimV .Version}}/caddy_{{trimV .Version}}_checksums.txt.pem
   - type: github_release
     repo_owner: cantino
     repo_name: mcfly


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
