### PR TITLE
feat: add k1LoW/roots

### DIFF
--- a/pkgs/k1LoW/roots/pkg.yaml
+++ b/pkgs/k1LoW/roots/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/roots@v0.2.0

--- a/pkgs/k1LoW/roots/registry.yaml
+++ b/pkgs/k1LoW/roots/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: roots
+    description: "`roots` is a tool for exploring multiple root directories, such as those in a monorepo project"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: roots_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -32271,6 +32271,25 @@ packages:
             format: zip
   - type: github_release
     repo_owner: k1LoW
+    repo_name: roots
+    description: "`roots` is a tool for exploring multiple root directories, such as those in a monorepo project"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: roots_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: runn
     asset: runn_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz


### PR DESCRIPTION
[k1LoW/roots](https://github.com/k1LoW/roots): `roots` is a tool for exploring multiple root directories, such as those in a monorepo project

```console
$ aqua g -i k1LoW/roots
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@2a40cd3d3f2d:/workspace# roots --help
roots is a tool for exploring multiple root directories, such as those in a monorepo project.

Usage:
  roots [flags]

Flags:
  -d, --depth int            Depth for exploring directories (default 3)
      --fast                 Fast mode
  -h, --help                 help for roots
      --ignore-dir strings   Directory to ignore (default [node_modules,vendor,testdata])
  -p, --parent int           Number of parent root directories to explore (default 2)
      --root-file strings    File or directory that exist in the root directory
  -v, --version              version for roots
```

If files such as configuration file are needed, please share them.

Reference

- Blog (JP)
	- https://k1low.hatenablog.com/entry/2025/02/07/083000
- README
	- https://github.com/k1LoW/roots/blob/main/README.md
