### PR TITLE
feat: add dlvhdr/diffnav

### DIFF
--- a/pkgs/dlvhdr/diffnav/pkg.yaml
+++ b/pkgs/dlvhdr/diffnav/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dlvhdr/diffnav@v0.2.4

--- a/pkgs/dlvhdr/diffnav/registry.yaml
+++ b/pkgs/dlvhdr/diffnav/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: dlvhdr
+    repo_name: diffnav
+    description: A git diff pager based on delta but with a file tree, à la GitHub
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: diffnav_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: diffnav_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -17138,6 +17138,27 @@ packages:
       - name: registry
   - type: github_release
     repo_owner: dlvhdr
+    repo_name: diffnav
+    description: A git diff pager based on delta but with a file tree, à la GitHub
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: diffnav_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: diffnav_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: dlvhdr
     repo_name: gh-dash
     description: A beautiful CLI dashboard for GitHub
     version_constraint: "false"


### PR DESCRIPTION
[dlvhdr/diffnav](https://github.com/dlvhdr/diffnav): A git diff pager based on delta but with a file tree, à la GitHub

```console
$ aqua g -i dlvhdr/diffnav
```

Close #27342 