### PR TITLE
feat(int128/ghcp): re-scaffold int128/ghcp

### DIFF
--- a/pkgs/int128/ghcp/pkg.yaml
+++ b/pkgs/int128/ghcp/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: int128/ghcp@v1.13.5
+  - name: int128/ghcp
+    version: v1.13.0
+  - name: int128/ghcp
+    version: v1.5.0

--- a/pkgs/int128/ghcp/registry.yaml
+++ b/pkgs/int128/ghcp/registry.yaml
@@ -3,9 +3,36 @@ packages:
   - type: github_release
     repo_owner: int128
     repo_name: ghcp
-    asset: ghcp_{{.OS}}_amd64.zip
     description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.5.0")
+        asset: ghcp_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.0")
+        asset: ghcp_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: ghcp_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -27820,12 +27820,39 @@ packages:
   - type: github_release
     repo_owner: int128
     repo_name: ghcp
-    asset: ghcp_{{.OS}}_amd64.zip
     description: Tool to fork a repository, commit files, create a pull request and upload assets using GitHub API
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.5.0")
+        asset: ghcp_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.0")
+        asset: ghcp_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: ghcp_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - type: github_release
     repo_owner: int128
     repo_name: kauthproxy


### PR DESCRIPTION
int128/ghcp supported multiple architecture after v1.13.1 but the aqua-registry still pointed to amd64 binary.

(This caused https://github.com/suzuki-shunsuke/tfaction not working in arm64 environment)

Ref:
- https://github.com/int128/ghcp
- https://github.com/int128/ghcp/releases