### PR TITLE
feat: add jmespath/jp

### DIFF
--- a/pkgs/jmespath/jp/pkg.yaml
+++ b/pkgs/jmespath/jp/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: jmespath/jp@0.2.1
+  - name: jmespath/jp
+    version: 0.2.0
+  - name: jmespath/jp
+    version: 0.1.3

--- a/pkgs/jmespath/jp/registry.yaml
+++ b/pkgs/jmespath/jp/registry.yaml
@@ -1,0 +1,28 @@
+packages:
+  - type: github_release
+    repo_owner: jmespath
+    repo_name: jp
+    description: Command line interface to JMESPath - http://jmespath.org
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.3")
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.2.0"
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+      - version_constraint: "true"
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -25523,6 +25523,33 @@ packages:
     description: Generate type-safe Go converters by simply defining an interface
     path: github.com/jmattheis/goverter/cmd/goverter
   - type: github_release
+    repo_owner: jmespath
+    repo_name: jp
+    description: Command line interface to JMESPath - http://jmespath.org
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.3")
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.2.0"
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+      - version_constraint: "true"
+        asset: jp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+  - type: github_release
     repo_owner: joehillen
     repo_name: sysz
     description: An fzf  terminal UI for systemctl


### PR DESCRIPTION
[jmespath/jp](https://github.com/jmespath/jp): Command line interface to JMESPath - http://jmespath.org

```console
$ aqua g -i jmespath/jp
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@ed8284a19868:/workspace# jp --help
NAME:
   jp - jp [<options>] <expression>

USAGE:
   jp-linux-arm64 [global options] command [command options] [arguments...]

VERSION:
   0.2.1

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --compact, -c                Produce compact JSON output that omits nonessential whitespace.
   --filename value, -f value   Read input JSON from a file instead of stdin.
   --expr-file value, -e value  Read JMESPath expression from the specified file.
   --unquoted, -u               If the final result is a string, it will be printed without quotes. [$JP_UNQUOTED]
   --ast                        Only print the AST of the parsed expression.  Do not rely on this output, only useful for debugging purposes.
   --help, -h                   show help
   --version, -v                print the version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/jmespath/jp/blob/master/README.md
