### PR TITLE
feat: add crates.io/cargo-deb

### DIFF
--- a/pkgs/crates.io/cargo-deb/pkg.yaml
+++ b/pkgs/crates.io/cargo-deb/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/cargo-deb@2.9.0

--- a/pkgs/crates.io/cargo-deb/registry.yaml
+++ b/pkgs/crates.io/cargo-deb/registry.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: crates.io/cargo-deb
+    type: cargo
+    repo_owner: kornelski
+    repo_name: cargo-deb
+    description: Make Debian packages (.deb) easily with a Cargo subcommand
+    link: https://lib.rs/crates/cargo-deb
+    crate: cargo-deb

--- a/registry.yaml
+++ b/registry.yaml
@@ -16199,6 +16199,13 @@ packages:
     description: A new file manager
     link: https://dystroy.org/broot
     crate: broot
+  - name: crates.io/cargo-deb
+    type: cargo
+    repo_owner: kornelski
+    repo_name: cargo-deb
+    description: Make Debian packages (.deb) easily with a Cargo subcommand
+    link: https://lib.rs/crates/cargo-deb
+    crate: cargo-deb
   - name: crates.io/cargo-expand
     type: cargo
     repo_owner: dtolnay


### PR DESCRIPTION
[crates.io/cargo-deb](https://crates.io/crates/cargo-deb): Make Debian packages (.deb) easily with a Cargo subcommand

```console
$ aqua g -i crates.io/cargo-deb
```

- https://github.com/aquaproj/aqua-registry/issues/29339