### PR TITLE
fix: set version_filter for hashicorp/vault and hashicorp/consul

### DIFF
--- a/pkgs/hashicorp/consul/registry.yaml
+++ b/pkgs/hashicorp/consul/registry.yaml
@@ -8,6 +8,7 @@ packages:
       - darwin
       - linux
       - amd64
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     version_constraint: semver(">= 1.11.1")
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/hashicorp/vault/registry.yaml
+++ b/pkgs/hashicorp/vault/registry.yaml
@@ -3,6 +3,7 @@ packages:
     repo_owner: hashicorp
     repo_name: vault
     description: A tool for secrets management, encryption as a service, and privileged access management
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -24981,6 +24981,7 @@ packages:
       - darwin
       - linux
       - amd64
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     version_constraint: semver(">= 1.11.1")
     version_overrides:
       - version_constraint: "true"
@@ -25145,6 +25146,7 @@ packages:
     repo_owner: hashicorp
     repo_name: vault
     description: A tool for secrets management, encryption as a service, and privileged access management
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     supported_envs:
       - darwin
       - linux


### PR DESCRIPTION
https://github.com/hashicorp/consul/releases
https://github.com/hashicorp/vault/releases

Versions `ent-changelog-*` are excluded.

## Before

```sh
aqua g -s hashicorp/consul
```

