### PR TITLE
feat: add shini4i/argo-compare

### DIFF
--- a/pkgs/shini4i/argo-compare/pkg.yaml
+++ b/pkgs/shini4i/argo-compare/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: shini4i/argo-compare@v0.4.0
+  - name: shini4i/argo-compare
+    version: v0.2.0

--- a/pkgs/shini4i/argo-compare/registry.yaml
+++ b/pkgs/shini4i/argo-compare/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: shini4i
+    repo_name: argo-compare
+    description: A comparison tool for displaying the differences between ArgoCD Applications in different Git branches
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: argo-compare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: argo-compare_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: argo-compare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: argo-compare_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -44714,6 +44714,36 @@ packages:
           asset: tfvar_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: shini4i
+    repo_name: argo-compare
+    description: A comparison tool for displaying the differences between ArgoCD Applications in different Git branches
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        asset: argo-compare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: argo-compare_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: argo-compare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: argo-compare_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: sho-hata
     repo_name: tparagen
     description: tparagen inserts `testing.T.Parallel()` in a test function in a specific source file or in an entire directory


### PR DESCRIPTION
[shini4i/argo-compare](https://github.com/shini4i/argo-compare): A comparison tool for displaying the differences between ArgoCD Applications in different Git branches

```console
$ aqua g -i shini4i/argo-compare
```