### PR TITLE
fix(sharkdp/bat): re-scaffold sharkdp/bat

### DIFF
--- a/pkgs/sharkdp/bat/pkg.yaml
+++ b/pkgs/sharkdp/bat/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: sharkdp/bat@v0.25.0
   - name: sharkdp/bat
+    version: v0.24.0
+  - name: sharkdp/bat
     version: v0.6.1
   - name: sharkdp/bat
     version: v0.6.0

--- a/pkgs/sharkdp/bat/registry.yaml
+++ b/pkgs/sharkdp/bat/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: sharkdp
     repo_name: bat
     description: A cat(1) clone with wings
+    files:
+      - name: bat
+        src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.2")
@@ -41,6 +44,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: bat.exe
         supported_envs:
           - darwin
           - windows

--- a/pkgs/sharkdp/bat/registry.yaml
+++ b/pkgs/sharkdp/bat/registry.yaml
@@ -10,44 +10,29 @@ packages:
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -56,20 +41,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: bat
-          - goos: linux
-            goarch: arm64
-            type: cargo
-            crate: bat
-      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -84,5 +64,18 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
           - goos: windows
             format: zip

--- a/pkgs/sharkdp/bat/registry.yaml
+++ b/pkgs/sharkdp/bat/registry.yaml
@@ -4,38 +4,50 @@ packages:
     repo_owner: sharkdp
     repo_name: bat
     description: A cat(1) clone with wings
-    files:
-      - name: bat
-        src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.2")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        supported_envs:
-          - linux/amd64
-          - darwin
+        overrides:
+          - envs:
+              - linux/arm64
+              - windows
+            type: cargo
+            crate: bat
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
+        overrides:
+          - envs:
+              - linux/arm64
+              - windows
+            type: cargo
+            crate: bat
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -45,16 +57,19 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: bat.exe
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+              - name: bat
+          - goos: linux
+            goarch: arm64
+            type: cargo
+            crate: bat
       - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -75,6 +90,9 @@ packages:
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -44908,38 +44908,50 @@ packages:
     repo_owner: sharkdp
     repo_name: bat
     description: A cat(1) clone with wings
-    files:
-      - name: bat
-        src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.2")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        supported_envs:
-          - linux/amd64
-          - darwin
+        overrides:
+          - envs:
+              - linux/arm64
+              - windows
+            type: cargo
+            crate: bat
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
+        overrides:
+          - envs:
+              - linux/arm64
+              - windows
+            type: cargo
+            crate: bat
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44949,16 +44961,19 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: bat.exe
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+              - name: bat
+          - goos: linux
+            goarch: arm64
+            type: cargo
+            crate: bat
       - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44979,6 +44994,9 @@ packages:
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: bat
+            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -44914,44 +44914,29 @@ packages:
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44960,20 +44945,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: bat
-          - goos: linux
-            goarch: arm64
-            type: cargo
-            crate: bat
-      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44988,6 +44968,19 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
           - goos: windows
             format: zip
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -44908,6 +44908,9 @@ packages:
     repo_owner: sharkdp
     repo_name: bat
     description: A cat(1) clone with wings
+    files:
+      - name: bat
+        src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.2")
@@ -44945,6 +44948,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: bat.exe
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
[sharkdp/bat](https://github.com/sharkdp/bat) - A cat(1) clone with wings.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

As of v0.25.0, bat now distributes pre-built binary for ARM Mac ([CHANGELOG.md](https://github.com/sharkdp/bat/blob/master/CHANGELOG.md#other-1)), so I updated the registry definition accordingly.
