### PR TITLE
feat: add rust-cross/cargo-zigbuild

### DIFF
--- a/pkgs/rust-cross/cargo-zigbuild/pkg.yaml
+++ b/pkgs/rust-cross/cargo-zigbuild/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: rust-cross/cargo-zigbuild@v0.19.4
+  - name: rust-cross/cargo-zigbuild
+    version: v0.10.0
+  - name: rust-cross/cargo-zigbuild
+    version: v0.9.0

--- a/pkgs/rust-cross/cargo-zigbuild/registry.yaml
+++ b/pkgs/rust-cross/cargo-zigbuild/registry.yaml
@@ -1,0 +1,84 @@
+packages:
+  - type: github_release
+    repo_owner: rust-cross
+    repo_name: cargo-zigbuild
+    description: Compile Cargo project with zig as linker
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+            checksum:
+              enabled: false
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            checksum:
+              enabled: false
+      - version_constraint: Version == "v0.10.0"
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+            checksum:
+              enabled: false
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            checksum:
+              enabled: false
+        supported_envs:
+          - linux/arm64
+          - darwin
+          - windows
+      - version_constraint: "true"
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64

--- a/registry.yaml
+++ b/registry.yaml
@@ -40533,6 +40533,89 @@ packages:
           - darwin
           - linux/amd64
   - type: github_release
+    repo_owner: rust-cross
+    repo_name: cargo-zigbuild
+    description: Compile Cargo project with zig as linker
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+            checksum:
+              enabled: false
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            checksum:
+              enabled: false
+      - version_constraint: Version == "v0.10.0"
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+            checksum:
+              enabled: false
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+            checksum:
+              enabled: false
+        supported_envs:
+          - linux/arm64
+          - darwin
+          - windows
+      - version_constraint: "true"
+        asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x64
+  - type: github_release
     repo_owner: rust-lang
     repo_name: mdBook
     rosetta2: true


### PR DESCRIPTION
[rust-cross/cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild): Compile Cargo project with zig as linker

```console
$ aqua g -i rust-cross/cargo-zigbuild
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx t rust-cross/cargo-zigbuild
$ cmdx con linux amd64
# apt update
# apt install -y xz-utils file
# wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
# tar -xvf zig-linux-x86_64-0.13.0.tar.xz
# export PATH=./zig-linux-x86_64-0.13.0:$PATH
# rustup target add aarch64-unknown-linux-gnu
# cargo init
# cargo zigbuild --target aarch64-unknown-linux-gnu
# file target/aarch64-unknown-linux-gnu/debug/workspace
target/aarch64-unknown-linux-gnu/debug/workspace: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 2.0.0, with debug_info, not stripped
# readelf -p .comment target/aarch64-unknown-linux-gnu/debug/workspace
String dump of section '.comment':
  [     0]  Linker: LLD 18.1.6
  [    13]  clang version 18.1.6 (https://github.com/ziglang/zig-bootstrap 98bc6bf4fc4009888d33941daf6b600d20a42a56)
  [    7d]  rustc version 1.82.0 (f6e511eec 2024-10-15)
  [    a9]  GCC: (crosstool-NG UNKNOWN) 13.2.0
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/rust-cross/cargo-zigbuild?tab=readme-ov-file#usage
