### PR TITLE
feat(IxDay/mruby): add support for linux arm64

### DIFF
--- a/pkgs/IxDay/mruby/pkg.yaml
+++ b/pkgs/IxDay/mruby/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: IxDay/mruby@3.3.0
+  - name: IxDay/mruby
+    version: 3.2.0

--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -26,4 +26,3 @@ packages:
           amd64: x86_64
           darwin: macos
           arm64: aarch64
-        supported_envs: ["all"]

--- a/pkgs/IxDay/mruby/registry.yaml
+++ b/pkgs/IxDay/mruby/registry.yaml
@@ -26,7 +26,4 @@ packages:
           amd64: x86_64
           darwin: macos
           arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        supported_envs: ["all"]

--- a/registry.yaml
+++ b/registry.yaml
@@ -2485,10 +2485,7 @@ packages:
           amd64: x86_64
           darwin: macos
           arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        supported_envs: ["all"]
   - type: github_release
     repo_owner: JFryy
     repo_name: qq

--- a/registry.yaml
+++ b/registry.yaml
@@ -2485,7 +2485,6 @@ packages:
           amd64: x86_64
           darwin: macos
           arm64: aarch64
-        supported_envs: ["all"]
   - type: github_release
     repo_owner: JFryy
     repo_name: qq


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
This commit and release: https://github.com/IxDay/mruby/commit/f2329d38af85c6760718ce65d35525c8a786e7f5 Add supports for linux arm64 architectures.