### PR TITLE
feat: add cloverrose/mockguard

### DIFF
--- a/pkgs/cloverrose/mockguard/pkg.yaml
+++ b/pkgs/cloverrose/mockguard/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloverrose/mockguard@v0.1.0

--- a/pkgs/cloverrose/mockguard/registry.yaml
+++ b/pkgs/cloverrose/mockguard/registry.yaml
@@ -8,6 +8,9 @@ packages:
       - version_constraint: "true"
         asset: mockguard_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: mockguard
+            src: mockguard_{{.OS}}_{{.Arch}}/mockguard
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/cloverrose/mockguard/registry.yaml
+++ b/pkgs/cloverrose/mockguard/registry.yaml
@@ -1,0 +1,22 @@
+packages:
+  - type: github_release
+    repo_owner: cloverrose
+    repo_name: mockguard
+    description: mockguard checks if mockgen is used in conventional filename and options
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mockguard_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: mockguard_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -14009,6 +14009,27 @@ packages:
             format: zip
   - type: github_release
     repo_owner: cloverrose
+    repo_name: mockguard
+    description: mockguard checks if mockgen is used in conventional filename and options
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mockguard_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: mockguard_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: cloverrose
     repo_name: pkgdep
     description: pkgdep checks if package dependency follows rule
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -14016,6 +14016,9 @@ packages:
       - version_constraint: "true"
         asset: mockguard_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: mockguard
+            src: mockguard_{{.OS}}_{{.Arch}}/mockguard
         replacements:
           amd64: x86_64
           darwin: Darwin


### PR DESCRIPTION
[cloverrose/mockguard](https://github.com/cloverrose/mockguard): mockguard checks if mockgen is used in conventional filename and options

```console
$ aqua g -i cloverrose/mockguard
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

`mockguard` is used in go vet. You need to setup sample go repository.

`go vet` may fail with aqua-proxy. So use `aqua which mockguard` to use mockguard directly.

```console
$ go vet -vettool=`aqua which mockguard` ./... && echo "OK"
```

If files such as configuration file are needed, please share them.

Reference

-
