### PR TITLE
fix(protocolbuffers/protobuf-go/protoc-gen-go): regenerate the setting

### DIFF
--- a/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/pkg.yaml
+++ b/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/pkg.yaml
@@ -1,2 +1,10 @@
 packages:
   - name: protocolbuffers/protobuf-go/protoc-gen-go@v1.35.1
+  - name: protocolbuffers/protobuf-go/protoc-gen-go
+    version: v1.28.0
+  - name: protocolbuffers/protobuf-go/protoc-gen-go
+    version: v1.26.0
+  - name: protocolbuffers/protobuf-go/protoc-gen-go
+    version: v1.24.0
+  - name: protocolbuffers/protobuf-go/protoc-gen-go
+    version: v1.23.0

--- a/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/registry.yaml
+++ b/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/registry.yaml
@@ -3,15 +3,51 @@ packages:
     type: github_release
     repo_owner: protocolbuffers
     repo_name: protobuf-go
-    description: Go support for Protocol Buffers
-    rosetta2: true
-    asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-    supported_envs:
-      - darwin
-      - amd64
-    files:
-      - name: protoc-gen-go
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
+    description: Go support for Google's protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.23.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.24.0"
+        asset: protoc-gen-go.{{.Version}}-devel.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.26.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.28.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/registry.yaml
+++ b/pkgs/protocolbuffers/protobuf-go/protoc-gen-go/registry.yaml
@@ -6,15 +6,6 @@ packages:
     description: Go support for Google's protocol buffers
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.23.0")
-        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.24.0"
         asset: protoc-gen-go.{{.Version}}-devel.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -38932,15 +38932,6 @@ packages:
     description: Go support for Google's protocol buffers
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.23.0")
-        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v1.24.0"
         asset: protoc-gen-go.{{.Version}}-devel.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -38929,18 +38929,54 @@ packages:
     type: github_release
     repo_owner: protocolbuffers
     repo_name: protobuf-go
-    description: Go support for Protocol Buffers
-    rosetta2: true
-    asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-    supported_envs:
-      - darwin
-      - amd64
-    files:
-      - name: protoc-gen-go
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
+    description: Go support for Google's protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.23.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v1.24.0"
+        asset: protoc-gen-go.{{.Version}}-devel.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.26.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.28.0")
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: protoc-gen-go.{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     name: protocolbuffers/protobuf/protoc
     repo_owner: protocolbuffers


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Since version [v1.28.1](https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.28.1), protoc-gen-go has been releasing binaries for arm64.
However, the current aqua-registry does not support them.
Therefore, I regenerated the settings using `cmdx s`.