### PR TITLE
fix(gradle/gradle-distributions): support milestone versions

### DIFF
--- a/pkgs/gradle/gradle-distributions/pkg.yaml
+++ b/pkgs/gradle/gradle-distributions/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: gradle/gradle-distributions@v8.12.0
   - name: gradle/gradle-distributions
+    version: v8.13.0-M1
+  - name: gradle/gradle-distributions
     version: v8.12.0-RC1
   - name: gradle/gradle-distributions
     version: v8.11.0

--- a/pkgs/gradle/gradle-distributions/registry.yaml
+++ b/pkgs/gradle/gradle-distributions/registry.yaml
@@ -6,7 +6,7 @@ packages:
     aliases:
       - name: gradle/gradle
     description: Adaptable, fast automation for all
-    asset: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | trimSuffix ".0"}}-bin.zip
+    asset: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | replace ".0-M" "-milestone-" | trimSuffix ".0"}}-bin.zip
     files:
       - name: gradle
-        src: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | trimSuffix ".0"}}/bin/gradle
+        src: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | replace ".0-M" "-milestone-" | trimSuffix ".0"}}/bin/gradle

--- a/registry.yaml
+++ b/registry.yaml
@@ -25956,10 +25956,10 @@ packages:
     aliases:
       - name: gradle/gradle
     description: Adaptable, fast automation for all
-    asset: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | trimSuffix ".0"}}-bin.zip
+    asset: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | replace ".0-M" "-milestone-" | trimSuffix ".0"}}-bin.zip
     files:
       - name: gradle
-        src: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | trimSuffix ".0"}}/bin/gradle
+        src: gradle-{{trimV .Version | replace ".0-RC" "-rc-" | replace ".0-M" "-milestone-" | trimSuffix ".0"}}/bin/gradle
   - type: github_release
     repo_owner: graelo
     repo_name: pumas


### PR DESCRIPTION
[gradle/gradle-distributions](https://github.com/gradle/gradle-distributions) - Adaptable, fast automation for all

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Fixes #30780