### PR TITLE
feat: add tailscale/tailscale

### DIFF
--- a/pkgs/tailscale/tailscale/pkg.yaml
+++ b/pkgs/tailscale/tailscale/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: tailscale/tailscale@
+  - name: tailscale/tailscale@v1.72.0

--- a/pkgs/tailscale/tailscale/pkg.yaml
+++ b/pkgs/tailscale/tailscale/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tailscale/tailscale@

--- a/pkgs/tailscale/tailscale/registry.yaml
+++ b/pkgs/tailscale/tailscale/registry.yaml
@@ -1,0 +1,6 @@
+packages:
+  - type: github_release
+    repo_owner: tailscale
+    repo_name: tailscale
+    description: The easiest, most secure way to use WireGuard and 2FA
+    no_asset: true

--- a/pkgs/tailscale/tailscale/registry.yaml
+++ b/pkgs/tailscale/tailscale/registry.yaml
@@ -1,6 +1,20 @@
 packages:
-  - type: github_release
+  - type: http
     repo_owner: tailscale
     repo_name: tailscale
     description: The easiest, most secure way to use WireGuard and 2FA
-    no_asset: true
+    url: https://pkgs.tailscale.com/stable/tailscale_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+    format: tgz
+    files:
+      - name: tailscale
+        src: "{{.AssetWithoutExt}}/tailscale"
+    overrides:
+      - goos: darwin
+        url: https://pkgs.tailscale.com/stable/Tailscale-{{trimV .Version}}-macos.{{.Format}}
+        format: pkg
+        files:
+          - name: tailscale
+            src: Distribution.pkg/Payload/Contents/MacOS/Tailscale
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -43265,11 +43265,11 @@ packages:
     repo_owner: tailscale
     repo_name: tailscale
     description: The easiest, most secure way to use WireGuard and 2FA
-    # https://pkgs.tailscale.com/stable/tailscale_1.72.1_amd64.tgz
-    # https://pkgs.tailscale.com/stable/tailscale_1.72.1_arm64.tgz
-    # https://pkgs.tailscale.com/stable/Tailscale-1.72.2-macos.pkg
     url: https://pkgs.tailscale.com/stable/tailscale_{{trimV .Version}}_{{.Arch}}.{{.Format}}
     format: tgz
+    files:
+      - name: tailscale
+        src: "{{.AssetWithoutExt}}/tailscale"
     overrides:
       - goos: darwin
         url: https://pkgs.tailscale.com/stable/Tailscale-{{trimV .Version}}-macos.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -43262,6 +43262,11 @@ packages:
       asset: kube-psp-advisor_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: tailscale
+    repo_name: tailscale
+    description: The easiest, most secure way to use WireGuard and 2FA
+    no_asset: true
+  - type: github_release
     repo_owner: takaishi
     repo_name: awscost
     description: Print AWS costs to text or graph image

--- a/registry.yaml
+++ b/registry.yaml
@@ -43261,11 +43261,25 @@ packages:
       type: github_release
       asset: kube-psp-advisor_{{trimV .Version}}_checksums.txt
       algorithm: sha256
-  - type: github_release
+  - type: http
     repo_owner: tailscale
     repo_name: tailscale
     description: The easiest, most secure way to use WireGuard and 2FA
-    no_asset: true
+    # https://pkgs.tailscale.com/stable/tailscale_1.72.1_amd64.tgz
+    # https://pkgs.tailscale.com/stable/tailscale_1.72.1_arm64.tgz
+    # https://pkgs.tailscale.com/stable/Tailscale-1.72.2-macos.pkg
+    url: https://pkgs.tailscale.com/stable/tailscale_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+    format: tgz
+    overrides:
+      - goos: darwin
+        url: https://pkgs.tailscale.com/stable/Tailscale-{{trimV .Version}}-macos.{{.Format}}
+        format: pkg
+        files:
+          - name: tailscale
+            src: Distribution.pkg/Payload/Contents/MacOS/Tailscale
+    supported_envs:
+      - linux
+      - darwin
   - type: github_release
     repo_owner: takaishi
     repo_name: awscost


### PR DESCRIPTION
Close #26715

[tailscale/tailscale](https://github.com/tailscale/tailscale): The easiest, most secure way to use WireGuard and 2FA

```console
$ aqua g -i tailscale/tailscale
```