### PR TITLE
feat: add ninxsoft/mist-cli

### DIFF
--- a/pkgs/ninxsoft/mist-cli/pkg.yaml
+++ b/pkgs/ninxsoft/mist-cli/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: ninxsoft/mist-cli@v2.1.1
-  - name: ninxsoft/mist-cli
-    version: v1.8

--- a/pkgs/ninxsoft/mist-cli/pkg.yaml
+++ b/pkgs/ninxsoft/mist-cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: ninxsoft/mist-cli@v2.1.1
+  - name: ninxsoft/mist-cli
+    version: v1.8

--- a/pkgs/ninxsoft/mist-cli/registry.yaml
+++ b/pkgs/ninxsoft/mist-cli/registry.yaml
@@ -4,15 +4,10 @@ packages:
     repo_owner: ninxsoft
     repo_name: mist-cli
     description: A Mac command-line tool that automatically downloads macOS Firmwares / Installers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 1.8.0")
-        asset: Mist.{{trimV .Version}}.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
-      - version_constraint: "true"
-        asset: mist-cli.{{trimV .Version}}.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
+    asset: mist-cli.{{trimV .Version}}.{{.Format}}
+    format: pkg
+    files:
+      - name: mist
+        src: Payload/usr/local/bin/mist
+    supported_envs:
+      - darwin

