### PR TITLE
feat(itaysk/kubectl-neat): scaffold itaysk/kubectl-neat

### DIFF
--- a/pkgs/itaysk/kubectl-neat/pkg.yaml
+++ b/pkgs/itaysk/kubectl-neat/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: itaysk/kubectl-neat@v2.0.4
+  - name: itaysk/kubectl-neat
+    version: v2.0.2
+  - name: itaysk/kubectl-neat
+    version: v1.0.0

--- a/pkgs/itaysk/kubectl-neat/registry.yaml
+++ b/pkgs/itaysk/kubectl-neat/registry.yaml
@@ -11,6 +11,9 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        files:
+          - name: kubectl-neat
+            src: dist/{{.OS}}/kubectl-neat
       - version_constraint: semver("<= 2.0.2")
         asset: kubectl-neat_{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/itaysk/kubectl-neat/registry.yaml
+++ b/pkgs/itaysk/kubectl-neat/registry.yaml
@@ -1,0 +1,33 @@
+packages:
+  - type: github_release
+    repo_owner: itaysk
+    repo_name: kubectl-neat
+    description: Clean up Kubernetes yaml and json output to make it readable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: kubectl-neat_{{.OS}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.2")
+        asset: kubectl-neat_{{.OS}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-neat_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -27940,6 +27940,38 @@ packages:
       - linux
       - darwin
   - type: github_release
+    repo_owner: itaysk
+    repo_name: kubectl-neat
+    description: Clean up Kubernetes yaml and json output to make it readable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.0.0")
+        asset: kubectl-neat_{{.OS}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.2")
+        asset: kubectl-neat_{{.OS}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-neat_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: itchyny
     repo_name: bed
     asset: bed_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -27951,6 +27951,9 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        files:
+          - name: kubectl-neat
+            src: dist/{{.OS}}/kubectl-neat
       - version_constraint: semver("<= 2.0.2")
         asset: kubectl-neat_{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[itaysk/kubectl-neat](https://github.com/itaysk/kubectl-neat): Clean up Kubernetes yaml and json output to make it readable

```console
$ aqua g -i itaysk/kubectl-neat
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@47d11b32dd79:/workspace# kubectl-neat --help
Usage:
  kubectl-neat [flags]
  kubectl-neat [command]

Examples:
kubectl get pod mypod -o yaml | kubectl neat
kubectl get pod mypod -oyaml | kubectl neat -o json
kubectl neat -f - <./my-pod.json
kubectl neat -f ./my-pod.json
kubectl neat -f ./my-pod.json --output yaml

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  get
  help        Help about any command
  version     Print kubectl-neat version

Flags:
  -f, --file string     file path to neat, or - to read from stdin (default "-")
  -h, --help            help for kubectl-neat
  -o, --output string   output format: yaml or json (default "yaml")

Use "kubectl-neat [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/itaysk/kubectl-neat/blob/master/Readme.md
