### PR TITLE
feat: add neondatabase/neonctl

### DIFF
--- a/pkgs/neondatabase/neonctl/pkg.yaml
+++ b/pkgs/neondatabase/neonctl/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: neondatabase/neonctl@v2.9.0
+  - name: neondatabase/neonctl
+    version: v1.27.4

--- a/pkgs/neondatabase/neonctl/registry.yaml
+++ b/pkgs/neondatabase/neonctl/registry.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: neondatabase
+    repo_name: neonctl
+    description: Neon CLI tool. The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres directly from the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.27.4")
+        asset: neonctl-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: neonctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+          windows: win

--- a/registry.yaml
+++ b/registry.yaml
@@ -42660,6 +42660,31 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: neondatabase
+    repo_name: neonctl
+    description: Neon CLI tool. The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres directly from the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.27.4")
+        asset: neonctl-{{.OS}}
+        format: raw
+        replacements:
+          darwin: macos
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: neonctl-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+          windows: win
+  - type: github_release
     repo_owner: neovim
     repo_name: neovim
     description: Vim-fork focused on extensibility and usability


### PR DESCRIPTION
[neondatabase/neonctl](https://github.com/neondatabase/neonctl): Neon CLI tool. The Neon CLI is a command-line interface that lets you manage Neon Serverless Postgres directly from the terminal.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->