### PR TITLE
feat: add umlx5h/gtrash

### DIFF
--- a/pkgs/umlx5h/gtrash/pkg.yaml
+++ b/pkgs/umlx5h/gtrash/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: umlx5h/gtrash@v0.0.6

--- a/pkgs/umlx5h/gtrash/registry.yaml
+++ b/pkgs/umlx5h/gtrash/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: umlx5h
+    repo_name: gtrash
+    description: "A Featureful Trash CLI manager: alternative to rm and trash-cli"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gtrash_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: gtrash_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -54785,6 +54785,26 @@ packages:
     files:
       - name: mockgen
   - type: github_release
+    repo_owner: umlx5h
+    repo_name: gtrash
+    description: "A Featureful Trash CLI manager: alternative to rm and trash-cli"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gtrash_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: gtrash_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: undistro
     repo_name: marvin
     description: Marvin is a CLI tool that scans a k8s cluster by performing CEL expressions to report potential issues, misconfigurations and vulnerabilities


### PR DESCRIPTION
[umlx5h/gtrash](https://github.com/umlx5h/gtrash): A Featureful Trash CLI manager: alternative to rm and trash-cli

```console
$ aqua g -i umlx5h/gtrash
```