### PR TITLE
feat: add cpisciotta/xcbeautify

### DIFF
--- a/pkgs/cpisciotta/xcbeautify/pkg.yaml
+++ b/pkgs/cpisciotta/xcbeautify/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: cpisciotta/xcbeautify@2.27.0
+  - name: cpisciotta/xcbeautify
+    version: 1.7.0
+  - name: cpisciotta/xcbeautify
+    version: 0.9.1
+  - name: cpisciotta/xcbeautify
+    version: 0.9.0
+  - name: cpisciotta/xcbeautify
+    version: 0.8.1
+  - name: cpisciotta/xcbeautify
+    version: 0.4.1
+  - name: cpisciotta/xcbeautify
+    version: 0.3.8

--- a/pkgs/cpisciotta/xcbeautify/registry.yaml
+++ b/pkgs/cpisciotta/xcbeautify/registry.yaml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: cpisciotta
+    repo_name: xcbeautify
+    description: A little beautifier tool for xcodebuild
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.5.0-beta.1"
+        no_asset: true
+      - version_constraint: Version == "0.9.0"
+        asset: xcbeautify-{{.Version}}-universal-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "0.9.1"
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.8")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx10.10.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.4.1")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx10.14.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 1.7.0")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.0-beta.3")
+        no_asset: true
+      - version_constraint: "true"
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -17829,6 +17829,94 @@ packages:
       - darwin
       - amd64
   - type: github_release
+    repo_owner: cpisciotta
+    repo_name: xcbeautify
+    description: A little beautifier tool for xcodebuild
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.5.0-beta.1"
+        no_asset: true
+      - version_constraint: Version == "0.9.0"
+        asset: xcbeautify-{{.Version}}-universal-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "0.9.1"
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.8")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx10.10.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.4.1")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx10.14.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 1.7.0")
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.0-beta.3")
+        no_asset: true
+      - version_constraint: "true"
+        asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}-macosx.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: apple
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            format: tar.xz
+            asset: xcbeautify-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: crate-ci
     repo_name: committed
     description: Nitpicking commit history since beabf39


### PR DESCRIPTION
[cpisciotta/xcbeautify](https://github.com/cpisciotta/xcbeautify): A little beautifier tool for xcodebuild

```console
$ aqua g -i cpisciotta/xcbeautify
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Command and output

```console
$ xcbeautify --version
2.27.0
```

```console
$ xcbeautify --help
OVERVIEW: A tool to format `swift` and `xcodebuild` command output.

EXAMPLE: xcodebuild test ... | xcbeautify

USAGE: xcbeautify [--quiet] [--quieter] [--preserve-unbeautified] [--is-ci] [--disable-colored-output] [--disable-logging] [--renderer <renderer>] [--report <report> ...] [--report-path <report-path>] [--junit-report-filename <junit-report-filename>]

OPTIONS:
  -q, --quiet             Only print tasks that have warnings or errors.
  --quieter, -qq          Only print tasks that have errors.
  --preserve-unbeautified Preserves unbeautified output lines.
  --is-ci                 Print test result too under quiet/quieter flag.
  --disable-colored-output
                          Disable the colored output
  --disable-logging       Suppress the xcbeautify information table when xcbeautify starts. It includes the active xcbeautify version.
  --renderer <renderer>   Specify a renderer to format raw xcodebuild output. (Options: terminal | github-actions | teamcity | azure-devops-pipelines). (values: terminal,
                          github-actions, teamcity, azure-devops-pipelines; default: terminal)
  --report <report>       Generate the specified reports. (Options: junit). (values: junit)
  --report-path <report-path>
                          The path to use when generating reports (default: build/reports)
  --junit-report-filename <junit-report-filename>
                          The name of JUnit report file name (default: junit.xml)
  --version               Show the version.
  -h, --help              Show help information.
```

`xcbeautify`'s function is to clean up the output of the `swift` and `xcodebuild` binaries. Here's an example:

```console
swift test --package-path $HOME/Developer/mine/Workbench | xcbeautify

----- xcbeautify -----
Version: 2.27.0
----------------------

Building for debugging...
[8/8] Linking WorkbenchPackageTests
Build complete! (2.59s)
Test Suite 'All tests' started at 2025-03-17 07:30:04.009.
Test Suite 'All tests' passed at 2025-03-17 07:30:04.011.
Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.002) seconds
Test run started.
Suite SysInfoKitTests started
    ✔ testPlistInit() (0.001 seconds)
Suite SysInfoKitTests passed after 0.001 seconds
Test run with 1 tests passed after 0.001 seconds
```