### PR TITLE
feat: add nextest-rs/nextest/cargo-nextest

### DIFF
--- a/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
@@ -34,6 +34,7 @@ packages:
     version: cargo-nextest-0.9.40
   - name: nextest-rs/nextest/cargo-nextest
     version: cargo-nextest-0.9.30-rc.2
+
   - name: nextest-rs/nextest/cargo-nextest
     version: cargo-nextest-0.9.30-rc.1
   - name: nextest-rs/nextest/cargo-nextest

--- a/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
@@ -1,0 +1,42 @@
+packages:
+  - name: nextest-rs/nextest/cargo-nextest@cargo-nextest-0.9.85
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.84
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.70
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.68
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.64
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.61
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.59
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.58-rc.1
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.57
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.49-rc.2
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.48
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.46
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.45
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.41
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.41-a.6
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.41-a.4
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.40
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.30-rc.2
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.30-rc.1
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.29
+  - name: nextest-rs/nextest/cargo-nextest
+    version: cargo-nextest-0.9.28

--- a/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/pkg.yaml
@@ -34,7 +34,6 @@ packages:
     version: cargo-nextest-0.9.40
   - name: nextest-rs/nextest/cargo-nextest
     version: cargo-nextest-0.9.30-rc.2
-
   - name: nextest-rs/nextest/cargo-nextest
     version: cargo-nextest-0.9.30-rc.1
   - name: nextest-rs/nextest/cargo-nextest

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -1,0 +1,385 @@
+packages:
+  - name: nextest-rs/nextest/cargo-nextest
+    type: github_release
+    repo_owner: nextest-rs
+    repo_name: nextest
+    description: A next-generation test runner for Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= nextest-metadata-0.9.3")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.28")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.29")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "cargo-nextest-0.9.30-rc.2"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= cargo-nextest-0.9.40")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.5"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= cargo-nextest-0.9.45")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.46"
+        asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.48")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.49-rc.1"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.57")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/arm64
+      - version_constraint: semver("<= cargo-nextest-0.9.59")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.61-rc.1")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.61")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.62-a.1")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.64")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.65"
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.68")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.69"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.70"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.71"
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.84")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.85-rc.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-universal-{{.OS}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -37,26 +37,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.46"
         asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -9,6 +9,19 @@ packages:
     version_overrides:
       - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
+      - version_constraint: semver("> 0.9.59, <= 0.9.61-rc.1")
+        no_asset: true
+      - version_constraint: semver("> 0.9.61, <= 0.9.62-a.1")
+        no_asset: true
+      - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
       - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -99,6 +112,26 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
+      - version_constraint: Version == "cargo-nextest-0.9.70"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -116,119 +149,6 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.41-a.3")
-        no_asset: true
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.9.59")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.61-rc.1")
-        no_asset: true
-      - version_constraint: semver("<= 0.9.61")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.62-a.1")
-        no_asset: true
-      - version_constraint: semver("<= 0.9.64")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.68")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.70"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -272,7 +192,6 @@ packages:
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
-        complete_windows_ext: false
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -4,11 +4,12 @@ packages:
     repo_owner: nextest-rs
     repo_name: nextest
     description: A next-generation test runner for Rust
+    version_prefix: "cargo-nextest-"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= nextest-metadata-0.9.3")
+      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.28")
+      - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -24,7 +25,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.29")
+      - version_constraint: semver("<= 0.9.29")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -66,7 +67,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= cargo-nextest-0.9.40")
+      - version_constraint: semver("<= 0.9.40")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -86,7 +87,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.41-a.3")
+      - version_constraint: semver("<= 0.9.41-a.3")
         no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
@@ -95,8 +96,6 @@ packages:
           darwin: apple-darwin
         supported_envs:
           - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.5"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -124,7 +123,7 @@ packages:
           darwin: apple-darwin
         supported_envs:
           - darwin
-      - version_constraint: semver("<= cargo-nextest-0.9.45")
+      - version_constraint: semver("<= 0.9.45")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -156,7 +155,7 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.48")
+      - version_constraint: semver("<= 0.9.48")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -176,8 +175,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.49-rc.1"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -198,7 +195,7 @@ packages:
         supported_envs:
           - linux
           - windows/amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.57")
