### PR TITLE
feat: add skaji/relocatable-perl

### DIFF
--- a/pkgs/skaji/relocatable-perl/pkg.yaml
+++ b/pkgs/skaji/relocatable-perl/pkg.yaml
@@ -4,3 +4,7 @@ packages:
     version: 5.38.2.0
   - name: skaji/relocatable-perl
     version: 5.36.1.0
+  - name: skaji/relocatable-perl
+    version: 5.36.0.0
+  - name: skaji/relocatable-perl
+    version: 5.34.1.0

--- a/pkgs/skaji/relocatable-perl/pkg.yaml
+++ b/pkgs/skaji/relocatable-perl/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: skaji/relocatable-perl@5.40.0.1
+  - name: skaji/relocatable-perl
+    version: 5.36.0.0
+  - name: skaji/relocatable-perl
+    version: 5.34.1.0

--- a/pkgs/skaji/relocatable-perl/pkg.yaml
+++ b/pkgs/skaji/relocatable-perl/pkg.yaml
@@ -1,6 +1,6 @@
 packages:
   - name: skaji/relocatable-perl@5.40.0.1
   - name: skaji/relocatable-perl
-    version: 5.36.0.0
+    version: 5.38.2.0
   - name: skaji/relocatable-perl
-    version: 5.34.1.0
+    version: 5.36.1.0

--- a/pkgs/skaji/relocatable-perl/registry.yaml
+++ b/pkgs/skaji/relocatable-perl/registry.yaml
@@ -3,6 +3,15 @@ packages:
     repo_owner: skaji
     repo_name: relocatable-perl
     description: self-contained, portable perl binaries
+    files:
+      - name: perl
+        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+      - name: cpanm
+        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+      - name: perldoc
+        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+      - name: prove
+        src: perl-{{.OS}}-{{.Arch}}/bin/prove
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 5.34.1.0")
@@ -35,12 +44,3 @@ packages:
         supported_envs:
           - linux
           - darwin
-    files:
-      - name: perl
-        src: perl-{{.OS}}-{{.Arch}}/bin/perl
-      - name: cpanm
-        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
-      - name: perldoc
-        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
-      - name: prove
-        src: perl-{{.OS}}-{{.Arch}}/bin/prove

--- a/pkgs/skaji/relocatable-perl/registry.yaml
+++ b/pkgs/skaji/relocatable-perl/registry.yaml
@@ -1,0 +1,37 @@
+packages:
+  - type: github_release
+    repo_owner: skaji
+    repo_name: relocatable-perl
+    description: self-contained, portable perl binaries
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 5.34.1.0")
+        asset: perl-{{.OS}}-2level.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            asset: perl-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 5.36.0.0")
+        asset: perl-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: perl-{{.OS}}-2level.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: perl-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/skaji/relocatable-perl/registry.yaml
+++ b/pkgs/skaji/relocatable-perl/registry.yaml
@@ -35,3 +35,12 @@ packages:
         supported_envs:
           - linux
           - darwin
+    files:
+      - name: perl
+        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+      - name: cpanm
+        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+      - name: perldoc
+        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+      - name: prove
+        src: perl-{{.OS}}-{{.Arch}}/bin/prove

--- a/pkgs/skaji/relocatable-perl/registry.yaml
+++ b/pkgs/skaji/relocatable-perl/registry.yaml
@@ -5,13 +5,13 @@ packages:
     description: self-contained, portable perl binaries
     files:
       - name: perl
-        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+        src: "{{.AssetWithoutExt}}/bin/perl"
       - name: cpanm
-        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+        src: "{{.AssetWithoutExt}}/bin/cpanm"
       - name: perldoc
-        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+        src: "{{.AssetWithoutExt}}/bin/perldoc"
       - name: prove
-        src: perl-{{.OS}}-{{.Arch}}/bin/prove
+        src: "{{.AssetWithoutExt}}/bin/prove"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 5.34.1.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -44585,6 +44585,42 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: skaji
+    repo_name: relocatable-perl
+    description: self-contained, portable perl binaries
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 5.34.1.0")
+        asset: perl-{{.OS}}-2level.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            asset: perl-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 5.36.0.0")
+        asset: perl-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: perl-{{.OS}}-2level.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: perl-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: skanehira
     repo_name: gjo
     asset: "{{.OS}}.zip"

--- a/registry.yaml
+++ b/registry.yaml
@@ -44588,6 +44588,15 @@ packages:
     repo_owner: skaji
     repo_name: relocatable-perl
     description: self-contained, portable perl binaries
+    files:
+      - name: perl
+        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+      - name: cpanm
+        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+      - name: perldoc
+        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+      - name: prove
+        src: perl-{{.OS}}-{{.Arch}}/bin/prove
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 5.34.1.0")
@@ -44620,15 +44629,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-    files:
-      - name: perl
-        src: perl-{{.OS}}-{{.Arch}}/bin/perl
-      - name: cpanm
-        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
-      - name: perldoc
-        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
-      - name: prove
-        src: perl-{{.OS}}-{{.Arch}}/bin/prove
   - type: github_release
     repo_owner: skanehira
     repo_name: gjo

--- a/registry.yaml
+++ b/registry.yaml
@@ -44629,7 +44629,6 @@ packages:
         src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
       - name: prove
         src: perl-{{.OS}}-{{.Arch}}/bin/prove
-
   - type: github_release
     repo_owner: skanehira
     repo_name: gjo

--- a/registry.yaml
+++ b/registry.yaml
@@ -44590,13 +44590,13 @@ packages:
     description: self-contained, portable perl binaries
     files:
       - name: perl
-        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+        src: "{{.AssetWithoutExt}}/bin/perl"
       - name: cpanm
-        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+        src: "{{.AssetWithoutExt}}/bin/cpanm"
       - name: perldoc
-        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+        src: "{{.AssetWithoutExt}}/bin/perldoc"
       - name: prove
-        src: perl-{{.OS}}-{{.Arch}}/bin/prove
+        src: "{{.AssetWithoutExt}}/bin/prove"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 5.34.1.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -44620,6 +44620,16 @@ packages:
         supported_envs:
           - linux
           - darwin
+    files:
+      - name: perl
+        src: perl-{{.OS}}-{{.Arch}}/bin/perl
+      - name: cpanm
+        src: perl-{{.OS}}-{{.Arch}}/bin/cpanm
+      - name: perldoc
+        src: perl-{{.OS}}-{{.Arch}}/bin/perldoc
+      - name: prove
+        src: perl-{{.OS}}-{{.Arch}}/bin/prove
+
   - type: github_release
     repo_owner: skanehira
     repo_name: gjo


### PR DESCRIPTION
[skaji/relocatable-perl](https://github.com/skaji/relocatable-perl): self-contained, portable perl binaries

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## Description

* In my project, there are cases where small maintenance scripts are written in Perl.
* I want to manage all development tools uniformly using aqua.
* relocatable-perl is a precompiled Perl runtime that can be used immediately after extraction, making it easy to adopt.
* aqua already supports installing language runtimes such as node and go, so adding perl follows an existing precedent.