### PR TITLE
feat(crates.io/bat): scaffold crates.io/bat

### DIFF
--- a/pkgs/crates.io/bat/pkg.yaml
+++ b/pkgs/crates.io/bat/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/bat@0.24.0

--- a/pkgs/crates.io/bat/registry.yaml
+++ b/pkgs/crates.io/bat/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/bat
+    type: cargo
+    repo_owner: sharkdp
+    repo_name: bat
+    description: A cat(1) clone with wings
+    crate: bat

--- a/registry.yaml
+++ b/registry.yaml
@@ -16475,6 +16475,12 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+  - name: crates.io/bat
+    type: cargo
+    repo_owner: sharkdp
+    repo_name: bat
+    description: A cat(1) clone with wings
+    crate: bat
   - name: crates.io/broot
     type: cargo
     repo_owner: Canop


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Since bat doesn't provide pre-built binary for the `aarch64-apple-darwin` target (cf. sharkdp/bat#1551), I'd like to install it with cargo.

I found some CLIs (e.g., skim and eza) have both `github_release` and `cargo` type packages in this registry, so I hope my PR would make sense as well.