### PR TITLE
feat(Trendyol/kink): cosign config

### DIFF
--- a/pkgs/Trendyol/kink/pkg.yaml
+++ b/pkgs/Trendyol/kink/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: Trendyol/kink@v0.2.1
+  - name: Trendyol/kink
+    version: v0.1.1

--- a/pkgs/Trendyol/kink/registry.yaml
+++ b/pkgs/Trendyol/kink/registry.yaml
@@ -20,6 +20,37 @@ packages:
           type: github_release
           asset: kink_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
+              - --insecure-ignore-tlog
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.2.1"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
+              - --insecure-ignore-tlog
         supported_envs:
           - darwin
           - windows
@@ -37,6 +68,12 @@ packages:
           type: github_release
           asset: kink_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
         supported_envs:
           - darwin
           - windows

--- a/pkgs/Trendyol/kink/registry.yaml
+++ b/pkgs/Trendyol/kink/registry.yaml
@@ -6,9 +6,10 @@ packages:
     description: KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.2.1"
+      - version_constraint: semver("< 0.2.1")
         asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -26,7 +27,6 @@ packages:
       - version_constraint: "true"
         asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/pkgs/Trendyol/kink/registry.yaml
+++ b/pkgs/Trendyol/kink/registry.yaml
@@ -3,15 +3,41 @@ packages:
   - type: github_release
     repo_owner: Trendyol
     repo_name: kink
-    asset: kink_{{trimV .Version}}_{{.OS}}-x86_64.tar.gz
     description: KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    checksum:
-      type: github_release
-      asset: kink_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.1"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4646,9 +4646,10 @@ packages:
     description: KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.2.1"
+      - version_constraint: semver("< 0.2.1")
         asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -4666,7 +4667,6 @@ packages:
       - version_constraint: "true"
         asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4643,18 +4643,44 @@ packages:
   - type: github_release
     repo_owner: Trendyol
     repo_name: kink
-    asset: kink_{{trimV .Version}}_{{.OS}}-x86_64.tar.gz
     description: KinK is a helper CLI that facilitates to manage KinD clusters as Kubernetes pods. Designed to ease clusters up for fast testing with batteries included in mind
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    checksum:
-      type: github_release
-      asset: kink_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.1"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
   - type: github_release
     repo_owner: UpCloudLtd
     repo_name: upcloud-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -4660,6 +4660,37 @@ packages:
           type: github_release
           asset: kink_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
+              - --insecure-ignore-tlog
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.2.1"
+        asset: kink_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kink_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
+              - --insecure-ignore-tlog
         supported_envs:
           - darwin
           - windows
@@ -4677,6 +4708,12 @@ packages:
           type: github_release
           asset: kink_checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --key
+              - https://raw.githubusercontent.com/Trendyol/kink/refs/tags/{{.Version}}/cosign.pub
+              - --signature
+              - https://github.com/Trendyol/kink/releases/download/{{.Version}}/kink_checksums.txt.sig
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
Skip transparency log verification for releases up to current 0.2.1, as
the signature does not appear to be uploaded. Configure to not skip for
future versions, assuming it will be.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
