### PR TITLE
feat(everstake/bip39): scaffold everstake/bip39

### DIFF
--- a/pkgs/everstake/bip39/pkg.yaml
+++ b/pkgs/everstake/bip39/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: everstake/bip39@v1.2.7

--- a/pkgs/everstake/bip39/registry.yaml
+++ b/pkgs/everstake/bip39/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: everstake
+    repo_name: bip39
+    description: CLI for generation and verification of mnemonics in BIP39 standard with hash in Argon2id
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: bip39_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: bip39_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -22150,6 +22150,19 @@ packages:
       asset: SHA256SUMS
       algorithm: sha256
   - type: github_release
+    repo_owner: everstake
+    repo_name: bip39
+    description: CLI for generation and verification of mnemonics in BIP39 standard with hash in Argon2id
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: bip39_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: bip39_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: evilmartians
     repo_name: lefthook
     description: Fast and powerful Git hooks manager for any type of projects


### PR DESCRIPTION
[everstake/bip39](https://github.com/everstake/bip39): CLI for generation and verification of mnemonics in BIP39 standard with hash in Argon2id

```console
$ aqua g -i everstake/bip39
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@e68368b47b28:/workspace# bip39
NAME:
   bip39 - Generation, verification of mnemonics in BIP39 standard and obtaining their hash in Argon2id format

USAGE:
   bip39 [global options] command [command options]

COMMANDS:
   generate    BIP39 mnemonic generation
               --words value  Word count (default: 24)
               --color value  First and last word color highlighting (default: green,blue)
                              Allowed colors: black, red, green, yellow, blue, magenta, cyan, white
               --save value   Save to file [yes/no] (default: yes)
                              File name format: <Argon2idHash>_<TimestampUnixNano>.bip39
               --dir value    Save file to directory (default: /root/bip39/mnemonics)

   existing    Check existing BIP39 mnemonic
               --color value  First and last word color highlighting (default: green,blue)
                              Allowed colors: black, red, green, yellow, blue, magenta, cyan, white
               --save value   Save to file [yes/no] (default: no)
                              File name format: <Argon2idHash>_<TimestampUnixNano>.bip39
               --dir value    Save file to directory (default: /root/bip39/mnemonics)

   version, v  Print the version

   help, h     Shows a list of commands or help for one command
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/everstake/bip39/blob/main/README.md
