### PR TITLE
fix(jedisct1/minisign): remove the support of darwin/amd64

### DIFF
--- a/pkgs/jedisct1/minisign/registry.yaml
+++ b/pkgs/jedisct1/minisign/registry.yaml
@@ -64,7 +64,6 @@ packages:
       - version_constraint: "true"
         asset: minisign-{{.Version}}-{{.OS}}.{{.Format}}
         format: zip
-        rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
         files:
@@ -82,6 +81,6 @@ packages:
             files:
               - name: minisign
         supported_envs:
-          - darwin
+          - darwin/arm64
           - windows
-          - amd64
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -31188,7 +31188,6 @@ packages:
       - version_constraint: "true"
         asset: minisign-{{.Version}}-{{.OS}}.{{.Format}}
         format: zip
-        rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
         files:
@@ -31206,9 +31205,9 @@ packages:
             files:
               - name: minisign
         supported_envs:
-          - darwin
+          - darwin/arm64
           - windows
-          - amd64
+          - linux/amd64
   - type: github_release
     repo_owner: jedisct1
     repo_name: piknik


### PR DESCRIPTION
```console
$ unzip minisign-0.12-macos.zip 
Archive:  minisign-0.12-macos.zip
  inflating: minisign                
  inflating: ._minisign              

$ file -s minisign
minisign: Mach-O 64-bit executable arm64
```

The binary isn't executable on darwin/amd64 anymore.