### PR TITLE
feat: add rui314/mold

### DIFF
--- a/pkgs/rui314/mold/pkg.yaml
+++ b/pkgs/rui314/mold/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: rui314/mold@v2.34.1
+  - name: rui314/mold
+    version: v1.5.1

--- a/pkgs/rui314/mold/registry.yaml
+++ b/pkgs/rui314/mold/registry.yaml
@@ -1,0 +1,39 @@
+packages:
+  - type: github_release
+    repo_owner: rui314
+    repo_name: mold
+    description: "Mold: A Modern Linker"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+        files:
+          - name: mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld64.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+      - version_constraint: Version == "v1.6.0-pre.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+        files:
+          - name: mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold

--- a/pkgs/rui314/mold/registry.yaml
+++ b/pkgs/rui314/mold/registry.yaml
@@ -5,7 +5,7 @@ packages:
     description: "Mold: A Modern Linker"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0.3")
+      - version_constraint: semver("<= 1.0.3") || Version == "v1.6.0-pre.1"
         no_asset: true
       - version_constraint: semver("<= 1.5.1")
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -22,8 +22,6 @@ packages:
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
           - name: ld64.mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
-      - version_constraint: Version == "v1.6.0-pre.1"
-        no_asset: true
       - version_constraint: "true"
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -40465,6 +40465,44 @@ packages:
       asset: curlie_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: rui314
+    repo_name: mold
+    description: "Mold: A Modern Linker"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+        files:
+          - name: mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld64.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+      - version_constraint: Version == "v1.6.0-pre.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+        files:
+          - name: mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+          - name: ld.mold
+            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+  - type: github_release
     repo_owner: runatlantis
     repo_name: atlantis
     description: Terraform Pull Request Automation

--- a/registry.yaml
+++ b/registry.yaml
@@ -40470,7 +40470,7 @@ packages:
     description: "Mold: A Modern Linker"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0.3")
+      - version_constraint: semver("<= 1.0.3") || Version == "v1.6.0-pre.1"
         no_asset: true
       - version_constraint: semver("<= 1.5.1")
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -40487,8 +40487,6 @@ packages:
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
           - name: ld64.mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
-      - version_constraint: Version == "v1.6.0-pre.1"
-        no_asset: true
       - version_constraint: "true"
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[rui314/mold](https://github.com/rui314/mold): Mold: A Modern Linker

```console
$ aqua g -i rui314/mold
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx t rui314/mold
$ cmdx con linux amd64
# cargo init
# mold -run cargo build
# readelf -p .comment target/debug/workspace
String dump of section '.comment':
  [     0]  GCC: (Debian 12.2.0-14) 12.2.0
  [    20]  mold 2.34.1 (de65f6bd75b93eeb9f3775fc136ee79683ff35f1; compatible with GNU ld)
  [    6f]  rustc version 1.82.0 (f6e511eec 2024-10-15)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/rui314/mold?tab=readme-ov-file#how-to-use
