### PR TITLE
feat: add Canop/rhit

### DIFF
--- a/pkgs/Canop/rhit/pkg.yaml
+++ b/pkgs/Canop/rhit/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Canop/rhit@v2.0.3

--- a/pkgs/Canop/rhit/registry.yaml
+++ b/pkgs/Canop/rhit/registry.yaml
@@ -18,4 +18,3 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux
-

--- a/pkgs/Canop/rhit/registry.yaml
+++ b/pkgs/Canop/rhit/registry.yaml
@@ -7,3 +7,15 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
+        asset: rhit_{{trimV .Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: rhit
+            src: build/{{.Arch}}-{{.OS}}/rhit
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+

--- a/pkgs/Canop/rhit/registry.yaml
+++ b/pkgs/Canop/rhit/registry.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Canop
+    repo_name: rhit
+    description: A nginx log explorer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1197,6 +1197,13 @@ packages:
         supported_envs:
           - linux
   - type: github_release
+    repo_owner: Canop
+    repo_name: rhit
+    description: A nginx log explorer
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+  - type: github_release
     repo_owner: Checkmarx
     repo_name: kics
     description: Find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle of your infrastructure-as-code with KICS by Checkmarx

--- a/registry.yaml
+++ b/registry.yaml
@@ -1203,6 +1203,18 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
+        asset: rhit_{{trimV .Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: rhit
+            src: build/{{.Arch}}-{{.OS}}/rhit
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+
   - type: github_release
     repo_owner: Checkmarx
     repo_name: kics

--- a/registry.yaml
+++ b/registry.yaml
@@ -1214,7 +1214,6 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux
-
   - type: github_release
     repo_owner: Checkmarx
     repo_name: kics


### PR DESCRIPTION
[Canop/rhit](https://github.com/Canop/rhit): A nginx log explorer

```console
$ aqua g -i Canop/rhit
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ rhit --help
                                                                rhit 2.0.3

Rhit analyzes your nginx logs.

Complete documentation at https://dystroy.org/rhit

Usage:  rhit [options] [FILES]

• FILES : The log file or folder to analyze. It not provided, logs will be opened at their standard location

Options:
┌─────┬───────────────┬───────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│short│     long      │ value │description                                                                                                │
├─────┼───────────────┼───────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│     │--help         │       │Print help information                                                                                     │
│     │--version      │       │Print the version                                                                                          │
│     │--color        │ color │Whether to have styles and colors                                                                          │
│     │               │       │ Possible values: [auto, yes, no]                                                                          │
│     │               │       │ Default: auto                                                                                             │
│ -k  │--key          │  KEY  │Key used in sorting and histogram, either hits or bytes                                                    │
│     │               │       │ Default: hits                                                                                             │
│ -l  │--length       │LENGTH │Detail level, from 0 to 6, impacts the lengths of tables                                                   │
│     │               │       │ Default: 1                                                                                                │
│ -f  │--fields       │FIELDS │Comma separated list of hit fields to display. Use -f a to get all fields. Use -f +i to add ip. Available  │
│     │               │       │fields: date,time,method,status,ip,ref,path                                                                │
│     │               │       │ Default: date,status,ref,path                                                                             │
│ -c  │--changes      │       │Add tables with more popular and less popular entries (ip, referers and paths)                             │
│ -d  │--date         │ DATE  │Filter the dates on a precise day or in an inclusive range (eg: -d 12/24 or -d '2021/12/24-2022/01/21')    │
│ -i  │--ip           │  IP   │Ip address to filter by. May be negated with a !                                                           │
│ -m  │--method       │METHOD │HTTP method to filter by. Make it negative with a !. (eg: -m PUT or -m !DELETE or -m none or -m other)     │
│ -p  │--path         │ PATH  │Pattern for path filtering (eg: -p broot or -p '^/\d+' or -p 'miaou | blog')                               │
│ -r  │--referer      │REFERER│Referrer filter                                                                                            │
│ -s  │--status       │STATUS │Comma separated list of statuses or status ranges to filter by (eg: -s 514 or -s 4xx,5xx, or               │
│     │               │       │-s 310-340,400-450 or -s 5xx,!502)                                                                         │
│ -t  │--time         │ TIME  │Filter the time of the day, in the logs' timezone (eg: -t '>19:30' to get evening hits)                    │
│ -a  │--all          │       │Show all paths, including resources                                                                        │
│     │--no-name-check│       │Try to open all files, whatever their names                                                                │
│ -o  │--output       │OUTPUT │Output: by default pretty summary tables but you can also output log lines as csv, json, or raw (as they   │
│     │               │       │appear in the log files)                                                                                   │
│     │               │       │ Default: tables                                                                                           │
│     │--silent-load  │       │Don't print anything during load: no progress bar or file list                                             │
└─────┴───────────────┴───────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┘


```

If files such as configuration file are needed, please share them.

Reference

-
