### PR TITLE
feat: add fioncat/otree

### DIFF
--- a/pkgs/fioncat/otree/pkg.yaml
+++ b/pkgs/fioncat/otree/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: fioncat/otree@v0.3.1
+  - name: fioncat/otree
+    version: v0.3.0

--- a/pkgs/fioncat/otree/registry.yaml
+++ b/pkgs/fioncat/otree/registry.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: fioncat
+    repo_name: otree
+    description: A command line tool to view objects (JSON/YAML/TOML) in TUI tree widget
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: otree-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: otree-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -22527,6 +22527,42 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: fioncat
+    repo_name: otree
+    description: A command line tool to view objects (JSON/YAML/TOML) in TUI tree widget
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: otree-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: otree-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
     repo_owner: firebase
     repo_name: firebase-tools
     description: The Firebase Command Line Tools


### PR DESCRIPTION
[fioncat/otree](https://github.com/fioncat/otree): A command line tool to view objects (JSON/YAML/TOML) in TUI tree widget

```console
$ aqua g -i fioncat/otree
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
otree --help
Usage: otree [OPTIONS] [PATH]

Arguments:
  [PATH]
          The file to read data. On non-macOS systems, this can be omitted, and data will be read from stdin

Options:
      --config <CONFIG>
          The config file to use. Default will try to read `~/.config/otree.toml`

  -t, --content-type <CONTENT_TYPE>
          The data content type. If the file extension is one of ["json", "yaml", "yml", "toml", "jsonl"], this can be automatically inferred. In other cases, this is required

          Possible values:
          - json
          - yaml
          - toml
          - jsonl: Useful for some logs file: https://jsonlines.org/

      --disable-header
          Don't show the header

      --disable-footer
          Don't show the footer

  -f, --header-format <HEADER_FORMAT>
          The header format

  -V, --vertical
          Use vertical layout

  -H, --horizontal
          Use horizontal layout

  -s, --size <SIZE>
          The tree widget size (percent), should be in range [10, 80]

      --disable-highlight
          Disable syntax highlighting in data block

      --show-config
          Print loaded config

      --ignore-config
          Force to use the default config

      --build-info
          Print build info

      --max-data-size <MAX_DATA_SIZE>
          Limit data size to read. In MiB

  -v, --version
          Print version

  -h, --help
          Print help (see a summary with '-h')
```
