### PR TITLE
feat(dependabot/cli): scaffold dependabot/cli

### DIFF
--- a/pkgs/dependabot/cli/pkg.yaml
+++ b/pkgs/dependabot/cli/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: dependabot/cli@v1.56.0
+  - name: dependabot/cli
+    version: v1.32.0
+  - name: dependabot/cli
+    version: v1.24.0

--- a/pkgs/dependabot/cli/registry.yaml
+++ b/pkgs/dependabot/cli/registry.yaml
@@ -1,0 +1,44 @@
+packages:
+  - type: github_release
+    repo_owner: dependabot
+    repo_name: cli
+    description: A tool for testing and debugging Dependabot update jobs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.24.0")
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.25.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.32.0")
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.33.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/dependabot/cli/registry.yaml
+++ b/pkgs/dependabot/cli/registry.yaml
@@ -5,31 +5,7 @@ packages:
     description: A tool for testing and debugging Dependabot update jobs
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.24.0")
-        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.25.0"
-        no_asset: true
-      - version_constraint: semver("<= 1.32.0")
-        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.33.0"
+      - version_constraint: Version in ["v1.25.0", "v1.33.0"]
         no_asset: true
       - version_constraint: "true"
         asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/dependabot/cli/registry.yaml
+++ b/pkgs/dependabot/cli/registry.yaml
@@ -18,3 +18,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: dependabot

--- a/registry.yaml
+++ b/registry.yaml
@@ -16657,31 +16657,7 @@ packages:
     description: A tool for testing and debugging Dependabot update jobs
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.24.0")
-        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.25.0"
-        no_asset: true
-      - version_constraint: semver("<= 1.32.0")
-        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.33.0"
+      - version_constraint: Version in ["v1.25.0", "v1.33.0"]
         no_asset: true
       - version_constraint: "true"
         asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -16694,6 +16670,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: dependabot
   - type: github_release
     repo_owner: derailed
     repo_name: k9s

--- a/registry.yaml
+++ b/registry.yaml
@@ -16652,6 +16652,49 @@ packages:
             replacements:
               arm64: arm64
   - type: github_release
+    repo_owner: dependabot
+    repo_name: cli
+    description: A tool for testing and debugging Dependabot update jobs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.24.0")
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.25.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.32.0")
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.33.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: dependabot-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: derailed
     repo_name: k9s
     description: Kubernetes CLI To Manage Your Clusters In Style


### PR DESCRIPTION
[dependabot/cli](https://github.com/dependabot/cli): A tool for testing and debugging Dependabot update jobs

```console
$ aqua g -i dependabot/cli
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@5e3ca1471b4d:/workspace# dependabot
Run Dependabot jobs from the command line.

Usage:
  dependabot [command]

Examples:
$ dependabot update go_modules rsc/quote
$ dependabot test -f input.yml


Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  test        Test scenarios
  update      Perform an update job

Flags:
      --collector-image string   container image to use for the OpenTelemetry collector (default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest")
  -h, --help                     help for dependabot
      --proxy-image string       container image to use for the proxy (default "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy:latest")
      --updater-image string     container image to use for the updater
  -v, --version                  version for dependabot

Use "dependabot [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/dependabot/cli/blob/main/README.md
