### PR TITLE
fix: rename the package lotabout/skim to skim-rs/skim

### DIFF
--- a/pkgs/lotabout/skim/pkg.yaml
+++ b/pkgs/lotabout/skim/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: lotabout/skim@v0.9.4

--- a/pkgs/skim-rs/skim/pkg.yaml
+++ b/pkgs/skim-rs/skim/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: skim-rs/skim@v0.9.4

--- a/pkgs/skim-rs/skim/registry.yaml
+++ b/pkgs/skim-rs/skim/registry.yaml
@@ -1,7 +1,9 @@
 packages:
   - type: github_release
-    repo_owner: lotabout
+    repo_owner: skim-rs
     repo_name: skim
+    aliases:
+      - name: lotabout/skim
     asset: skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
     description: Fuzzy Finder in rust
     rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -32242,21 +32242,6 @@ packages:
       - darwin
     rosetta2: true
   - type: github_release
-    repo_owner: lotabout
-    repo_name: skim
-    asset: skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
-    description: Fuzzy Finder in rust
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux/amd64
-    replacements:
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      amd64: x86_64
-    files:
-      - name: sk
-  - type: github_release
     repo_owner: lsd-rs
     repo_name: lsd
     aliases:
@@ -42633,6 +42618,23 @@ packages:
           type: github_release
           asset: skeema_checksums_{{trimV .Version}}.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: skim-rs
+    repo_name: skim
+    aliases:
+      - name: lotabout/skim
+    asset: skim-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    description: Fuzzy Finder in rust
+    rosetta2: true
+    supported_envs:
+      - darwin
+      - linux/amd64
+    replacements:
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      amd64: x86_64
+    files:
+      - name: sk
   - type: github_release
     repo_owner: sl1pm4t
     repo_name: k2tf


### PR DESCRIPTION
The GitHub Repository of the package was transferred from [lotabout/skim](https://github.com/lotabout/skim) to [skim-rs/skim](https://github.com/skim-rs/skim)

Close #28589