### PR TITLE
chore: revise asset format for latest zigtools/zls

### DIFF
--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -53,17 +53,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version in ["0.12.0", "0.13.0"]
-        asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.xz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: "true"
         asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -65,7 +65,7 @@ packages:
           - goos: windows
             format: zip
       - version_constraint: "true"
-        asset: zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -59225,17 +59225,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version in ["0.12.0", "0.13.0"]
-        asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.xz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: "true"
         asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz

--- a/registry.yaml
+++ b/registry.yaml
@@ -59237,7 +59237,7 @@ packages:
           - goos: windows
             format: zip
       - version_constraint: "true"
-        asset: zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        asset: zls-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
         replacements:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
Revises the asset name format for zls package artifacts to match what they're putting out over at https://github.com/zigtools/zls/releases/tag/0.14.0 