### PR TITLE
feat: add realm/SwiftLint

### DIFF
--- a/pkgs/realm/SwiftLint/pkg.yaml
+++ b/pkgs/realm/SwiftLint/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: realm/SwiftLint@0.58.2
+  - name: realm/SwiftLint
+    version: 0.48.0
+  - name: realm/SwiftLint
+    version: 0.47.0-rc.3
+  - name: realm/SwiftLint
+    version: 0.42.0-rc.1
+  - name: realm/SwiftLint
+    version: 0.40.0

--- a/pkgs/realm/SwiftLint/pkg.yaml
+++ b/pkgs/realm/SwiftLint/pkg.yaml
@@ -3,8 +3,4 @@ packages:
   - name: realm/SwiftLint
     version: 0.48.0
   - name: realm/SwiftLint
-    version: 0.47.0-rc.3
-  - name: realm/SwiftLint
-    version: 0.42.0-rc.1
-  - name: realm/SwiftLint
     version: 0.40.0

--- a/pkgs/realm/SwiftLint/registry.yaml
+++ b/pkgs/realm/SwiftLint/registry.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: realm
+    repo_name: SwiftLint
+    description: A tool to enforce Swift style and conventions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.42.0-rc.1"
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.40.0")
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.47.0-rc.3")
+        asset: swiftlint_{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            format: pkg
+            asset: SwiftLint.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.48.0")
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        overrides:
+          - goos: linux
+            format: zip
+            asset: swiftlint_{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: zip
+            asset: swiftlint_{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/pkgs/realm/SwiftLint/registry.yaml
+++ b/pkgs/realm/SwiftLint/registry.yaml
@@ -4,20 +4,23 @@ packages:
     repo_owner: realm
     repo_name: SwiftLint
     description: A tool to enforce Swift style and conventions
-    format: zip
-    files:
-      - name: swiftlint
-    overrides:
-      - goos: linux
-        asset: swiftlint_linux
-      - goos: darwin
-        asset: portable_swiftlint
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.40.0")
+        asset: portable_swiftlint.{{.Format}}
+        format: zip
+        files:
+          - name: swiftlint
         supported_envs:
           - darwin
       - version_constraint: "true"
+        asset: portable_swiftlint.{{.Format}}
+        format: zip
+        files:
+          - name: swiftlint
+        overrides:
+          - goos: linux
+            asset: swiftlint_linux.{{.Format}}
         supported_envs:
           - linux/amd64
           - darwin

--- a/pkgs/realm/SwiftLint/registry.yaml
+++ b/pkgs/realm/SwiftLint/registry.yaml
@@ -4,49 +4,20 @@ packages:
     repo_owner: realm
     repo_name: SwiftLint
     description: A tool to enforce Swift style and conventions
+    format: zip
+    files:
+      - name: swiftlint
+    overrides:
+      - goos: linux
+        asset: swiftlint_linux
+      - goos: darwin
+        asset: portable_swiftlint
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "0.42.0-rc.1"
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
       - version_constraint: semver("<= 0.40.0")
-        asset: SwiftLint.{{.Format}}
-        format: pkg
         supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.47.0-rc.3")
-        asset: swiftlint_{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            format: pkg
-            asset: SwiftLint.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.48.0")
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        overrides:
-          - goos: linux
-            format: zip
-            asset: swiftlint_{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux/amd64
           - darwin
       - version_constraint: "true"
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: zip
-            asset: swiftlint_{{.OS}}.{{.Format}}
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -46612,6 +46612,56 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: realm
+    repo_name: SwiftLint
+    description: A tool to enforce Swift style and conventions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.42.0-rc.1"
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.40.0")
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 0.47.0-rc.3")
+        asset: swiftlint_{{.OS}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: darwin
+            format: pkg
+            asset: SwiftLint.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.48.0")
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        overrides:
+          - goos: linux
+            format: zip
+            asset: swiftlint_{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: SwiftLint.{{.Format}}
+        format: pkg
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: zip
+            asset: swiftlint_{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: rebuy-de
     repo_name: aws-nuke
     description: Nuke a whole AWS account and delete all its resources

--- a/registry.yaml
+++ b/registry.yaml
@@ -46615,49 +46615,20 @@ packages:
     repo_owner: realm
     repo_name: SwiftLint
     description: A tool to enforce Swift style and conventions
+    format: zip
+    files:
+      - name: swiftlint
+    overrides:
+      - goos: linux
+        asset: swiftlint_linux
+      - goos: darwin
+        asset: portable_swiftlint
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "0.42.0-rc.1"
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        supported_envs:
-          - darwin
       - version_constraint: semver("<= 0.40.0")
-        asset: SwiftLint.{{.Format}}
-        format: pkg
         supported_envs:
-          - darwin
-      - version_constraint: semver("<= 0.47.0-rc.3")
-        asset: swiftlint_{{.OS}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: darwin
-            format: pkg
-            asset: SwiftLint.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.48.0")
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        overrides:
-          - goos: linux
-            format: zip
-            asset: swiftlint_{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux/amd64
           - darwin
       - version_constraint: "true"
-        asset: SwiftLint.{{.Format}}
-        format: pkg
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: zip
-            asset: swiftlint_{{.OS}}.{{.Format}}
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -46615,20 +46615,23 @@ packages:
     repo_owner: realm
     repo_name: SwiftLint
     description: A tool to enforce Swift style and conventions
-    format: zip
-    files:
-      - name: swiftlint
-    overrides:
-      - goos: linux
-        asset: swiftlint_linux
-      - goos: darwin
-        asset: portable_swiftlint
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.40.0")
+        asset: portable_swiftlint.{{.Format}}
+        format: zip
+        files:
+          - name: swiftlint
         supported_envs:
           - darwin
       - version_constraint: "true"
+        asset: portable_swiftlint.{{.Format}}
+        format: zip
+        files:
+          - name: swiftlint
+        overrides:
+          - goos: linux
+            asset: swiftlint_linux.{{.Format}}
         supported_envs:
           - linux/amd64
           - darwin


### PR DESCRIPTION
[realm/SwiftLint](https://github.com/realm/SwiftLint): A tool to enforce Swift style and conventions

```console
$ aqua g -i realm/SwiftLint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Command and output

```console
$ swiftlint --version
0.58.2
```

```console
$ swiftlint --help
OVERVIEW: A tool to enforce Swift style and conventions.

USAGE: swiftlint <subcommand>

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.

SUBCOMMANDS:
  analyze                 Run analysis rules
  docs                    Open SwiftLint documentation website in the default web browser
  generate-docs           Generates markdown documentation for selected group of rules
  lint (default)          Print lint warnings and errors
  baseline                Operations on existing baselines
  reporters               Display the list of reporters and their identifiers
  rules                   Display the list of rules and their identifiers
  version                 Display the current version of SwiftLint

  See 'swiftlint help <subcommand>' for detailed help.
```

```console
$ swiftlint lint $HOME/Developer/mine/Workbench/
Linting 'mine/Workbench/.build/checkouts/Path/Tuist/Config.swift' (1/8)
Linting 'mine/Workbench/.build/checkouts/Path/Project.swift' (2/8)
Linting 'mine/Workbench/.build/checkouts/Path/Package.swift' (3/8)
Linting 'mine/Workbench/.build/checkouts/Path/Sources/Path/Path.swift' (4/8)
Linting 'mine/Workbench/DerivedData/Workbench/SourcePackages/checkouts/Path/Project.swift' (5/8)
Linting 'mine/Workbench/DerivedData/Workbench/SourcePackages/checkouts/Path/Tuist/Config.swift' (6/8)
Linting 'mine/Workbench/DerivedData/Workbench/SourcePackages/checkouts/Path/Package.swift' (7/8)
Linting 'mine/Workbench/DerivedData/Workbench/SourcePackages/checkouts/Path/Sources/Path/Path.swift' (8/8)
Linting 'MachPortTests.swift' (1/86)
Linting 'TestingInfrastructure.swift' (2/86)
Linting 'FileOperationsTestWindows.swift' (3/86)
Linting 'FileTypesTest.swift' (4/86)
Linting 'UtilTests.swift' (5/86)
Linting 'SystemStringTests.swift' (6/86)
Linting 'ErrnoTest.swift' (7/86)
Linting 'SystemCharTest.swift' (8/86)
Linting 'FileOperationsTest.swift' (9/86)
Linting 'MockingTest.swift' (10/86)
Linting 'FilePathSyntaxTest.swift' (11/86)
.build/checkouts/swift-system/Tests/SystemTests/FileTypesTest.swift:75:1: warning: Line Length Violation: Line should be 120 characters or less; currently it has 123 characters (line_length)
.build/checkouts/swift-system/Tests/SystemTests/FileTypesTest.swift:62:6: warning: Todo Violation: TODOs should be resolved (test string conversion) (todo)
.build/checkouts/swift-system/Tests/SystemTests/FileTypesTest.swift:63:6: warning: Todo Violation: TODOs should be resolved (test option set string convers...) (todo)
.build/checkouts/swift-system/Tests/SystemTests/FileTypesTest.swift:71:8: warning: Todo Violation: TODOs should be resolved (exhaustive tests) (todo)
...
src/SysInfoKit_classic/Sources/Commands/SystemProfile.swift:444:3: warning: Comment Spacing Violation: Prefer at least one space after slashes for comments (comment_spacing)
src/SysInfoKit_classic/Sources/Commands/SystemProfile.swift:446:3: warning: Comment Spacing Violation: Prefer at least one space after slashes for comments (comment_spacing)
src/SysInfoKit_classic/Sources/Commands/SystemProfile.swift:447:3: warning: Comment Spacing Violation: Prefer at least one space after slashes for comments (comment_spacing)
SysInfoKit_classic/Sources/Commands/SystemProfile.swift:449:3: warning: Comment Spacing Violation: Prefer at least one space after slashes for comments (comment_spacing)
SysInfoKit_classic/Sources/Commands/SystemProfile.swift:449:1: warning: File Length Violation: File should contain 400 lines or less: currently contains 449 (file_length)
Done linting! Found 2053 violations, 406 serious in 94 files.