### PR TITLE
feat: add turbot/tailpipe

### DIFF
--- a/pkgs/turbot/tailpipe/pkg.yaml
+++ b/pkgs/turbot/tailpipe/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: turbot/tailpipe@v0.1.0

--- a/pkgs/turbot/tailpipe/registry.yaml
+++ b/pkgs/turbot/tailpipe/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: turbot
+    repo_name: tailpipe
+    description: select * from logs! Tailpipe is an open source SIEM for instant log insights, powered by DuckDB. Analyze millions of events in seconds, right from your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tailpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -53401,6 +53401,22 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: turbot
+    repo_name: tailpipe
+    description: select * from logs! Tailpipe is an open source SIEM for instant log insights, powered by DuckDB. Analyze millions of events in seconds, right from your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tailpipe.{{.OS}}.{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - type: http
     repo_owner: twistedpair
     repo_name: google-cloud-sdk


### PR DESCRIPTION
[turbot/tailpipe](https://github.com/turbot/tailpipe): select * from logs! Tailpipe is an open source SIEM for instant log insights, powered by DuckDB. Analyze millions of events in seconds, right from your terminal

```console
$ aqua g -i turbot/tailpipe
```

Close #31558