### PR TITLE
fix(neovim/neovim): linux asset due to v0.10.4 change

### DIFF
--- a/pkgs/neovim/neovim/pkg.yaml
+++ b/pkgs/neovim/neovim/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: neovim/neovim@v0.10.3
+  - name: neovim/neovim@v0.10.4
+  - name: neovim/neovim
+    version: v0.10.3
   - name: neovim/neovim
     version: v0.9.5
   - name: neovim/neovim

--- a/pkgs/neovim/neovim/registry.yaml
+++ b/pkgs/neovim/neovim/registry.yaml
@@ -216,7 +216,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.10.3")
         asset: nvim-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -245,3 +245,35 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: nvim-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: nvim
+            src: nvim-{{.OS}}/bin/nvim
+        replacements:
+          darwin: macos
+          windows: win64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: nvim
+                src: "{{.AssetWithoutExt}}/bin/nvim"
+            replacements:
+              amd64: x86_64
+          - goos: linux
+            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - windows

--- a/pkgs/neovim/neovim/registry.yaml
+++ b/pkgs/neovim/neovim/registry.yaml
@@ -170,29 +170,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.8.3")
-        asset: nvim-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
-        replacements:
-          darwin: macos
-          windows: win64
-          linux: linux64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256sum"
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 0.9.5")
         asset: nvim-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -200,7 +177,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64

--- a/pkgs/neovim/neovim/registry.yaml
+++ b/pkgs/neovim/neovim/registry.yaml
@@ -222,7 +222,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64
@@ -234,9 +234,6 @@ packages:
         overrides:
           - goos: darwin
             asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: nvim
-                src: "{{.AssetWithoutExt}}/bin/nvim"
             replacements:
               amd64: x86_64
           - goos: windows
@@ -246,12 +243,12 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
-        asset: nvim-{{.OS}}.{{.Format}}
+        asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64
@@ -261,17 +258,13 @@ packages:
           algorithm: sha256
         overrides:
           - goos: darwin
-            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: nvim
-                src: "{{.AssetWithoutExt}}/bin/nvim"
             replacements:
               amd64: x86_64
           - goos: linux
-            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
           - goos: windows
+            asset: nvim-{{.OS}}.{{.Format}}
             format: zip
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -39360,7 +39360,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64
@@ -39372,9 +39372,6 @@ packages:
         overrides:
           - goos: darwin
             asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: nvim
-                src: "{{.AssetWithoutExt}}/bin/nvim"
             replacements:
               amd64: x86_64
           - goos: windows
@@ -39384,12 +39381,12 @@ packages:
           - windows
           - amd64
       - version_constraint: "true"
-        asset: nvim-{{.OS}}.{{.Format}}
+        asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64
@@ -39399,17 +39396,13 @@ packages:
           algorithm: sha256
         overrides:
           - goos: darwin
-            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: nvim
-                src: "{{.AssetWithoutExt}}/bin/nvim"
             replacements:
               amd64: x86_64
           - goos: linux
-            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
           - goos: windows
+            asset: nvim-{{.OS}}.{{.Format}}
             format: zip
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -39308,29 +39308,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.8.3")
-        asset: nvim-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
-        replacements:
-          darwin: macos
-          windows: win64
-          linux: linux64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256sum"
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: semver("<= 0.9.5")
         asset: nvim-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -39338,7 +39315,7 @@ packages:
         windows_arm_emulation: true
         files:
           - name: nvim
-            src: nvim-{{.OS}}/bin/nvim
+            src: "{{.AssetWithoutExt}}/bin/nvim"
         replacements:
           darwin: macos
           windows: win64

--- a/registry.yaml
+++ b/registry.yaml
@@ -39354,7 +39354,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.10.3")
         asset: nvim-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -39383,6 +39383,38 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: nvim-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: nvim
+            src: nvim-{{.OS}}/bin/nvim
+        replacements:
+          darwin: macos
+          windows: win64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: nvim
+                src: "{{.AssetWithoutExt}}/bin/nvim"
+            replacements:
+              amd64: x86_64
+          - goos: linux
+            asset: nvim-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - windows
   - type: github_release
     repo_owner: newrelic
     repo_name: newrelic-cli


### PR DESCRIPTION
Neovim v0.10.4 added `linux-arm64` tarball and renamed x86 release to `linux-x86_64`

Ref: https://github.com/neovim/neovim/releases/tag/v0.10.4
Ref: https://github.com/neovim/neovim/commit/fdcdf560da30e65b1e7840be0e18066492b72ccd

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Please let me know if there's suggestion. Thank you.

Close #31493