### PR TITLE
fix: set version_prefix for cargo-bins/cargo-binstall

### DIFF
--- a/pkgs/cargo-bins/cargo-binstall/registry.yaml
+++ b/pkgs/cargo-bins/cargo-binstall/registry.yaml
@@ -3,6 +3,7 @@ packages:
     repo_owner: cargo-bins
     repo_name: cargo-binstall
     description: Binary installation for rust projects
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version in ["install-cargo-binstall-1.0.0", "v1.4.0"]

--- a/registry.yaml
+++ b/registry.yaml
@@ -11538,6 +11538,7 @@ packages:
     repo_owner: cargo-bins
     repo_name: cargo-binstall
     description: Binary installation for rust projects
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version in ["install-cargo-binstall-1.0.0", "v1.4.0"]


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
