### PR TITLE
refactor(sxyazi/yazi): use musl build on linux where available

### DIFF
--- a/pkgs/sxyazi/yazi/pkg.yaml
+++ b/pkgs/sxyazi/yazi/pkg.yaml
@@ -3,6 +3,8 @@ packages:
   - name: sxyazi/yazi
     version: v0.2.4
   - name: sxyazi/yazi
+    version: v0.2.3
+  - name: sxyazi/yazi
     version: v0.1.5
   - name: sxyazi/yazi
     version: v0.1.4

--- a/pkgs/sxyazi/yazi/registry.yaml
+++ b/pkgs/sxyazi/yazi/registry.yaml
@@ -46,7 +46,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.2.4")
+      - version_constraint: semver("<= 0.2.3")
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -58,6 +58,19 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.2.4"
+        asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: yazi
+            src: yazi-{{.Arch}}-{{.OS}}/yazi
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -72,5 +85,5 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -49928,7 +49928,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.2.4")
+      - version_constraint: semver("<= 0.2.3")
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -49940,6 +49940,19 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "v0.2.4"
+        asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: yazi
+            src: yazi-{{.Arch}}-{{.OS}}/yazi
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
       - version_constraint: "true"
         asset: yazi-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -49954,7 +49967,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
   - type: github_release
     repo_owner: syncthing


### PR DESCRIPTION


## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

musl build is available in >= [0.2.4](https://github.com/sxyazi/yazi/releases/tag/v0.2.4).