### PR TITLE
feat(Songmu/r2sync): scaffold Songmu/r2sync

### DIFF
--- a/pkgs/Songmu/r2sync/pkg.yaml
+++ b/pkgs/Songmu/r2sync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Songmu/r2sync@v0.0.3

--- a/pkgs/Songmu/r2sync/registry.yaml
+++ b/pkgs/Songmu/r2sync/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: Songmu
     repo_name: r2sync
+    description: r2sync is a command-line tool for synchronizing files between a local directory and Cloudflare R2
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.1")

--- a/pkgs/Songmu/r2sync/registry.yaml
+++ b/pkgs/Songmu/r2sync/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: Songmu
+    repo_name: r2sync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: r2sync_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/Songmu/r2sync/registry.yaml
+++ b/pkgs/Songmu/r2sync/registry.yaml
@@ -19,3 +19,6 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: r2sync
+            src: r2sync_{{.Version}}_{{.OS}}_{{.Arch}}/r2sync

--- a/registry.yaml
+++ b/registry.yaml
@@ -3775,6 +3775,26 @@ packages:
             src: podbard_{{.Version}}_{{.OS}}_{{.Arch}}/podbard
   - type: github_release
     repo_owner: Songmu
+    repo_name: r2sync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: r2sync_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: Songmu
     repo_name: tagpr
     description: The tagpr automatically creates and updates a pull request for unreleased items, tag them when they are merged, and create releases
     asset: tagpr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -3776,6 +3776,7 @@ packages:
   - type: github_release
     repo_owner: Songmu
     repo_name: r2sync
+    description: r2sync is a command-line tool for synchronizing files between a local directory and Cloudflare R2
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.1")

--- a/registry.yaml
+++ b/registry.yaml
@@ -3793,6 +3793,9 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: r2sync
+            src: r2sync_{{.Version}}_{{.OS}}_{{.Arch}}/r2sync
   - type: github_release
     repo_owner: Songmu
     repo_name: tagpr


### PR DESCRIPTION
[Songmu/r2sync](https://github.com/Songmu/r2sync): r2sync is a command-line tool for synchronizing files between a local directory and Cloudflare R2

```console
$ aqua g -i Songmu/r2sync
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@786bfb502949:/workspace# r2sync --help
Usage: r2sync [OPTIONS] <SOURCE> <DESTINATION>

Arguments:
  <SOURCE>
  <DESTINATION>

Options:
  -p, --public-domain <PUBLIC_DOMAIN>
  -h, --help                           Print help
```

If files such as configuration file are needed, please share them.

Reference

- Blog (JP)
	- https://songmu.jp/riji/entry/2024-10-15-r2sync.html
- README
	- https://github.com/Songmu/r2sync/blob/main/README.md
