### PR TITLE
feat: add amalshaji/portr

### DIFF
--- a/pkgs/amalshaji/portr/pkg.yaml
+++ b/pkgs/amalshaji/portr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: amalshaji/portr@0.0.19-beta

--- a/pkgs/amalshaji/portr/registry.yaml
+++ b/pkgs/amalshaji/portr/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: amalshaji
+    repo_name: portr
+    description: Open source ngrok alternative designed for teams. Tunnel http, tcp or websocket connections
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: portr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -6178,6 +6178,26 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: amalshaji
+    repo_name: portr
+    description: Open source ngrok alternative designed for teams. Tunnel http, tcp or websocket connections
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: portr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: amber-lang
     repo_name: amber
     aliases:


### PR DESCRIPTION
[amalshaji/portr](https://github.com/amalshaji/portr): Open source ngrok alternative designed for teams. Tunnel http, tcp or websocket connections

```console
$ aqua g -i amalshaji/portr
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ root@01219814df2e:/workspace# portr 
NAME:
   portr - Expose local ports to the public internet

USAGE:
   portr [global options] command [command options] 

VERSION:
   0.0.19-beta

COMMANDS:
   start    Start the tunnels from the config file
   config   Edit the portr config file
   http     Expose http/ws port
   tcp      Expose tcp port
   auth     Setup portr cli auth
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value  Config file (default: "/root/.portr/config.yaml")
   --help, -h                show help
   --version, -v             print the version


$ root@01219814df2e:/workspace# portr --version 
portr version 0.0.19-beta
```

If files such as configuration file are needed, please share them.

Reference

-
