### PR TITLE
fix(koalaman/shellcheck): re-scaffold koalaman/shellcheck

### DIFF
--- a/pkgs/koalaman/shellcheck/pkg.yaml
+++ b/pkgs/koalaman/shellcheck/pkg.yaml
@@ -4,5 +4,3 @@ packages:
     version: v0.9.0
   - name: koalaman/shellcheck
     version: v0.6.0
-  - name: koalaman/shellcheck
-    version: stable

--- a/pkgs/koalaman/shellcheck/pkg.yaml
+++ b/pkgs/koalaman/shellcheck/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
   - name: koalaman/shellcheck@v0.10.0
+  - name: koalaman/shellcheck
+    version: v0.9.0
+  - name: koalaman/shellcheck
+    version: v0.6.0
+  - name: koalaman/shellcheck
+    version: stable

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -20,6 +20,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: shellcheck-{{.Version}}.exe
         replacements:
           amd64: x86_64
         supported_envs:

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
+    files:
+      - name: shellcheck
+        src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= stable")

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
+    version_filter: (not (Version in ["latest", "stable"])) and semver("> 0.4.5")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.5")

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -4,20 +4,45 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    replacements:
-      arm64: aarch64
-      amd64: x86_64
-    files:
-      - name: shellcheck
-        src: shellcheck-{{.Version}}/shellcheck
-    asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.tar.xz
-    overrides:
-      - goos: windows
-        asset: shellcheck-{{.Version}}.zip
-        files:
-          - name: shellcheck
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= stable")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.5")
+        no_asset: true
+      - version_constraint: semver("<= 0.6.0")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.9.0")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -9,24 +9,20 @@ packages:
         src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= stable")
-        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-        format: tar.xz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.4.5")
         no_asset: true
       - version_constraint: semver("<= 0.6.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        overrides:
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip
         replacements:
           amd64: x86_64
         supported_envs:
           - linux/amd64
+          - windows
       - version_constraint: semver("<= 0.9.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
@@ -37,15 +33,16 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
         replacements:
           amd64: x86_64
           arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
+        overrides:
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip

--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -4,9 +4,6 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
-    files:
-      - name: shellcheck
-        src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.5")
@@ -14,10 +11,15 @@ packages:
       - version_constraint: semver("<= 0.6.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         overrides:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck
         replacements:
           amd64: x86_64
         supported_envs:
@@ -27,6 +29,9 @@ packages:
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
         rosetta2: true
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         replacements:
           amd64: x86_64
         overrides:
@@ -36,9 +41,14 @@ packages:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -46,3 +56,5 @@ packages:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck

--- a/registry.yaml
+++ b/registry.yaml
@@ -31690,6 +31690,7 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
+    version_filter: (not (Version in ["latest", "stable"])) and semver("> 0.4.5")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.5")

--- a/registry.yaml
+++ b/registry.yaml
@@ -31695,24 +31695,20 @@ packages:
         src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= stable")
-        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
-        format: tar.xz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.4.5")
         no_asset: true
       - version_constraint: semver("<= 0.6.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        overrides:
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip
         replacements:
           amd64: x86_64
         supported_envs:
           - linux/amd64
+          - windows
       - version_constraint: semver("<= 0.9.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
@@ -31723,18 +31719,19 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
         replacements:
           amd64: x86_64
           arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
+        overrides:
+          - goos: windows
+            asset: shellcheck-{{.Version}}.{{.Format}}
+            format: zip
   - type: github_release
     repo_owner: koki-develop
     repo_name: clive

--- a/registry.yaml
+++ b/registry.yaml
@@ -31690,6 +31690,9 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
+    files:
+      - name: shellcheck
+        src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= stable")

--- a/registry.yaml
+++ b/registry.yaml
@@ -31690,23 +31690,48 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    replacements:
-      arm64: aarch64
-      amd64: x86_64
-    files:
-      - name: shellcheck
-        src: shellcheck-{{.Version}}/shellcheck
-    asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.tar.xz
-    overrides:
-      - goos: windows
-        asset: shellcheck-{{.Version}}.zip
-        files:
-          - name: shellcheck
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= stable")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.5")
+        no_asset: true
+      - version_constraint: semver("<= 0.6.0")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.9.0")
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: koki-develop
     repo_name: clive

--- a/registry.yaml
+++ b/registry.yaml
@@ -31706,6 +31706,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: shellcheck-{{.Version}}.exe
         replacements:
           amd64: x86_64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -31690,9 +31690,6 @@ packages:
     repo_owner: koalaman
     repo_name: shellcheck
     description: ShellCheck, a static analysis tool for shell scripts
-    files:
-      - name: shellcheck
-        src: shellcheck-{{.Version}}/shellcheck
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.5")
@@ -31700,10 +31697,15 @@ packages:
       - version_constraint: semver("<= 0.6.0")
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         overrides:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck
         replacements:
           amd64: x86_64
         supported_envs:
@@ -31713,6 +31715,9 @@ packages:
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
         rosetta2: true
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         replacements:
           amd64: x86_64
         overrides:
@@ -31722,9 +31727,14 @@ packages:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: shellcheck
+            src: shellcheck-{{.Version}}/shellcheck
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -31732,6 +31742,8 @@ packages:
           - goos: windows
             asset: shellcheck-{{.Version}}.{{.Format}}
             format: zip
+            files:
+              - name: shellcheck
   - type: github_release
     repo_owner: koki-develop
     repo_name: clive


### PR DESCRIPTION
[koalaman/shellcheck](https://github.com/koalaman/shellcheck) - ShellCheck, a static analysis tool for shell scripts

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

ShellCheck v0.10.0 started distributing precompiled binary for ARM64 mac ([changelog](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#added-1)), so I updated the registry definition accordingly.

One thing I fail to understand is that the following section is removed by re-scaffolding, but the test seems to pass for Windows as well. Is this OK? Windows binary still  follows this naming convention.

```yaml
    overrides:
      - goos: windows
        asset: shellcheck-{{.Version}}.zip
        files:
          - name: shellcheck
```

```console
$ cmdx t koalaman/shellcheck
+ set -eu

PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

bash scripts/start.sh
bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry exists
[INFO] Checking if the container aqua-registry is running
[INFO] Dockerfile isn't updated
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 3.58kB to aqua-registry:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=linux/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=linux/arm64 package_name=koalaman/shellcheck package_version=v0.10.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=linux/arm64 package_name=koalaman/shellcheck package_version=v0.9.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=linux/arm64 package_name=koalaman/shellcheck package_version=stable program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=darwin/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.41.0 env=darwin/amd64 package_name=koalaman/shellcheck package_version=stable program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.41.0 env=darwin/amd64 package_name=koalaman/shellcheck package_version=v0.9.0 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.41.0 env=darwin/amd64 package_name=koalaman/shellcheck package_version=v0.10.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=darwin/arm64 package_name=koalaman/shellcheck package_version=v0.10.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=darwin/arm64 package_name=koalaman/shellcheck package_version=stable program=aqua registry=standard
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Checking if the container aqua-registry-windows is running
[INFO] Dockerfile is updated, so the container aqua-registry-windows is being recreated
[INFO] Checking if the container aqua-registry-windows exists
aqua-registry-windows
aqua-registry-windows
[INFO] Get a GitHub Access token by gh auth token
3f11c65b3f878b7efcfc9aa6fb4adf0fb57cf5de10b95ca109d34304802ffc53
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 3.58kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] create a symbolic link                        aqua_version=2.41.0 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.41.0 env=windows/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
$ echo $?
0
```