### PR TITLE
refactor(ynqa/jnv): use musl build on linux where available

### DIFF
--- a/pkgs/ynqa/jnv/pkg.yaml
+++ b/pkgs/ynqa/jnv/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: ynqa/jnv@v0.5.0
   - name: ynqa/jnv
+    version: v0.3.0
+  - name: ynqa/jnv
     version: v0.1.0

--- a/pkgs/ynqa/jnv/registry.yaml
+++ b/pkgs/ynqa/jnv/registry.yaml
@@ -22,7 +22,7 @@ packages:
         files:
           - name: jnv
             src: "{{.AssetWithoutExt}}/jnv"
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.0")
         asset: jnv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         rosetta2: true
@@ -30,6 +30,24 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux/amd64
+        files:
+          - name: jnv
+            src: "{{.AssetWithoutExt}}/jnv"
+      - version_constraint: "true"
+        asset: jnv-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -54800,7 +54800,7 @@ packages:
         files:
           - name: jnv
             src: "{{.AssetWithoutExt}}/jnv"
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.0")
         asset: jnv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         rosetta2: true
@@ -54808,6 +54808,24 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux/amd64
+        files:
+          - name: jnv
+            src: "{{.AssetWithoutExt}}/jnv"
+      - version_constraint: "true"
+        asset: jnv-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"


### PR DESCRIPTION
[ynqa/jnv](https://github.com/ynqa/jnv) - interactive JSON filter using jq

- https://github.com/ynqa/jnv/releases/tag/v0.4.0 <= musl was added
- https://github.com/ynqa/jnv/releases/tag/v0.3.0

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

SSIA.