### PR TITLE
Revert "chore(deps): update golang docker tag to v1.23.4"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-bookworm
+FROM golang:1.23.3-bookworm
 WORKDIR /workspace
 ENV AQUA_LOG_COLOR=always
 ENV AQUA_POLICY_CONFIG=/workspace/aqua-policy.yaml


### PR DESCRIPTION
Reverts aquaproj/aqua-registry#29498

```
[INFO] Building the docker image aquaproj/aqua-registry
[+] Building 0.1s (2/2) FINISHED                                                                                                 docker:colima
 => [internal] load build definition from Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 865B                                                                                                      0.0s
 => ERROR [internal] load metadata for docker.io/library/golang:1.23.4-bookworm                                                           0.1s
------
 > [internal] load metadata for docker.io/library/golang:1.23.4-bookworm:
------
Dockerfile:1
--------------------
   1 | >>> FROM golang:1.23.4-bookworm
   2 |     WORKDIR /workspace
   3 |     ENV AQUA_LOG_COLOR=always
--------------------
ERROR: failed to solve: golang:1.23.4-bookworm: failed to resolve source metadata for docker.io/library/golang:1.23.4-bookworm: failed to do request: Head "https://registry-1.docker.io/v2/library/golang/manifests/1.23.4-bookworm": dial tcp: lookup registry-1.docker.io on 127.0.0.53:53: server misbehaving
exit status 1
```

- https://github.com/aquaproj/aqua-registry/pull/29500#issuecomment-2516076434