### PR TITLE
feat: add sacloud/usacloud

### DIFF
--- a/pkgs/sacloud/usacloud/pkg.yaml
+++ b/pkgs/sacloud/usacloud/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: sacloud/usacloud@v1.14.1
+  - name: sacloud/usacloud
+    version: v1.6.1
+  - name: sacloud/usacloud
+    version: v1.1.4
+  - name: sacloud/usacloud
+    version: v1.0.0-beta.1
+  - name: sacloud/usacloud
+    version: v0.29.1
+  - name: sacloud/usacloud
+    version: v0.26.0
+  - name: sacloud/usacloud
+    version: v0.15.0

--- a/pkgs/sacloud/usacloud/registry.yaml
+++ b/pkgs/sacloud/usacloud/registry.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sacloud
+    repo_name: usacloud
+    description: "usacloud:rabbit: : CLI client for the Sakura Cloud:cherry_blossom::cloud:"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.15.0")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.16.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.26.0")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.27.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.29.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.30.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.0.0-beta.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.4")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 1.6.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256

--- a/pkgs/sacloud/usacloud/registry.yaml
+++ b/pkgs/sacloud/usacloud/registry.yaml
@@ -6,38 +6,7 @@ packages:
     description: "CLI client for the Sakura Cloud"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.15.0")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.16.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.26.0")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.27.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.29.1")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.30.0"
+      - version_constraint: Version in ["v0.16.0", "v0.27.0", "v0.30.0"]
         no_asset: true
       - version_constraint: semver("<= 1.0.0-beta.1")
         asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/sacloud/usacloud/registry.yaml
+++ b/pkgs/sacloud/usacloud/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: sacloud
     repo_name: usacloud
-    description: "usacloud:rabbit: : CLI client for the Sakura Cloud:cherry_blossom::cloud:"
+    description: "CLI client for the Sakura Cloud"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.15.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -46192,38 +46192,7 @@ packages:
     description: "CLI client for the Sakura Cloud"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.15.0")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.16.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.26.0")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.27.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.29.1")
-        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v0.30.0"
+      - version_constraint: Version in ["v0.16.0", "v0.27.0", "v0.30.0"]
         no_asset: true
       - version_constraint: semver("<= 1.0.0-beta.1")
         asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -46189,7 +46189,7 @@ packages:
   - type: github_release
     repo_owner: sacloud
     repo_name: usacloud
-    description: "usacloud:rabbit: : CLI client for the Sakura Cloud:cherry_blossom::cloud:"
+    description: "CLI client for the Sakura Cloud"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.15.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -46187,6 +46187,78 @@ packages:
           asset: viddy-{{.Version}}-{{.OS}}-{{.Arch}}.sha256
           algorithm: sha256
   - type: github_release
+    repo_owner: sacloud
+    repo_name: usacloud
+    description: "usacloud:rabbit: : CLI client for the Sakura Cloud:cherry_blossom::cloud:"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.15.0")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.16.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.26.0")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.27.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.29.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.30.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.0.0-beta.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.4")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 1.6.1")
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: usacloud_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: usacloud_SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: sahilm
     repo_name: yamldiff
     description: A CLI tool to diff two YAML files


### PR DESCRIPTION
[sacloud/usacloud](https://github.com/sacloud/usacloud): CLI client for the Sakura Cloud

```console
$ aqua g -i sacloud/usacloud
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@3831a2846335:/workspace# usacloud --help
CLI to manage to resources on the SAKURA Cloud

Usage:
  usacloud [global options] <command> <sub-command> [options] [arguments] [flags]
  usacloud [command]

Available Commands:
  completion            Generate completion script
  config                Management commands for Configuration file/Profile
  help                  Help about any command
  iaas                  SubCommands for IaaS
  rest                  Invoke SAKURA cloud API directly
  update-self           Update Usacloud to latest-stable version
  version               Show version info
  web-accelerator       SubCommands for WebAccelerator

Flags:
      --profile string               the name of saved credentials
      --token string                 the API token used when calling SAKURA Cloud API
      --secret string                the API secret used when calling SAKURA Cloud API
      --zones strings                permitted zone names
      --no-color                     disable ANSI color output
      --trace                        enable trace logs for API calling
      --fake                         enable fake API driver
      --fake-store string            path to file store used by the fake API driver
      --process-timeout-sec int      number of seconds before the command execution is timed out
      --argument-match-mode string   how to compare the argument and resource name when identifying the resource to be manipulated  options: [partial/exact]
  -v, --version                      show version info
  -h, --help                         help for usacloud

Use "usacloud [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/sacloud/usacloud/blob/main/README.md
