### PR TITLE
feat: add mitsuhiko/minijinja

### DIFF
--- a/pkgs/mitsuhiko/minijinja/pkg.yaml
+++ b/pkgs/mitsuhiko/minijinja/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: mitsuhiko/minijinja@2.5.0
+  - name: mitsuhiko/minijinja
+    version: 2.3.1

--- a/pkgs/mitsuhiko/minijinja/registry.yaml
+++ b/pkgs/mitsuhiko/minijinja/registry.yaml
@@ -12,6 +12,9 @@ packages:
         asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: minijinja-cli
+            src: "{{.AssetWithoutExt}}/minijinja-cli"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27,6 +30,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: minijinja-cli
         supported_envs:
           - darwin
           - windows
@@ -35,6 +40,9 @@ packages:
         asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: minijinja-cli
+            src: "{{.AssetWithoutExt}}/minijinja-cli"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -48,3 +56,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: minijinja-cli

--- a/pkgs/mitsuhiko/minijinja/registry.yaml
+++ b/pkgs/mitsuhiko/minijinja/registry.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mitsuhiko
+    repo_name: minijinja
+    description: MiniJinja is a powerful but minimal dependency template engine for Rust compatible with Jinja/Jinja2
+    files:
+      - name: minijinja-cli
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.3.1")
+        asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36072,6 +36072,9 @@ packages:
         asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: minijinja-cli
+            src: "{{.AssetWithoutExt}}/minijinja-cli"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -36087,6 +36090,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: minijinja-cli
         supported_envs:
           - darwin
           - windows
@@ -36095,6 +36100,9 @@ packages:
         asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: minijinja-cli
+            src: "{{.AssetWithoutExt}}/minijinja-cli"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -36108,6 +36116,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: minijinja-cli
   - type: github_release
     repo_owner: mkchoi212
     repo_name: fac

--- a/registry.yaml
+++ b/registry.yaml
@@ -36061,6 +36061,54 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: mitsuhiko
+    repo_name: minijinja
+    description: MiniJinja is a powerful but minimal dependency template engine for Rust compatible with Jinja/Jinja2
+    files:
+      - name: minijinja-cli
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.3.1")
+        asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: minijinja-cli-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: mkchoi212
     repo_name: fac
     description: Easy-to-use CUI for fixing git conflicts


### PR DESCRIPTION
[mitsuhiko/minijinja](https://github.com/mitsuhiko/minijinja): MiniJinja is a powerful but minimal dependency template engine for Rust compatible with Jinja/Jinja2

```console
$ aqua g -i mitsuhiko/minijinja
```

Close #30415