### PR TITLE
feat: add containers/podman

### DIFF
--- a/pkgs/containers/podman/pkg.yaml
+++ b/pkgs/containers/podman/pkg.yaml
@@ -1,10 +1,6 @@
 packages:
   - name: containers/podman@v5.4.0
   - name: containers/podman
-    version: v5.0.0-rc7
-  - name: containers/podman
-    version: v5.0.0-rc2
-  - name: containers/podman
     version: v4.9.5
   - name: containers/podman
     version: v4.4.4
@@ -18,6 +14,8 @@ packages:
     version: v3.4.4
   - name: containers/podman
     version: v3.3.1
+  - name: containers/podman
+    version: v3.3.0
   - name: containers/podman
     version: v3.2.3
   - name: containers/podman
@@ -34,19 +32,3 @@ packages:
     version: v2.0.5
   - name: containers/podman
     version: v2.0.3
-  - name: containers/podman
-    version: v1.9.3
-  - name: containers/podman
-    version: v1.9.2
-  - name: containers/podman
-    version: v1.8.2
-  - name: containers/podman
-    version: v1.8.1
-  - name: containers/podman
-    version: v1.6.0
-  - name: containers/podman
-    version: v1.5.1
-  - name: containers/podman
-    version: v1.4.2
-  - name: containers/podman
-    version: v1.3.1

--- a/pkgs/containers/podman/pkg.yaml
+++ b/pkgs/containers/podman/pkg.yaml
@@ -1,0 +1,52 @@
+packages:
+  - name: containers/podman@v5.4.0
+  - name: containers/podman
+    version: v5.0.0-rc7
+  - name: containers/podman
+    version: v5.0.0-rc2
+  - name: containers/podman
+    version: v4.9.5
+  - name: containers/podman
+    version: v4.4.4
+  - name: containers/podman
+    version: v4.3.1
+  - name: containers/podman
+    version: v4.1.1
+  - name: containers/podman
+    version: v4.0.3
+  - name: containers/podman
+    version: v3.4.4
+  - name: containers/podman
+    version: v3.3.1
+  - name: containers/podman
+    version: v3.2.3
+  - name: containers/podman
+    version: v3.1.2
+  - name: containers/podman
+    version: v3.0.1
+  - name: containers/podman
+    version: v2.2.1
+  - name: containers/podman
+    version: v2.1.1
+  - name: containers/podman
+    version: v2.0.6
+  - name: containers/podman
+    version: v2.0.5
+  - name: containers/podman
+    version: v2.0.3
+  - name: containers/podman
+    version: v1.9.3
+  - name: containers/podman
+    version: v1.9.2
+  - name: containers/podman
+    version: v1.8.2
+  - name: containers/podman
+    version: v1.8.1
+  - name: containers/podman
+    version: v1.6.0
+  - name: containers/podman
+    version: v1.5.1
+  - name: containers/podman
+    version: v1.4.2
+  - name: containers/podman
+    version: v1.3.1

--- a/pkgs/containers/podman/registry.yaml
+++ b/pkgs/containers/podman/registry.yaml
@@ -6,96 +6,8 @@ packages:
     description: "Podman: A tool for managing OCI containers and pods"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v1.8.2-rc1", "v2.0.4", "v2.0.6-rc1", "v4.3.0-rc1"]
