### PR TITLE
feat: add viaduct-ai/kustomize-sops

### DIFF
--- a/pkgs/viaduct-ai/kustomize-sops/pkg.yaml
+++ b/pkgs/viaduct-ai/kustomize-sops/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: viaduct-ai/kustomize-sops@v4.3.3
+  - name: viaduct-ai/kustomize-sops
+    version: v3.0.1
+  - name: viaduct-ai/kustomize-sops
+    version: v2.5.6
+  - name: viaduct-ai/kustomize-sops
+    version: v2.3.2

--- a/pkgs/viaduct-ai/kustomize-sops/registry.yaml
+++ b/pkgs/viaduct-ai/kustomize-sops/registry.yaml
@@ -5,6 +5,12 @@ packages:
     repo_name: kustomize-sops
     description: KSOPS - A Flexible Kustomize Plugin for SOPS Encrypted Resources
     version_constraint: "false"
+    checksum:
+      type: github_release
+      asset: checksums.txt 
+      algorithm: sha256
+    files:
+      - name: ksops
     version_overrides:
       - version_constraint: semver("<= 2.1.5")
         no_asset: true

--- a/pkgs/viaduct-ai/kustomize-sops/registry.yaml
+++ b/pkgs/viaduct-ai/kustomize-sops/registry.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: viaduct-ai
+    repo_name: kustomize-sops
+    description: KSOPS - A Flexible Kustomize Plugin for SOPS Encrypted Resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.1.5")
+        no_asset: true
+      - version_constraint: semver("<= 2.3.2")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.5.6")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.1")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/viaduct-ai/kustomize-sops/registry.yaml
+++ b/pkgs/viaduct-ai/kustomize-sops/registry.yaml
@@ -7,7 +7,7 @@ packages:
     version_constraint: "false"
     checksum:
       type: github_release
-      asset: checksums.txt 
+      asset: checksums.txt
       algorithm: sha256
     files:
       - name: ksops

--- a/registry.yaml
+++ b/registry.yaml
@@ -54744,7 +54744,7 @@ packages:
     version_constraint: "false"
     checksum:
       type: github_release
-      asset: checksums.txt 
+      asset: checksums.txt
       algorithm: sha256
     files:
       - name: ksops

--- a/registry.yaml
+++ b/registry.yaml
@@ -54742,6 +54742,12 @@ packages:
     repo_name: kustomize-sops
     description: KSOPS - A Flexible Kustomize Plugin for SOPS Encrypted Resources
     version_constraint: "false"
+    checksum:
+      type: github_release
+      asset: checksums.txt 
+      algorithm: sha256
+    files:
+      - name: ksops
     version_overrides:
       - version_constraint: semver("<= 2.1.5")
         no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -54738,6 +54738,71 @@ packages:
           linux: linux64
           windows: win64
   - type: github_release
+    repo_owner: viaduct-ai
+    repo_name: kustomize-sops
+    description: KSOPS - A Flexible Kustomize Plugin for SOPS Encrypted Resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.1.5")
+        no_asset: true
+      - version_constraint: semver("<= 2.3.2")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 2.5.6")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.1")
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: ksops_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: vishaltelangre
     repo_name: ff
     asset: find-files-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
#31981 [viaduct-ai/kustomize-sops](https://github.com/viaduct-ai/kustomize-sops) - KSOPS - A Flexible Kustomize Plugin for SOPS Encrypted Resources

Hi! Thank you for always providing great tools.
This time I want to add [ksops](https://github.com/viaduct-ai/kustomize-sops)(kustomize-sops), which can be used by integrating [sops](https://github.com/viaduct-ai/kustomize-sops) with kustomize.
Please review!

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
## Testing
- `cmdx t viaduct-ai/kustomize-sops`
- `cmdx con`
- `ksops`

```bash
root@276d86d58552:/workspace# ksops

KSOPS is a flexible kustomize plugin for SOPS encrypted resources.
KSOPS supports both legacy and KRM style exec kustomize functions.

kustomize Usage:
- kustomize build --enable-alpha-plugins --enable-exec

Standalone Usage :
- Legacy: ksops secret-generator.yaml
- KRM: cat secret-generator.yaml | ksops
root@276d86d58552:/workspace#
```