### PR TITLE
feat: Add asciidoctor/asciidoctor-reveal.js

### DIFF
--- a/pkgs/asciidoctor/asciidoctor-reveal.js/pkg.yaml
+++ b/pkgs/asciidoctor/asciidoctor-reveal.js/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: asciidoctor/asciidoctor-reveal.js@v5.1.0

--- a/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
+++ b/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: asciidoctor
     repo_name: asciidoctor-reveal.js
-    description: ":crystal_ball: A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    description: "A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 3.0.0")

--- a/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
+++ b/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
@@ -10,8 +10,6 @@ packages:
       - version_constraint: "true"
         asset: asciidoctor-revealjs-{{.OS}}
         format: raw
-        rosetta2: true
-        windows_arm_emulation: true
         replacements:
           darwin: macos
           windows: win

--- a/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
+++ b/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
@@ -3,6 +3,8 @@ packages:
     repo_owner: asciidoctor
     repo_name: asciidoctor-reveal.js
     description: "A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    files:
+      - name: asciidoctor-revealjs
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 3.0.0")
@@ -10,6 +12,9 @@ packages:
       - version_constraint: "true"
         asset: asciidoctor-revealjs-{{.OS}}
         format: raw
+        files:
+          - name: asciidoctor-revealjs
+            src: asciidoctor-reveal.js
         replacements:
           darwin: macos
           windows: win

--- a/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
+++ b/pkgs/asciidoctor/asciidoctor-reveal.js/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: asciidoctor
+    repo_name: asciidoctor-reveal.js
+    description: ":crystal_ball: A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.0.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: asciidoctor-revealjs-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -8122,6 +8122,8 @@ packages:
     repo_owner: asciidoctor
     repo_name: asciidoctor-reveal.js
     description: "A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    files:
+      - name: asciidoctor-revealjs
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 3.0.0")
@@ -8129,6 +8131,9 @@ packages:
       - version_constraint: "true"
         asset: asciidoctor-revealjs-{{.OS}}
         format: raw
+        files:
+          - name: asciidoctor-revealjs
+            src: asciidoctor-reveal.js
         replacements:
           darwin: macos
           windows: win

--- a/registry.yaml
+++ b/registry.yaml
@@ -8129,8 +8129,6 @@ packages:
       - version_constraint: "true"
         asset: asciidoctor-revealjs-{{.OS}}
         format: raw
-        rosetta2: true
-        windows_arm_emulation: true
         replacements:
           darwin: macos
           windows: win

--- a/registry.yaml
+++ b/registry.yaml
@@ -8119,6 +8119,26 @@ packages:
           asset: "{{.Asset}}.md5"
           algorithm: md5
   - type: github_release
+    repo_owner: asciidoctor
+    repo_name: asciidoctor-reveal.js
+    description: ":crystal_ball: A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.0.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: asciidoctor-revealjs-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: asciimoo
     repo_name: wuzz
     asset: wuzz_{{.OS}}_{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -8121,7 +8121,7 @@ packages:
   - type: github_release
     repo_owner: asciidoctor
     repo_name: asciidoctor-reveal.js
-    description: ":crystal_ball: A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
+    description: "A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 3.0.0")


### PR DESCRIPTION
[asciidoctor/asciidoctor-reveal.js](https://github.com/asciidoctor/asciidoctor-reveal.js): A reveal.js converter for Asciidoctor and Asciidoctor.js. Write your slides in AsciiDoc!

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

See: [docs.asciidoctor.org/reveal.js-converter/latest/setup/standalone-executable](https://docs.asciidoctor.org/reveal.js-converter/latest/setup/standalone-executable/)

> [Download the executable](https://github.com/asciidoctor/asciidoctor-reveal.js/releases) for your platform and make it executable with chmod or using the files properties' user interface.