### PR TITLE
feat: add pinterest/ktlint

### DIFF
--- a/pkgs/pinterest/ktlint/pkg.yaml
+++ b/pkgs/pinterest/ktlint/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: pinterest/ktlint@1.5.0
+  - name: pinterest/ktlint
+    version: 0.49.0

--- a/pkgs/pinterest/ktlint/pkg.yaml
+++ b/pkgs/pinterest/ktlint/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: pinterest/ktlint@0.48.2
+  - name: pinterest/ktlint
+    version: 0.37.2

--- a/pkgs/pinterest/ktlint/pkg.yaml
+++ b/pkgs/pinterest/ktlint/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
-  - name: pinterest/ktlint@0.48.2
-  - name: pinterest/ktlint
-    version: 0.37.2
+  - name: pinterest/ktlint@1.5.0

--- a/pkgs/pinterest/ktlint/registry.yaml
+++ b/pkgs/pinterest/ktlint/registry.yaml
@@ -4,8 +4,10 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    asset: "ktlint"
-    format: raw
+    asset: "ktlint-{{.Version}}.{{.Format}}"
+    format: zip
     checksum:
       enabled: false
-    complete_windows_ext: false
+    files:
+      - name: ktlint
+        src: ktlint-{{.Version}}/bin/ktlint

--- a/pkgs/pinterest/ktlint/registry.yaml
+++ b/pkgs/pinterest/ktlint/registry.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: pinterest
+    repo_name: ktlint
+    description: An anti-bikeshedding Kotlin linter with built-in formatter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.37.2")
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5

--- a/pkgs/pinterest/ktlint/registry.yaml
+++ b/pkgs/pinterest/ktlint/registry.yaml
@@ -4,10 +4,14 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    asset: "ktlint-{{.Version}}.{{.Format}}"
-    format: zip
-    checksum:
-      enabled: false
-    files:
-      - name: ktlint
-        src: ktlint-{{.Version}}/bin/ktlint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.49.0")
+        complete_windows_ext: false
+        asset: ktlint
+      - version_constraint: "true"
+        asset: "ktlint-{{.Version}}.{{.Format}}"
+        format: zip
+        files:
+          - name: ktlint
+            src: "{{.AssetWithoutExt}}/bin/ktlint"

--- a/pkgs/pinterest/ktlint/registry.yaml
+++ b/pkgs/pinterest/ktlint/registry.yaml
@@ -4,11 +4,8 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.37.2")
-      - version_constraint: "true"
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
+    asset: "ktlint"
+    format: raw
+    checksum:
+      enabled: false
+    complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -40738,6 +40738,18 @@ packages:
           # https://github.com/soywod/himalaya/issues/144
           - name: himalaya
             src: himalaya.exe
+  - type: github_release
+    repo_owner: pinterest
+    repo_name: ktlint
+    description: An anti-bikeshedding Kotlin linter with built-in formatter
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.37.2")
+      - version_constraint: "true"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
   - name: pipe-cd/pipecd/pipectl
     type: github_release
     repo_owner: pipe-cd

--- a/registry.yaml
+++ b/registry.yaml
@@ -40742,13 +40742,17 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    asset: "ktlint-{{.Version}}.{{.Format}}"
-    format: zip
-    checksum:
-      enabled: false
-    files:
-      - name: ktlint
-        src: ktlint-{{.Version}}/bin/ktlint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.49.0")
+        complete_windows_ext: false
+        asset: ktlint
+      - version_constraint: "true"
+        asset: "ktlint-{{.Version}}.{{.Format}}"
+        format: zip
+        files:
+          - name: ktlint
+            src: "{{.AssetWithoutExt}}/bin/ktlint"
   - name: pipe-cd/pipecd/pipectl
     type: github_release
     repo_owner: pipe-cd

--- a/registry.yaml
+++ b/registry.yaml
@@ -40742,11 +40742,13 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    asset: "ktlint"
-    format: raw
+    asset: "ktlint-{{.Version}}.{{.Format}}"
+    format: zip
     checksum:
       enabled: false
-    complete_windows_ext: false
+    files:
+      - name: ktlint
+        src: ktlint-{{.Version}}/bin/ktlint
   - name: pipe-cd/pipecd/pipectl
     type: github_release
     repo_owner: pipe-cd

--- a/registry.yaml
+++ b/registry.yaml
@@ -40742,14 +40742,11 @@ packages:
     repo_owner: pinterest
     repo_name: ktlint
     description: An anti-bikeshedding Kotlin linter with built-in formatter
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.37.2")
-      - version_constraint: "true"
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.md5"
-          algorithm: md5
+    asset: "ktlint"
+    format: raw
+    checksum:
+      enabled: false
+    complete_windows_ext: false
   - name: pipe-cd/pipecd/pipectl
     type: github_release
     repo_owner: pipe-cd


### PR DESCRIPTION
[pinterest/ktlint](https://github.com/pinterest/ktlint): An anti-bikeshedding Kotlin linter with built-in formatter

```console
$ aqua g -i pinterest/ktlint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Command and output

REQUIRED: Java

```console
$ java -version
openjdk version "21.0.5" 2024-10-15 LTS
OpenJDK Runtime Environment Zulu21.38+21-CA (build 21.0.5+11-LTS)
OpenJDK 64-Bit Server VM Zulu21.38+21-CA (build 21.0.5+11-LTS, mixed mode, sharing)
$ ktlint
22:21:40.686 [main] INFO com.pinterest.ktlint.cli.internal.KtlintCommandLine -- Enable default patterns [**/*.kt, **/*.kts]
22:21:40.935 [main] WARN com.pinterest.ktlint.cli.internal.KtlintCommandLine -- No files matched [**/*.kt, **/*.kts]
```