### PR TITLE
fix(smallstep/certificates): resolve the key duplication error

### DIFF
--- a/pkgs/smallstep/certificates/registry.yaml
+++ b/pkgs/smallstep/certificates/registry.yaml
@@ -293,5 +293,19 @@ packages:
         checksum:
           enabled: false
         format: tar.gz
-      - <<: *smallstep_certificates_default
-        version_constraint: "true"
+      - version_constraint: "true"
+        asset: step-ca_{{.OS}}_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: step-ca
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -45901,8 +45901,22 @@ packages:
         checksum:
           enabled: false
         format: tar.gz
-      - <<: *smallstep_certificates_default
-        version_constraint: "true"
+      - version_constraint: "true"
+        asset: step-ca_{{.OS}}_{{trimV .Version}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: step-ca
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: smallstep
     repo_name: cli


### PR DESCRIPTION
```
--- FAIL: BenchmarkUnmarshalYAML/goccy/go-yaml
    foo_test.go:47: [45875:9] duplicate key "version_constraint"
          45872 |           enabled: false
          45873 |         format: tar.gz
          45874 |       - <<: *smallstep_certificates_default
        > 45875 |         version_constraint: "true"
                          ^
          45876 |   - type: github_release
          45877 |     repo_owner: smallstep
          45878 |     repo_name: cli
          45879 |
```