### PR TITLE
feat: add yarnpkg/yarn

### DIFF
--- a/pkgs/yarnpkg/yarn/pkg.yaml
+++ b/pkgs/yarnpkg/yarn/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yarnpkg/yarn@

--- a/pkgs/yarnpkg/yarn/pkg.yaml
+++ b/pkgs/yarnpkg/yarn/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: yarnpkg/yarn@
+  - name: yarnpkg/yarn@v1.22.22

--- a/pkgs/yarnpkg/yarn/registry.yaml
+++ b/pkgs/yarnpkg/yarn/registry.yaml
@@ -3,6 +3,8 @@ packages:
   - type: github_release
     repo_owner: yarnpkg
     repo_name: yarn
+    search_words:
+      - v1 only
     description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"
     version_constraint: "false"
     version_overrides:

--- a/pkgs/yarnpkg/yarn/registry.yaml
+++ b/pkgs/yarnpkg/yarn/registry.yaml
@@ -13,4 +13,3 @@ packages:
         files:
           - name: yarn
             src: "{{.AssetWithoutExt}}/bin/yarn"
-

--- a/pkgs/yarnpkg/yarn/registry.yaml
+++ b/pkgs/yarnpkg/yarn/registry.yaml
@@ -4,3 +4,11 @@ packages:
     repo_owner: yarnpkg
     repo_name: yarn
     description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: yarn-{{.Version}}.tar.gz
+        files:
+          - name: yarn
+            src: "{{.AssetWithoutExt}}/bin/yarn"
+

--- a/pkgs/yarnpkg/yarn/registry.yaml
+++ b/pkgs/yarnpkg/yarn/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: yarnpkg
+    repo_name: yarn
+    description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"

--- a/registry.yaml
+++ b/registry.yaml
@@ -57544,6 +57544,8 @@ packages:
   - type: github_release
     repo_owner: yarnpkg
     repo_name: yarn
+    search_words:
+      - v1 only
     description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -57554,7 +57554,6 @@ packages:
         files:
           - name: yarn
             src: "{{.AssetWithoutExt}}/bin/yarn"
-
   - type: github_release
     repo_owner: yassinebenaid
     repo_name: bunster

--- a/registry.yaml
+++ b/registry.yaml
@@ -57545,6 +57545,14 @@ packages:
     repo_owner: yarnpkg
     repo_name: yarn
     description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: yarn-{{.Version}}.tar.gz
+        files:
+          - name: yarn
+            src: "{{.AssetWithoutExt}}/bin/yarn"
+
   - type: github_release
     repo_owner: yassinebenaid
     repo_name: bunster

--- a/registry.yaml
+++ b/registry.yaml
@@ -57542,6 +57542,10 @@ packages:
       asset: CHECKSUMS
       algorithm: sha256
   - type: github_release
+    repo_owner: yarnpkg
+    repo_name: yarn
+    description: "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry"
+  - type: github_release
     repo_owner: yassinebenaid
     repo_name: bunster
     description: Compile shell scripts to static binaries


### PR DESCRIPTION
[yarnpkg/yarn](https://github.com/yarnpkg/yarn): The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry

```console
$ aqua g -i yarnpkg/yarn
```

Close #32299

## ⚠️ v1 only

yarn has two lines.

- v1 https://github.com/yarnpkg/yarn
- v2 ~ (berry) https://github.com/yarnpkg/berry

This package is for v1.

## ⚠️ yarn global

If you want to install packages globally by yarn, you need to add `$(yarn global bin)` to `$PATH`.
aqua can't change `$PATH` dynamically, so `$(yarn global bin)` must be static.
If `$(yarn global bin)` depends on the yarn version, you need to fix it.

e.g.

```sh
yarn config set prefix ~/.yarn
export PATH=$HOME/.yarn/bin:$PATH
```

https://classic.yarnpkg.com/en/docs/cli/global