### PR TITLE
feat(cargo-bins/cargo-binstall): add minisign config

### DIFF
--- a/pkgs/cargo-bins/cargo-binstall/registry.yaml
+++ b/pkgs/cargo-bins/cargo-binstall/registry.yaml
@@ -71,6 +71,18 @@ packages:
           - goos: windows
             replacements:
               arm64: arm64
+      - version_constraint: semver("<= 1.3.1")
+        asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tgz
       - version_constraint: "true"
         asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -80,6 +92,10 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        minisign:
+          type: github_release
+          asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}.sig
+          public_key_url: https://github.com/cargo-bins/cargo-binstall/releases/download/v{{.Version}}/minisign.pub
         overrides:
           - goos: linux
             format: tgz

--- a/registry.yaml
+++ b/registry.yaml
@@ -11118,6 +11118,18 @@ packages:
           - goos: windows
             replacements:
               arm64: arm64
+      - version_constraint: semver("<= 1.3.1")
+        asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tgz
       - version_constraint: "true"
         asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -11127,6 +11139,10 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        minisign:
+          type: github_release
+          asset: cargo-binstall-{{.Arch}}-{{.OS}}.{{.Format}}.sig
+          public_key_url: https://github.com/cargo-bins/cargo-binstall/releases/download/v{{.Version}}/minisign.pub
         overrides:
           - goos: linux
             format: tgz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

Adds minisign config for cargo-bins/cargo-binstall.

https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.4.1#:~:text=Binstall%27s%20releases%20are,its%20own%20signature%3A

https://github.com/aquaproj/aqua/issues/3073 is needed.
