### PR TITLE
Fix gitleaks installing wrong binary for arm64 systems

### DIFF
--- a/pkgs/gitleaks/gitleaks/pkg.yaml
+++ b/pkgs/gitleaks/gitleaks/pkg.yaml
@@ -1,8 +1,16 @@
 packages:
   - name: gitleaks/gitleaks@v8.23.2
   - name: gitleaks/gitleaks
+    version: v8.17.0
+  - name: gitleaks/gitleaks
+    version: v8.15.0
+  - name: gitleaks/gitleaks
     version: v8.2.7
   - name: gitleaks/gitleaks
     version: v8.1.2
   - name: gitleaks/gitleaks
     version: v7.6.1
+  - name: gitleaks/gitleaks
+    version: v1.2.0
+  - name: gitleaks/gitleaks
+    version: v0.4.0

--- a/pkgs/gitleaks/gitleaks/registry.yaml
+++ b/pkgs/gitleaks/gitleaks/registry.yaml
@@ -3,42 +3,103 @@ packages:
   - type: github_release
     repo_owner: gitleaks
     repo_name: gitleaks
-    aliases:
-      - name: zricethezav/gitleaks
-    description: Scan git repos (or files) for secrets using regex and entropy
-    asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      amd64: x64
-      aarch64: arm64
-      386: x32
-    version_constraint: semver(">= 8.3.0")
-    checksum:
-      type: github_release
-      asset: gitleaks_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    description: Find secrets with Gitleaks
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 8.1.3")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 8.0.0")
-        rosetta2: true
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: Version == "v0.4.0"
         asset: gitleaks-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 1.2.0")
+        asset: gitleaks-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
-        rosetta2: true
+      - version_constraint: Version == "v1.2.1"
+        no_asset: true
+      - version_constraint: semver("<= 7.6.1")
+        asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
-        overrides: []
-        replacements: {}
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 8.1.2")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
         checksum:
-          enabled: false
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 8.2.7")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 8.15.0")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 8.15.1-test3")
+        no_asset: true
+      - version_constraint: semver("<= 8.17.0")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/gitleaks/gitleaks/registry.yaml
+++ b/pkgs/gitleaks/gitleaks/registry.yaml
@@ -3,27 +3,18 @@ packages:
   - type: github_release
     repo_owner: gitleaks
     repo_name: gitleaks
+    aliases:
+      - name: zricethezav/gitleaks
     description: Find secrets with Gitleaks
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.0")
+      - version_constraint: semver("<= 0.3.0") || Version == "v1.2.1"
         no_asset: true
       - version_constraint: Version == "v0.4.0"
         asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-      - version_constraint: semver("<= 1.2.0")
-        asset: gitleaks-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v1.2.1"
-        no_asset: true
       - version_constraint: semver("<= 7.6.1")
         asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
@@ -64,20 +55,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 8.15.0")
-        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-        checksum:
-          type: github_release
-          asset: gitleaks_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 8.15.1-test3")
-        no_asset: true
       - version_constraint: semver("<= 8.17.0")
         asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/gitleaks/gitleaks/registry.yaml
+++ b/pkgs/gitleaks/gitleaks/registry.yaml
@@ -13,7 +13,7 @@ packages:
         format: zip
     replacements:
       amd64: x64
-      arm64: x64
+      aarch64: arm64
       386: x32
     version_constraint: semver(">= 8.3.0")
     checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -24687,45 +24687,106 @@ packages:
   - type: github_release
     repo_owner: gitleaks
     repo_name: gitleaks
-    aliases:
-      - name: zricethezav/gitleaks
-    description: Scan git repos (or files) for secrets using regex and entropy
-    asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      amd64: x64
-      arm64: x64
-      386: x32
-    version_constraint: semver(">= 8.3.0")
-    checksum:
-      type: github_release
-      asset: gitleaks_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    description: Find secrets with Gitleaks
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 8.1.3")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 8.0.0")
-        rosetta2: true
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.0")
+        no_asset: true
+      - version_constraint: Version == "v0.4.0"
         asset: gitleaks-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 1.2.0")
+        asset: gitleaks-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
+          - windows
           - amd64
-        rosetta2: true
+      - version_constraint: Version == "v1.2.1"
+        no_asset: true
+      - version_constraint: semver("<= 7.6.1")
+        asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
-        overrides: []
-        replacements: {}
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 8.1.2")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
         checksum:
-          enabled: false
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 8.2.7")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 8.15.0")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 8.15.1-test3")
+        no_asset: true
+      - version_constraint: semver("<= 8.17.0")
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: gitleaks_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: gittuf
     repo_name: gittuf

--- a/registry.yaml
+++ b/registry.yaml
@@ -24687,27 +24687,18 @@ packages:
   - type: github_release
     repo_owner: gitleaks
     repo_name: gitleaks
+    aliases:
+      - name: zricethezav/gitleaks
     description: Find secrets with Gitleaks
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.0")
+      - version_constraint: semver("<= 0.3.0") || Version == "v1.2.1"
         no_asset: true
       - version_constraint: Version == "v0.4.0"
         asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-      - version_constraint: semver("<= 1.2.0")
-        asset: gitleaks-{{.OS}}-{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v1.2.1"
-        no_asset: true
       - version_constraint: semver("<= 7.6.1")
         asset: gitleaks-{{.OS}}-{{.Arch}}
         format: raw
@@ -24748,20 +24739,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 8.15.0")
-        asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-        checksum:
-          type: github_release
-          asset: gitleaks_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 8.15.1-test3")
-        no_asset: true
       - version_constraint: semver("<= 8.17.0")
         asset: gitleaks_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
https://github.com/gitleaks/gitleaks

On arm64 systems, it appears that gitleaks was installing the x86 version.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