-        no_asset: true
-      - version_constraint: Version == "v1.3.1"
-        asset: podman-{{.Version}}.{{.Format}}
-        format: dmg
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.4.2"
-        asset: podman-{{.Version}}.{{.Format}}
-        format: dmg
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.6.0"
-        asset: podman-remote-{{.Version}}-28-gdac7889d-master-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tgz
-        rosetta2: true
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.8.1"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version in ["v1.8.2", "v1.9.1"]
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version == "v1.9.2"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: raw
-            asset: podman-remote-{{.OS}}
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v1.9.3"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version in ["v2.0.5", "v3.3.0"]
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v2.0.6"
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v3.3.1"
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: dmg
-            asset: podman-{{.Version}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows/amd64
+      - version_constraint: semver("< 2.0.0")
+        error_message: The version is too old. Please upgrade to a newer version.
       - version_constraint: Version == "v5.0.0-rc7"
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -106,59 +18,6 @@ packages:
           algorithm: sha256
         supported_envs:
           - windows/amd64
-      - version_constraint: semver("<= 1.4.4")
-        no_asset: true
-      - version_constraint: semver("<= 1.5.1")
-      - version_constraint: semver("<= 2.0.0-rc7")
-        no_asset: true
-      - version_constraint: semver("<= 2.0.3")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 2.1.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 2.1.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 2.2.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 2.2.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.0.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 3.0.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.1.0")
-        no_asset: true
       - version_constraint: semver("<= 3.1.2")
         asset: podman-remote-release-{{.OS}}.{{.Format}}
         format: zip
@@ -166,22 +25,18 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
         supported_envs:
+          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 3.2.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 3.2.3")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.4.0-rc2")
         no_asset: true
       - version_constraint: semver("<= 3.4.4")
         asset: podman-remote-release-{{.OS}}.{{.Format}}
@@ -190,36 +45,26 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/podman
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/podman.exe
         supported_envs:
+          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 4.0.1")
-        no_asset: true
-      - version_constraint: semver("<= 4.0.3")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 4.1.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 4.1.1")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 4.2.0-rc3")
         no_asset: true
       - version_constraint: semver("<= 4.3.1")
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
@@ -229,42 +74,25 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman.exe
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: semver("<= 4.4.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 4.4.4")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver("<= 4.5.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 4.9.5")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver("<= 5.0.0-rc2")
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
+          - linux/amd64
       - version_constraint: "true"
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -277,3 +105,20 @@ packages:
           - goos: linux
             format: tar.gz
             asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+            files:
+              - name: podman
+                src: bin/{{.AssetWithoutExt}}
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman.exe
+              # - name: gvproxy
+              #   src: podman-{{trimV .Version}}/usr/bin/gvproxy.exe
+              # - name: win-sshproxy
+              #   src: podman-{{trimV .Version}}/usr/bin/win-sshproxy.exe
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman
+              - name: podman-mac-helper
+                src: podman-{{trimV .Version}}/usr/bin/podman-mac-helper

--- a/pkgs/containers/podman/registry.yaml
+++ b/pkgs/containers/podman/registry.yaml
@@ -1,0 +1,279 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: containers
+    repo_name: podman
+    description: "Podman: A tool for managing OCI containers and pods"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v1.8.2-rc1", "v2.0.4", "v2.0.6-rc1", "v4.3.0-rc1"]
+        no_asset: true
+      - version_constraint: Version == "v1.3.1"
+        asset: podman-{{.Version}}.{{.Format}}
+        format: dmg
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.4.2"
+        asset: podman-{{.Version}}.{{.Format}}
+        format: dmg
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.6.0"
+        asset: podman-remote-{{.Version}}-28-gdac7889d-master-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.8.1"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version in ["v1.8.2", "v1.9.1"]
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v1.9.2"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: raw
+            asset: podman-remote-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v1.9.3"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version in ["v2.0.5", "v3.3.0"]
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v2.0.6"
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v3.3.1"
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: dmg
+            asset: podman-{{.Version}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v5.0.0-rc7"
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 1.4.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 2.0.0-rc7")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.3")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.1.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.2.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 2.2.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.0.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 3.0.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 3.1.2")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.2.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 3.2.3")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.4.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.4")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.0.1")
+        no_asset: true
+      - version_constraint: semver("<= 4.0.3")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.1.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 4.1.1")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.2.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 4.3.1")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.4.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 4.4.4")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 4.5.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 4.9.5")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 5.0.0-rc2")
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}

--- a/pkgs/containers/podman/scaffold.yaml
+++ b/pkgs/containers/podman/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: containers/podman
+# version_filter: not (Version matches "-rc$")
+# version_prefix: cli-
+all_assets_filter: not ((Asset matches "installer") or (Asset matches "machine"))

