### PR TITLE
feat: add handlename/awsc

### DIFF
--- a/pkgs/handlename/awsc/pkg.yaml
+++ b/pkgs/handlename/awsc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: handlename/awsc@v0.2.0

--- a/pkgs/handlename/awsc/registry.yaml
+++ b/pkgs/handlename/awsc/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: handlename
+    repo_name: awsc
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: awsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: awsc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/pkgs/handlename/awsc/registry.yaml
+++ b/pkgs/handlename/awsc/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: handlename
     repo_name: awsc
+    description: awsc (AWS cli with Caution) is wrapper for AWS CLI. It displays AWS account information before running any AWS CLI subcommands
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -24307,6 +24307,7 @@ packages:
   - type: github_release
     repo_owner: handlename
     repo_name: awsc
+    description: awsc (AWS cli with Caution) is wrapper for AWS CLI. It displays AWS account information before running any AWS CLI subcommands
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -24306,6 +24306,18 @@ packages:
       algorithm: sha512
   - type: github_release
     repo_owner: handlename
+    repo_name: awsc
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: awsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: awsc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: handlename
     repo_name: let-rds-sleep
     description: Keep sleeping AWS RDS/Aurora Cluster
     version_constraint: "false"


### PR DESCRIPTION
[handlename/awsc](https://github.com/handlename/awsc): awsc (AWS cli with Caution) is wrapper for AWS CLI. It displays AWS account information before running any AWS CLI subcommands

```console
$ aqua g -i handlename/awsc
```