### PR TITLE
feat(busser/murmur): scaffold busser/murmur

### DIFF
--- a/pkgs/busser/murmur/pkg.yaml
+++ b/pkgs/busser/murmur/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: busser/murmur@v0.6.1
+  - name: busser/murmur
+    version: v0.4.2

--- a/pkgs/busser/murmur/registry.yaml
+++ b/pkgs/busser/murmur/registry.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: busser
+    repo_name: murmur
+    description: Pass secrets as environment variables to a process
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.2")
+        asset: whisper_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: murmur_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/busser/murmur/registry.yaml
+++ b/pkgs/busser/murmur/registry.yaml
@@ -21,6 +21,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        # https://github.com/busser/murmur#changes-from-v04-to-v05
+        files:
+          - name: whisper
       - version_constraint: "true"
         asset: murmur_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -12334,6 +12334,42 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: busser
+    repo_name: murmur
+    description: Pass secrets as environment variables to a process
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.2")
+        asset: whisper_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: murmur_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: busser
     repo_name: tfautomv
     description: Generate Terraform moved blocks automatically for painless refactoring
     asset: tfautomv_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -12353,6 +12353,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        # https://github.com/busser/murmur#changes-from-v04-to-v05
+        files:
+          - name: whisper
       - version_constraint: "true"
         asset: murmur_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[busser/murmur](https://github.com/busser/murmur): Pass secrets as environment variables to a process

```console
$ aqua g -i busser/murmur
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@26cc70fa37d0:/workspace# murmur
A plug-and-play shim that fetches secrets from a secure
        location and passes them to your application as environment variables.

Usage:
  murmur [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  run         Run a command with secrets injected into its environment variables

Flags:
  -h, --help   help for murmur

Use "murmur [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/busser/murmur/blob/main/README.md
