### PR TITLE
feat: add howardjohn/kubeconfig-proxy

### DIFF
--- a/pkgs/howardjohn/kubeconfig-proxy/pkg.yaml
+++ b/pkgs/howardjohn/kubeconfig-proxy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: howardjohn/kubeconfig-proxy@v0.4.0

--- a/pkgs/howardjohn/kubeconfig-proxy/registry.yaml
+++ b/pkgs/howardjohn/kubeconfig-proxy/registry.yaml
@@ -1,0 +1,14 @@
+packages:
+  - type: github_release
+    repo_owner: howardjohn
+    repo_name: kubeconfig-proxy
+    description: Tunnel Kubectl requests over `kubectl proxy` to avoid round trips to API server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kubeconfig-proxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kubeconfig-proxy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -24958,6 +24958,19 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: howardjohn
+    repo_name: kubeconfig-proxy
+    description: Tunnel Kubectl requests over `kubectl proxy` to avoid round trips to API server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kubeconfig-proxy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kubeconfig-proxy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: hrmsk66
     repo_name: terraformify
     description: An experimental CLI that generates Terraform files for managing existing Fastly services


### PR DESCRIPTION
[howardjohn/kubeconfig-proxy](https://github.com/howardjohn/kubeconfig-proxy): Tunnel Kubectl requests over `kubectl proxy` to avoid round trips to API server

```console
$ aqua g -i howardjohn/kubeconfig-proxy
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@786bfb502949:/workspace# kubeconfig-proxy --help
kubeconfig-proxy is a tool to open a persistent tunnel to an api server to improve kubectl speed

Usage:
  kubeconfig-proxy [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  proxy       register the current context to be proxied
  server      start proxy server

Flags:
  -h, --help   help for kubeconfig-proxy

Use "kubeconfig-proxy [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/howardjohn/kubeconfig-proxy/blob/main/README.md
