### PR TITLE
fix(crate-ci/typos): Add suport for ARM64

### DIFF
--- a/pkgs/crate-ci/typos/pkg.yaml
+++ b/pkgs/crate-ci/typos/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: crate-ci/typos@v1.29.9
   - name: crate-ci/typos
+    version: v1.17.1
+  - name: crate-ci/typos
     version: v1.13.18
   - name: crate-ci/typos
     version: v1.13.17

--- a/pkgs/crate-ci/typos/registry.yaml
+++ b/pkgs/crate-ci/typos/registry.yaml
@@ -10,6 +10,7 @@ packages:
       - goos: windows
         format: zip
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl
@@ -17,9 +18,10 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    rosetta2: true
-    version_constraint: semver(">= 1.13.18")
+    version_constraint: semver(">= 1.17.1")
     version_overrides:
+      - version_constraint: semver(">= 1.13.18")
+        rosetta2: true
       - version_constraint: Version == "v1.13.17"
         format: zip
         overrides:
@@ -32,10 +34,13 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
+        rosetta2: true
       - version_constraint: semver(">= 1.1.0")
+        rosetta2: true
       - version_constraint: semver("< 1.1.0")
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -17496,6 +17496,7 @@ packages:
       - goos: windows
         format: zip
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl
@@ -17503,9 +17504,10 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    rosetta2: true
-    version_constraint: semver(">= 1.13.18")
+    version_constraint: semver(">= 1.17.1")
     version_overrides:
+      - version_constraint: semver(">= 1.13.18")
+        rosetta2: true
       - version_constraint: Version == "v1.13.17"
         format: zip
         overrides:
@@ -17518,13 +17520,16 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
+        rosetta2: true
       - version_constraint: semver(">= 1.1.0")
+        rosetta2: true
       - version_constraint: semver("< 1.1.0")
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        rosetta2: true
   - name: crates.io/bat
     type: cargo
     repo_owner: sharkdp


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
## Description

`crate-ci/typos` has supported ARM64 on macOS since v1.17.1 and on Linux since v1.29.8. Therefore, I have updated the configuration to support the ARM64 architecture!

v1.17.1 Release: https://github.com/crate-ci/typos/releases/tag/v1.17.1
v1.29.8 Release: https://github.com/crate-ci/typos/releases/tag/v1.29.8
