### PR TITLE
feat: add gdubicki/ets

### DIFF
--- a/pkgs/gdubicki/ets/pkg.yaml
+++ b/pkgs/gdubicki/ets/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: gdubicki/ets@v0.3.0

--- a/pkgs/gdubicki/ets/registry.yaml
+++ b/pkgs/gdubicki/ets/registry.yaml
@@ -1,0 +1,17 @@
+packages:
+  - type: github_release
+    repo_owner: gdubicki
+    repo_name: ets
+    description: A maintained fork of zmwangx's command output timestamper
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ets_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ets_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -23026,6 +23026,22 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: gdubicki
+    repo_name: ets
+    description: A maintained fork of zmwangx's command output timestamper
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ets_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ets_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: gefyrahq
     repo_name: gefyra
     description: "Blazingly-fast :rocket:, rock-solid, local application development :arrow_right: with Kubernetes"


### PR DESCRIPTION
[gdubicki/ets](https://github.com/gdubicki/ets): A maintained fork of zmwangx's command output timestamper

```console
$ aqua g -i gdubicki/ets
```

- https://github.com/aquaproj/aqua-registry/pull/29699#issuecomment-2531738488