--- a/registry.yaml
+++ b/registry.yaml
@@ -17265,6 +17265,283 @@ packages:
     supported_envs:
       - linux/amd64
   - type: github_release
+    repo_owner: containers
+    repo_name: podman
+    description: "Podman: A tool for managing OCI containers and pods"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v1.8.2-rc1", "v2.0.4", "v2.0.6-rc1", "v4.3.0-rc1"]
+        no_asset: true
+      - version_constraint: Version == "v1.3.1"
+        asset: podman-{{.Version}}.{{.Format}}
+        format: dmg
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.4.2"
+        asset: podman-{{.Version}}.{{.Format}}
+        format: dmg
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.6.0"
+        asset: podman-remote-{{.Version}}-28-gdac7889d-master-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tgz
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v1.8.1"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version in ["v1.8.2", "v1.9.1"]
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v1.9.2"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: raw
+            asset: podman-remote-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v1.9.3"
+        asset: podman-remote-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version in ["v2.0.5", "v3.3.0"]
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v2.0.6"
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v3.3.1"
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: dmg
+            asset: podman-{{.Version}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v5.0.0-rc7"
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: semver("<= 1.4.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 2.0.0-rc7")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.3")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.1.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.2.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 2.2.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.0.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 3.0.1")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 3.1.2")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.2.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 3.2.3")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 3.4.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.4")
+        asset: podman-remote-release-{{.OS}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.0.1")
+        no_asset: true
+      - version_constraint: semver("<= 4.0.3")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.1.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 4.1.1")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.2.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 4.3.1")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 4.4.0-rc3")
+        no_asset: true
+      - version_constraint: semver("<= 4.4.4")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 4.5.0-rc2")
+        no_asset: true
+      - version_constraint: semver("<= 4.9.5")
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 5.0.0-rc2")
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: shasums
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+  - type: github_release
     repo_owner: containrrr
     repo_name: shoutrrr
     description: Notification library for gophers and their furry friends

--- a/registry.yaml
+++ b/registry.yaml
@@ -17270,96 +17270,8 @@ packages:
     description: "Podman: A tool for managing OCI containers and pods"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v1.8.2-rc1", "v2.0.4", "v2.0.6-rc1", "v4.3.0-rc1"]
-        no_asset: true
-      - version_constraint: Version == "v1.3.1"
-        asset: podman-{{.Version}}.{{.Format}}
-        format: dmg
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.4.2"
-        asset: podman-{{.Version}}.{{.Format}}
-        format: dmg
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.6.0"
-        asset: podman-remote-{{.Version}}-28-gdac7889d-master-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tgz
-        rosetta2: true
-        supported_envs:
-          - darwin
-      - version_constraint: Version == "v1.8.1"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version in ["v1.8.2", "v1.9.1"]
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - windows/amd64
-      - version_constraint: Version == "v1.9.2"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: raw
-            asset: podman-remote-{{.OS}}
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v1.9.3"
-        asset: podman-remote-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version in ["v2.0.5", "v3.3.0"]
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v2.0.6"
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: Version == "v3.3.1"
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            format: dmg
-            asset: podman-{{.Version}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows/amd64
+      - version_constraint: semver("< 2.0.0")
+        error_message: The version is too old. Please upgrade to a newer version.
       - version_constraint: Version == "v5.0.0-rc7"
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -17370,59 +17282,6 @@ packages:
           algorithm: sha256
         supported_envs:
           - windows/amd64
-      - version_constraint: semver("<= 1.4.4")
-        no_asset: true
-      - version_constraint: semver("<= 1.5.1")
-      - version_constraint: semver("<= 2.0.0-rc7")
-        no_asset: true
-      - version_constraint: semver("<= 2.0.3")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 2.1.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 2.1.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 2.2.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 2.2.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.0.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 3.0.1")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.1.0")
-        no_asset: true
       - version_constraint: semver("<= 3.1.2")
         asset: podman-remote-release-{{.OS}}.{{.Format}}
         format: zip
