### PR TITLE
feat: add cloverrose/connectnew

### DIFF
--- a/pkgs/cloverrose/connectnew/pkg.yaml
+++ b/pkgs/cloverrose/connectnew/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloverrose/connectnew@v0.1.0

--- a/pkgs/cloverrose/connectnew/registry.yaml
+++ b/pkgs/cloverrose/connectnew/registry.yaml
@@ -7,6 +7,9 @@ packages:
       - version_constraint: "true"
         asset: connectnew_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: connectnew
+            src: "connectnew_{{.OS}}_{{.Arch}}/connectnew"
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/cloverrose/connectnew/registry.yaml
+++ b/pkgs/cloverrose/connectnew/registry.yaml
@@ -2,6 +2,9 @@ packages:
   - type: github_release
     repo_owner: cloverrose
     repo_name: connectnew
+    description: |
+      Go linter checking if &connect.Request or &connect.Response are used.
+      Instead connect.NewRequest or connect.NewResponse should be used.
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -9,7 +12,7 @@ packages:
         format: tar.gz
         files:
           - name: connectnew
-            src: "connectnew_{{.OS}}_{{.Arch}}/connectnew"
+            src: connectnew_{{.OS}}_{{.Arch}}/connectnew
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/cloverrose/connectnew/registry.yaml
+++ b/pkgs/cloverrose/connectnew/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: cloverrose
+    repo_name: connectnew
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: connectnew_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: connectnew_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/cloverrose/connectnew/registry.yaml
+++ b/pkgs/cloverrose/connectnew/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_name: connectnew
     description: |
       Go linter checking if &connect.Request or &connect.Response are used.
-      Instead connect.NewRequest or connect.NewResponse should be used.
+      Instead connect.NewRequest or connect.NewResponse should be used
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13887,6 +13887,9 @@ packages:
       - version_constraint: "true"
         asset: connectnew_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: connectnew
+            src: "connectnew_{{.OS}}_{{.Arch}}/connectnew"
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -13882,6 +13882,9 @@ packages:
   - type: github_release
     repo_owner: cloverrose
     repo_name: connectnew
+    description: |
+      Go linter checking if &connect.Request or &connect.Response are used.
+      Instead connect.NewRequest or connect.NewResponse should be used.
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -13889,7 +13892,7 @@ packages:
         format: tar.gz
         files:
           - name: connectnew
-            src: "connectnew_{{.OS}}_{{.Arch}}/connectnew"
+            src: connectnew_{{.OS}}_{{.Arch}}/connectnew
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -13881,6 +13881,26 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: cloverrose
+    repo_name: connectnew
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: connectnew_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: connectnew_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: cloverrose
     repo_name: pkgdep
     description: pkgdep checks if package dependency follows rule
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13884,7 +13884,7 @@ packages:
     repo_name: connectnew
     description: |
       Go linter checking if &connect.Request or &connect.Response are used.
-      Instead connect.NewRequest or connect.NewResponse should be used.
+      Instead connect.NewRequest or connect.NewResponse should be used
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
[cloverrose/connectnew](https://github.com/cloverrose/connectnew): Go linter checking if &connect.Request or &connect.Response are used. Instead connect.NewRequest or connect.NewResponse should be used.

```console
$ aqua g -i cloverrose/connectnew
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

`connectnew` is used in go vet. You need to setup sample go repository.

`go vet` may fail with aqua-proxy. So use `aqua which connectnew` to use connectnew directly.

```console
$ go vet -vettool=`aqua which connectnew` ./... && echo "OK"
```

If files such as configuration file are needed, please share them.

Reference

-
