### PR TITLE
ci: use Linux ARM runner

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -11,15 +11,15 @@ jobs:
           - runs-on: windows-latest
             goos: ""
             goarch: ""
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24.04
             goos: ""
             goarch: ""
           - runs-on: macos-13
             goos: ""
             goarch: ""
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-24.04-arm
             goos: ""
-            goarch: arm64
+            goarch: ""
           - runs-on: macos-14
             goos: ""
             goarch: ""


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
