### PR TITLE
feat: add crates.io/dd-rust-license-tool

### DIFF
--- a/pkgs/crates.io/dd-rust-license-tool/pkg.yaml
+++ b/pkgs/crates.io/dd-rust-license-tool/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/dd-rust-license-tool@1.0.3

--- a/pkgs/crates.io/dd-rust-license-tool/registry.yaml
+++ b/pkgs/crates.io/dd-rust-license-tool/registry.yaml
@@ -3,5 +3,5 @@ packages:
     type: cargo
     repo_owner: DataDog
     repo_name: rust-license-tool
-    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects.
+    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects
     crate: dd-rust-license-tool

--- a/pkgs/crates.io/dd-rust-license-tool/registry.yaml
+++ b/pkgs/crates.io/dd-rust-license-tool/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/dd-rust-license-tool
+    type: cargo
+    repo_owner: DataDog
+    repo_name: rust-license-tool
+    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects.
+    crate: dd-rust-license-tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -16218,6 +16218,12 @@ packages:
     repo_name: cargo-run-script
     description: Bringing `npm run-script` to Rust
     crate: cargo-run-script
+  - name: crates.io/dd-rust-license-tool
+    type: cargo
+    repo_owner: DataDog
+    repo_name: rust-license-tool
+    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects.
+    crate: dd-rust-license-tool
   # TODO: Merge this package with eza-community/eza
   # https://github.com/aquaproj/aqua/issues/2649
   - name: crates.io/eza

--- a/registry.yaml
+++ b/registry.yaml
@@ -16222,7 +16222,7 @@ packages:
     type: cargo
     repo_owner: DataDog
     repo_name: rust-license-tool
-    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects.
+    description: A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects
     crate: dd-rust-license-tool
   # TODO: Merge this package with eza-community/eza
   # https://github.com/aquaproj/aqua/issues/2649


### PR DESCRIPTION
[crates.io/dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool): A tool for creating the `LICENSE-3rdparty.csv` file for DataDog open-source Rust projects

```console
$ aqua g -i crates.io/dd-rust-license-tool
```

- https://github.com/aquaproj/aqua-registry/issues/29339