### PR TITLE
Add make binary to IxDay/mruby

### DIFF
--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -15,6 +15,12 @@ packages:
         files:
           - name: mruby
           - name: mrake
+        overrides:
+          - goos: windows
+            files:
+              - name: mruby
+              - name: mrake
+                src: mrake.bat
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -7,8 +7,11 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        asset: mruby-{{.OS}}-{{.Arch}}
-        format: raw
+        asset: mruby-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: mruby
+          - name: mrake
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: IxDay
     repo_name: mruby
     description: Lightweight Ruby
+    files:
+      - name: mruby
+      - name: mrake
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -16,10 +16,7 @@ packages:
         replacements:
           amd64: x86_64
           darwin: macos
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
+          arm64: aarch64
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -2308,8 +2308,11 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        asset: mruby-{{.OS}}-{{.Arch}}
-        format: raw
+        asset: mruby-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: mruby
+          - name: mrake
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -2316,6 +2316,12 @@ packages:
         files:
           - name: mruby
           - name: mrake
+        overrides:
+          - goos: windows
+            files:
+              - name: mruby
+              - name: mrake
+                src: mrake.bat
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -2305,6 +2305,9 @@ packages:
     repo_owner: IxDay
     repo_name: mruby
     description: Lightweight Ruby
+    files:
+      - name: mruby
+      - name: mrake
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2317,10 +2317,7 @@ packages:
         replacements:
           amd64: x86_64
           darwin: macos
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
+          arm64: aarch64
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
[IxDay/mruby](https://github.com/IxDay/mruby) - Lightweight Ruby

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
