### PR TITLE
fix: re-add darwin amd64 support for jj

### DIFF
--- a/pkgs/martinvonz/jj/registry.yaml
+++ b/pkgs/martinvonz/jj/registry.yaml
@@ -72,7 +72,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.20.0")
         asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -87,6 +87,24 @@ packages:
             format: zip
         supported_envs:
           # darwin/amd64 was dropped. https://github.com/martinvonz/jj/pull/3999#issuecomment-2198984242
+          - darwin/arm64
+          - windows
+          - linux
+      - version_constraint: "true"
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+          arm64: aarch64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin/amd64
           - darwin/arm64
           - windows
           - linux

--- a/pkgs/martinvonz/jj/registry.yaml
+++ b/pkgs/martinvonz/jj/registry.yaml
@@ -103,8 +103,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin/amd64
-          - darwin/arm64
-          - windows
-          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -34268,7 +34268,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.20.0")
         asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -34283,6 +34283,24 @@ packages:
             format: zip
         supported_envs:
           # darwin/amd64 was dropped. https://github.com/martinvonz/jj/pull/3999#issuecomment-2198984242
+          - darwin/arm64
+          - windows
+          - linux
+      - version_constraint: "true"
+        asset: jj-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+          arm64: aarch64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin/amd64
           - darwin/arm64
           - windows
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -34299,11 +34299,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin/amd64
-          - darwin/arm64
-          - windows
-          - linux
   - type: go_install
     repo_owner: marwan-at-work
     repo_name: mod


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

darwin/amd64 binaries are back since [0.21.0](https://github.com/martinvonz/jj/releases/tag/v0.21.0)