### PR TITLE
feat(projectdiscovery/proxify): scaffold projectdiscovery/proxify

### DIFF
--- a/pkgs/projectdiscovery/proxify/pkg.yaml
+++ b/pkgs/projectdiscovery/proxify/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: projectdiscovery/proxify@v0.0.15
+  - name: projectdiscovery/proxify
+    version: v0.0.6
+  - name: projectdiscovery/proxify
+    version: v0.0.4

--- a/pkgs/projectdiscovery/proxify/registry.yaml
+++ b/pkgs/projectdiscovery/proxify/registry.yaml
@@ -1,0 +1,42 @@
+packages:
+  - type: github_release
+    repo_owner: projectdiscovery
+    repo_name: proxify
+    description: A versatile and portable proxy for capturing, manipulating, and replaying HTTP/HTTPS traffic on the go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.6")
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.7"
+        no_asset: true
+      - version_constraint: "true"
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -38004,6 +38004,47 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: projectdiscovery
+    repo_name: proxify
+    description: A versatile and portable proxy for capturing, manipulating, and replaying HTTP/HTTPS traffic on the go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.6")
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.7"
+        no_asset: true
+      - version_constraint: "true"
+        asset: proxify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: proxify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: projectdiscovery
     repo_name: subfinder
     asset: subfinder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
     description: Subfinder is a subdomain discovery tool that discovers valid subdomains for websites. Designed as a passive framework to be useful for bug bounties and safe for penetration testing


### PR DESCRIPTION
#27877 [projectdiscovery/proxify](https://github.com/projectdiscovery/proxify): A versatile and portable proxy for capturing, manipulating, and replaying HTTP/HTTPS traffic on the go

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->
