### PR TITLE
Add jkfran/killport

### DIFF
--- a/pkgs/jkfran/killport/pkg.yaml
+++ b/pkgs/jkfran/killport/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: jkfran/killport@v1.1.0
+  - name: jkfran/killport
+    version: v1.0.0
+  - name: jkfran/killport
+    version: v0.8.0
+  - name: jkfran/killport
+    version: v0.5.0
+  - name: jkfran/killport
+    version: v0.1.0

--- a/pkgs/jkfran/killport/registry.yaml
+++ b/pkgs/jkfran/killport/registry.yaml
@@ -26,29 +26,14 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v1.0.0"
-        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+      - version_constraint: semver("<= 0.8.0") || Version == "v1.0.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-        overrides:
-          - goos: darwin
-            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.8.0")
-        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-        overrides:
-          - goos: darwin
-            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+          linux: linux-gnu
         supported_envs:
           - linux
           - darwin
@@ -61,6 +46,4 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-gnu
-        overrides:
-          - goos: linux
-            asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+          linux: linux-gnu

--- a/pkgs/jkfran/killport/registry.yaml
+++ b/pkgs/jkfran/killport/registry.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jkfran
+    repo_name: killport
+    description: A command-line tool to easily kill processes running on a specified port
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+      - version_constraint: Version == "v0.5.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v1.0.0"
+        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: darwin
+            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.8.0")
+        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: darwin
+            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+        overrides:
+          - goos: linux
+            asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -33711,29 +33711,14 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v1.0.0"
-        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+      - version_constraint: semver("<= 0.8.0") || Version == "v1.0.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-        overrides:
-          - goos: darwin
-            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.8.0")
-        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-        overrides:
-          - goos: darwin
-            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+          linux: linux-gnu
         supported_envs:
           - linux
           - darwin
@@ -33746,9 +33731,7 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-gnu
-        overrides:
-          - goos: linux
-            asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+          linux: linux-gnu
   - type: go_install
     repo_owner: jmattheis
     repo_name: goverter

--- a/registry.yaml
+++ b/registry.yaml
@@ -33685,6 +33685,70 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: jkfran
+    repo_name: killport
+    description: A command-line tool to easily kill processes running on a specified port
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+      - version_constraint: Version == "v0.5.0"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v1.0.0"
+        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: darwin
+            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.8.0")
+        asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: darwin
+            asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+        overrides:
+          - goos: linux
+            asset: killport-{{.Arch}}-{{.OS}}-gnu.{{.Format}}
   - type: go_install
     repo_owner: jmattheis
     repo_name: goverter


### PR DESCRIPTION
[jkfran/killport](https://github.com/jkfran/killport) - A command-line tool to easily kill processes running on a specified port

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
