### PR TITLE
fix(sharkdp/bat): drop the support of old versions using cargo

### DIFF
--- a/pkgs/sharkdp/bat/registry.yaml
+++ b/pkgs/sharkdp/bat/registry.yaml
@@ -12,34 +12,28 @@ packages:
         rosetta2: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -47,7 +41,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -58,10 +52,10 @@ packages:
             format: zip
             files:
               - name: bat
-          - goos: linux
-            goarch: arm64
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - windows
+          - linux/amd64
       - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -69,7 +63,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -92,7 +86,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -44916,34 +44916,28 @@ packages:
         rosetta2: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: semver("<= 0.6.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        overrides:
-          - envs:
-              - linux/arm64
-              - windows
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: Version == "v0.6.1"
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -44951,7 +44945,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44962,10 +44956,10 @@ packages:
             format: zip
             files:
               - name: bat
-          - goos: linux
-            goarch: arm64
-            type: cargo
-            crate: bat
+        supported_envs:
+          - darwin
+          - windows
+          - linux/amd64
       - version_constraint: semver("<= 0.24.0")
         asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -44973,7 +44967,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -44996,7 +44990,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: bat
-            src: bat-{{.Version}}-{{.Arch}}-{{.OS}}/bat
+            src: "{{.AssetWithoutExt}}/bat"
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
These versions are too old.
I don't think we need to support these versions using cargo type package.
This setting makes test really slow.