### PR TITLE
ci: disable the check of GPG signing

### DIFF
--- a/scripts/check_gpgsign.sh
+++ b/scripts/check_gpgsign.sh
@@ -2,8 +2,10 @@
 
 set -eu
 
-if [ "$(git config commit.gpgSign)" != true ]; then
-    echo "[ERROR] This repository requires commit signing, so please configure it." >&2
-    echo "        https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md" >&2
-    exit 1
-fi
+# Disable the check https://github.com/suzuki-shunsuke/oss-contribution-guide/issues/77
+
+# if [ "$(git config commit.gpgSign)" != true ]; then
+#     echo "[ERROR] This repository requires commit signing, so please configure it." >&2
+#     echo "        https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md" >&2
+#     exit 1
+# fi


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/oss-contribution-guide/issues/77

I'm not sure the correct way to check if commit signing is enabled.
So I disable the validation for now.