### PR TITLE
feat: add kubernetes-sigs/gwctl

### DIFF
--- a/pkgs/kubernetes-sigs/gwctl/pkg.yaml
+++ b/pkgs/kubernetes-sigs/gwctl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubernetes-sigs/gwctl@v0.1.0

--- a/pkgs/kubernetes-sigs/gwctl/registry.yaml
+++ b/pkgs/kubernetes-sigs/gwctl/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: gwctl
+    description: gwctl is a command-line tool for managing and understanding Gateway API resources in your Kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gwctl_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gwctl_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -37578,6 +37578,27 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: kubernetes-sigs
+    repo_name: gwctl
+    description: gwctl is a command-line tool for managing and understanding Gateway API resources in your Kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gwctl_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gwctl_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: kubernetes-sigs
     repo_name: kind
     asset: kind-{{.OS}}-{{.Arch}}
     format: raw


### PR DESCRIPTION
[kubernetes-sigs/gwctl](https://github.com/kubernetes-sigs/gwctl): gwctl is a command-line tool for managing and understanding Gateway API resources in your Kubernetes cluster

```console
$ aqua g -i kubernetes-sigs/gwctl
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@01de2cdaa03c:/workspace# gwctl --help
gwctl provides a familiar kubectl-like interface for navigating the Kubernetes Gateway API's multi-resource model, offering visibility into resource relationships and the policies that affect them.

Usage:
  gwctl [command]

Available Commands:
  analyze     Analyze resources by file names or stdin
  apply       Apply the provided resources from file or stdin to the cluster.
  completion  Generate the autocompletion script for the specified shell
  delete      Delete resources by file names, stdin, resources and names, or by resources and label selector.
  describe    Display one or many resources
  get         Display one or many resources
  help        Help about any command
  version     Print the version information of gwctl

Flags:
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/root/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --disable-compression            If true, opt-out of response compression for all requests to the server
  -h, --help                           help for gwctl
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
  -v, --v int                          number for the log level verbosity (defaults to 0)

Use "gwctl [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/kubernetes-sigs/gwctl/blob/main/README.md
