### PR TITLE
feat: add turbot/powerpipe

### DIFF
--- a/pkgs/turbot/powerpipe/pkg.yaml
+++ b/pkgs/turbot/powerpipe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: turbot/powerpipe@v1.0.0

--- a/pkgs/turbot/powerpipe/registry.yaml
+++ b/pkgs/turbot/powerpipe/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: turbot
+    repo_name: powerpipe
+    description: "Powerpipe: Dashboards for DevOps. Visualize cloud configurations. Assess security posture against a massive library of benchmarks. Build custom dashboards with code"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: powerpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -46765,6 +46765,22 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: turbot
+    repo_name: powerpipe
+    description: "Powerpipe: Dashboards for DevOps. Visualize cloud configurations. Assess security posture against a massive library of benchmarks. Build custom dashboards with code"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: powerpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: turbot
     repo_name: steampipe
     asset: steampipe_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
[turbot/powerpipe](https://github.com/turbot/powerpipe): Powerpipe: Dashboards for DevOps. Visualize cloud configurations. Assess security posture against a massive library of benchmarks. Build custom dashboards with code

```console
$ aqua g -i turbot/powerpipe
```

Close #28164