### PR TITLE
fix(lsd-rs/lsd): regenerate the registry file to remove Rosetta2 dependency

### DIFF
--- a/pkgs/lsd-rs/lsd/pkg.yaml
+++ b/pkgs/lsd-rs/lsd/pkg.yaml
@@ -1,4 +1,10 @@
 packages:
-  - name: lsd-rs/lsd@v1.1.5
+  - name: lsd-rs/lsd@v1.1.0
+  - name: lsd-rs/lsd
+    version: 0.23.1
   - name: lsd-rs/lsd
     version: 0.19.0
+  - name: lsd-rs/lsd
+    version: 0.16.0
+  - name: lsd-rs/lsd
+    version: 0.15.1

--- a/pkgs/lsd-rs/lsd/registry.yaml
+++ b/pkgs/lsd-rs/lsd/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: lsd-rs
     repo_name: lsd
     description: The next gen ls command
+    files:
+      - name: lsd
+        src: lsd-{{.Version}}-{{.Arch}}-{{.OS}}/lsd
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.15.1")

--- a/pkgs/lsd-rs/lsd/registry.yaml
+++ b/pkgs/lsd-rs/lsd/registry.yaml
@@ -3,31 +3,76 @@ packages:
   - type: github_release
     repo_owner: lsd-rs
     repo_name: lsd
-    aliases:
-      - name: Peltoche/lsd
-    rosetta2: true
-    asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: The next gen ls command
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      windows: pc-windows-msvc
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl # Set musl as default. If architecture matches, this can be executable without relying on external libraries
-    files:
-      - name: lsd
-        src: lsd-{{.Version}}-{{.Arch}}-{{.OS}}/lsd
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.20.1")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.15.1")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.16.0"
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.19.0")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: Version == "0.20.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.23.1")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36510,34 +36510,79 @@ packages:
   - type: github_release
     repo_owner: lsd-rs
     repo_name: lsd
-    aliases:
-      - name: Peltoche/lsd
-    rosetta2: true
-    asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: The next gen ls command
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      windows: pc-windows-msvc
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl # Set musl as default. If architecture matches, this can be executable without relying on external libraries
-    files:
-      - name: lsd
-        src: lsd-{{.Version}}-{{.Arch}}-{{.OS}}/lsd
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.20.1")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.15.1")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.16.0"
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.19.0")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: Version == "0.20.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.23.1")
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lsd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: lusingander
     repo_name: serie

--- a/registry.yaml
+++ b/registry.yaml
@@ -36511,6 +36511,9 @@ packages:
     repo_owner: lsd-rs
     repo_name: lsd
     description: The next gen ls command
+    files:
+      - name: lsd
+        src: lsd-{{.Version}}-{{.Arch}}-{{.OS}}/lsd
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.15.1")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

## Description

<!-- Please write the description here -->

Since v1.0.0, `lsd` has had native support for Apple Silicon (Release: https://github.com/lsd-rs/lsd/releases/tag/v1.0.0). Therefore, Rosetta 2 is no longer required. However, the registry file was still configured to use it.
To resolve this, I regenerated the registry file using the scaffolding command!