### PR TITLE
feat: add cloverrose/unusedinterface

### DIFF
--- a/pkgs/cloverrose/unusedinterface/pkg.yaml
+++ b/pkgs/cloverrose/unusedinterface/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloverrose/unusedinterface@v0.1.0

--- a/pkgs/cloverrose/unusedinterface/registry.yaml
+++ b/pkgs/cloverrose/unusedinterface/registry.yaml
@@ -7,6 +7,9 @@ packages:
       - version_constraint: "true"
         asset: unusedinterface_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: unusedinterface
+            src: "unusedinterface_{{.OS}}_{{.Arch}}/unusedinterface"
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/cloverrose/unusedinterface/registry.yaml
+++ b/pkgs/cloverrose/unusedinterface/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: cloverrose
+    repo_name: unusedinterface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: unusedinterface_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: unusedinterface_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -13889,6 +13889,9 @@ packages:
       - version_constraint: "true"
         asset: unusedinterface_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: unusedinterface
+            src: "unusedinterface_{{.OS}}_{{.Arch}}/unusedinterface"
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -13882,6 +13882,26 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: cloverrose
+    repo_name: unusedinterface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: unusedinterface_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: unusedinterface_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: cloverstd
     repo_name: tcping
     description: ping over a tcp connection


### PR DESCRIPTION
[cloverrose/unusedinterface](https://github.com/cloverrose/unusedinterface): 

```console
$ aqua g -i cloverrose/unusedinterface
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

`unusedinterface` is used in go vet. You need to setup sample go repository.

`go vet` may fail with aqua-proxy. So use `aqua which unusedinterface` to use unusedinterface directly.

```console
$ go vet -vettool=`aqua which unusedinterface` ./... && echo "OK"
```

If files such as configuration file are needed, please share them.

Reference

-
