### PR TITLE
feat: add tldr-pages/tlrc

### DIFF
--- a/pkgs/tldr-pages/tlrc/pkg.yaml
+++ b/pkgs/tldr-pages/tlrc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tldr-pages/tlrc@v1.9.3

--- a/pkgs/tldr-pages/tlrc/registry.yaml
+++ b/pkgs/tldr-pages/tlrc/registry.yaml
@@ -1,0 +1,26 @@
+packages:
+  - type: github_release
+    repo_owner: tldr-pages
+    repo_name: tlrc
+    description: A tldr client written in Rust
+    files:
+      - name: tldr
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -48141,6 +48141,31 @@ packages:
           type: github_release
           asset: slp_{{.Version}}_checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: tldr-pages
+    repo_name: tlrc
+    description: A tldr client written in Rust
+    files:
+      - name: tldr
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
   - type: go_install
     repo_owner: tmc
     repo_name: json-to-struct


### PR DESCRIPTION
[tldr-pages/tlrc](https://github.com/tldr-pages/tlrc): A tldr client written in Rust

```console
$ aqua g -i tldr-pages/tlrc
```

Close #29309