### PR TITLE
feat(sigstore/cosign): cosign config

### DIFF
--- a/pkgs/sigstore/cosign/pkg.yaml
+++ b/pkgs/sigstore/cosign/pkg.yaml
@@ -1,2 +1,16 @@
 packages:
   - name: sigstore/cosign@v2.4.3
+  - name: sigstore/cosign
+    version: v1.4.1
+  - name: sigstore/cosign
+    version: v1.2.1
+  - name: sigstore/cosign
+    version: v0.6.0
+  - name: sigstore/cosign
+    version: v0.5.0
+  - name: sigstore/cosign
+    version: v0.3.1
+  - name: sigstore/cosign
+    version: v0.2.0
+  - name: sigstore/cosign
+    version: v0.1.0

--- a/pkgs/sigstore/cosign/registry.yaml
+++ b/pkgs/sigstore/cosign/registry.yaml
@@ -8,10 +8,13 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
+        asset: cosign
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
       - version_constraint: Version == "v0.2.0"
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/sigstore/cosign/registry.yaml
+++ b/pkgs/sigstore/cosign/registry.yaml
@@ -3,14 +3,106 @@ packages:
   - type: github_release
     repo_owner: sigstore
     repo_name: cosign
-    format: raw
-    asset: cosign-{{.OS}}-{{.Arch}}
-    description: Container Signing
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    checksum:
-      type: github_release
-      asset: cosign_checksums.txt
-      algorithm: sha256
+    description: Code signing and transparency for containers and binaries
+    version_filter: not (Version matches "-dev$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: cosign.sha256
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.6.0"
+        asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_linux_amd64
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_darwin_amd64
+          - goos: darwin
+            goarch: arm64
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_darwin_arm64
+          - goos: windows
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_windows_amd64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.2.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.4.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/sigstore/cosign/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.sig

--- a/pkgs/sigstore/cosign/registry.yaml
+++ b/pkgs/sigstore/cosign/registry.yaml
@@ -103,9 +103,9 @@ packages:
             opts:
               - --certificate
               - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/sigstore/cosign/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - keyless@projectsigstore.iam.gserviceaccount.com
               - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
+              - https://accounts.google.com
               - --signature
               - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.sig

--- a/pkgs/sigstore/cosign/scaffold.yaml
+++ b/pkgs/sigstore/cosign/scaffold.yaml
@@ -1,0 +1,5 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: sigstore/cosign
+all_assets_filter: Asset matches "^cosign"
+version_filter: not (Version matches "-dev$")

--- a/registry.yaml
+++ b/registry.yaml
@@ -51966,10 +51966,10 @@ packages:
             opts:
               - --certificate
               - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/sigstore/cosign/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - keyless@projectsigstore.iam.gserviceaccount.com
               - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
+              - https://accounts.google.com
               - --signature
               - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.sig
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -51871,10 +51871,13 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
+        asset: cosign
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
       - version_constraint: Version == "v0.2.0"
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -51866,17 +51866,109 @@ packages:
   - type: github_release
     repo_owner: sigstore
     repo_name: cosign
-    format: raw
-    asset: cosign-{{.OS}}-{{.Arch}}
-    description: Container Signing
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    checksum:
-      type: github_release
-      asset: cosign_checksums.txt
-      algorithm: sha256
+    description: Code signing and transparency for containers and binaries
+    version_filter: not (Version matches "-dev$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: Version == "v0.2.0"
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: cosign.sha256
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.6.0"
+        asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_linux_amd64
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_darwin_amd64
+          - goos: darwin
+            goarch: arm64
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_darwin_arm64
+          - goos: windows
+            asset: cosign_{{.OS}}_{{.Arch}}_{{trimV .Version}}_windows_amd64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.2.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.4.1")
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: cosign-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cosign_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/sigstore/cosign/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/sigstore/cosign/releases/download/{{.Version}}/cosign_checksums.txt-keyless.sig
   - type: github_release
     repo_owner: sigstore
     repo_name: gitsign


### PR DESCRIPTION
https://github.com/sigstore/cosign/releases

Note: I saw this error once when doing `cmdx t`, apparently a race condition if the already installed cosign is verifying the signature of some other downloaded one while the same version (as the one doing a verification) is being downloaded.
```
ERRO[0320] install the package                           aqua_version=2.46.1-1 env=linux/amd64 error="open the file (/root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/sigstore/cosign/v2.4.3/cosign-linux-amd64/cosign-linux-amd64): open /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/sigstore/cosign/v2.4.3/cosign-linux-amd64/cosign-linux-amd64: text file busy" package_name=sigstore/cosign package_version=v2.4.3 program=aqua registry=standard
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
