### PR TITLE
feat: add github/github-mcp-server

### DIFF
--- a/pkgs/github/github-mcp-server/pkg.yaml
+++ b/pkgs/github/github-mcp-server/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: github/github-mcp-server@v0.1.1

--- a/pkgs/github/github-mcp-server/registry.yaml
+++ b/pkgs/github/github-mcp-server/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: github
+    repo_name: github-mcp-server
+    description: GitHub's official MCP Server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: github-mcp-server_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: github-mcp-server_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -27818,6 +27818,27 @@ packages:
           - amd64
   - type: github_release
     repo_owner: github
+    repo_name: github-mcp-server
+    description: GitHub's official MCP Server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: github-mcp-server_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: github-mcp-server_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: github
     repo_name: licensed
     asset: licensed-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
     description: A Ruby gem to cache and verify the licenses of dependencies


### PR DESCRIPTION
[github/github-mcp-server](https://github.com/github/github-mcp-server): GitHub's official MCP Server

```console
$ aqua g -i github/github-mcp-server
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ github-mcp-server
A GitHub MCP server that handles various tools and resources.

Usage:
  server [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  stdio       Start stdio server

Flags:
      --enable-command-logging   When enabled, the server will log all command requests and responses to the log file
      --export-translations      Save translations to a JSON file
      --gh-host string           Specify the GitHub hostname (for GitHub Enterprise etc.)
  -h, --help                     help for server
      --log-file string          Path to log file
      --pretty-print-json        Pretty print JSON output
      --read-only                Restrict the server to read-only operations
  -v, --version                  version for server

Use "server [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/github/github-mcp-server
