### PR TITLE
feat(bufbuild/buf): add minisign config

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
       - run: actionlint -ignore "duplicate value"

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-generate-registry.yaml
+++ b/.github/workflows/wc-generate-registry.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
       - uses: aquaproj/registry-action/generate-registry@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v0.2.1

--- a/.github/workflows/wc-generate-registry.yaml
+++ b/.github/workflows/wc-generate-registry.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
       - uses: aquaproj/registry-action/generate-registry@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v0.2.1

--- a/.github/workflows/wc-generate-registry.yaml
+++ b/.github/workflows/wc-generate-registry.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
       - uses: aquaproj/registry-action/generate-registry@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v0.2.1

--- a/.github/workflows/wc-generate-registry.yaml
+++ b/.github/workflows/wc-generate-registry.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
       - uses: aquaproj/registry-action/generate-registry@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v0.2.1

--- a/.github/workflows/wc-generate-registry.yaml
+++ b/.github/workflows/wc-generate-registry.yaml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
       - uses: aquaproj/registry-action/generate-registry@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v0.2.1

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-2
+          aqua_version: v2.34.0-4
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.33.0
+          aqua_version: v2.34.0-1
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-5
+          aqua_version: v2.34.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-4
+          aqua_version: v2.34.0-5
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
         with:
-          aqua_version: v2.34.0-1
+          aqua_version: v2.34.0-2
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "fb4b3b7d026e5aba1fc478c268e8fbd653e01404c8a8c6284fdba88ae62eda6a  aqua-installer" | sha256sum -c
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.34.0-5
+RUN ./aqua-installer -v v2.34.0
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "fb4b3b7d026e5aba1fc478c268e8fbd653e01404c8a8c6284fdba88ae62eda6a  aqua-installer" | sha256sum -c
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.33.0
+RUN ./aqua-installer -v v2.34.0-2
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "fb4b3b7d026e5aba1fc478c268e8fbd653e01404c8a8c6284fdba88ae62eda6a  aqua-installer" | sha256sum -c
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.34.0-4
+RUN ./aqua-installer -v v2.34.0-5
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "fb4b3b7d026e5aba1fc478c268e8fbd653e01404c8a8c6284fdba88ae62eda6a  aqua-installer" | sha256sum -c
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.34.0-2
+RUN ./aqua-installer -v v2.34.0-4
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml

--- a/pkgs/bufbuild/buf/pkg.yaml
+++ b/pkgs/bufbuild/buf/pkg.yaml
@@ -3,6 +3,8 @@ packages:
   - name: bufbuild/buf
     version: v0.53.0
   - name: bufbuild/buf
+    version: v0.45.0
+  - name: bufbuild/buf
     version: v0.42.0
   - name: bufbuild/buf
     version: v0.41.0

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -52,6 +52,31 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.45.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: semver("<= 0.53.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -70,6 +95,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
+        minisign:
+          type: github_release
+          asset: sha256.txt.minisig
+          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:
@@ -96,6 +125,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
+        minisign:
+          type: github_release
+          asset: sha256.txt.minisig
+          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -95,10 +95,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
-        minisign:
-          type: github_release
-          asset: sha256.txt.minisig
-          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
+          minisign:
+            type: github_release
+            asset: sha256.txt.minisig
+            public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:

--- a/pkgs/bufbuild/buf/registry.yaml
+++ b/pkgs/bufbuild/buf/registry.yaml
@@ -125,10 +125,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
-        minisign:
-          type: github_release
-          asset: sha256.txt.minisig
-          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
+          minisign:
+            type: github_release
+            asset: sha256.txt.minisig
+            public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -10678,10 +10678,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
-        minisign:
-          type: github_release
-          asset: sha256.txt.minisig
-          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
+          minisign:
+            type: github_release
+            asset: sha256.txt.minisig
+            public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -10648,10 +10648,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
-        minisign:
-          type: github_release
-          asset: sha256.txt.minisig
-          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
+          minisign:
+            type: github_release
+            asset: sha256.txt.minisig
+            public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -10488,6 +10488,31 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.45.0")
+        asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: buf
+            src: buf/bin/buf
+          - name: protoc-gen-buf-breaking
+            src: buf/bin/protoc-gen-buf-breaking
+          - name: protoc-gen-buf-lint
+            src: buf/bin/protoc-gen-buf-lint
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: semver("<= 0.53.0")
         asset: buf-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -10506,6 +10531,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
+        minisign:
+          type: github_release
+          asset: sha256.txt.minisig
+          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:
@@ -10532,6 +10561,10 @@ packages:
           type: github_release
           asset: sha256.txt
           algorithm: sha256
+        minisign:
+          type: github_release
+          asset: sha256.txt.minisig
+          public_key: RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
         overrides:
           - goos: linux
             replacements:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Adds minisign config for bufbuild/buf.

- https://buf.build/docs/installation > "GitHub" tab > "Verifying a release"

https://github.com/aquaproj/aqua/issues/3072 is needed.