@@ -17430,22 +17289,18 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
         supported_envs:
+          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 3.2.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 3.2.3")
-        asset: podman-remote-release-{{.OS}}.{{.Format}}
-        format: zip
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 3.4.0-rc2")
         no_asset: true
       - version_constraint: semver("<= 3.4.4")
         asset: podman-remote-release-{{.OS}}.{{.Format}}
@@ -17454,36 +17309,26 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/podman
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/podman.exe
         supported_envs:
+          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 4.0.1")
-        no_asset: true
-      - version_constraint: semver("<= 4.0.3")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 4.1.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 4.1.1")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows/amd64
-      - version_constraint: semver("<= 4.2.0-rc3")
         no_asset: true
       - version_constraint: semver("<= 4.3.1")
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
@@ -17493,42 +17338,25 @@ packages:
           type: github_release
           asset: shasums
           algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            asset: podman-remote-static.{{.Format}}
+            files:
+              - name: podman
+                src: podman-remote-static
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman.exe
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: semver("<= 4.4.0-rc3")
-        no_asset: true
-      - version_constraint: semver("<= 4.4.4")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver("<= 4.5.0-rc2")
-        no_asset: true
-      - version_constraint: semver("<= 4.9.5")
-        asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.gz
-            asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver("<= 5.0.0-rc2")
-        checksum:
-          type: github_release
-          asset: shasums
-          algorithm: sha256
+          - linux/amd64
       - version_constraint: "true"
         asset: podman-remote-release-{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -17541,6 +17369,23 @@ packages:
           - goos: linux
             format: tar.gz
             asset: podman-remote-static-{{.OS}}_{{.Arch}}.{{.Format}}
+            files:
+              - name: podman
+                src: bin/{{.AssetWithoutExt}}
+          - goos: windows
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman.exe
+              # - name: gvproxy
+              #   src: podman-{{trimV .Version}}/usr/bin/gvproxy.exe
+              # - name: win-sshproxy
+              #   src: podman-{{trimV .Version}}/usr/bin/win-sshproxy.exe
+          - goos: darwin
+            files:
+              - name: podman
+                src: podman-{{trimV .Version}}/usr/bin/podman
+              - name: podman-mac-helper
+                src: podman-{{trimV .Version}}/usr/bin/podman-mac-helper
   - type: github_release
     repo_owner: containrrr
     repo_name: shoutrrr


### PR DESCRIPTION
[containers/podman](https://github.com/containers/podman): Podman: A tool for managing OCI containers and pods

```console
$ aqua g -i containers/podman
```

Close #32664

## ⚠️ Note

I'm not familiar with Podman, so I'm not sure if it works well.
aqua installs static binaries from GitHub Releases.

https://github.com/containers/podman/releases/tag/v5.4.0

- linux/amd64: [podman-remote-static-linux_amd64.tar.gz](https://github.com/containers/podman/releases/download/v5.4.0/podman-remote-static-linux_amd64.tar.gz)
  - podman: `bin/podman-remote-static-{{.OS}}_{{.Arch}}`
- darwin/arm64: [podman-remote-release-darwin_arm64.zip](https://github.com/containers/podman/releases/download/v5.4.0/podman-remote-release-darwin_arm64.zip)
  - podman: `podman-{{trimV .Version}}/usr/bin/podman`
  - podman-mac-helper: `podman-{{trimV .Version}}/usr/bin/podman-mac-helper`
- windows: [podman-remote-release-windows_amd64.zip](https://github.com/containers/podman/releases/download/v5.4.0/podman-remote-release-windows_amd64.zip)
  - podman: `podman-{{trimV .Version}}/usr/bin/podman.exe`

https://github.com/aquaproj/aqua-registry/blob/dcec1dfbe0fa6e74d6efec8190a6daadb0bde9f3/pkgs/containers/podman/registry.yaml#L96-L124