### PR TITLE
feat: add aurc/loggo

### DIFF
--- a/pkgs/aurc/loggo/pkg.yaml
+++ b/pkgs/aurc/loggo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: aurc/loggo@v0.3.21

--- a/pkgs/aurc/loggo/registry.yaml
+++ b/pkgs/aurc/loggo/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: aurc
+    repo_name: loggo
+    description: A powerful terminal app for structured log streaming
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: loggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: loggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -10034,6 +10034,19 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: aurc
+    repo_name: loggo
+    description: A powerful terminal app for structured log streaming
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: loggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: loggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: auth0
     repo_name: auth0-cli
     asset: auth0-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[aurc/loggo](https://github.com/aurc/loggo): A powerful terminal app for structured log streaming

```console
$ aqua g -i aurc/loggo
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
❯ 
loggo --help
l'oGGo provides a rich Terminal User Interface for streaming json based
logs and a toolset to assist you tailoring the display format.

Usage:
  loggo [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  debug       Continuously stream l'oggo log
  gcp-stream  Continuously stream GCP stack driver logs
  help        Help about any command
  stream      Continuously stream log input source
  template    Starts the loggo template manager app only
  version     Retrieves the build version

Flags:
  -h, --help   help for loggo

Use "loggo [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

-
