### PR TITLE
chore: support aqua gr config

### DIFF
--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/cmdx/v1.7.7/json-schema/cmdx.json
 # the configuration file of cmdx - task runner
 # https://github.com/suzuki-shunsuke/cmdx
 tasks:
@@ -34,9 +35,16 @@ tasks:
           - CMD
       - name: limit
         type: string
+        short: l
         usage: The maximum number of versions
         script_envs:
           - LIMIT
+      - name: config
+        short: c
+        type: string
+        usage: A configuration file path
+        script_envs:
+          - CONFIG
     shell:
       - "bash"
       - "-c"
@@ -55,7 +63,7 @@ tasks:
       fi
 
       bash scripts/start.sh
-      bash scripts/scaffold.sh "$PACKAGE" "$CMD" "$LIMIT"
+      bash scripts/scaffold.sh "$PACKAGE" "$CMD" "$LIMIT" "$CONFIG"
       aqua exec -- cmdx gr
       bash scripts/commit.sh "$PACKAGE"
       bash scripts/test.sh "$PACKAGE"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v3.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "e9d4c99577c6b2ce0b62edf61f089e9b9891af1708e88c6592907d2de66e3714  aqua-installer" | sha256sum -c -
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.44.1
+RUN ./aqua-installer -v v2.45.0-0
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -5,6 +5,7 @@ set -eu
 pkg=$1
 cmd=$2
 limit=$3
+config=$4
 
 opts=""
 if [ -n "$cmd" ]; then
@@ -12,6 +13,9 @@ if [ -n "$cmd" ]; then
 fi
 if [ -n "$limit" ]; then
 	opts="$opts -limit $limit"
+fi
+if [ -n "$config" ]; then
+	opts="$opts -c $config"
 fi
 
 mkdir -p "pkgs/$pkg"


### PR DESCRIPTION
- https://github.com/aquaproj/aqua/releases/tag/v2.45.0-0
- https://github.com/aquaproj/aqua/pull/3562

aqua >= v2.45.0-0 is required.

e.g.

```sh
aqua gr -init fission/fission # Generate aqua-generate-registry.yaml
vi aqua-generate-registry.yaml # Edit settings
```

```yaml
package: fission/fission
version: Version matches "^v?\\d"
asset: not ((Asset matches "\\.json$") or (Asset matches "\\.yaml$")) # Ignore JSON and YAML
```

```sh
cmdx s -c aqua-generate-registry.yaml fission/fission
```