### PR TITLE
fix(sudorandom/protoc-gen-connect-openapi): regenerate the setting

### DIFF
--- a/pkgs/sudorandom/protoc-gen-connect-openapi/pkg.yaml
+++ b/pkgs/sudorandom/protoc-gen-connect-openapi/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: sudorandom/protoc-gen-connect-openapi@v0.13.0
+  - name: sudorandom/protoc-gen-connect-openapi@v0.13.1
+  - name: sudorandom/protoc-gen-connect-openapi
+    version: v0.13.0

--- a/pkgs/sudorandom/protoc-gen-connect-openapi/registry.yaml
+++ b/pkgs/sudorandom/protoc-gen-connect-openapi/registry.yaml
@@ -7,10 +7,20 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.13.0")
         asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
           asset: protoc-gen-connect-openapi_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_all.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -43497,13 +43497,23 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.13.0")
         asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
           asset: protoc-gen-connect-openapi_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: protoc-gen-connect-openapi_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
   - type: github_release
     repo_owner: sue445
     repo_name: plant_erd


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

The release assets have been changed in the latest version v0.13.1, so I will regenerate the settings.

https://github.com/sudorandom/protoc-gen-connect-openapi/releases/tag/v0.13.1

