### PR TITLE
fix(crates.io/skim): transfer the repository

### DIFF
--- a/pkgs/crates.io/skim/registry.yaml
+++ b/pkgs/crates.io/skim/registry.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: crates.io/skim
     type: cargo
-    repo_owner: lotabout
+    repo_owner: skim-rs
     repo_name: skim
     description: Fuzzy Finder in rust!
     crate: skim

--- a/registry.yaml
+++ b/registry.yaml
@@ -16374,7 +16374,7 @@ packages:
     crate: gitu
   - name: crates.io/skim
     type: cargo
-    repo_owner: lotabout
+    repo_owner: skim-rs
     repo_name: skim
     description: Fuzzy Finder in rust!
     crate: skim


### PR DESCRIPTION
Close https://github.com/aquaproj/aqua-registry/pull/29472

The GitHub Repository of the package "crates.io/skim" was transferred from [lotabout/skim](https://github.com/lotabout/skim) to [skim-rs/skim](https://github.com/skim-rs/skim).