### PR TITLE
feat: use go_version_path

### DIFF
--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-key/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-key/registry.yaml
@@ -3,3 +3,4 @@ packages:
     type: go_install
     description: One of Sigsum command line tools. Generate new keys, create and verify signatures, and convert between different key formats.
     path: sigsum.org/sigsum-go/cmd/sigsum-key
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-monitor/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-monitor/registry.yaml
@@ -3,3 +3,4 @@ packages:
     type: go_install
     description: One of Sigsum command line tools
     path: sigsum.org/sigsum-go/cmd/sigsum-monitor
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-submit/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-submit/registry.yaml
@@ -5,3 +5,4 @@ packages:
       One of Sigsum command line tools.
       The sigsum-submit tool is used to create and/or submit add-leaf requests to a Sigsum log
     path: sigsum.org/sigsum-go/cmd/sigsum-submit
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-token/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-token/registry.yaml
@@ -5,3 +5,4 @@ packages:
       One of Sigsum command line tools.
       The sigsum-token tool is used to manage the Sigsum "submit tokens" that are used for domain based rate limiting
     path: sigsum.org/sigsum-go/cmd/sigsum-token
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-verify/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-verify/registry.yaml
@@ -3,3 +3,4 @@ packages:
     type: go_install
     description: One of Sigsum command line tools. sigsum-verify tool verifies a Sigsum proof, as created by sigsum-submit
     path: sigsum.org/sigsum-go/cmd/sigsum-verify
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-witness/registry.yaml
+++ b/pkgs/_go/sigsum.org/sigsum-go/cmd/sigsum-witness/registry.yaml
@@ -3,3 +3,4 @@ packages:
     type: go_install
     description: One of Sigsum command line tools
     path: sigsum.org/sigsum-go/cmd/sigsum-witness
+    go_version_path: sigsum.org/sigsum-go

--- a/pkgs/golang.org/x/tools/gopls/registry.yaml
+++ b/pkgs/golang.org/x/tools/gopls/registry.yaml
@@ -7,6 +7,6 @@ packages:
     repo_owner: golang
     repo_name: tools
     description: Go language server
-    version_filter: Version startsWith "gopls/"
+    go_version_path: golang.org/x/tools/gopls
     files:
       - name: gopls

--- a/registry.yaml
+++ b/registry.yaml
@@ -5236,6 +5236,7 @@ packages:
     type: go_install
     description: One of Sigsum command line tools. Generate new keys, create and verify signatures, and convert between different key formats.
     path: sigsum.org/sigsum-go/cmd/sigsum-key
+    go_version_path: sigsum.org/sigsum-go
   - name: _go/sigsum.org/sigsum-go#cmd/sigsum-monitor
     type: go_install
     description: One of Sigsum command line tools
@@ -23371,7 +23372,7 @@ packages:
     repo_owner: golang
     repo_name: tools
     description: Go language server
-    version_filter: Version startsWith "gopls/"
+    go_version_path: golang.org/x/tools/gopls
     files:
       - name: gopls
   - repo_owner: golang

--- a/registry.yaml
+++ b/registry.yaml
@@ -5241,26 +5241,31 @@ packages:
     type: go_install
     description: One of Sigsum command line tools
     path: sigsum.org/sigsum-go/cmd/sigsum-monitor
+    go_version_path: sigsum.org/sigsum-go
   - name: _go/sigsum.org/sigsum-go#cmd/sigsum-submit
     type: go_install
     description: |
       One of Sigsum command line tools.
       The sigsum-submit tool is used to create and/or submit add-leaf requests to a Sigsum log
     path: sigsum.org/sigsum-go/cmd/sigsum-submit
+    go_version_path: sigsum.org/sigsum-go
   - name: _go/sigsum.org/sigsum-go#cmd/sigsum-token
     type: go_install
     description: |
       One of Sigsum command line tools.
       The sigsum-token tool is used to manage the Sigsum "submit tokens" that are used for domain based rate limiting
     path: sigsum.org/sigsum-go/cmd/sigsum-token
+    go_version_path: sigsum.org/sigsum-go
   - name: _go/sigsum.org/sigsum-go#cmd/sigsum-verify
     type: go_install
     description: One of Sigsum command line tools. sigsum-verify tool verifies a Sigsum proof, as created by sigsum-submit
     path: sigsum.org/sigsum-go/cmd/sigsum-verify
+    go_version_path: sigsum.org/sigsum-go
   - name: _go/sigsum.org/sigsum-go#cmd/sigsum-witness
     type: go_install
     description: One of Sigsum command line tools
     path: sigsum.org/sigsum-go/cmd/sigsum-witness
+    go_version_path: sigsum.org/sigsum-go
   - type: github_release
     repo_owner: a-h
     repo_name: templ


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/pull/3269
- https://aquaproj.github.io/docs/reference/registry-config/go-version-path

aqua v2.38.0 or later can get available versions of the following packages from Go Module Proxy.

- `_go/sigsum.org/sigsum-go#cmd/sigsum-key`
- `_go/sigsum.org/sigsum-go#cmd/sigsum-monitor`
- `_go/sigsum.org/sigsum-go#cmd/sigsum-submit`
- `_go/sigsum.org/sigsum-go#cmd/sigsum-token`
- `_go/sigsum.org/sigsum-go#cmd/sigsum-verify`
- `_go/sigsum.org/sigsum-go#cmd/sigsum-witness`
- `golang.org/x/tools/gopls`