+      - version_constraint: semver("<= 0.9.57")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -226,7 +223,7 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
-      - version_constraint: semver("<= cargo-nextest-0.9.59")
+      - version_constraint: semver("<= 0.9.59")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -246,9 +243,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.61-rc.1")
+      - version_constraint: semver("<= 0.9.61-rc.1")
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.61")
+      - version_constraint: semver("<= 0.9.61")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -268,9 +265,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.62-a.1")
+      - version_constraint: semver("<= 0.9.62-a.1")
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.64")
+      - version_constraint: semver("<= 0.9.64")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -290,9 +287,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.65"
-        no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.68")
+      - version_constraint: semver("<= 0.9.68")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -312,8 +307,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.69"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.70"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -334,9 +327,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.71"
-        no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.84")
+      - version_constraint: semver("<= 0.9.84")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -356,8 +347,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.85-rc.1"
-        no_asset: true
       - version_constraint: "true"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -369,7 +358,7 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Version}}-universal-{{.OS}}.sha256"
+          asset: "{{.Version}}-{{.Arch}}-{{.OS}}.sha256"
           algorithm: sha256
         overrides:
           - goos: linux
@@ -382,4 +371,6 @@ packages:
               arm64: aarch64
               linux: unknown-linux-gnu
           - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+            replacements:
+              amd64: universal
+              arm64: universal

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -7,13 +7,7 @@ packages:
     version_prefix: "cargo-nextest-"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
-        no_asset: true
-      - version_constraint: semver("> 0.9.59, <= 0.9.61-rc.1")
-        no_asset: true
-      - version_constraint: semver("> 0.9.61, <= 0.9.62-a.1")
-        no_asset: true
-      - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
+      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"] or semver("> 0.9.59, <= 0.9.61-rc.1") or semver("> 0.9.61, <= 0.9.62-a.1") or semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
       - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41", "cargo-nextest-0.9.41-a.4"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -15,14 +15,7 @@ packages:
         no_asset: true
       - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
+      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -98,26 +98,6 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
-      - version_constraint: Version == "cargo-nextest-0.9.70"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -15,7 +15,7 @@ packages:
         no_asset: true
       - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
-      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41"]
+      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41", "cargo-nextest-0.9.41-a.4"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:
@@ -36,13 +36,6 @@ packages:
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         supported_envs:
           - linux/amd64
-          - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
           - darwin
       - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
@@ -141,26 +134,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.84")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
+++ b/pkgs/nextest-rs/nextest/cargo-nextest/registry.yaml
@@ -9,42 +9,6 @@ packages:
     version_overrides:
       - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
-      - version_constraint: semver("<= 0.9.28")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.9.29")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -67,28 +31,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.41-a.3")
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -116,36 +58,10 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.9.45")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.46"
         asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
         format: tar.gz
+        windows_arm_emulation: true
         replacements:
           darwin: apple-darwin
           windows: pc-windows-msvc
@@ -154,27 +70,7 @@ packages:
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         supported_envs:
           - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 0.9.48")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+          - windows
       - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -194,8 +90,32 @@ packages:
               linux: unknown-linux-gnu
         supported_envs:
           - linux
-          - windows/amd64
-      - version_constraint: semver("<= 0.9.57")
+          - windows
+      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/arm64
+      - version_constraint: semver("<= 0.9.28")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.9.40")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -215,14 +135,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= 0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:
-          arm64: aarch64
-          linux: unknown-linux-gnu
+          darwin: apple-darwin
         supported_envs:
-          - linux/arm64
+          - darwin
       - version_constraint: semver("<= 0.9.59")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -36623,11 +36623,12 @@ packages:
     repo_owner: nextest-rs
     repo_name: nextest
     description: A next-generation test runner for Rust
+    version_prefix: "cargo-nextest-"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= nextest-metadata-0.9.3")
+      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.28")
+      - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36643,7 +36644,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.29")
+      - version_constraint: semver("<= 0.9.29")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36685,7 +36686,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= cargo-nextest-0.9.40")
+      - version_constraint: semver("<= 0.9.40")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36705,7 +36706,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.41-a.3")
+      - version_constraint: semver("<= 0.9.41-a.3")
         no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
