### PR TITLE
fix(rust-lang/rust-analyzer): use gnu instead of musl target env

### DIFF
--- a/pkgs/rust-lang/rust-analyzer/registry.yaml
+++ b/pkgs/rust-lang/rust-analyzer/registry.yaml
@@ -141,7 +141,7 @@ packages:
           - goos: linux
             goarch: amd64
             replacements:
-              linux: unknown-linux-musl
+              linux: unknown-linux-gnu
           - goos: linux
             goarch: arm64
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -43059,7 +43059,7 @@ packages:
           - goos: linux
             goarch: amd64
             replacements:
-              linux: unknown-linux-musl
+              linux: unknown-linux-gnu
           - goos: linux
             goarch: arm64
             replacements:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

rust-analyzer is actually dynamically linking musl libc, it's more generic to use gnu libc instead

```console
$ file ./rust-analyzer-x86_64-unknown-linux-musl
./rust-analyzer-x86_64-unknown-linux-musl: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, BuildID[sha1]=3ee6d6ae7f11ba8557005ec900f137e324c7402e, not stripped
$ ldd ./rust-analyzer-x86_64-unknown-linux-musl
        linux-vdso.so.1 (0x00007ffc8bbc5000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fde7043a000)
        libc.musl-x86_64.so.1 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fde70259000)
        /lib/ld-musl-x86_64.so.1 => /lib64/ld-linux-x86-64.so.2 (0x00007fde727cf000)

$ file ./rust-analyzer-x86_64-unknown-linux-gnu
./rust-analyzer-x86_64-unknown-linux-gnu: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=e63d6ba979f0c5ebf3959550cd1af2d3539db2d2, not stripped
$ ldd ./rust-analyzer-x86_64-unknown-linux-gnu
        linux-vdso.so.1 (0x00007ffcaa7a0000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f5d51b81000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5d51b7c000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f5d4f521000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5d51b77000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5d4f340000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5d51bab000)
```

refs：

* rust-lang/rust-analyzer#13086
* rust-lang/rust-analyzer#7658
* rust-lang/rust-analyzer#16793