### PR TITLE
feat: add Lifailon/lazyjournal

### DIFF
--- a/pkgs/Lifailon/lazyjournal/pkg.yaml
+++ b/pkgs/Lifailon/lazyjournal/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: Lifailon/lazyjournal@0.6.0
+  - name: Lifailon/lazyjournal
+    version: 0.4.0

--- a/pkgs/Lifailon/lazyjournal/registry.yaml
+++ b/pkgs/Lifailon/lazyjournal/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Lifailon
+    repo_name: lazyjournal
+    description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -2701,6 +2701,23 @@ packages:
       - name: gorss
         src: dist/gorss_{{.OS}}
   - type: github_release
+    repo_owner: Lifailon
+    repo_name: lazyjournal
+    description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: LuaLS
     repo_name: lua-language-server
     aliases:


### PR DESCRIPTION
[Lifailon/lazyjournal](https://github.com/Lifailon/lazyjournal): TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library

```console
$ aqua g -i Lifailon/lazyjournal
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ lazyjournal
(TUI pops up)
```

If files such as configuration file are needed, please share them.

Reference

-
