### PR TITLE
chore: spelling fix in test start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,7 +10,7 @@ if ! bash scripts/is_build_image.sh; then
 fi
 
 if ! bash scripts/exist_container.sh "$container_name"; then
-	echo "[INFO] Creaing a container $container_name" >&2
+	echo "[INFO] Creating a container $container_name" >&2
 	bash scripts/run.sh "$container_name"
 	exit 0
 fi


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

Cosmetic fix to a test script - corrects spelling of output: `Creaed` to `Created`

