### PR TITLE
feat(a-h/templ): cosign config

### DIFF
--- a/pkgs/a-h/templ/pkg.yaml
+++ b/pkgs/a-h/templ/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: a-h/templ@v0.3.833
   - name: a-h/templ
-    version: v0.2.639
+    version: v0.2.598
   - name: a-h/templ
     version: v0.2.194
   - name: a-h/templ

--- a/pkgs/a-h/templ/pkg.yaml
+++ b/pkgs/a-h/templ/pkg.yaml
@@ -1,8 +1,8 @@
 packages:
   - name: a-h/templ@v0.3.833
   - name: a-h/templ
-    version: v0.0.153
+    version: v0.2.194
   - name: a-h/templ
-    version: v0.0.139
+    version: v0.0.148
   - name: a-h/templ
-    version: v0.0.80
+    version: v0.0.126

--- a/pkgs/a-h/templ/pkg.yaml
+++ b/pkgs/a-h/templ/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: a-h/templ@v0.3.833
   - name: a-h/templ
+    version: v0.2.639
+  - name: a-h/templ
     version: v0.2.194
   - name: a-h/templ
     version: v0.0.148

--- a/pkgs/a-h/templ/registry.yaml
+++ b/pkgs/a-h/templ/registry.yaml
@@ -4,31 +4,56 @@ packages:
     repo_owner: a-h
     repo_name: templ
     description: A language for writing HTML user interfaces in Go
-    asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.2.202")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.0.153")
+      - version_constraint: semver("<= 0.0.126")
         asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver(">= 0.0.139")
-        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver("< 0.0.139")
-        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        format: tar.gz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.148")
+        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.2.194")
+        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/a-h/templ/registry.yaml
+++ b/pkgs/a-h/templ/registry.yaml
@@ -45,6 +45,18 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+      - version_constraint: semver("< 0.2.639")
+        asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -57,3 +69,9 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --signature
+              - https://github.com/a-h/templ/releases/download/{{.Version}}/checksums.txt.sig
+              - --key
+              - https://raw.githubusercontent.com/a-h/templ/refs/tags/{{.Version}}/cosign.pub

--- a/registry.yaml
+++ b/registry.yaml
@@ -6162,6 +6162,18 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+      - version_constraint: semver("< 0.2.639")
+        asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -6174,6 +6186,12 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --signature
+              - https://github.com/a-h/templ/releases/download/{{.Version}}/checksums.txt.sig
+              - --key
+              - https://raw.githubusercontent.com/a-h/templ/refs/tags/{{.Version}}/cosign.pub
   - type: github_release
     repo_owner: a8m
     repo_name: envsubst

--- a/registry.yaml
+++ b/registry.yaml
@@ -6121,34 +6121,59 @@ packages:
     repo_owner: a-h
     repo_name: templ
     description: A language for writing HTML user interfaces in Go
-    asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.2.202")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.0.153")
+      - version_constraint: semver("<= 0.0.126")
         asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-      - version_constraint: semver(">= 0.0.139")
-        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver("< 0.0.139")
-        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        format: tar.gz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.148")
+        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.2.194")
+        asset: templ_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: templ_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: a8m
     repo_name: envsubst


### PR DESCRIPTION
https://github.com/a-h/templ/releases

https://github.com/a-h/templ/blob/main/docs/docs/10-security/03-code-signing.md

I did not have luck verifying releases < 0.2.639, which was the first version where cosign.pub was in the repo.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
