### PR TITLE
fix(sxyazi/yazi): add ya command

### DIFF
--- a/pkgs/sxyazi/yazi/pkg.yaml
+++ b/pkgs/sxyazi/yazi/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: sxyazi/yazi@v0.3.3
   - name: sxyazi/yazi
+    version: v0.2.4
+  - name: sxyazi/yazi
     version: v0.1.5
   - name: sxyazi/yazi
     version: v0.1.4

--- a/pkgs/sxyazi/yazi/registry.yaml
+++ b/pkgs/sxyazi/yazi/registry.yaml
@@ -3,6 +3,9 @@ packages:
     repo_owner: sxyazi
     repo_name: yazi
     description: Blazing fast terminal file manager written in Rust, based on async I/O
+    files:
+      - name: yazi
+      - name: ya
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.3")
@@ -59,7 +62,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip

--- a/pkgs/sxyazi/yazi/registry.yaml
+++ b/pkgs/sxyazi/yazi/registry.yaml
@@ -42,12 +42,32 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.2.4")
+        asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: yazi
+            src: yazi-{{.Arch}}-{{.OS}}/yazi
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
           - name: yazi
             src: yazi-{{.Arch}}-{{.OS}}/yazi
+          - name: ya
+            src: yazi-{{.Arch}}-{{.OS}}/ya
         windows_arm_emulation: true
         overrides:
           - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -43148,6 +43148,9 @@ packages:
     repo_owner: sxyazi
     repo_name: yazi
     description: Blazing fast terminal file manager written in Rust, based on async I/O
+    files:
+      - name: yazi
+      - name: ya
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.3")
@@ -43204,7 +43207,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43187,12 +43187,32 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.2.4")
+        asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: yazi
+            src: yazi-{{.Arch}}-{{.OS}}/yazi
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            replacements:
+              arm64: arm64
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
           - name: yazi
             src: yazi-{{.Arch}}-{{.OS}}/yazi
+          - name: ya
+            src: yazi-{{.Arch}}-{{.OS}}/ya
         windows_arm_emulation: true
         overrides:
           - goos: windows


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

## Description

Yazi introduced a separate command called `ya` in Yazi v0.2.5. Therefore, I added the `ya` command to the executable file.

### Reference

Yazi v0.2.5 Release Note: https://github.com/sxyazi/yazi/releases/tag/v0.2.5
Document: https://yazi-rs.github.io/docs/dds/