### PR TITLE
fix(volta-cli/volta): follow up changes of volta v2.0.0

### DIFF
--- a/pkgs/volta-cli/volta/pkg.yaml
+++ b/pkgs/volta-cli/volta/pkg.yaml
@@ -1,2 +1,18 @@
 packages:
-  - name: volta-cli/volta@v1.1.1
+  - name: volta-cli/volta@v2.0.0
+  - name: volta-cli/volta
+    version: v1.1.1
+  - name: volta-cli/volta
+    version: v1.0.8
+  - name: volta-cli/volta
+    version: v1.0.6
+  - name: volta-cli/volta
+    version: v1.0.0
+  - name: volta-cli/volta
+    version: v0.7.2
+  - name: volta-cli/volta
+    version: v0.4.1
+  - name: volta-cli/volta
+    version: v0.3.0
+  - name: volta-cli/volta
+    version: v0.1.5

--- a/pkgs/volta-cli/volta/registry.yaml
+++ b/pkgs/volta-cli/volta/registry.yaml
@@ -2,19 +2,151 @@ packages:
   - type: github_release
     repo_owner: volta-cli
     repo_name: volta
-    asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
-    format: tar.gz
     description: "Volta: JS Toolchains as Code"
-    link: https://volta.sh
-    replacements:
-      arm64: aarch64
-      darwin: macos
-    overrides:
-      - goos: darwin
-        goarch: arm64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        asset: notion-{{trimV .Version}}-{{.OS}}.sh
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.sh
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: notion-{{trimV .Version}}-{{.OS}}.sh
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.4.1")
+        asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.1.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: notion-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.2")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.0")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.6")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.8")
         asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - goos: windows
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+          - goos: darwin
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.1")
+        asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-    supported_envs:
-      - darwin
-      - amd64
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: volta-{{trimV .Version}}-{{.OS}}-arm.{{.Format}}
+          - goos: darwin
+            format: tar.gz
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows

--- a/pkgs/volta-cli/volta/registry.yaml
+++ b/pkgs/volta-cli/volta/registry.yaml
@@ -9,6 +9,8 @@ packages:
         asset: notion-{{trimV .Version}}-{{.OS}}.sh
         format: raw
         rosetta2: true
+        files:
+          - name: notion
         replacements:
           darwin: macos
         supported_envs:
@@ -18,6 +20,8 @@ packages:
         asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.sh
         format: raw
         rosetta2: true
+        files:
+          - name: notion
         replacements:
           darwin: macos
         overrides:
@@ -32,6 +36,8 @@ packages:
         rosetta2: true
         replacements:
           darwin: macos
+        files:
+          - name: notion
         overrides:
           - goos: darwin
             asset: notion-{{trimV .Version}}-{{.OS}}.{{.Format}}
@@ -131,22 +137,17 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
-        asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
+        asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           darwin: macos
         overrides:
           - goos: linux
-            format: tar.gz
+            goarch: arm64
             asset: volta-{{trimV .Version}}-{{.OS}}-arm.{{.Format}}
-          - goos: darwin
-            format: tar.gz
-            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
           - goos: windows
-            goarch: amd64
-            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-          - windows
+            format: zip
+          - goos: windows
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-arm64.{{.Format}}
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -45159,6 +45159,8 @@ packages:
         asset: notion-{{trimV .Version}}-{{.OS}}.sh
         format: raw
         rosetta2: true
+        files:
+          - name: notion
         replacements:
           darwin: macos
         supported_envs:
@@ -45168,6 +45170,8 @@ packages:
         asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.sh
         format: raw
         rosetta2: true
+        files:
+          - name: notion
         replacements:
           darwin: macos
         overrides:
@@ -45182,6 +45186,8 @@ packages:
         rosetta2: true
         replacements:
           darwin: macos
+        files:
+          - name: notion
         overrides:
           - goos: darwin
             asset: notion-{{trimV .Version}}-{{.OS}}.{{.Format}}
@@ -45281,25 +45287,20 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
-        asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
+        asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           darwin: macos
         overrides:
           - goos: linux
-            format: tar.gz
+            goarch: arm64
             asset: volta-{{trimV .Version}}-{{.OS}}-arm.{{.Format}}
-          - goos: darwin
-            format: tar.gz
-            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
           - goos: windows
-            goarch: amd64
-            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-          - windows
+            format: zip
+          - goos: windows
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-arm64.{{.Format}}
+            format: zip
   - type: github_release
     repo_owner: wader
     repo_name: fq

--- a/registry.yaml
+++ b/registry.yaml
@@ -45152,22 +45152,154 @@ packages:
   - type: github_release
     repo_owner: volta-cli
     repo_name: volta
-    asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
-    format: tar.gz
     description: "Volta: JS Toolchains as Code"
-    link: https://volta.sh
-    replacements:
-      arm64: aarch64
-      darwin: macos
-    overrides:
-      - goos: darwin
-        goarch: arm64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        asset: notion-{{trimV .Version}}-{{.OS}}.sh
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.sh
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: notion-{{trimV .Version}}-{{.OS}}.sh
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.4.1")
+        asset: notion-{{trimV .Version}}-{{.OS}}-openssl-1.0.1.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: notion-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.2")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.0")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.6")
+        asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.8")
         asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - goos: windows
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: volta-{{trimV .Version}}-{{.OS}}-openssl-1.0.{{.Format}}
+          - goos: darwin
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.1")
+        asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: arm64
+            asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: volta-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
-    supported_envs:
-      - darwin
-      - amd64
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: volta-{{trimV .Version}}-{{.OS}}-arm.{{.Format}}
+          - goos: darwin
+            format: tar.gz
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            goarch: amd64
+            asset: volta-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
   - type: github_release
     repo_owner: wader
     repo_name: fq


### PR DESCRIPTION
Close #25794

> Volta will now use a universal binary on Mac, rather than separate Intel- & ARM-specific builds (https://github.com/volta-cli/volta/pull/1635)

- https://github.com/volta-cli/volta/releases/tag/v2.0.0