### PR TITLE
feat(artempyanykh/marksman): add artempyanykh/marksman

### DIFF
--- a/pkgs/artempyanykh/marksman/pkg.yaml
+++ b/pkgs/artempyanykh/marksman/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: artempyanykh/marksman@2024-12-18
+  - name: artempyanykh/marksman
+    version: "2023-04-12"
+  - name: artempyanykh/marksman
+    version: "2022-03-26"

--- a/pkgs/artempyanykh/marksman/registry.yaml
+++ b/pkgs/artempyanykh/marksman/registry.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: artempyanykh
+    repo_name: marksman
+    description: Write Markdown with code assist and intelligence in the comfort of your favourite editor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2022-03-26")
+        asset: zeta-note-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2023-04-12")
+        asset: marksman-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: windows
+            asset: marksman
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: marksman-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            asset: marksman-{{.OS}}
+          - goos: windows
+            asset: marksman

--- a/registry.yaml
+++ b/registry.yaml
@@ -9192,6 +9192,46 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: artempyanykh
+    repo_name: marksman
+    description: Write Markdown with code assist and intelligence in the comfort of your favourite editor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2022-03-26")
+        asset: zeta-note-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2023-04-12")
+        asset: marksman-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: windows
+            asset: marksman
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: marksman-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            asset: marksman-{{.OS}}
+          - goos: windows
+            asset: marksman
+  - type: github_release
     repo_owner: artemsalimov
     repo_name: jenkins-job-cli
     aliases:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
## Description

**Update**: ~CI marked the commits as unsigned, so there's probably an issue in my local git config. I will submit another PR once I get to the bottom of the issue, but in the meantime this PR will be closed.~ I fixed the problem that prevented proper commit signing on my dev environment and submitted a new PR at #31906.

This PR adds [markman](https://github.com/artempyanykh/marksman) to the Aqua registry. Marksman implements the Language Server Protocol for Markdown to be used in terminal- and non-terminal-based text editors. Marksman is developed in F# and distributed as a single binary for Linux, MacOS, an Windows.

This addition was authored using standard Aqua tooling (`cmdx` tasks mentionned in [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)), and tested successfully on Fedora and Ubuntu.