### PR TITLE
fix(jenkins-x/jx): Regenerate the setting

### DIFF
--- a/pkgs/jenkins-x/jx/pkg.yaml
+++ b/pkgs/jenkins-x/jx/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
-  - name: jenkins-x/jx@v3.10.182
+  - name: jenkins-x/jx@v3.2.94
+  - name: jenkins-x/jx
+    version: v3.2.6
+  - name: jenkins-x/jx
+    version: v3.2.5
+  - name: jenkins-x/jx
+    version: v2.1.156
+  - name: jenkins-x/jx
+    version: v2.1.155
+  - name: jenkins-x/jx
+    version: v0.0.1

--- a/pkgs/jenkins-x/jx/pkg.yaml
+++ b/pkgs/jenkins-x/jx/pkg.yaml
@@ -1,5 +1,25 @@
 packages:
-  - name: jenkins-x/jx@v3.2.94
+  - name: jenkins-x/jx@v3.11.1
+  - name: jenkins-x/jx
+    version: v3.10.182
+  - name: jenkins-x/jx
+    version: v3.10.158
+  - name: jenkins-x/jx
+    version: v3.6.15
+  - name: jenkins-x/jx
+    version: v3.5.18
+  - name: jenkins-x/jx
+    version: v3.4.11
+  - name: jenkins-x/jx
+    version: v3.4.9
+  - name: jenkins-x/jx
+    version: v3.3.4
+  - name: jenkins-x/jx
+    version: v3.2.382
+  - name: jenkins-x/jx
+    version: v3.2.380
+  - name: jenkins-x/jx
+    version: v3.2.261
   - name: jenkins-x/jx
     version: v3.2.6
   - name: jenkins-x/jx

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -37,7 +37,6 @@ packages:
       - version_constraint: semver("<= 0.0.1")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -97,64 +96,9 @@ packages:
             format: zip
       - version_constraint: semver("<= 3.4.2")
         no_asset: true
-      - version_constraint: semver("<= 3.4.9")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        # complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.4.11")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.5.18")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.6.15")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.10.158")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 3.10.182")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -166,7 +110,6 @@ packages:
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -74,11 +74,130 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.2.261")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.2.380")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "3.2.381"
+        no_asset: true
+      - version_constraint: semver("<= 3.2.382")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.2.383")
+        no_asset: true
+      - version_constraint: semver("<= 3.3.4")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.4.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.9")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.4.11")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.5.18")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.5.19"
+        no_asset: true
+      - version_constraint: semver("<= 3.6.15")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 3.10.158")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.10.159"
+        no_asset: true
+      - version_constraint: semver("<= 3.10.182")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -2,13 +2,87 @@ packages:
   - type: github_release
     repo_owner: jenkins-x
     repo_name: jx
-    asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: Jenkins X provides automated CI+CD for Kubernetes with Preview Environments on Pull Requests using Cloud Native pipelines from Tekton
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: jx-checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.1.155")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.1.156"
+        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-cli-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 3.2.5")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.2.6"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -5,6 +5,35 @@ packages:
     description: Jenkins X provides automated CI+CD for Kubernetes with Preview Environments on Pull Requests using Cloud Native pipelines from Tekton
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version in ["v3.2.0", "3.2.381", "3.2.382", "3.2.383", "v3.5.19", "v3.7.0", "v3.10.159"]
+        no_asset: true
+      - version_constraint: Version == "v3.2.6"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: Version == "v2.1.156"
+        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-cli-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 0.0.1")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -32,20 +61,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "v2.1.156"
-        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: jx-cli-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v3.2.0"
-        no_asset: true
       - version_constraint: semver("<= 3.2.5")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -58,22 +73,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.2.6"
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 3.2.261")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -86,30 +85,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 3.2.380")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "3.2.381"
-        no_asset: true
-      - version_constraint: semver("<= 3.2.382")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.2.383")
-        no_asset: true
       - version_constraint: semver("<= 3.3.4")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -125,7 +100,7 @@ packages:
       - version_constraint: semver("<= 3.4.9")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
+        # complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -154,8 +129,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.5.19"
-        no_asset: true
       - version_constraint: semver("<= 3.6.15")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -167,8 +140,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.7.0"
-        no_asset: true
       - version_constraint: semver("<= 3.10.158")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -180,8 +151,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.10.159"
-        no_asset: true
       - version_constraint: semver("<= 3.10.182")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -27248,11 +27248,130 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.2.261")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.2.380")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "3.2.381"
+        no_asset: true
+      - version_constraint: semver("<= 3.2.382")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.2.383")
+        no_asset: true
+      - version_constraint: semver("<= 3.3.4")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.4.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.9")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.4.11")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.5.18")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.5.19"
+        no_asset: true
+      - version_constraint: semver("<= 3.6.15")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 3.10.158")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.10.159"
+        no_asset: true
+      - version_constraint: semver("<= 3.10.182")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -27211,7 +27211,6 @@ packages:
       - version_constraint: semver("<= 0.0.1")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -27271,64 +27270,9 @@ packages:
             format: zip
       - version_constraint: semver("<= 3.4.2")
         no_asset: true
-      - version_constraint: semver("<= 3.4.9")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        # complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.4.11")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.5.18")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.6.15")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.10.158")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        complete_windows_ext: false
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 3.10.182")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -27340,7 +27284,6 @@ packages:
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -27179,6 +27179,35 @@ packages:
     description: Jenkins X provides automated CI+CD for Kubernetes with Preview Environments on Pull Requests using Cloud Native pipelines from Tekton
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version in ["v3.2.0", "3.2.381", "3.2.382", "3.2.383", "v3.5.19", "v3.7.0", "v3.10.159"]
+        no_asset: true
+      - version_constraint: Version == "v3.2.6"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+      - version_constraint: Version == "v2.1.156"
+        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-cli-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 0.0.1")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27206,20 +27235,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "v2.1.156"
-        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: jx-cli-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v3.2.0"
-        no_asset: true
       - version_constraint: semver("<= 3.2.5")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27232,22 +27247,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.2.6"
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 3.2.261")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27260,30 +27259,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 3.2.380")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "3.2.381"
-        no_asset: true
-      - version_constraint: semver("<= 3.2.382")
-        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: jx-checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 3.2.383")
-        no_asset: true
       - version_constraint: semver("<= 3.3.4")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27299,7 +27274,7 @@ packages:
       - version_constraint: semver("<= 3.4.9")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
+        # complete_windows_ext: false
         checksum:
           type: github_release
           asset: jx-checksums.txt
@@ -27328,8 +27303,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.5.19"
-        no_asset: true
       - version_constraint: semver("<= 3.6.15")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27341,8 +27314,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.7.0"
-        no_asset: true
       - version_constraint: semver("<= 3.10.158")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -27354,8 +27325,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v3.10.159"
-        no_asset: true
       - version_constraint: semver("<= 3.10.182")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -27176,16 +27176,90 @@ packages:
   - type: github_release
     repo_owner: jenkins-x
     repo_name: jx
-    asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
     description: Jenkins X provides automated CI+CD for Kubernetes with Preview Environments on Pull Requests using Cloud Native pipelines from Tekton
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: jx-checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        complete_windows_ext: false
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.1.155")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v2.1.156"
+        asset: jx-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-cli-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 3.2.5")
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v3.2.6"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: jenkins-zh
     repo_name: jenkins-cli


### PR DESCRIPTION
⚠️ jenkins-x/jx has too many release versions, so we support only latest 200 versions.

```sh
cmdx s -limit 200 jenkins-x/jx
```

Close #28725
Close #28737