### PR TITLE
feat: add support for arm64 to ninja-build/ninja

### DIFF
--- a/pkgs/ninja-build/ninja/pkg.yaml
+++ b/pkgs/ninja-build/ninja/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: ninja-build/ninja@v1.11.1
+  - name: ninja-build/ninja@v1.12.1
+  - name: ninja-build/ninja
+    version: v1.11.1

--- a/pkgs/ninja-build/ninja/registry.yaml
+++ b/pkgs/ninja-build/ninja/registry.yaml
@@ -11,4 +11,20 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver("< 1.12.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.12.0")
+        supported_envs:
+          - darwin
+          - windows
+          - linux
+        overrides:
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: linux-aarch64
+          - goos: windows
+            goarch: arm64
+            replacements:
+              windows: winarm64
     rosetta2: true

--- a/pkgs/ninja-build/ninja/registry.yaml
+++ b/pkgs/ninja-build/ninja/registry.yaml
@@ -3,28 +3,33 @@ packages:
   - type: github_release
     repo_owner: ninja-build
     repo_name: ninja
-    asset: ninja-{{.OS}}.zip
     description: a small build system with a focus on speed
-    replacements:
-      darwin: mac
-      windows: win
-    supported_envs:
-      - darwin
-      - amd64
-    version_constraint: semver("< 1.12.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.12.0")
+      - version_constraint: semver("<= 1.3.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.11.1")
+        asset: ninja-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+          windows: win
         supported_envs:
           - darwin
           - windows
-          - linux
+          - amd64
+      - version_constraint: "true"
+        asset: ninja-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+          windows: win
         overrides:
           - goos: linux
             goarch: arm64
+            asset: ninja-{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
-              linux: linux-aarch64
+              arm64: aarch64
           - goos: windows
             goarch: arm64
-            replacements:
-              windows: winarm64
-    rosetta2: true
+            asset: ninja-{{.OS}}{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -43148,31 +43148,36 @@ packages:
   - type: github_release
     repo_owner: ninja-build
     repo_name: ninja
-    asset: ninja-{{.OS}}.zip
     description: a small build system with a focus on speed
-    replacements:
-      darwin: mac
-      windows: win
-    supported_envs:
-      - darwin
-      - amd64
-    version_constraint: semver("< 1.12.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.12.0")
+      - version_constraint: semver("<= 1.3.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.11.1")
+        asset: ninja-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+          windows: win
         supported_envs:
           - darwin
           - windows
-          - linux
+          - amd64
+      - version_constraint: "true"
+        asset: ninja-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+          windows: win
         overrides:
           - goos: linux
             goarch: arm64
+            asset: ninja-{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
-              linux: linux-aarch64
+              arm64: aarch64
           - goos: windows
             goarch: arm64
-            replacements:
-              windows: winarm64
-    rosetta2: true
+            asset: ninja-{{.OS}}{{.Arch}}.{{.Format}}
   - type: github_release
     repo_owner: ninxsoft
     repo_name: mist-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -43156,6 +43156,22 @@ packages:
     supported_envs:
       - darwin
       - amd64
+    version_constraint: semver("< 1.12.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.12.0")
+        supported_envs:
+          - darwin
+          - windows
+          - linux
+        overrides:
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: linux-aarch64
+          - goos: windows
+            goarch: arm64
+            replacements:
+              windows: winarm64
     rosetta2: true
   - type: github_release
     repo_owner: ninxsoft


### PR DESCRIPTION
Starting in 1.12, ninja supports arm64 for Linux and Windows. Therefore this adds correct arm64 support.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
