### PR TITLE
feat: add ysugimoto/gcsdeploy

### DIFF
--- a/pkgs/ysugimoto/gcsdeploy/pkg.yaml
+++ b/pkgs/ysugimoto/gcsdeploy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: ysugimoto/gcsdeploy@v0.6.2

--- a/pkgs/ysugimoto/gcsdeploy/registry.yaml
+++ b/pkgs/ysugimoto/gcsdeploy/registry.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ysugimoto
+    repo_name: gcsdeploy
+    description: Deploy files to GCS like rsync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gcsdeploy-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -57234,6 +57234,18 @@ packages:
         rosetta2: true
   - type: github_release
     repo_owner: ysugimoto
+    repo_name: gcsdeploy
+    description: Deploy files to GCS like rsync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gcsdeploy-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: ysugimoto
     repo_name: vintage
     description: VCL Transpiler for Edge Runtime
     asset: vintage-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[ysugimoto/gcsdeploy](https://github.com/ysugimoto/gcsdeploy): Deploy files to GCS like rsync

```console
$ aqua g -i ysugimoto/gcsdeploy
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@0eb7e75bc8a8:/workspace# gcsdeploy
NAME:
   gcsdeploy - GCS deploy management with rsync-like operation

USAGE:
   gcsdeploy [global options] command [command options]

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --dry-run                      Dry run (default: false)
   --delete                       Delete GCS object if not exists in local (default: false)
   --version, -v                  Print tool version (default: false)
   --bucket value, -b value       Specify deploy destination bucket
   --source value, -s value       Specify local root directory to deploy (default: ".")
   --credential value             Specify credential file path
   --concurrency value, -c value  Specify operation concurrency (default: 1)
   --help, -h                     show help
Required flag "bucket" not set
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/ysugimoto/gcsdeploy/blob/main/README.md
