### PR TITLE
feat(sorah/mairu): scaffold sorah/mairu

### DIFF
--- a/pkgs/sorah/mairu/pkg.yaml
+++ b/pkgs/sorah/mairu/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sorah/mairu@v0.7.0

--- a/pkgs/sorah/mairu/registry.yaml
+++ b/pkgs/sorah/mairu/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sorah
+    repo_name: mairu
+    description: on-memory AWS credentials agent and executor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mairu-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mairu-universal-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -48988,6 +48988,29 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: sorah
+    repo_name: mairu
+    description: on-memory AWS credentials agent and executor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mairu-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mairu-universal-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: sorenisanerd
     repo_name: gotty
     description: Share your terminal as a web application


### PR DESCRIPTION
[sorah/mairu](https://github.com/sorah/mairu): on-memory AWS credentials agent and executor

```console
$ aqua g -i sorah/mairu
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@8182ed68cef5:/workspace# mairu --help
Mairu: on-memory AWS credentials agent

Usage: mairu <COMMAND>

Commands:
  exec                Execute command with AWS credentials
  login               Login to your credential server
  credential-process  Use Mairu as a credenital process provider
  list-sessions       List active sessions
  list-roles          List available roles
  show                Show current 'auto' role
  agent               Manually start agent process; it is automatically spawned when not present
  setup-sso           Setup Mairu for your AWS SSO (AWS IAM Identity Center) instance
  help                Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/sorah/mairu/blob/main/README.md