@@ -36714,8 +36715,6 @@ packages:
           darwin: apple-darwin
         supported_envs:
           - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.5"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36743,7 +36742,7 @@ packages:
           darwin: apple-darwin
         supported_envs:
           - darwin
-      - version_constraint: semver("<= cargo-nextest-0.9.45")
+      - version_constraint: semver("<= 0.9.45")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36775,7 +36774,7 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.48")
+      - version_constraint: semver("<= 0.9.48")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36795,8 +36794,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.49-rc.1"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36817,7 +36814,7 @@ packages:
         supported_envs:
           - linux
           - windows/amd64
-      - version_constraint: semver("<= cargo-nextest-0.9.57")
+      - version_constraint: semver("<= 0.9.57")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36845,7 +36842,7 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
-      - version_constraint: semver("<= cargo-nextest-0.9.59")
+      - version_constraint: semver("<= 0.9.59")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36865,9 +36862,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.61-rc.1")
+      - version_constraint: semver("<= 0.9.61-rc.1")
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.61")
+      - version_constraint: semver("<= 0.9.61")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36887,9 +36884,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= cargo-nextest-0.9.62-a.1")
+      - version_constraint: semver("<= 0.9.62-a.1")
         no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.64")
+      - version_constraint: semver("<= 0.9.64")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36909,9 +36906,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.65"
-        no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.68")
+      - version_constraint: semver("<= 0.9.68")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36931,8 +36926,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.69"
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.70"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36953,9 +36946,7 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.71"
-        no_asset: true
-      - version_constraint: semver("<= cargo-nextest-0.9.84")
+      - version_constraint: semver("<= 0.9.84")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36975,8 +36966,6 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.85-rc.1"
-        no_asset: true
       - version_constraint: "true"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36988,7 +36977,7 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Version}}-universal-{{.OS}}.sha256"
+          asset: "{{.Version}}-{{.Arch}}-{{.OS}}.sha256"
           algorithm: sha256
         overrides:
           - goos: linux
@@ -37001,7 +36990,9 @@ packages:
               arm64: aarch64
               linux: unknown-linux-gnu
           - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+            replacements:
+              amd64: universal
+              arm64: universal
   - type: github_release
     repo_owner: nicarl
     repo_name: somafm

--- a/registry.yaml
+++ b/registry.yaml
@@ -36656,26 +36656,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.46"
         asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -36626,13 +36626,7 @@ packages:
     version_prefix: "cargo-nextest-"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
-        no_asset: true
-      - version_constraint: semver("> 0.9.59, <= 0.9.61-rc.1")
-        no_asset: true
-      - version_constraint: semver("> 0.9.61, <= 0.9.62-a.1")
-        no_asset: true
-      - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
+      - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"] or semver("> 0.9.59, <= 0.9.61-rc.1") or semver("> 0.9.61, <= 0.9.62-a.1") or semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
       - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41", "cargo-nextest-0.9.41-a.4"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"

--- a/registry.yaml
+++ b/registry.yaml
@@ -36618,6 +36618,390 @@ packages:
       type: github_release
       asset: newrelic-cli_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - name: nextest-rs/nextest/cargo-nextest
+    type: github_release
+    repo_owner: nextest-rs
+    repo_name: nextest
+    description: A next-generation test runner for Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= nextest-metadata-0.9.3")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.28")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.29")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "cargo-nextest-0.9.30-rc.2"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= cargo-nextest-0.9.40")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.5"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= cargo-nextest-0.9.45")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.46"
+        asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.48")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.49-rc.1"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= cargo-nextest-0.9.57")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/arm64
+      - version_constraint: semver("<= cargo-nextest-0.9.59")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.61-rc.1")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.61")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= cargo-nextest-0.9.62-a.1")
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.64")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.65"
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.68")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.69"
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.70"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.71"
+        no_asset: true
+      - version_constraint: semver("<= cargo-nextest-0.9.84")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+      - version_constraint: Version == "cargo-nextest-0.9.85-rc.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-universal-{{.OS}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
   - type: github_release
     repo_owner: nicarl
     repo_name: somafm

--- a/registry.yaml
+++ b/registry.yaml
@@ -36628,6 +36628,19 @@ packages:
     version_overrides:
       - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
