### PR TITLE
ADD replacement aarch64 to arm64 for ned1313/terrahash

### DIFF
--- a/pkgs/ned1313/terrahash/registry.yaml
+++ b/pkgs/ned1313/terrahash/registry.yaml
@@ -9,6 +9,7 @@ packages:
         asset: terrahash_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
+          aarch64: arm64
           amd64: x86_64
           darwin: Darwin
           linux: Linux


### PR DESCRIPTION
https://github.com/ned1313/terrahash

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Do only one thing in one Pull Request

<!-- Please write the description here -->

ADD replacement aarch64 to arm64 for ned1313/terrahash to enable installation on aarch64 (MacBook Pros M* based machines for example).