### PR TITLE
feat(t-kikuc/ecstop): scaffold t-kikuc/ecstop

### DIFF
--- a/pkgs/t-kikuc/ecstop/pkg.yaml
+++ b/pkgs/t-kikuc/ecstop/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: t-kikuc/ecstop@v0.0.1

--- a/pkgs/t-kikuc/ecstop/registry.yaml
+++ b/pkgs/t-kikuc/ecstop/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: t-kikuc
+    repo_name: ecstop
+    description: Stop your running resources of Amazon ECS easily
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ecstop_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: ecstop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -48607,6 +48607,27 @@ packages:
       asset: kube-psp-advisor_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: t-kikuc
+    repo_name: ecstop
+    description: Stop your running resources of Amazon ECS easily
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ecstop_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: ecstop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: tailor-platform
     repo_name: tailorctl
     description: Command line tool for Tailor Platform


### PR DESCRIPTION
[t-kikuc/ecstop](https://github.com/t-kikuc/ecstop) - Stop your running resources of Amazon ECS easily

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

```console
root@43718f6f9b8a:/workspace# ecstop
ecstop stops ECS resources instantly

Usage:
  ecstop [command]

Available Commands:
  all         'all' stops ECS Services, Standalone Tasks, and Container Instances
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  instances   'instances' stops ECS Container Instances
  services    'services' scale-ins ECS Services by updating desiredCount to 0
  tasks       'tasks' stops ECS Tasks

Flags:
  -h, --help   help for ecstop

Use "ecstop [command] --help" for more information about a command.
```
