### PR TITLE
feat: add suzuki-shunsuke/rgo

### DIFF
--- a/pkgs/suzuki-shunsuke/rgo/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/rgo/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/suzuki-shunsuke/rgo/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/rgo/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: suzuki-shunsuke/rgo@v0.0.1

--- a/pkgs/suzuki-shunsuke/rgo/registry.yaml
+++ b/pkgs/suzuki-shunsuke/rgo/registry.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: rgo
+    description: rgo is a tiny script to release a Homebrew-tap recipe, Scoop App Manifest, and a winget manifest built with GoReleaser
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/suzuki-shunsuke/rgo/registry.yaml
+++ b/pkgs/suzuki-shunsuke/rgo/registry.yaml
@@ -1,10 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: github_content
     repo_owner: suzuki-shunsuke
     repo_name: rgo
     description: rgo is a tiny script to release a Homebrew-tap recipe, Scoop App Manifest, and a winget manifest built with GoReleaser
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        no_asset: true
+        path: rgo
+        supported_envs:
+          - darwin
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -55466,6 +55466,14 @@ packages:
               - https://github.com/suzuki-shunsuke/renovate-issue-action/releases/download/{{.Version}}/renovate-issue-action_{{trimV .Version}}_checksums.txt.sig
               - --certificate
               - https://github.com/suzuki-shunsuke/renovate-issue-action/releases/download/{{.Version}}/renovate-issue-action_{{trimV .Version}}_checksums.txt.pem
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: rgo
+    description: rgo is a tiny script to release a Homebrew-tap recipe, Scoop App Manifest, and a winget manifest built with GoReleaser
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
   - type: github_content
     repo_owner: suzuki-shunsuke
     repo_name: rjsa

--- a/registry.yaml
+++ b/registry.yaml
@@ -55466,14 +55466,17 @@ packages:
               - https://github.com/suzuki-shunsuke/renovate-issue-action/releases/download/{{.Version}}/renovate-issue-action_{{trimV .Version}}_checksums.txt.sig
               - --certificate
               - https://github.com/suzuki-shunsuke/renovate-issue-action/releases/download/{{.Version}}/renovate-issue-action_{{trimV .Version}}_checksums.txt.pem
-  - type: github_release
+  - type: github_content
     repo_owner: suzuki-shunsuke
     repo_name: rgo
     description: rgo is a tiny script to release a Homebrew-tap recipe, Scoop App Manifest, and a winget manifest built with GoReleaser
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        no_asset: true
+        path: rgo
+        supported_envs:
+          - darwin
+          - linux
   - type: github_content
     repo_owner: suzuki-shunsuke
     repo_name: rjsa


### PR DESCRIPTION
[suzuki-shunsuke/rgo](https://github.com/suzuki-shunsuke/rgo): rgo is a tiny script to release a Homebrew-tap recipe, Scoop App Manifest, and a winget manifest built with GoReleaser

```console
$ aqua g -i suzuki-shunsuke/rgo
```