### PR TITLE
feat: add k1LoW/hclstr

### DIFF
--- a/pkgs/k1LoW/hclstr/pkg.yaml
+++ b/pkgs/k1LoW/hclstr/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/hclstr@v0.2.0

--- a/pkgs/k1LoW/hclstr/registry.yaml
+++ b/pkgs/k1LoW/hclstr/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: hclstr
+    description: hclstr is a utility tool for string literals in HCL files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: hclstr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -33400,6 +33400,23 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: k1LoW
+    repo_name: hclstr
+    description: hclstr is a utility tool for string literals in HCL files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: hclstr_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: ndiag
     asset: ndiag_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: zip


### PR DESCRIPTION
[k1LoW/hclstr](https://github.com/k1LoW/hclstr): hclstr is a utility tool for string literals in HCL files

```console
$ aqua g -i k1LoW/hclstr
```