### PR TITLE
feat: add CrunchyData/postgres-operator-client

### DIFF
--- a/pkgs/CrunchyData/postgres-operator-client/pkg.yaml
+++ b/pkgs/CrunchyData/postgres-operator-client/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: CrunchyData/postgres-operator-client@v0.5.1
+  - name: CrunchyData/postgres-operator-client
+    version: v0.1.0

--- a/pkgs/CrunchyData/postgres-operator-client/registry.yaml
+++ b/pkgs/CrunchyData/postgres-operator-client/registry.yaml
@@ -3,6 +3,7 @@ packages:
   - type: github_release
     repo_owner: CrunchyData
     repo_name: postgres-operator-client
+    description: the Command Line Interface (CLI) for the Crunchy Postgres Operator
     files:
       - name: kubectl-pgo
     version_constraint: "false"

--- a/pkgs/CrunchyData/postgres-operator-client/registry.yaml
+++ b/pkgs/CrunchyData/postgres-operator-client/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: CrunchyData
+    repo_name: postgres-operator-client
+    files:
+      - name: kubectl-pgo
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: kubectl-pgo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-pgo-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -1448,6 +1448,26 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: CrunchyData
+    repo_name: postgres-operator-client
+    files:
+      - name: kubectl-pgo
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        asset: kubectl-pgo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-pgo-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     asset: cyclonedx-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -1450,6 +1450,7 @@ packages:
   - type: github_release
     repo_owner: CrunchyData
     repo_name: postgres-operator-client
+    description: the Command Line Interface (CLI) for the Crunchy Postgres Operator
     files:
       - name: kubectl-pgo
     version_constraint: "false"


### PR DESCRIPTION
[CrunchyData/postgres-operator-client](https://github.com/CrunchyData/postgres-operator-client): the Command Line Interface (CLI) for the Crunchy Postgres Operator

```console
$ aqua g -i CrunchyData/postgres-operator-client
```

Close #31115