### PR TITLE
feat: use musl with latest on linux, enable linux/arm64

### DIFF
--- a/pkgs/qdrant/qdrant/pkg.yaml
+++ b/pkgs/qdrant/qdrant/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: qdrant/qdrant@v1.13.1
   - name: qdrant/qdrant
+    version: v1.8.0
+  - name: qdrant/qdrant
     version: v1.3.0
   - name: qdrant/qdrant
     version: v1.2.2

--- a/pkgs/qdrant/qdrant/registry.yaml
+++ b/pkgs/qdrant/qdrant/registry.yaml
@@ -54,7 +54,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64

--- a/pkgs/qdrant/qdrant/registry.yaml
+++ b/pkgs/qdrant/qdrant/registry.yaml
@@ -22,7 +22,7 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.8.0")
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -35,6 +35,23 @@ packages:
           - goos: darwin
             replacements:
               arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
           - goos: windows
             format: zip
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -42444,7 +42444,7 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.8.0")
         asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -42457,6 +42457,23 @@ packages:
           - goos: darwin
             replacements:
               arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: qdrant-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
           - goos: windows
             format: zip
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -42476,10 +42476,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
   - type: github_release
     repo_owner: quantumsheep
     repo_name: sshs


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Refs https://github.com/aquaproj/aqua-registry/issues/31296

I don't know if this counts as doing more than one thing in a PR, but the linux/arm64 enablement for latest would either conflict or follow the musl one.