### PR TITLE
feat: add Zxilly/go-size-analyzer

### DIFF
--- a/pkgs/Zxilly/go-size-analyzer/pkg.yaml
+++ b/pkgs/Zxilly/go-size-analyzer/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: Zxilly/go-size-analyzer@v1.6.3
+  - name: Zxilly/go-size-analyzer
+    version: v1.0.9
+  - name: Zxilly/go-size-analyzer
+    version: v1.0.5
+  - name: Zxilly/go-size-analyzer
+    version: ui-v1
+  - name: Zxilly/go-size-analyzer
+    version: v0.4.0
+  - name: Zxilly/go-size-analyzer
+    version: ui
+  - name: Zxilly/go-size-analyzer
+    version: 0.2.2
+  - name: Zxilly/go-size-analyzer
+    version: 0.1.0

--- a/pkgs/Zxilly/go-size-analyzer/pkg.yaml
+++ b/pkgs/Zxilly/go-size-analyzer/pkg.yaml
@@ -5,12 +5,6 @@ packages:
   - name: Zxilly/go-size-analyzer
     version: v1.0.5
   - name: Zxilly/go-size-analyzer
-    version: ui-v1
-  - name: Zxilly/go-size-analyzer
     version: v0.4.0
   - name: Zxilly/go-size-analyzer
-    version: ui
-  - name: Zxilly/go-size-analyzer
     version: 0.2.2
-  - name: Zxilly/go-size-analyzer
-    version: 0.1.0

--- a/pkgs/Zxilly/go-size-analyzer/registry.yaml
+++ b/pkgs/Zxilly/go-size-analyzer/registry.yaml
@@ -8,65 +8,14 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.0")
-      - version_constraint: semver("<= 0.2.2")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= ui")
-      - version_constraint: semver("<= 0.4.0")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "ui-v1"
-      - version_constraint: semver("<= 1.0.5")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.9")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
-          - goos: windows
-            format: zip
+        no_asset: true
       - version_constraint: "true"
-        asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}v3.pkg.{{.Format}}
-        format: tar.zst
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            goarch: arm64
-            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
-          - goos: darwin
-            format: tar.gz
-            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/pkgs/Zxilly/go-size-analyzer/registry.yaml
+++ b/pkgs/Zxilly/go-size-analyzer/registry.yaml
@@ -1,0 +1,72 @@
+packages:
+  - type: github_release
+    repo_owner: Zxilly
+    repo_name: go-size-analyzer
+    description: A tool for analyzing the size of compiled Go binaries, offering cross-platform support, detailed breakdowns, and multiple output formats
+    files:
+      - name: gsa
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+      - version_constraint: semver("<= 0.2.2")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= ui")
+      - version_constraint: semver("<= 0.4.0")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "ui-v1"
+      - version_constraint: semver("<= 1.0.5")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.9")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}v3.pkg.{{.Format}}
+        format: tar.zst
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: darwin
+            format: tar.gz
+            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -5040,68 +5040,17 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.0")
-      - version_constraint: semver("<= 0.2.2")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= ui")
-      - version_constraint: semver("<= 0.4.0")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "ui-v1"
-      - version_constraint: semver("<= 1.0.5")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.9")
-        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
-          - goos: windows
-            format: zip
+        no_asset: true
       - version_constraint: "true"
-        asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}v3.pkg.{{.Format}}
-        format: tar.zst
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            goarch: arm64
-            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
-          - goos: darwin
-            format: tar.gz
-            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
   - type: github_release
     repo_owner: a-h
     repo_name: templ

--- a/registry.yaml
+++ b/registry.yaml
@@ -5032,6 +5032,77 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: Zxilly
+    repo_name: go-size-analyzer
+    description: A tool for analyzing the size of compiled Go binaries, offering cross-platform support, detailed breakdowns, and multiple output formats
+    files:
+      - name: gsa
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+      - version_constraint: semver("<= 0.2.2")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= ui")
+      - version_constraint: semver("<= 0.4.0")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "ui-v1"
+      - version_constraint: semver("<= 1.0.5")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.9")
+        asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}v3.pkg.{{.Format}}
+        format: tar.zst
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: go-size-analyzer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: darwin
+            format: tar.gz
+            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: go-size-analyzer_{{.OS}}_{{.Arch}}.{{.Format}}
+  - type: github_release
     repo_owner: a-h
     repo_name: templ
     description: A language for writing HTML user interfaces in Go


### PR DESCRIPTION
[Zxilly/go-size-analyzer](https://github.com/Zxilly/go-size-analyzer): A tool for analyzing the size of compiled Go binaries, offering cross-platform support, detailed breakdowns, and multiple output formats

```console
$ aqua g -i Zxilly/go-size-analyzer
```