### PR TITLE
feat: add rgwood/systemctl-tui

### DIFF
--- a/pkgs/rgwood/systemctl-tui/pkg.yaml
+++ b/pkgs/rgwood/systemctl-tui/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rgwood/systemctl-tui@v0.4.0

--- a/pkgs/rgwood/systemctl-tui/registry.yaml
+++ b/pkgs/rgwood/systemctl-tui/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: rgwood
+    repo_name: systemctl-tui
+    description: A fast, simple TUI for interacting with systemd services and their logs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.3.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: systemctl-tui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -46376,6 +46376,23 @@ packages:
     rosetta2: true
     complete_windows_ext: false
   - type: github_release
+    repo_owner: rgwood
+    repo_name: systemctl-tui
+    description: A fast, simple TUI for interacting with systemd services and their logs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.3.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: systemctl-tui-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+  - type: github_release
     repo_owner: rhysd
     repo_name: actionlint
     asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[rgwood/systemctl-tui](https://github.com/rgwood/systemctl-tui): A fast, simple TUI for interacting with systemd services and their logs

```console
$ aqua g -i rgwood/systemctl-tui
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ 
systemctl-tui --help
A simple TUI for systemd services

Usage: systemctl-tui [OPTIONS]

Options:
  -s, --scope <SCOPE>                 The scope of the services to display. Defaults to "all" normally and "global" on WSL [possible values: global, user, all]
  -t, --trace                         Enable performance tracing (in Chromium Event JSON format)
  -l, --limit-units <LIMIT_UNITS>...  Limit view to only these unit files [default: *.service]
  -h, --help                          Print help
  -V, --version                       Print version
```

If files such as configuration file are needed, please share them.

Reference

-
