### PR TITLE
feat: add rfjakob/gocryptfs

### DIFF
--- a/pkgs/rfjakob/gocryptfs/pkg.yaml
+++ b/pkgs/rfjakob/gocryptfs/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: rfjakob/gocryptfs@v2.4.0
+  - name: rfjakob/gocryptfs
+    version: v1.3

--- a/pkgs/rfjakob/gocryptfs/pkg.yaml
+++ b/pkgs/rfjakob/gocryptfs/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: rfjakob/gocryptfs@v2.4.0
-  - name: rfjakob/gocryptfs
-    version: v1.3

--- a/pkgs/rfjakob/gocryptfs/registry.yaml
+++ b/pkgs/rfjakob/gocryptfs/registry.yaml
@@ -6,6 +6,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.3")
+        no_asset: true
       - version_constraint: "true"
         asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/rfjakob/gocryptfs/registry.yaml
+++ b/pkgs/rfjakob/gocryptfs/registry.yaml
@@ -10,5 +10,8 @@ packages:
       - version_constraint: "true"
         asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gocryptfs
+          - name: gocryptfs-xray
         supported_envs:
           - linux/amd64

--- a/pkgs/rfjakob/gocryptfs/registry.yaml
+++ b/pkgs/rfjakob/gocryptfs/registry.yaml
@@ -1,0 +1,13 @@
+packages:
+  - type: github_release
+    repo_owner: rfjakob
+    repo_name: gocryptfs
+    description: Encrypted overlay filesystem written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3")
+      - version_constraint: "true"
+        asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -41814,6 +41814,9 @@ packages:
       - version_constraint: "true"
         asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gocryptfs
+          - name: gocryptfs-xray
         supported_envs:
           - linux/amd64
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -41804,6 +41804,18 @@ packages:
           - linux
           - amd64
   - type: github_release
+    repo_owner: rfjakob
+    repo_name: gocryptfs
+    description: Encrypted overlay filesystem written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3")
+      - version_constraint: "true"
+        asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+  - type: github_release
     repo_owner: rgreinho
     repo_name: tfe-cli
     description: CLI client for Terraform enterprise

--- a/registry.yaml
+++ b/registry.yaml
@@ -41810,6 +41810,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.3")
+        no_asset: true
       - version_constraint: "true"
         asset: gocryptfs_{{.Version}}_{{.OS}}-static_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[rfjakob/gocryptfs](https://github.com/rfjakob/gocryptfs): Encrypted overlay filesystem written in Go

```console
$ aqua g -i rfjakob/gocryptfs
```

⚠️ Support Only linux/amd64

Close #29676