### PR TITLE
feat: add Macmod/godap

### DIFF
--- a/pkgs/Macmod/godap/pkg.yaml
+++ b/pkgs/Macmod/godap/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Macmod/godap@v2.10.4

--- a/pkgs/Macmod/godap/registry.yaml
+++ b/pkgs/Macmod/godap/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Macmod
+    repo_name: godap
+    description: A complete terminal user interface (TUI) for LDAP
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: godap-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -2968,6 +2968,23 @@ packages:
             format: raw
             asset: macchina-{{.Version}}-{{.OS}}-{{.Arch}}
   - type: github_release
+    repo_owner: Macmod
+    repo_name: godap
+    description: A complete terminal user interface (TUI) for LDAP
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: godap-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: Madh93
     repo_name: tpm
     description: A package manager for Terraform providers


### PR DESCRIPTION
[Macmod/godap](https://github.com/Macmod/godap): A complete terminal user interface (TUI) for LDAP

```console
$ aqua g -i Macmod/godap
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ 
godap --help
A complete TUI for LDAP.

Usage:
  godap <server address> [flags]
  godap [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     Print the version number of the application
```
