### PR TITLE
feat: update bufbuild/protoc-gen-validate

### DIFF
--- a/pkgs/bufbuild/protoc-gen-validate/pkg.yaml
+++ b/pkgs/bufbuild/protoc-gen-validate/pkg.yaml
@@ -1,6 +1,16 @@
 packages:
   - name: bufbuild/protoc-gen-validate@v1.2.1
   - name: bufbuild/protoc-gen-validate
+    version: v1.2.0
+  - name: bufbuild/protoc-gen-validate
     version: v1.0.2
+  - name: bufbuild/protoc-gen-validate
+    version: v1.0.1
+  - name: bufbuild/protoc-gen-validate
+    version: v1.0.0
+  - name: bufbuild/protoc-gen-validate
+    version: v0.10.1
+  - name: bufbuild/protoc-gen-validate
+    version: v0.10.0
   - name: bufbuild/protoc-gen-validate
     version: v0.9.1

--- a/pkgs/bufbuild/protoc-gen-validate/pkg.yaml
+++ b/pkgs/bufbuild/protoc-gen-validate/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: bufbuild/protoc-gen-validate@v1.2.1
+  - name: bufbuild/protoc-gen-validate
+    version: v1.0.2
+  - name: bufbuild/protoc-gen-validate
+    version: v0.9.1

--- a/pkgs/bufbuild/protoc-gen-validate/registry.yaml
+++ b/pkgs/bufbuild/protoc-gen-validate/registry.yaml
@@ -4,6 +4,11 @@ packages:
     repo_owner: bufbuild
     repo_name: protoc-gen-validate
     description: "Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate"
+    files:
+      - name: protoc-gen-validate
+      - name: protoc-gen-validate-cpp
+      - name: protoc-gen-validate-go
+      - name: protoc-gen-validate-java
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.13")

--- a/pkgs/bufbuild/protoc-gen-validate/registry.yaml
+++ b/pkgs/bufbuild/protoc-gen-validate/registry.yaml
@@ -3,18 +3,34 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: protoc-gen-validate
-    asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: protoc plugin to generate polyglot message validators
-    supported_envs:
-      - linux
-      - darwin
-    files:
-      - name: protoc-gen-validate
-      # 2022-12-29 @suzuki-shunsuke I wasn't sure if we should install protoc-gen-validate-* in $PATH, so I commented out them at the moment
-      # - name: protoc-gen-validate-cpp
-      # - name: protoc-gen-validate-go
-      # - name: protoc-gen-validate-java
-    checksum:
-      type: github_release
-      asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    description: "Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.13")
+        no_asset: true
+      - version_constraint: semver("<= 0.9.1")
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.2")
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -13088,21 +13088,37 @@ packages:
   - type: github_release
     repo_owner: bufbuild
     repo_name: protoc-gen-validate
-    asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    description: protoc plugin to generate polyglot message validators
-    supported_envs:
-      - linux
-      - darwin
-    files:
-      - name: protoc-gen-validate
-      # 2022-12-29 @suzuki-shunsuke I wasn't sure if we should install protoc-gen-validate-* in $PATH, so I commented out them at the moment
-      # - name: protoc-gen-validate-cpp
-      # - name: protoc-gen-validate-go
-      # - name: protoc-gen-validate-java
-    checksum:
-      type: github_release
-      asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    description: "Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.13")
+        no_asset: true
+      - version_constraint: semver("<= 0.9.1")
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.2")
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protoc-gen-validate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: protoc-gen-validate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: buildkite
     repo_name: agent

--- a/registry.yaml
+++ b/registry.yaml
@@ -13089,6 +13089,11 @@ packages:
     repo_owner: bufbuild
     repo_name: protoc-gen-validate
     description: "Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate"
+    files:
+      - name: protoc-gen-validate
+      - name: protoc-gen-validate-cpp
+      - name: protoc-gen-validate-go
+      - name: protoc-gen-validate-java
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.13")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
[bufbuild/protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate) Protocol Buffer Validation - Being replaced by github.com/bufbuild/protovalidate

Add all required plugins and updates the version compatibility

Tested via `aqua i` after importing `pkgs/bufbuild/protoc-gen-validate/pkg.yaml`