### PR TITLE
feat(pkgdep): use go_install

### DIFF
--- a/pkgs/cloverrose/pkgdep/pkg.yaml
+++ b/pkgs/cloverrose/pkgdep/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: cloverrose/pkgdep@v0.3.0
+  - name: cloverrose/pkgdep@v0.3.1

--- a/pkgs/cloverrose/pkgdep/registry.yaml
+++ b/pkgs/cloverrose/pkgdep/registry.yaml
@@ -5,6 +5,15 @@ packages:
     description: pkgdep checks if package dependency follows rule
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 0.3.2")
+        # using go_install
+        type: go_install
+        path: github.com/cloverrose/pkgdep/cmd/pkgdep
+        files:
+          - name: pkgdep
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: pkgdep_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -13863,6 +13863,15 @@ packages:
     description: pkgdep checks if package dependency follows rule
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 0.3.2")
+        # using go_install
+        type: go_install
+        path: github.com/cloverrose/pkgdep/cmd/pkgdep
+        files:
+          - name: pkgdep
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: pkgdep_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

This PR seems strange, that's true. This is kind of investigation purpose.
If you know the better way, please let me know :)

### Issue
I am using pkgdep in our Github action with Makefile.

```makefile
@go vet -vettool=`which pkgdep` -pkgdep.config=$(PWD)/.pkgdep.yaml ./...
```

Only when we run pkgdep on github action, we face error. When we run lint on local Macbook, there is no error.
And if we install pkgdep via `go install` instead of aqua, there is no error even on Github action.

To break down issue, I want to change type to go_install.