### PR TITLE
fix(kubernetes/kubectl): add exe to url for windows

### DIFF
--- a/pkgs/kubernetes/kubectl/registry.yaml
+++ b/pkgs/kubernetes/kubectl/registry.yaml
@@ -16,6 +16,7 @@ packages:
       algorithm: sha256
     overrides:
       - goos: windows
+        url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl.exe
         checksum:
           type: http
           url: https://dl.k8s.io/{{.Version}}/bin/{{.OS}}/{{.Arch}}/kubectl.exe.sha256


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Per #30398, aqua doesn't appear to add .exe to the URL for Windows, this change ensures the correct URL is used for Windows.