### PR TITLE
feat: add yokecd/yoke

### DIFF
--- a/pkgs/yokecd/yoke/pkg.yaml
+++ b/pkgs/yokecd/yoke/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yokecd/yoke@v0.9.3

--- a/pkgs/yokecd/yoke/registry.yaml
+++ b/pkgs/yokecd/yoke/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: yokecd
+    repo_name: yoke
+    version_filter: not (Version matches "installer")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.exe.{{.Format}}

--- a/pkgs/yokecd/yoke/registry.yaml
+++ b/pkgs/yokecd/yoke/registry.yaml
@@ -10,6 +10,9 @@ packages:
         asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: gz
         windows_arm_emulation: true
+        files:
+          - name: yoke
+            src: "{{.AssetWithoutExt}}"
         overrides:
           - goos: windows
             asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.exe.{{.Format}}

--- a/pkgs/yokecd/yoke/registry.yaml
+++ b/pkgs/yokecd/yoke/registry.yaml
@@ -3,6 +3,7 @@ packages:
   - type: github_release
     repo_owner: yokecd
     repo_name: yoke
+    description: yoke is a Helm-inspired infrastructure-as-code (IaC) package deployer
     version_filter: not (Version matches "installer")
     version_constraint: "false"
     version_overrides:

--- a/pkgs/yokecd/yoke/scaffold.yaml
+++ b/pkgs/yokecd/yoke/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: yokecd/yoke
+version_filter: not (Version matches "installer")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -58642,6 +58642,19 @@ packages:
           - darwin
         rosetta2: true
   - type: github_release
+    repo_owner: yokecd
+    repo_name: yoke
+    version_filter: not (Version matches "installer")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+  - type: github_release
     repo_owner: yonahd
     repo_name: kor
     description: A Golang Tool to discover unused Kubernetes Resources

--- a/registry.yaml
+++ b/registry.yaml
@@ -58644,6 +58644,7 @@ packages:
   - type: github_release
     repo_owner: yokecd
     repo_name: yoke
+    description: yoke is a Helm-inspired infrastructure-as-code (IaC) package deployer
     version_filter: not (Version matches "installer")
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -58651,6 +58651,9 @@ packages:
         asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: gz
         windows_arm_emulation: true
+        files:
+          - name: yoke
+            src: "{{.AssetWithoutExt}}"
         overrides:
           - goos: windows
             asset: yoke_{{.Version}}_{{.OS}}_{{.Arch}}.exe.{{.Format}}


### PR DESCRIPTION
[yokecd/yoke](https://github.com/yokecd/yoke): yoke is a Helm-inspired infrastructure-as-code (IaC) package deployer

```console
$ aqua g -i yokecd/yoke
```

Close #32743