### PR TITLE
feat(go-simpler/goversion): scaffold go-simpler/goversion

### DIFF
--- a/pkgs/go-simpler/goversion/pkg.yaml
+++ b/pkgs/go-simpler/goversion/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: go-simpler/goversion@v0.5.0

--- a/pkgs/go-simpler/goversion/registry.yaml
+++ b/pkgs/go-simpler/goversion/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: go-simpler
+    repo_name: goversion
+    description: Easily switch between multiple Go versions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: goversion_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: goversion_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -25956,6 +25956,27 @@ packages:
     asset: jira-{{.OS}}-{{.Arch}}
   - type: github_release
     repo_owner: go-simpler
+    repo_name: goversion
+    description: Easily switch between multiple Go versions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: goversion_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: goversion_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
+    repo_owner: go-simpler
     repo_name: sloglint
     description: Ensure consistent code style when using log/slog
     version_constraint: "false"


### PR DESCRIPTION
[go-simpler/goversion](https://github.com/go-simpler/goversion): Easily switch between multiple Go versions

```console
$ aqua g -i go-simpler/goversion
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@e68368b47b28:/workspace# goversion --help
Usage: goversion [flags] <command> [command flags]

Commands:
    use main              switch to the main Go version
    use <version>         switch to the specified Go version (will be installed if not exists)
    ls                    print the list of installed Go versions
        -a (-all)         print also available versions from go.dev
        -only=<prefix>    print only versions starting with the prefix
        -only=latest      print only the latest patch for each version
    rm <version>          remove the specified Go version (both binary and SDK)

Flags:
    -h (-help)            print this message and quit
    -v (-version)         print the version of goversion itself and quit
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/go-simpler/goversion/blob/main/README.md