### PR TITLE
feat: add ymtdzzz/otel-tui

### DIFF
--- a/pkgs/ymtdzzz/otel-tui/pkg.yaml
+++ b/pkgs/ymtdzzz/otel-tui/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ymtdzzz/otel-tui@v0.3.7

--- a/pkgs/ymtdzzz/otel-tui/registry.yaml
+++ b/pkgs/ymtdzzz/otel-tui/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: ymtdzzz
+    repo_name: otel-tui
+    description: A terminal OpenTelemetry viewer inspired by otel-desktop-viewer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: otel-tui_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: otel-tui_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -50458,6 +50458,27 @@ packages:
           asset: totp-cli_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: ymtdzzz
+    repo_name: otel-tui
+    description: A terminal OpenTelemetry viewer inspired by otel-desktop-viewer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: otel-tui_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: otel-tui_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: ynqa
     repo_name: jnv
     description: interactive JSON filter using jq


### PR DESCRIPTION
[ymtdzzz/otel-tui](https://github.com/ymtdzzz/otel-tui): A terminal OpenTelemetry viewer inspired by otel-desktop-viewer

```console
$ aqua g -i ymtdzzz/otel-tui
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@499c2b923551:/workspace# otel-tui --help
Usage:
  otel-tui [flags]

Flags:
      --enable-prom               Enable the prometheus receiver
      --enable-zipkin             Enable the zipkin receiver
      --from-json-file string     The JSON file path exported by JSON exporter
      --grpc int                  The port number on which we listen for OTLP grpc payloads (default 4317)
  -h, --help                      help for otel-tui
      --host string               The host where we expose our OTLP endpoints (default "0.0.0.0")
      --http int                  The port number on which we listen for OTLP http payloads (default 4318)
      --prom-target stringArray   The target endpoints for the prometheus receiver (--prom-target "localhost:9000" --prom-target "other-host:9000")
  -v, --version                   version for otel-tui
```

If files such as configuration file are needed, please share them.

Reference

- Blog (Japanese)
	- https://zenn.dev/ymtdzzz/articles/a3a809ca1ba440
- README
	- https://github.com/ymtdzzz/otel-tui/blob/main/README.md
