### PR TITLE
feat: add suzuki-shunsuke/migrate-urfave-cli-v3

### DIFF
--- a/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/migrate-urfave-cli-v3@v0.1.0

--- a/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/registry.yaml
+++ b/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/registry.yaml
@@ -18,7 +18,7 @@ packages:
               - --certificate
               - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/migrate-urfave-cli-v3/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature

--- a/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/registry.yaml
+++ b/pkgs/suzuki-shunsuke/migrate-urfave-cli-v3/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: migrate-urfave-cli-v3
+    description: Migrate github.com/urfave/cli/v2 to v3. This tool doesn't aim to the complete migration. Probably you need to fix code manually after running this tool, but this tool makes the migration easy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: migrate-urfave-cli-v3_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/migrate-urfave-cli-v3/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -54721,6 +54721,35 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: migrate-urfave-cli-v3
+    description: Migrate github.com/urfave/cli/v2 to v3. This tool doesn't aim to the complete migration. Probably you need to fix code manually after running this tool, but this tool makes the migration easy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: migrate-urfave-cli-v3_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/migrate-urfave-cli-v3/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: mkghtag
     description: CLI to create GitHub Tags via API
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -54737,7 +54737,7 @@ packages:
               - --certificate
               - https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3/releases/download/{{.Version}}/migrate-urfave-cli-v3_{{trimV .Version}}_checksums.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/migrate-urfave-cli-v3/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature


### PR DESCRIPTION
[suzuki-shunsuke/migrate-urfave-cli-v3](https://github.com/suzuki-shunsuke/migrate-urfave-cli-v3): Migrate github.com/urfave/cli/v2 to v3. This tool doesn't aim to the complete migration. Probably you need to fix code manually after running this tool, but this tool makes the migration easy

```console
$ aqua g -i suzuki-shunsuke/migrate-urfave-cli-v3
```