### PR TITLE
feat(tealdeer-rs/tealdeer): scaffold tealdeer-rs/tealdeer

### DIFF
--- a/pkgs/tealdeer-rs/tealdeer/pkg.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/pkg.yaml
@@ -1,4 +1,8 @@
 packages:
   - name: tealdeer-rs/tealdeer@v1.7.1
   - name: tealdeer-rs/tealdeer
-    version: v1.5.0
+    version: v1.6.1
+  - name: tealdeer-rs/tealdeer
+    version: v1.4.1
+  - name: tealdeer-rs/tealdeer
+    version: v1.1.0

--- a/pkgs/tealdeer-rs/tealdeer/registry.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/registry.yaml
@@ -60,4 +60,3 @@ packages:
             asset: tealdeer-{{.OS}}-{{.Arch}}
           - goos: windows
             asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
-            replacements: {}

--- a/pkgs/tealdeer-rs/tealdeer/registry.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/registry.yaml
@@ -6,6 +6,8 @@ packages:
     aliases:
       - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
+    files:
+      - name: tldr
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.1.0")

--- a/pkgs/tealdeer-rs/tealdeer/registry.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/registry.yaml
@@ -3,6 +3,8 @@ packages:
   - type: github_release
     repo_owner: tealdeer-rs
     repo_name: tealdeer
+    aliases:
+      - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
     version_constraint: "false"
     version_overrides:

--- a/pkgs/tealdeer-rs/tealdeer/registry.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/registry.yaml
@@ -3,32 +3,53 @@ packages:
   - type: github_release
     repo_owner: tealdeer-rs
     repo_name: tealdeer
-    aliases:
-      - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
-    format: raw
-    asset: tealdeer-{{.OS}}-{{.Arch}}-musl
-    replacements:
-      amd64: x86_64
-      darwin: macos
-    overrides:
-      - goos: darwin
-        asset: tealdeer-{{.OS}}-{{.Arch}}
-      - goos: windows
-        asset: tealdeer-{{.OS}}-{{.Arch}}-msvc.exe
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
-    version_constraint: semver(">= 1.5.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        # https://github.com/dbrgn/tealdeer/releases/tag/v1.5.0 supports checksum, macOS, and windows.
-        checksum:
-          enabled: false
+      - version_constraint: semver("<= 1.1.0")
+      - version_constraint: semver("<= 1.4.1")
+        asset: tldr-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        replacements:
+          amd64: x86_64
         supported_envs:
           - linux/amd64
+      - version_constraint: semver("<= 1.6.1")
+        asset: tealdeer-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: tealdeer-{{.OS}}-{{.Arch}}
+          - goos: windows
+            asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: tealdeer-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: tealdeer-{{.OS}}-{{.Arch}}
+          - goos: windows
+            asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
+            replacements: {}

--- a/pkgs/tealdeer-rs/tealdeer/registry.yaml
+++ b/pkgs/tealdeer-rs/tealdeer/registry.yaml
@@ -9,6 +9,12 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.1.0")
+        asset: tldr-{{.Arch}}-musl
+        format: raw
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.4.1")
         asset: tldr-{{.OS}}-{{.Arch}}-musl
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -48551,6 +48551,8 @@ packages:
     aliases:
       - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
+    files:
+      - name: tldr
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.1.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -48548,10 +48548,18 @@ packages:
   - type: github_release
     repo_owner: tealdeer-rs
     repo_name: tealdeer
+    aliases:
+      - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.1.0")
+        asset: tldr-{{.Arch}}-musl
+        format: raw
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.4.1")
         asset: tldr-{{.OS}}-{{.Arch}}-musl
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -48605,7 +48605,6 @@ packages:
             asset: tealdeer-{{.OS}}-{{.Arch}}
           - goos: windows
             asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
-            replacements: {}
   - type: github_release
     repo_owner: tektoncd
     repo_name: cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -48548,35 +48548,56 @@ packages:
   - type: github_release
     repo_owner: tealdeer-rs
     repo_name: tealdeer
-    aliases:
-      - name: dbrgn/tealdeer
     description: A very fast implementation of tldr in Rust
-    format: raw
-    asset: tealdeer-{{.OS}}-{{.Arch}}-musl
-    replacements:
-      amd64: x86_64
-      darwin: macos
-    overrides:
-      - goos: darwin
-        asset: tealdeer-{{.OS}}-{{.Arch}}
-      - goos: windows
-        asset: tealdeer-{{.OS}}-{{.Arch}}-msvc.exe
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
-    version_constraint: semver(">= 1.5.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        # https://github.com/dbrgn/tealdeer/releases/tag/v1.5.0 supports checksum, macOS, and windows.
-        checksum:
-          enabled: false
+      - version_constraint: semver("<= 1.1.0")
+      - version_constraint: semver("<= 1.4.1")
+        asset: tldr-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        replacements:
+          amd64: x86_64
         supported_envs:
           - linux/amd64
+      - version_constraint: semver("<= 1.6.1")
+        asset: tealdeer-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: tealdeer-{{.OS}}-{{.Arch}}
+          - goos: windows
+            asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: tealdeer-{{.OS}}-{{.Arch}}-musl
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: tealdeer-{{.OS}}-{{.Arch}}
+          - goos: windows
+            asset: tealdeer-{{.OS}}-{{.Arch}}-msvc
+            replacements: {}
   - type: github_release
     repo_owner: tektoncd
     repo_name: cli


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Starting from v1.7.0, tealdeer has started providing pre-built binaries for ARM architecture. Below is an excerpt from [their changelog](https://github.com/tealdeer-rs/tealdeer/blob/main/CHANGELOG.md#v170-2024-10-02):

> Our **binary releases now include builds for ARM64 (aka `aarch64`) on macOS (Apple Silicon, M1/M2/M3)
and Linux**.

Current aqua registry still installs amd64-flavored tealdeer on ARM Mac, so I submit this PR.

```console
$ uname -sm
Darwin arm64
$ aqua g -i tealdeer-rs/tealdeer
$ aqua install --only-link
INFO[0000] create a symbolic link                        aqua_version=2.37.2 command=tealdeer env=darwin/arm64 package_name=tealdeer-rs/tealdeer package_version=v1.7.1 program=aqua
$ aqua which tealdeer  # notice the x86_64 suffix
/Users/ynkt/.local/share/aquaproj-aqua/pkgs/github_release/github.com/tealdeer-rs/tealdeer/v1.7.1/tealdeer-macos-x86_64/tealdeer-macos-x86_64
$ tealdeer --help  # rosetta 2 is not installed on my machine, hence the failure
INFO[0000] download and unarchive the package            aqua_version=2.37.2 env=darwin/arm64 exe_name=tealdeer package_name=tealdeer-rs/tealdeer package_version=v1.7.1 program=aqua registry=standard
INFO[0001] downloading a checksum file                   aqua_version=2.37.2 env=darwin/arm64 exe_name=tealdeer package_name=tealdeer-rs/tealdeer package_version=v1.7.1 program=aqua registry=standard
FATA[0002] aqua failed                                   aqua_version=2.37.2 env=darwin/arm64 error="it failed to start the process" exe_name=tealdeer package_name=tealdeer-rs/tealdeer package_version=v1.7.1 program=aqua
```

As I first tried manually updating the registry but couldn't get it right, I just ran the scaffolding command again.