+      - version_constraint: semver("> 0.9.59, <= 0.9.61-rc.1")
+        no_asset: true
+      - version_constraint: semver("> 0.9.61, <= 0.9.62-a.1")
+        no_asset: true
+      - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
       - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36718,6 +36731,26 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
+      - version_constraint: Version == "cargo-nextest-0.9.70"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36735,119 +36768,6 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.41-a.3")
-        no_asset: true
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.9.59")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.61-rc.1")
-        no_asset: true
-      - version_constraint: semver("<= 0.9.61")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.62-a.1")
-        no_asset: true
-      - version_constraint: semver("<= 0.9.64")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.68")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.70"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36891,7 +36811,6 @@ packages:
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
-        complete_windows_ext: false
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -36634,7 +36634,7 @@ packages:
         no_asset: true
       - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
-      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41"]
+      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41", "cargo-nextest-0.9.41-a.4"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:
@@ -36655,13 +36655,6 @@ packages:
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         supported_envs:
           - linux/amd64
-          - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
           - darwin
       - version_constraint: Version == "cargo-nextest-0.9.41-a.6"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
@@ -36760,26 +36753,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.84")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -36628,42 +36628,6 @@ packages:
     version_overrides:
       - version_constraint: SemVer in ["0.9.85-rc.1", "0.9.41-a.5", "0.9.49-rc.1", "0.9.65", "0.9.69", "0.9.71"]
         no_asset: true
-      - version_constraint: semver("<= 0.9.28")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.9.29")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36686,28 +36650,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 0.9.40")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: semver("<= 0.9.41-a.3")
-        no_asset: true
       - version_constraint: Version == "cargo-nextest-0.9.41-a.4"
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36735,36 +36677,10 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.9.45")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: Version == "cargo-nextest-0.9.46"
         asset: "{{.Version}}-i686-{{.OS}}.{{.Format}}"
         format: tar.gz
+        windows_arm_emulation: true
         replacements:
           darwin: apple-darwin
           windows: pc-windows-msvc
@@ -36773,27 +36689,7 @@ packages:
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         supported_envs:
           - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 0.9.48")
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+          - windows
       - version_constraint: Version == "cargo-nextest-0.9.49-rc.2"
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
@@ -36813,8 +36709,32 @@ packages:
               linux: unknown-linux-gnu
         supported_envs:
           - linux
-          - windows/amd64
-      - version_constraint: semver("<= 0.9.57")
+          - windows
+      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/arm64
+      - version_constraint: semver("<= 0.9.28")
+        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.9.40")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz
         windows_arm_emulation: true
@@ -36834,14 +36754,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: darwin
             asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-      - version_constraint: Version == "cargo-nextest-0.9.58-rc.1"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
+      - version_constraint: semver("<= 0.9.41-a.3")
+        no_asset: true
+      - version_constraint: Version == "cargo-nextest-0.9.41"
+        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:
-          arm64: aarch64
-          linux: unknown-linux-gnu
+          darwin: apple-darwin
         supported_envs:
-          - linux/arm64
+          - darwin
       - version_constraint: semver("<= 0.9.59")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -36634,14 +36634,7 @@ packages:
         no_asset: true
       - version_constraint: semver("> 0.9.40, <= 0.9.41-a.3")
         no_asset: true
-      - version_constraint: Version == "cargo-nextest-0.9.41"
-        asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "cargo-nextest-0.9.30-rc.1"
+      - version_constraint: Version in ["cargo-nextest-0.9.30-rc.1", "cargo-nextest-0.9.41"]
         asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
         format: tar.gz
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -36717,26 +36717,6 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/arm64
-      - version_constraint: Version == "cargo-nextest-0.9.70"
-        asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: darwin
-            asset: "{{.Version}}-universal-{{.OS}}.{{.Format}}"
       - version_constraint: semver("<= 0.9.28")
         asset: "{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}"
         format: tar.gz


### PR DESCRIPTION
[nextest-rs/nextest/cargo-nextest](https://github.com/nextest-rs/nextest): A next-generation test runner for Rust

```console
$ aqua g -i nextest-rs/nextest/cargo-nextest
```

- https://github.com/aquaproj/aqua-registry/issues/29339