### PR TITLE
feat: add firecracker-microvm/firectl

### DIFF
--- a/pkgs/firecracker-microvm/firectl/pkg.yaml
+++ b/pkgs/firecracker-microvm/firectl/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: firecracker-microvm/firectl
+    version: v0.2.0

--- a/pkgs/firecracker-microvm/firectl/registry.yaml
+++ b/pkgs/firecracker-microvm/firectl/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: firecracker-microvm
+    repo_name: firectl
+    description: firectl is a command-line tool to run Firecracker microVMs
+    asset: firectl-{{ .Version }}
+    format: raw
+    supported_envs:
+      - linux
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256

--- a/pkgs/firecracker-microvm/firectl/registry.yaml
+++ b/pkgs/firecracker-microvm/firectl/registry.yaml
@@ -6,7 +6,7 @@ packages:
     asset: firectl-{{ .Version }}
     format: raw
     supported_envs:
-      - linux
+      - linux/amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -20374,7 +20374,7 @@ packages:
     asset: firectl-{{ .Version }}
     format: raw
     supported_envs:
-      - linux
+      - linux/amd64
     checksum:
       type: github_release
       asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -20368,6 +20368,18 @@ packages:
       asset: "{{.Asset}}.sha256.txt"
       algorithm: sha256
   - type: github_release
+    repo_owner: firecracker-microvm
+    repo_name: firectl
+    description: firectl is a command-line tool to run Firecracker microVMs
+    asset: firectl-{{ .Version }}
+    format: raw
+    supported_envs:
+      - linux
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha256"
+      algorithm: sha256
+  - type: github_release
     repo_owner: fishi0x01
     repo_name: vsh
     format: raw


### PR DESCRIPTION
[firecracker-microvm/firectl](https://github.com/firecracker-microvm/firectl): firectl is a command-line tool to run Firecracker microVMs

```console
$ aqua g -i firecracker-microvm/firectl
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ firectl

Usage:
  firectl-v0.2.0 [OPTIONS]

Application Options:
      --firecracker-binary= Path to firecracker binary
      --kernel=             Path to the kernel image
      --kernel-opts=        Kernel commandline
      --initrd-path=        Path to initrd
      --root-drive=         Path to root disk image
      --root-partition=     Root partition UUID
      --add-drive=          Path to additional drive, suffixed with :ro or :rw, can be specified multiple times
      --tap-device=         NIC info, specified as DEVICE/MAC, can be specified multiple times
      --vsock-device=       Vsock interface, specified as PATH:CID. Multiple OK
      --vmm-log-fifo=       FIFO for firecracker logs
      --log-level=          vmm log level
      --metrics-fifo=       FIFO for firecracker metrics
  -t, --disable-smt         Disable CPU Simultaneous Multithreading
  -c, --ncpus=              Number of CPUs
      --cpu-template=       Firecracker CPU Template (C3 or T2)
  -m, --memory=             VM memory, in MiB
      --metadata=           Firecracker Metadata for MMDS (json)
  -l, --firecracker-log=    pipes the fifo contents to the specified file
  -s, --socket-path=        path to use for firecracker socket, defaults to a unique file in in the first existing directory from {$HOME, $TMPDIR, or /tmp}
  -d, --debug               Enable debug output
      --version             Outputs the version of the application
      --id=                 Jailer VMM id
      --exec-file=          Jailer executable
      --jailer=             Jailer binary
      --uid=                Jailer uid for dropping privileges
      --gid=                Jailer gid for dropping privileges
      --node=               Jailer numa node
      --chroot-base-dir=    Jailer chroot base directory
      --daemonize           Run jailer as daemon

```