--- a/pkgs/ninxsoft/mist-cli/registry.yaml
+++ b/pkgs/ninxsoft/mist-cli/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ninxsoft
+    repo_name: mist-cli
+    description: A Mac command-line tool that automatically downloads macOS Firmwares / Installers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.8.0")
+        asset: Mist.{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: mist-cli.{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -41927,6 +41927,22 @@ packages:
       - amd64
     rosetta2: true
   - type: github_release
+    repo_owner: ninxsoft
+    repo_name: mist-cli
+    description: A Mac command-line tool that automatically downloads macOS Firmwares / Installers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.8.0")
+        asset: Mist.{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: mist-cli.{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: nishanths
     repo_name: license
     description: Command line license text generator

--- a/registry.yaml
+++ b/registry.yaml
@@ -41930,18 +41930,13 @@ packages:
     repo_owner: ninxsoft
     repo_name: mist-cli
     description: A Mac command-line tool that automatically downloads macOS Firmwares / Installers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 1.8.0")
-        asset: Mist.{{trimV .Version}}.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
-      - version_constraint: "true"
-        asset: mist-cli.{{trimV .Version}}.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
+    asset: mist-cli.{{trimV .Version}}.{{.Format}}
+    format: pkg
+    files:
+      - name: mist
+        src: Payload/usr/local/bin/mist
+    supported_envs:
+      - darwin
   - type: github_release
     repo_owner: nishanths
     repo_name: license


### PR DESCRIPTION
This is a draft until I can get things working. See comments below for context.

---

[ninxsoft/mist-cli](https://github.com/ninxsoft/mist-cli): A Mac command-line tool that automatically downloads macOS Firmwares / Installers

```console
$ aqua g -i ninxsoft/mist-cli
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ mist --version
2.1.1 (latest: 2.1.1)
```

```console
$ mist list installer
┌──────────────────┐
│ INPUT VALIDATION │
└──────────────────┘
  ├─ Search only for latest (first) result will be 'false'...
  ├─ Include betas in search results will be 'false'...
  ├─ Only include compatible installers will be 'false'...
  ├─ Output type will be 'ascii'...
┌────────┐
│ SEARCH │
└────────┘
  ├─ Searching for macOS Installer versions...
  └─ Found 30 macOS Installer(s) available for download

┌───────────────┬────────────────────┬─────────┬─────────┬──────────┬────────────┬────────────┐
│ IDENTIFIER    │ NAME               │ VERSION │ BUILD   │ SIZE     │ DATE       │ COMPATIBLE │
├───────────────┼────────────────────┼─────────┼─────────┼──────────┼────────────┼────────────┤
│ 082-01336     │ macOS Sequoia      │ 15.3.2  │ 24D81   │ 15.25 GB │ 2025-03-11 │ True       │
│ 082-04099     │ macOS Sequoia      │ 15.3.2  │ 24D2082 │ 13.05 GB │ 2025-03-11 │ False      │
│ 072-70706     │ macOS Sequoia      │ 15.3.1  │ 24D70   │ 15.26 GB │ 2025-02-17 │ True       │
│ 072-08251     │ macOS Sequoia      │ 15.3    │ 24D60   │ 15.25 GB │ 2025-02-03 │ True       │
│ 072-44286     │ macOS Sequoia      │ 15.2    │ 24C101  │ 15.29 GB │ 2024-12-11 │ True       │
│ 072-84039     │ macOS Sonoma       │ 14.7.4  │ 23H420  │ 13.67 GB │ 2025-02-17 │ True       │
│ 072-61299     │ macOS Sonoma       │ 14.7.3  │ 23H417  │ 13.67 GB │ 2025-02-03 │ True       │
│ 072-36705     │ macOS Sonoma       │ 14.7.2  │ 23H311  │ 13.67 GB │ 2024-12-11 │ True       │
│ 072-83845     │ macOS Ventura      │ 13.7.4  │ 22H420  │ 12.21 GB │ 2025-02-17 │ True       │
│ 072-61270     │ macOS Ventura      │ 13.7.3  │ 22H417  │ 12.21 GB │ 2025-02-03 │ True       │
│ 072-36728     │ macOS Ventura      │ 13.7.2  │ 22H313  │ 12.22 GB │ 2024-12-11 │ True       │
│ 052-60131     │ macOS Monterey     │ 12.7.4  │ 21H1123 │ 12.42 GB │ 2024-03-18 │ True       │
│ 042-45246     │ macOS Big Sur      │ 11.7.10 │ 20G1427 │ 12.42 GB │ 2023-09-11 │ False      │
│ 001-68446     │ macOS Catalina     │ 10.15.7 │ 19H15   │ 08.75 GB │ 2020-11-11 │ False      │
│ 001-57224     │ macOS Catalina     │ 10.15.7 │ 19H4    │ 08.75 GB │ 2020-10-27 │ False      │
│ 001-51042     │ macOS Catalina     │ 10.15.7 │ 19H2    │ 08.75 GB │ 2020-09-24 │ False      │
│ 001-36801     │ macOS Catalina     │ 10.15.6 │ 19G2021 │ 08.75 GB │ 2020-08-12 │ False      │
│ 001-36735     │ macOS Catalina     │ 10.15.6 │ 19G2006 │ 08.75 GB │ 2020-08-06 │ False      │
│ 001-15219     │ macOS Catalina     │ 10.15.5 │ 19F2200 │ 08.74 GB │ 2020-06-15 │ False      │
│ 001-04366     │ macOS Catalina     │ 10.15.4 │ 19E2269 │ 08.75 GB │ 2020-05-04 │ False      │
│ 061-86291     │ macOS Catalina     │ 10.15.3 │ 19D2064 │ 08.69 GB │ 2020-03-23 │ False      │
│ 061-26589     │ macOS Mojave       │ 10.14.6 │ 18G103  │ 06.52 GB │ 2019-10-14 │ False      │
│ 061-26578     │ macOS Mojave       │ 10.14.5 │ 18F2059 │ 06.52 GB │ 2019-10-14 │ False      │
│ 041-88800     │ macOS Mojave       │ 10.14.4 │ 18E2034 │ 06.53 GB │ 2019-10-23 │ False      │
│ 041-91758     │ macOS High Sierra  │ 10.13.6 │ 17G66   │ 05.71 GB │ 2019-10-19 │ False      │
│ 10.12.6-16G29 │ macOS Sierra       │ 10.12.6 │ 16G29   │ 05.01 GB │ 2017-07-15 │ False      │
│ 10.11.6-15G31 │ OS X El Capitan    │ 10.11.6 │ 15G31   │ 06.20 GB │ 2016-05-18 │ False      │
│ 10.10.5-14F27 │ OS X Yosemite      │ 10.10.5 │ 14F27   │ 05.72 GB │ 2015-08-05 │ False      │
│ 10.8.5-12F45  │ OS X Mountain Lion │ 10.8.5  │ 12F45   │ 04.45 GB │ 2013-09-27 │ False      │
│ 10.7.5-11G63  │ Mac OS X Lion      │ 10.7.5  │ 11G63   │ 04.72 GB │ 2012-09-28 │ False      │
└───────────────┴────────────────────┴─────────┴─────────┴──────────┴────────────┴────────────┘
```