### PR TITLE
refactor(so-dang-cool/findup): use musl for latest on linux

### DIFF
--- a/pkgs/so-dang-cool/findup/registry.yaml
+++ b/pkgs/so-dang-cool/findup/registry.yaml
@@ -10,7 +10,12 @@ packages:
       amd64: x86_64
       arm64: aarch64
       darwin: macos-none
-      linux: linux-gnu
+      linux: linux-musl
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: linux-musleabi
     supported_envs:
       - linux
       - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -47339,7 +47339,12 @@ packages:
       amd64: x86_64
       arm64: aarch64
       darwin: macos-none
-      linux: linux-gnu
+      linux: linux-musl
+    overrides:
+      - goos: linux
+        goarch: arm64
+        replacements:
+          linux: linux-musleabi
     supported_envs:
       - linux
       - darwin


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Refs https://github.com/aquaproj/aqua-registry/issues/31296

Looks like the gnu and musl binaries are identical for 1.1.2 on amd64 at least, but I guess this does not hurt.