### PR TITLE
fix(budimanjojo/talhelper): add windows support

### DIFF
--- a/pkgs/budimanjojo/talhelper/pkg.yaml
+++ b/pkgs/budimanjojo/talhelper/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: budimanjojo/talhelper@v3.0.14
+  - name: budimanjojo/talhelper
+    version: v1.6.4

--- a/pkgs/budimanjojo/talhelper/registry.yaml
+++ b/pkgs/budimanjojo/talhelper/registry.yaml
@@ -3,13 +3,24 @@ packages:
   - type: github_release
     repo_owner: budimanjojo
     repo_name: talhelper
-    description: A helper tool to help creating Talos in GitOps repository
-    asset: talhelper_{{.OS}}_{{.Arch}}.tar.gz
-    supported_envs:
-      - darwin
-      - linux
-      - windows
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: A tool to help creating Talos kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.4")
+        asset: talhelper_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: talhelper_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/budimanjojo/talhelper/registry.yaml
+++ b/pkgs/budimanjojo/talhelper/registry.yaml
@@ -8,6 +8,7 @@ packages:
     supported_envs:
       - darwin
       - linux
+      - windows
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -11410,15 +11410,27 @@ packages:
   - type: github_release
     repo_owner: budimanjojo
     repo_name: talhelper
-    description: A helper tool to help creating Talos in GitOps repository
-    asset: talhelper_{{.OS}}_{{.Arch}}.tar.gz
-    supported_envs:
-      - darwin
-      - linux
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: A tool to help creating Talos kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.4")
+        asset: talhelper_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: talhelper_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: bufbuild
     repo_name: buf


### PR DESCRIPTION
https://github.com/budimanjojo/talhelper

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Talhelper supports Windows, this change enables Windows support