### PR TITLE
feat: add external-secrets/external-secrets/esoctl

### DIFF
--- a/pkgs/external-secrets/external-secrets/esoctl/pkg.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: external-secrets/external-secrets/esoctl@
+  - name: external-secrets/external-secrets/esoctl@v0.1.0-esoctl

--- a/pkgs/external-secrets/external-secrets/esoctl/pkg.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: external-secrets/external-secrets/esoctl@

--- a/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: external-secrets/external-secrets/esoctl
+    type: github_release
+    repo_owner: external-secrets
+    repo_name: external-secrets
+    description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets

--- a/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
@@ -5,8 +5,8 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
-    version_constraint: "false"
     version_filter: 'Version endsWith "-esoctl"'
+    version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
@@ -5,15 +5,19 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
-    asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    rosetta2: true
-    windows_arm_emulation: true
-    supported_envs:
-      - darwin
-      - windows
-      - amd64
-    checksum:
-      type: github_release
-      asset: esoctl_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_filter: 'Version endsWith "-esoctl"'
+    version_overrides:
+      - version_constraint: "true"
+        asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: esoctl_checksums.txt
+          algorithm: sha256

--- a/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
+++ b/pkgs/external-secrets/external-secrets/esoctl/registry.yaml
@@ -5,3 +5,15 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
+    asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    rosetta2: true
+    windows_arm_emulation: true
+    supported_envs:
+      - darwin
+      - windows
+      - amd64
+    checksum:
+      type: github_release
+      asset: esoctl_checksums.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -22589,6 +22589,18 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
+    asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    rosetta2: true
+    windows_arm_emulation: true
+    supported_envs:
+      - darwin
+      - windows
+      - amd64
+    checksum:
+      type: github_release
+      asset: esoctl_checksums.txt
+      algorithm: sha256
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui

--- a/registry.yaml
+++ b/registry.yaml
@@ -22589,18 +22589,22 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
-    asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    rosetta2: true
-    windows_arm_emulation: true
-    supported_envs:
-      - darwin
-      - windows
-      - amd64
-    checksum:
-      type: github_release
-      asset: esoctl_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_filter: 'Version endsWith "-esoctl"'
+    version_overrides:
+      - version_constraint: "true"
+        asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        checksum:
+          type: github_release
+          asset: esoctl_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui

--- a/registry.yaml
+++ b/registry.yaml
@@ -22589,8 +22589,8 @@ packages:
     repo_owner: external-secrets
     repo_name: external-secrets
     description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
-    version_constraint: "false"
     version_filter: 'Version endsWith "-esoctl"'
+    version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: esoctl_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -22584,6 +22584,11 @@ packages:
             asset: exoscale-cli_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
+  - name: external-secrets/external-secrets/esoctl
+    type: github_release
+    repo_owner: external-secrets
+    repo_name: external-secrets
+    description: External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets
   - type: github_release
     repo_owner: extrawurst
     repo_name: gitui


### PR DESCRIPTION
[external-secrets/external-secrets/esoctl](https://github.com/external-secrets/external-secrets): External Secrets Operator reads information from a third-party service like AWS Secrets Manager and automatically injects the values as Kubernetes Secrets

```console
$ aqua g -i external-secrets/external-secrets/esoctl
```

Close #31761