### PR TITLE
feat(chime/mani-diffy): scaffold chime/mani-diffy

### DIFF
--- a/pkgs/chime/mani-diffy/pkg.yaml
+++ b/pkgs/chime/mani-diffy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: chime/mani-diffy@v0.1.2

--- a/pkgs/chime/mani-diffy/registry.yaml
+++ b/pkgs/chime/mani-diffy/registry.yaml
@@ -5,7 +5,12 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        asset: mani-diffy
         format: raw
         supported_envs:
+          - linux/amd64
           - darwin/arm64
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        asset: mani-diffy-{{.OS}}-{{.Arch}}

--- a/pkgs/chime/mani-diffy/registry.yaml
+++ b/pkgs/chime/mani-diffy/registry.yaml
@@ -1,0 +1,11 @@
+packages:
+  - type: github_release
+    repo_owner: chime
+    repo_name: mani-diffy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin/arm64

--- a/pkgs/chime/mani-diffy/registry.yaml
+++ b/pkgs/chime/mani-diffy/registry.yaml
@@ -11,7 +11,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin/arm64
-    overrides:
-      - goos: darwin
-        goarch: arm64
-        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        overrides:
+          - goos: darwin
+            goarch: arm64
+            asset: mani-diffy-{{.OS}}-{{.Arch}}

--- a/pkgs/chime/mani-diffy/registry.yaml
+++ b/pkgs/chime/mani-diffy/registry.yaml
@@ -2,7 +2,7 @@ packages:
   - type: github_release
     repo_owner: chime
     repo_name: mani-diffy
-    description: mani-diffy is walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
+    description: mani-diffy walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/chime/mani-diffy/registry.yaml
+++ b/pkgs/chime/mani-diffy/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: chime
     repo_name: mani-diffy
+    description: mani-diffy is walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12739,10 +12739,10 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin/arm64
-    overrides:
-      - goos: darwin
-        goarch: arm64
-        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        overrides:
+          - goos: darwin
+            goarch: arm64
+            asset: mani-diffy-{{.OS}}-{{.Arch}}
   - type: github_release
     repo_owner: chmln
     repo_name: handlr

--- a/registry.yaml
+++ b/registry.yaml
@@ -12733,10 +12733,15 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        asset: mani-diffy
         format: raw
         supported_envs:
+          - linux/amd64
           - darwin/arm64
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        asset: mani-diffy-{{.OS}}-{{.Arch}}
   - type: github_release
     repo_owner: chmln
     repo_name: handlr

--- a/registry.yaml
+++ b/registry.yaml
@@ -12730,6 +12730,7 @@ packages:
   - type: github_release
     repo_owner: chime
     repo_name: mani-diffy
+    description: mani-diffy is walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12730,7 +12730,7 @@ packages:
   - type: github_release
     repo_owner: chime
     repo_name: mani-diffy
-    description: mani-diffy is walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
+    description: mani-diffy walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12728,6 +12728,16 @@ packages:
           - darwin
           - amd64
   - type: github_release
+    repo_owner: chime
+    repo_name: mani-diffy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mani-diffy-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - darwin/arm64
+  - type: github_release
     repo_owner: chmln
     repo_name: handlr
     asset: handlr


### PR DESCRIPTION
[chime/mani-diffy](https://github.com/chime/mani-diffy): mani-diffy walks a hierarchy of Argo CD Application templates, renders Kubernetes manifests from the input templates, and posts the rendered files back for the user to review and validate

```console
$ aqua g -i chime/mani-diffy
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mani-diffy --help
Usage of mani-diffy-darwin-arm64:
  -hash-store sumfile
        The hashing backend to use. Can be sumfile or `json`. (default "sumfile")
  -hash-strategy readwrite
        Whether to read + write, or just read hashes. Can be readwrite or `read`. (default "readwrite")
  -ignore-suffix string
        Suffix used to identify apps to ignore (default "-ignore")
  -ignore-value-file string
        Override file to ignore based on filename (default "overrides-to-ignore")
  -max-depth int
        Maximum depth for the depth first walk. (default -1)
  -output string
        Path to store the compiled Argo applications. (default ".zz.auto-generated")
  -post-renderer string
        When provided, binary will be called after an application is rendered.
  -root string
        Directory to initially look for k8s manifests containing Argo applications. The root of the tree. (default "bootstrap")
  -skip-render-key string
        Key to not render (default "do-not-render")
  -workdir string
        Directory to run the command in. (default ".")
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/chime/mani-diffy/blob/main/README.md
