### PR TITLE
feat: add suzuki-shunsuke/disable-checkout-persist-credentials

### DIFF
--- a/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/disable-checkout-persist-credentials@v0.1.0

--- a/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/registry.yaml
+++ b/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: disable-checkout-persist-credentials
+    description: CLI to disable actions/checkout's persist-credentials
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: disable-checkout-persist-credentials_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/registry.yaml
+++ b/pkgs/suzuki-shunsuke/disable-checkout-persist-credentials/registry.yaml
@@ -9,10 +9,23 @@ packages:
       - version_constraint: "true"
         asset: disable-checkout-persist-credentials_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
         checksum:
           type: github_release
           asset: disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials/releases/download/{{.Version}}/disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials/releases/download/{{.Version}}/disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt.pem
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -47763,10 +47763,23 @@ packages:
       - version_constraint: "true"
         asset: disable-checkout-persist-credentials_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
         checksum:
           type: github_release
           asset: disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials/releases/download/{{.Version}}/disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials/releases/download/{{.Version}}/disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt.pem
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -47756,6 +47756,22 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: disable-checkout-persist-credentials
+    description: CLI to disable actions/checkout's persist-credentials
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: disable-checkout-persist-credentials_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: disable-checkout-persist-credentials_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: discussion-slack-notifier
     asset: discussion-slack-notifier_{{.OS}}_{{.Arch}}.tar.gz
     description: Notify GitHub Discussions events to Slack with GitHub Actions


### PR DESCRIPTION
[suzuki-shunsuke/disable-checkout-persist-credentials](https://github.com/suzuki-shunsuke/disable-checkout-persist-credentials): CLI to disable actions/checkout's persist-credentials

```console
$ aqua g -i suzuki-shunsuke/disable-checkout-persist-credentials
```