### PR TITLE
feat: add triyanox/lla

### DIFF
--- a/pkgs/triyanox/lla/pkg.yaml
+++ b/pkgs/triyanox/lla/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: triyanox/lla@v0.2.9

--- a/pkgs/triyanox/lla/registry.yaml
+++ b/pkgs/triyanox/lla/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - type: github_release
+    repo_owner: triyanox
+    repo_name: lla
+    description: A modern alternative to ls
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.7")
+        no_asset: true
+      - version_constraint: "true"
+        asset: lla-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -48729,6 +48729,26 @@ packages:
           - amd64
         rosetta2: true
   - type: github_release
+    repo_owner: triyanox
+    repo_name: lla
+    description: A modern alternative to ls
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.7")
+        no_asset: true
+      - version_constraint: "true"
+        asset: lla-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: trufflesecurity
     repo_name: driftwood
     description: Private key usage verification


### PR DESCRIPTION
[triyanox/lla](https://github.com/triyanox/lla): A modern alternative to ls

```console
$ aqua g -i triyanox/lla
```

Close #29329 