### PR TITLE
feat: add pyama86/pachanger

### DIFF
--- a/pkgs/pyama86/pachanger/pkg.yaml
+++ b/pkgs/pyama86/pachanger/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pyama86/pachanger@v0.0.9

--- a/pkgs/pyama86/pachanger/registry.yaml
+++ b/pkgs/pyama86/pachanger/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: pyama86
+    repo_name: pachanger
+    description: Pachanger - A CLI tool for renaming Go package names safely and efficiently
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pachanger_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: pachanger_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -43082,6 +43082,22 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: pyama86
+    repo_name: pachanger
+    description: Pachanger - A CLI tool for renaming Go package names safely and efficiently
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: pachanger_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: pachanger_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: qdrant
     repo_name: qdrant
     description: High-performance, massive-scale Vector Database for the next generation of AI


### PR DESCRIPTION
[pyama86/pachanger](https://github.com/pyama86/pachanger): Pachanger - A CLI tool for renaming Go package names safely and efficiently

```console
$ aqua g -i pyama86/pachanger
```