### PR TITLE
feat: add plumber-cd/terraform-backend-git

### DIFF
--- a/pkgs/plumber-cd/terraform-backend-git/pkg.yaml
+++ b/pkgs/plumber-cd/terraform-backend-git/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: plumber-cd/terraform-backend-git@v0.1.8
+  - name: plumber-cd/terraform-backend-git
+    version: v0.0.16
+  - name: plumber-cd/terraform-backend-git
+    version: v0.0.1

--- a/pkgs/plumber-cd/terraform-backend-git/registry.yaml
+++ b/pkgs/plumber-cd/terraform-backend-git/registry.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: plumber-cd
+    repo_name: terraform-backend-git
+    description: Terraform HTTP Backend implementation that uses Git repository as storage
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.16")
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/pkgs/plumber-cd/terraform-backend-git/registry.yaml
+++ b/pkgs/plumber-cd/terraform-backend-git/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Terraform HTTP Backend implementation that uses Git repository as storage
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.0.1")
+      - version_constraint: Version == "v0.0.1"
         asset: terraform-backend-git-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -42648,7 +42648,7 @@ packages:
     description: Terraform HTTP Backend implementation that uses Git repository as storage
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.0.1")
+      - version_constraint: Version == "v0.0.1"
         asset: terraform-backend-git-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -42643,6 +42643,42 @@ packages:
       - amd64
     asset: sinker-{{.OS}}-{{.Arch}}
   - type: github_release
+    repo_owner: plumber-cd
+    repo_name: terraform-backend-git
+    description: Terraform HTTP Backend implementation that uses Git repository as storage
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.1")
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.16")
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: terraform-backend-git-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: pluveto
     repo_name: upgit
     description: Another upload hub that supports clipboard. It works well with Typora, Snipaste, VSCode


### PR DESCRIPTION
[plumber-cd/terraform-backend-git](https://github.com/plumber-cd/terraform-backend-git): Terraform HTTP Backend implementation that uses Git repository as storage

```console
$ aqua g -i plumber-cd/terraform-backend-git
```

Close #31610