### PR TITLE
[feat] add tauri

### DIFF
--- a/pkgs/tauri-apps/tauri/pkg.yaml
+++ b/pkgs/tauri-apps/tauri/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tauri-apps/tauri@tauri-cli-v2.2.7

--- a/pkgs/tauri-apps/tauri/registry.yaml
+++ b/pkgs/tauri-apps/tauri/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tauri-apps
+    repo_name: tauri
+    asset: cargo-tauri-{{.Arch}}-{{.OS}}.{{.Format}}
+    description: "Tauri cli"
+    version_prefix: tauri-cli-
+    format: zip
+    files:
+      - name: tauri
+        src: cargo-tauri
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        format: tgz
+    supported_envs:
+      - linux/amd64
+      - darwin
+      - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -53405,6 +53405,29 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: tauri-apps
+    repo_name: tauri
+    asset: cargo-tauri-{{.Arch}}-{{.OS}}.{{.Format}}
+    description: "Tauri cli"
+    version_prefix: tauri-cli-
+    format: zip
+    files:
+      - name: tauri
+        src: cargo-tauri
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: linux
+        format: tgz
+    supported_envs:
+      - linux/amd64
+      - darwin
+      - windows
+  - type: github_release
     repo_owner: tcnksm
     repo_name: ghr
     description: Upload multiple artifacts to GitHub Release in parallel


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

-  [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
# Tauri cli
this adds tauri cli used in tauri app development
```sh
❯ tauri
Command line interface for building Tauri apps

Usage: cargo-tauri [OPTIONS] <COMMAND>

Commands:
  init         Initialize a Tauri project in an existing directory
  dev          Run your app in development mode
  build        Build your app in release mode and generate bundles and installers
  bundle       Generate bundles and installers for your app (already built by `tauri build`)
  android      Android commands
  migrate      Migrate from v1 to v2
  info         Show a concise list of information about the environment, Rust, Node.js and their versions as well as a few relevant project configurations
  add          Add a tauri plugin to the project
  remove       Remove a tauri plugin from the project
  plugin       Manage or create Tauri plugins
  icon         Generate various icons for all major platforms
  signer       Generate signing keys for Tauri updater or sign files
  completions  Generate Tauri CLI shell completions for Bash, Zsh, PowerShell or Fish
  permission   Manage or create permissions for your app or plugin
  capability   Manage or create capabilities for your app
  inspect      Manage or create permissions for your app or plugin
  help         Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Enables verbose logging
  -h, --help        Print help
  -V, --version     Print version
  ```