### PR TITLE
chore: add a task summarize

### DIFF
--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -273,3 +273,15 @@ tasks:
       cmdx gr
       git add registry.yaml
       git commit
+
+  - name: summarize
+    short: sum
+    description: Summarize a given pull request
+    usage: Summarize a given pull request
+    args:
+      - name: pr
+        required: true
+        script_envs:
+          - PR_NUMBER
+    script: |
+      bash scripts/summarize.sh "$PR_NUMBER"

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pr=$1
+
+env=$(ci-info run -owner aquaproj -repo aqua-registry -pr "$pr")
+eval "$env"
+
+list_pkgs() {
+    grep -E "^pkgs/.*\.yaml" "$CI_INFO_TEMP_DIR/pr_files.txt" | sed -E "s|^pkgs/(.+)/[^/]+\.yaml|\1|" | sort -u
+}
+
+while read -r pkg; do
+    desc=$(yq ".packages[0].description" "pkgs/$pkg/registry.yaml")
+    repo_owner=$(yq ".packages[0].repo_owner" "pkgs/$pkg/registry.yaml")
+    repo_name=$(yq ".packages[0].repo_name" "pkgs/$pkg/registry.yaml")
+    if [ "$repo_owner" == "null" ] || [ "$repo_name" == "null" ]; then
+        echo "$pkg - $desc"
+        continue
+    fi
+    echo "[$pkg](https://github.com/$repo_owner/$repo_name) - $desc"
+done < <(list_pkgs)


### PR DESCRIPTION
This pull request add a cmdx task `summarize`, outputting a summary of a give pull request.
For now, the feature of this task is very simple but enough.
This task outputs a list of changed packages.

e.g.

```console
$ cmdx sum 29826
+ bash scripts/summarize.sh "$PR_NUMBER"

[gardener/docforge](https://github.com/gardener/docforge) - Scalable build tool for distributed documentation sources
```

We assume that we run this command at our laptops and paste the result to the pull request description.

## Why is this task necessary?

We provide a task `new`, creating a pull request to add packages.

```sh
cmdx new
```

This task is useful, but it has a problem that it doesn't work well if users don't have the permission to push a commit to `origin`.

- https://github.com/aquaproj/aqua-registry/issues/29797

We tried to resolve this issue, but it's a bit hard because this depends on user's environment.

So we changed the mind.
Users would be able to create a pull request easily without `cmdx new`.
The benefit of `cmdx new` is to give a good description.
The description is for maintainers mainly.
We decided to abandon `cmdx new` and complement the benefit by adding a new task creating a good description.
The maintainer can run the task at their laptops.
Maintainers can resolve issues regarding their environment themselves.

## TODO

- Update the contribution guide