```
  v1.17.1                                                     │ ## 1.19.3 (Enterprise) (October 29, 2024)                   │
  v1.16.5                                                     │ _This release is created to share the Consul Enterprise ch..│
  v1.15.9                                                     │ and assets do not include Consul Enterprise code and shoul..│
  v1.17.2                                                     │                                                             │
  v1.15.10                                                    │ BREAKING CHANGES:                                           │
  v1.16.6                                                     │                                                             │
  v1.17.3                                                     │ * mesh: **(Enterprise Only)** Enable Envoy `HttpConnection..│
  v1.18.0                                                     │ ies. This resolves [CVE-2024-10005](https://nvd.nist.gov/v..│
  ent-changelog-1.15.11                                       │                                                             │
  ent-changelog-1.16.7                                        │ SECURITY:                                                   │
  ent-changelog-1.17.4                                        │                                                             │
  v1.18.1                                                     │ * Explicitly set 'Content-Type' header to mitigate XSS vul..│
  ent-changelog-1.15.12                                       │ /21704)]                                                    │
  ent-changelog-1.16.8                                        │ * Implement HTML sanitization for user-generated content t..│
  ent-changelog-1.17.5                                        │ shicorp/consul/issues/21711)]                               │
  v1.18.2                                                     │ * UI: Remove codemirror linting due to package dependency ..│
  v1.19.0                                                     │ * Upgrade Go to use 1.22.7. This addresses CVE              │
  ent-changelog-1.15.13                                       │ [CVE-2024-34155](https://nvd.nist.gov/vuln/detail/CVE-2024..│
  ent-changelog-1.17.6                                        │ 05)]                                                        │
  ent-changelog-1.18.3                                        │ * Upgrade to support aws/aws-sdk-go `v1.55.5 or higher`. T..│
  v1.19.1                                                     │ [CVE-2020-8911](https://nvd.nist.gov/vuln/detail/cve-2020-..│
  ent-changelog-1.15.14                                       │ [CVE-2020-8912](https://nvd.nist.gov/vuln/detail/cve-2020-..│
  ent-changelog-1.17.7                                        │ 4)]                                                         │
  ent-changelog-1.18.4                                        │ * mesh: **(Enterprise Only)** Add `contains` and `ignoreCa..│
  v1.19.2                                                     │ iguration resilient to variable casing and multiple values..│
  v1.20.0                                                     │ CVE-2024-10006).                                            │
  v1.20.1                                                     │ * mesh: **(Enterprise Only)** Add `http.incoming.requestNo..│
  ent-changelog-1.15.15                                       │ e traffic request normalization. This resolves [CVE-2024-1..│
  ent-changelog-1.18.5                                        │ 24-10006](https://nvd.nist.gov/vuln/detail/CVE-2024-10006)..│
> ent-changelog-1.19.3                                        │ * ui: Pin a newer resolution of Braces [[GH-21710](https:/..│
  30/30                                                       │ * ui: Pin a newer resolution of Codemirror [[GH-21715](htt..│
>   
```

```sh
aqua g -s hashicorp/vault
```

```
v1.14.7                                                     │ ## 1.18.2                                                   │
  v1.15.3                                                     │ ### November 21, 2024                                       │
  v1.13.12                                                    │                                                             │
  v1.14.8                                                     │ SECURITY:                                                   │
  v1.15.4                                                     │                                                             │
  v1.15.5                                                     │ * raft/snapshotagent (enterprise): upgrade raft-snapshotag..│
  v1.13.13                                                    │                                                             │
  v1.14.9                                                     │ CHANGES:                                                    │
  v1.14.10                                                    │                                                             │
  v1.15.6                                                     │ * auth/azure: Update plugin to v0.19.2 [[GH-28848](https:/..│
  v1.16.0                                                     │ * core/ha (enterprise): Failed attempts to become a perfor..│
  v1.16.1                                                     │  a                                                          │
  v1.16.2                                                     │ 10 second delay in between retries. The backoff starts at ..│
  ent-changelog-1.14.11                                       │ the maximum of 16s. This should make unsealing of the node..│
  ent-changelog-1.14.12                                       │ * login (enterprise): Return a 500 error during logins whe..│
  ent-changelog-1.15.7                                        │ e node. [[GH-28807](https://github.com/hashicorp/vault/pul..│
  ent-changelog-1.15.8                                        │                                                             │
  v1.16.3                                                     │ FEATURES:                                                   │
  ent-changelog-1.14.13                                       │                                                             │
  ent-changelog-1.15.9                                        │ * **Product Usage Reporting**: Added product usage reporti..│
  v1.17.0                                                     │ Vault secrets usage, and adds it to the existing utilizati..│
  v1.17.1                                                     │ docs/enterprise/license/product-usage-reporting)] for more..│
  v1.17.2                                                     │                                                             │
  v1.17.3                                                     │                                                             │
  v1.17.4                                                     │ IMPROVEMENTS:                                               │
  v1.17.5                                                     │                                                             │
  v1.17.6                                                     │ * secret/pki: Introduce a new value `always_enforce_err` w..│
  v1.18.0                                                     │ ances such as CA issuance and ACME requests if requested T..│
  v1.18.1                                                     │ thub.com/hashicorp/vault/pull/28907)]                       │
> v1.18.2                                                     │ * secrets-sync (enterprise): No longer attempt to unsync a..│
  30/30                                                       │ * ui: Adds navigation for LDAP hierarchical roles [[GH-288..│
>                                                             └─────────────────────────────────────────────────────────────┘
```

## After


```sh
aqua g -s hashicorp/consul
```

```
  v1.14.8                                                     │ ## 1.20.1 (October 29, 2024)                                │
  v1.15.4                                                     │ BREAKING CHANGES:                                           │
  v1.16.0                                                     │                                                             │
  v1.14.9                                                     │ * mesh: Enable Envoy `HttpConnectionManager.normalize_path..│
  v1.15.5                                                     │ E-2024-10005](https://nvd.nist.gov/vuln/detail/CVE-2024-10..│
  v1.16.1                                                     │ )]                                                          │
  v1.14.10                                                    │                                                             │
  v1.15.6                                                     │ SECURITY:                                                   │
  v1.16.2                                                     │                                                             │
  v1.14.11                                                    │ * mesh: Add `contains` and `ignoreCase` to L7 Intentions H..│
  v1.15.7                                                     │  variable casing and multiple values. This resolves [CVE-2..│
  v1.16.3                                                     │ 21816](https://github.com/hashicorp/consul/issues/21816)]   │
  v1.17.0                                                     │ * mesh: Add `http.incoming.requestNormalization` to Mesh c..│
  v1.15.8                                                     │ alization. This resolves [CVE-2024-10005](https://nvd.nist..│
  v1.16.4                                                     │ nist.gov/vuln/detail/CVE-2024-10006). [[GH-21816](https://..│
  v1.17.1                                                     │                                                             │
  v1.16.5                                                     │ IMPROVEMENTS:                                               │
  v1.15.9                                                     │                                                             │
  v1.17.2                                                     │ * api: remove dependency on proto-public, protobuf, and gr..│
  v1.15.10                                                    │ * snapshot agent: **(Enterprise only)**  Implement Service..│
  v1.16.6                                                     │ * xds: configures Envoy to load balance over all instances..│
  v1.17.3                                                     │ discovery_type" is set to "STRICT_DNS" [[GH-21655](https:/..│
  v1.18.0                                                     │                                                             │
  v1.18.1                                                     │                                                             │
  v1.18.2                                                     │                                                             │
  v1.19.0                                                     │                                                             │
  v1.19.1                                                     │                                                             │
  v1.19.2                                                     │                                                             │
  v1.20.0                                                     │                                                             │
> v1.20.1                                                     │                                                             │
  30/30                                                       │                                                             │
> 
```

```sh
aqua g -s hashicorp/vault
```

```
  v1.14.5                                                     │ ## 1.18.2                                                   │
  v1.15.1                                                     │ ### November 21, 2024                                       │
  v1.13.10                                                    │                                                             │
  v1.14.6                                                     │ SECURITY:                                                   │
  v1.15.2                                                     │                                                             │
  v1.13.11                                                    │ * raft/snapshotagent (enterprise): upgrade raft-snapshotag..│
  v1.14.7                                                     │                                                             │
  v1.15.3                                                     │ CHANGES:                                                    │
  v1.13.12                                                    │                                                             │
  v1.14.8                                                     │ * auth/azure: Update plugin to v0.19.2 [[GH-28848](https:/..│
  v1.15.4                                                     │ * core/ha (enterprise): Failed attempts to become a perfor..│
  v1.15.5                                                     │  a                                                          │
  v1.13.13                                                    │ 10 second delay in between retries. The backoff starts at ..│
  v1.14.9                                                     │ the maximum of 16s. This should make unsealing of the node..│
  v1.14.10                                                    │ * login (enterprise): Return a 500 error during logins whe..│
  v1.15.6                                                     │ e node. [[GH-28807](https://github.com/hashicorp/vault/pul..│
  v1.16.0                                                     │                                                             │
  v1.16.1                                                     │ FEATURES:                                                   │
  v1.16.2                                                     │                                                             │
  v1.16.3                                                     │ * **Product Usage Reporting**: Added product usage reporti..│
  v1.17.0                                                     │ Vault secrets usage, and adds it to the existing utilizati..│
  v1.17.1                                                     │ docs/enterprise/license/product-usage-reporting)] for more..│
  v1.17.2                                                     │                                                             │
  v1.17.3                                                     │                                                             │
  v1.17.4                                                     │ IMPROVEMENTS:                                               │
  v1.17.5                                                     │                                                             │
  v1.17.6                                                     │ * secret/pki: Introduce a new value `always_enforce_err` w..│
  v1.18.0                                                     │ ances such as CA issuance and ACME requests if requested T..│
  v1.18.1                                                     │ thub.com/hashicorp/vault/pull/28907)]                       │
> v1.18.2                                                     │ * secrets-sync (enterprise): No longer attempt to unsync a..│
  30/30                                                       │ * ui: Adds navigation for LDAP hierarchical roles [[GH-288..│
>                                                             └─────────────────────────────────────────────────────────────┘
```