### PR TITLE
feat: add robinovitch61/kl

### DIFF
--- a/pkgs/robinovitch61/kl/pkg.yaml
+++ b/pkgs/robinovitch61/kl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: robinovitch61/kl@v0.4.0

--- a/pkgs/robinovitch61/kl/registry.yaml
+++ b/pkgs/robinovitch61/kl/registry.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: robinovitch61
+    repo_name: kl
+    description: An interactive Kubernetes log viewer for your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kl_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: kl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: kl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -42742,6 +42742,30 @@ packages:
       - goos: darwin
         format: zip
   - type: github_release
+    repo_owner: robinovitch61
+    repo_name: kl
+    description: An interactive Kubernetes log viewer for your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kl_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: kl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: kl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+  - type: github_release
     repo_owner: robscott
     repo_name: kube-capacity
     asset: kube-capacity_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[robinovitch61/kl](https://github.com/robinovitch61/kl): An interactive Kubernetes log viewer for your terminal

```console
$ aqua g -i robinovitch61/kl
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ kl --help
kl v0.4.0
Leo Robinovitch <leorobinovitch@gmail.com>

kl is an interactive, cross-cluster, multi-container Kubernetes log viewer

Home page: https://github.com/robinovitch61/kl

Usage:
  kl [flags]

Flags:
  -A, --all-namespaces              If present, view all namespaces. Overrides other specified namespaces
      --context string              Context(s). Can be a comma-separated list. Defaults to current context
  -d, --desc                        If present, start with logs in descending order by timestamp. Default false
      --help                        Print usage
      --ic string                   Ignore containers matching this regex pattern
      --iclust string               Ignore containers clusters matching this regex pattern
      --ignore-owner-types string   Comma-separated list of pod owner types to exclude, e.g. 'Deployment' or 'Job,Unowned,DaemonSet'
      --ins string                  Ignore namespaces matching this regex pattern
      --iown string                 Ignore pod owners matching this regex pattern
      --ipod string                 Ignore pods matching this regex pattern
      --kubeconfig string           Config file path. Defaults to $HOME/.kube/config
      --limit int                   Limit the number of selected containers. Default unlimited (default -1)
  -f, --log-filter string           Filter logs by this string on startup. Default no filter
  -r, --log-regex string            Filter logs by this regex pattern on startup. Default no regex pattern
      --logs-view                   If present, start with logs view. Default false (selection page)
      --mc string                   Auto-select containers matching this regex pattern
      --mclust string               Auto-select clusters matching this regex pattern
      --mns string                  Auto-select namespaces matching this regex pattern
      --mown string                 Auto-select pod owners matching this regex pattern
      --mpod string                 Auto-select pods matching this regex pattern
  -n, --namespace string            Namespace(s). Can be comma-separated list. Defaults to current namespace
  -l, --selector string             Auto-select containers matching all these label constraints. E.g. 'app=nginx,env!=dev'
      --since string                Show logs since startup time minus this duration. E.g. 5s, 2m, 1.5h, 2h45m. Default 1m
  -v, --version                     Show kl version
```

If files such as configuration file are needed, please share them.

Reference

-
