### PR TITLE
feat: add kjokjo/ipcalc

### DIFF
--- a/pkgs/kjokjo/ipcalc/pkg.yaml
+++ b/pkgs/kjokjo/ipcalc/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/kjokjo/ipcalc/pkg.yaml
+++ b/pkgs/kjokjo/ipcalc/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: kjokjo/ipcalc@0.51

--- a/pkgs/kjokjo/ipcalc/registry.yaml
+++ b/pkgs/kjokjo/ipcalc/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - type: github_release
+    repo_owner: kjokjo
+    repo_name: ipcalc
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/kjokjo/ipcalc/registry.yaml
+++ b/pkgs/kjokjo/ipcalc/registry.yaml
@@ -1,8 +1,5 @@
 packages:
-  - type: github_release
+  - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    path: ipcalc

--- a/pkgs/kjokjo/ipcalc/registry.yaml
+++ b/pkgs/kjokjo/ipcalc/registry.yaml
@@ -3,3 +3,4 @@ packages:
     repo_owner: kjokjo
     repo_name: ipcalc
     path: ipcalc
+    description: ipcalc takes an IP address and netmask and calculates the resulting broadcast, network, Cisco wildcard mask, and host range

--- a/registry.yaml
+++ b/registry.yaml
@@ -28465,13 +28465,10 @@ packages:
     overrides:
       - goos: windows
         format: zip
-  - type: github_release
+  - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    path: ipcalc
   - type: github_release
     repo_owner: kkdai
     repo_name: youtube

--- a/registry.yaml
+++ b/registry.yaml
@@ -28466,6 +28466,13 @@ packages:
       - goos: windows
         format: zip
   - type: github_release
+    repo_owner: kjokjo
+    repo_name: ipcalc
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: kkdai
     repo_name: youtube
     asset: youtubedr_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -28469,6 +28469,7 @@ packages:
     repo_owner: kjokjo
     repo_name: ipcalc
     path: ipcalc
+    description: ipcalc takes an IP address and netmask and calculates the resulting broadcast, network, Cisco wildcard mask, and host range
   - type: github_release
     repo_owner: kkdai
     repo_name: youtube


### PR DESCRIPTION
[kjokjo/ipcalc](https://github.com/kjokjo/ipcalc): ipcalc takes an IP address and netmask and calculates the resulting broadcast, network, Cisco wildcard mask, and host range

```console
$ aqua g -i kjokjo/ipcalc
```