### PR TITLE
feat: add reteps/dockerfmt

### DIFF
--- a/pkgs/reteps/dockerfmt/pkg.yaml
+++ b/pkgs/reteps/dockerfmt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: reteps/dockerfmt@0.2.6

--- a/pkgs/reteps/dockerfmt/registry.yaml
+++ b/pkgs/reteps/dockerfmt/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: reteps
+    repo_name: dockerfmt
+    description: Dockerfile format and parser. a modern dockfmt
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dockerfmt-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -48924,6 +48924,22 @@ packages:
       asset: SHA256SUMS
       algorithm: sha256
   - type: github_release
+    repo_owner: reteps
+    repo_name: dockerfmt
+    description: Dockerfile format and parser. a modern dockfmt
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dockerfmt-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
     repo_owner: reviewdog
     repo_name: reviewdog
     asset: reviewdog_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[reteps/dockerfmt](https://github.com/reteps/dockerfmt): Dockerfile format and parser. a modern dockfmt

```console
$ aqua g -i reteps/dockerfmt
```

Close #34217