### PR TITLE
feat: add bjesus/pipet

### DIFF
--- a/pkgs/bjesus/pipet/pkg.yaml
+++ b/pkgs/bjesus/pipet/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bjesus/pipet@0.2.2

--- a/pkgs/bjesus/pipet/registry.yaml
+++ b/pkgs/bjesus/pipet/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: bjesus
+    repo_name: pipet
+    description: a swiss-army tool for scraping and extracting data from online assets, made for hackers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pipet-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/bjesus/pipet/registry.yaml
+++ b/pkgs/bjesus/pipet/registry.yaml
@@ -8,6 +8,9 @@ packages:
       - version_constraint: "true"
         asset: pipet-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: pipet
+            src: pipet-{{.OS}}-{{.Arch}}
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -9993,6 +9993,18 @@ packages:
       asset: bw-{{.OS}}-sha256-{{trimPrefix "cli-v" .Version}}.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: bjesus
+    repo_name: pipet
+    description: a swiss-army tool for scraping and extracting data from online assets, made for hackers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pipet-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: blacknon
     repo_name: hwatch
     description: A modern alternative to the watch command, records the differences in execution results and can check this differences at after

--- a/registry.yaml
+++ b/registry.yaml
@@ -10001,6 +10001,9 @@ packages:
       - version_constraint: "true"
         asset: pipet-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: pipet
+            src: pipet-{{.OS}}-{{.Arch}}
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
[bjesus/pipet](https://github.com/bjesus/pipet): a swiss-army tool for scraping and extracting data from online assets, made for hackers

```console
$ aqua g -i bjesus/pipet
```

Close #27569 