### PR TITLE
fix(aereal/jsondiff): update registry.yaml

### DIFF
--- a/pkgs/aereal/jsondiff/pkg.yaml
+++ b/pkgs/aereal/jsondiff/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: aereal/jsondiff@v0.2.3
+  - name: aereal/jsondiff@v0.4.1
+  - name: aereal/jsondiff
+    version: v0.2.3

--- a/pkgs/aereal/jsondiff/registry.yaml
+++ b/pkgs/aereal/jsondiff/registry.yaml
@@ -3,9 +3,24 @@ packages:
   - type: github_release
     repo_owner: aereal
     repo_name: jsondiff
-    asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: functions to calculate JSON objects differences with gojq filter
-    checksum:
-      type: github_release
-      asset: jsondiff_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.2.3")
+        asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jsondiff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jsondiff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -6636,12 +6636,27 @@ packages:
   - type: github_release
     repo_owner: aereal
     repo_name: jsondiff
-    asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     description: functions to calculate JSON objects differences with gojq filter
-    checksum:
-      type: github_release
-      asset: jsondiff_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.2.3")
+        asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jsondiff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: jsondiff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: jsondiff_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: afnanenayet
     repo_name: diffsitter


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

I have updated the registry because fix to correctly add binaries to GitHub Release.
https://github.com/aereal/jsondiff/pull/40

Result of `aqua g -s`.
![CleanShot 2025-02-04 at 12 48 26](https://github.com/user-attachments/assets/f9e78b1a-7151-43f6-8f54-345274657dfa)
