### PR TITLE
ci: add conditional for specific repository in workflow

### DIFF
--- a/.github/workflows/count-pkgs.yaml
+++ b/.github/workflows/count-pkgs.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "count=$n" >> "$GITHUB_OUTPUT"
         id: mise
       - run: gh issue comment "$NUMBER" --body "$BODY"
-        if: github.repository == "aquaproj/aqua-registry"
+        if: github.repository == 'aquaproj/aqua-registry'
         env:
           NUMBER: "19792"
           BODY: |

--- a/.github/workflows/count-pkgs.yaml
+++ b/.github/workflows/count-pkgs.yaml
@@ -32,6 +32,7 @@ jobs:
           echo "count=$n" >> "$GITHUB_OUTPUT"
         id: mise
       - run: gh issue comment "$NUMBER" --body "$BODY"
+        if: github.repository == "aquaproj/aqua-registry"
         env:
           NUMBER: "19792"
           BODY: |


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

## Motivation

The count-pkgs action always fails on fork repositories, so make sure it is the origin repository before running it.

see also: https://github.com/takumin/aqua-registry/actions/runs/12487355968