### PR TITLE
feat(github/git-sizer): scaffold github/git-sizer

### DIFF
--- a/pkgs/github/git-sizer/pkg.yaml
+++ b/pkgs/github/git-sizer/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: github/git-sizer@v1.5.0
+  - name: github/git-sizer
+    version: v1.3.0

--- a/pkgs/github/git-sizer/registry.yaml
+++ b/pkgs/github/git-sizer/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: github
+    repo_name: git-sizer
+    description: Compute various size metrics for a Git repository, flagging those that might cause problems
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3.0")
+        asset: git-sizer-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: git-sizer-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -24100,6 +24100,29 @@ packages:
       - name: goctl
   - type: github_release
     repo_owner: github
+    repo_name: git-sizer
+    description: Compute various size metrics for a Git repository, flagging those that might cause problems
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3.0")
+        asset: git-sizer-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: git-sizer-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
+    repo_owner: github
     repo_name: licensed
     asset: licensed-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
     description: A Ruby gem to cache and verify the licenses of dependencies


### PR DESCRIPTION
[github/git-sizer](https://github.com/github/git-sizer): Compute various size metrics for a Git repository, flagging those that might cause problems

```console
$ aqua g -i github/git-sizer
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ git-sizer --help
usage: git-sizer [OPTS]

      --threshold THRESHOLD    minimum level of concern (i.e., number of stars)
                               that should be reported. Default:
                               '--threshold=1'. Can be set via gitconfig:
                               'sizer.threshold'.
  -v, --verbose                report all statistics, whether concerning or
                               not; equivalent to '--threshold=0
      --no-verbose             equivalent to '--threshold=1'
      --critical               only report critical statistics; equivalent
                               to '--threshold=30'
      --names=[none|hash|full] display names of large objects in the specified
                               style. Values:
                               * 'none' - omit footnotes entirely
                               * 'hash' - show only the SHA-1s of objects
                               * 'full' - show full names
                               Default is '--names=full'. Can be set via
                               gitconfig: 'sizer.names'.
  -j, --json                   output results in JSON format
      --json-version=[1|2]     choose which JSON format version to output.
                               Default: --json-version=1. Can be set via
                               gitconfig: 'sizer.jsonVersion'.
      --[no-]progress          report (don't report) progress to stderr. Can
                               be set via gitconfig: 'sizer.progress'.
      --version                only report the git-sizer version number

 Reference selection:

 By default, git-sizer processes all Git objects that are reachable
 from any reference. The following options can be used to limit which
 references to process. The last rule matching a reference determines
 whether that reference is processed.

      --[no-]branches          process [don't process] branches
      --[no-]tags              process [don't process] tags
      --[no-]remotes           process [don't process] remote-tracking
                               references
      --[no-]notes             process [don't process] git-notes references
      --[no-]stash             process [don't process] refs/stash
      --include PREFIX, --exclude PREFIX
                               process [don't process] references with the
                               specified PREFIX (e.g.,
                               '--include=refs/remotes/origin')
      --include /REGEXP/, --exclude /REGEXP/
                               process [don't process] references matching the
                               specified regular expression (e.g.,
                               '--include=refs/tags/release-.*')
      --include @REFGROUP, --exclude @REFGROUP
                               process [don't process] references in the
                               specified reference group (see below)
      --show-refs              show which refs are being included/excluded

 PREFIX must match at a boundary; for example 'refs/foo' matches
 'refs/foo' and 'refs/foo/bar' but not 'refs/foobar'.

 REGEXP patterns must match the full reference name.

 REFGROUP can be the name of a predefined reference group ('branches',
 'tags', 'remotes', 'pulls', 'changes', 'notes', or 'stash'), or one
 defined via gitconfig settings like the following (the
 include/exclude settings can be repeated):

   * 'refgroup.REFGROUP.name=NAME'
   * 'refgroup.REFGROUP.include=PREFIX'
   * 'refgroup.REFGROUP.includeRegexp=REGEXP'
   * 'refgroup.REFGROUP.exclude=PREFIX'
   * 'refgroup.REFGROUP.excludeRegexp=REGEXP'
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/github/git-sizer/blob/master/README.md
