### PR TITLE
feat: add uutils/coreutils

### DIFF
--- a/pkgs/uutils/coreutils/pkg.yaml
+++ b/pkgs/uutils/coreutils/pkg.yaml
@@ -1,0 +1,22 @@
+packages:
+  - name: uutils/coreutils@0.0.30
+  - name: uutils/coreutils
+    version: 0.0.28
+  - name: uutils/coreutils
+    version: 0.0.27
+  - name: uutils/coreutils
+    version: 0.0.26
+  - name: uutils/coreutils
+    version: 0.0.23
+  - name: uutils/coreutils
+    version: 0.0.22
+  - name: uutils/coreutils
+    version: 0.0.14
+  - name: uutils/coreutils
+    version: 0.0.7
+  - name: uutils/coreutils
+    version: 0.0.2
+  - name: uutils/coreutils
+    version: 0.0.1.1
+  - name: uutils/coreutils
+    version: 0.0.1

--- a/pkgs/uutils/coreutils/registry.yaml
+++ b/pkgs/uutils/coreutils/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Cross-platform Rust rewrite of the GNU coreutils
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["0.0.9", "0.0.29"]
+      - version_constraint: Version in ["0.0.9", "0.0.24", "0.0.25", "0.0.29"]
         no_asset: true
       - version_constraint: Version == "0.0.1"
         asset: uutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -23,9 +23,12 @@ packages:
             format: zip
         supported_envs:
           - darwin
+          - linux/amd64
           - windows
-          - amd64
-      - version_constraint: Version in ["0.0.1.1", "0.0.8"]
+        files:
+          - name: uutils
+            src: uutils-{{.Version}}-{{.Arch}}-{{.OS}}/uutils
+      - version_constraint: Version == "0.0.1.1"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
@@ -33,19 +36,18 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.2"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -54,14 +56,16 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.7"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -69,41 +73,50 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
+          linux: unknown-linux-musl
         supported_envs:
-          - linux
           - darwin
+          - linux/amd64
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.14"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
         supported_envs:
-          - linux
-          - windows/amd64
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
+      - version_constraint: semver("<= 0.0.22")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.23"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -112,18 +125,18 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.26"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -135,15 +148,15 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
           - goos: windows
             format: zip
         supported_envs:
-          - linux
           - darwin/arm64
-          - windows/amd64
+          - linux
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.27"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -157,41 +170,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "0.0.28"
-        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.0.22")
-        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.0.25")
-        no_asset: true
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: "true"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -204,3 +185,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils

--- a/pkgs/uutils/coreutils/registry.yaml
+++ b/pkgs/uutils/coreutils/registry.yaml
@@ -1,0 +1,206 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: uutils
+    repo_name: coreutils
+    description: Cross-platform Rust rewrite of the GNU coreutils
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["0.0.9", "0.0.29"]
+        no_asset: true
+      - version_constraint: Version == "0.0.1"
+        asset: uutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["0.0.1.1", "0.0.8"]
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.2"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.7"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "0.0.14"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: Version == "0.0.23"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.26"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: Version == "0.0.27"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.28"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.22")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.25")
+        no_asset: true
+      - version_constraint: "true"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -60069,6 +60069,210 @@ packages:
           - name: pv-migrate
             src: bin/{{.OS}}/pv-migrate
   - type: github_release
+    repo_owner: uutils
+    repo_name: coreutils
+    description: Cross-platform Rust rewrite of the GNU coreutils
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["0.0.9", "0.0.29"]
+        no_asset: true
+      - version_constraint: Version == "0.0.1"
+        asset: uutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["0.0.1.1", "0.0.8"]
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.2"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.7"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "0.0.14"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: Version == "0.0.23"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.26"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: Version == "0.0.27"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "0.0.28"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.22")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.0.25")
+        no_asset: true
+      - version_constraint: "true"
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox
     description: Encryption for Git users

--- a/registry.yaml
+++ b/registry.yaml
@@ -60074,7 +60074,7 @@ packages:
     description: Cross-platform Rust rewrite of the GNU coreutils
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["0.0.9", "0.0.29"]
+      - version_constraint: Version in ["0.0.9", "0.0.24", "0.0.25", "0.0.29"]
         no_asset: true
       - version_constraint: Version == "0.0.1"
         asset: uutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -60091,9 +60091,12 @@ packages:
             format: zip
         supported_envs:
           - darwin
+          - linux/amd64
           - windows
-          - amd64
-      - version_constraint: Version in ["0.0.1.1", "0.0.8"]
+        files:
+          - name: uutils
+            src: uutils-{{.Version}}-{{.Arch}}-{{.OS}}/uutils
+      - version_constraint: Version == "0.0.1.1"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
@@ -60101,19 +60104,18 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.2"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60122,14 +60124,16 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.7"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60137,41 +60141,50 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
+          linux: unknown-linux-musl
         supported_envs:
-          - linux
           - darwin
+          - linux/amd64
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.14"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
         supported_envs:
-          - linux
-          - windows/amd64
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
+      - version_constraint: semver("<= 0.0.22")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.23"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60180,18 +60193,18 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.26"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60203,15 +60216,15 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
           - goos: windows
             format: zip
         supported_envs:
-          - linux
           - darwin/arm64
-          - windows/amd64
+          - linux
+          - windows
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: Version == "0.0.27"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60225,41 +60238,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "0.0.28"
-        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.0.22")
-        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.0.25")
-        no_asset: true
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: "true"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -60272,6 +60253,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
   - type: github_release
     repo_owner: uw-labs
     repo_name: strongbox


### PR DESCRIPTION
[uutils/coreutils](https://github.com/uutils/coreutils): Cross-platform Rust rewrite of the GNU coreutils

```console
$ aqua g -i uutils/coreutils
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ coreutils
coreutils 0.0.30 (multi-call binary)

Usage: coreutils [function [arguments...]]
       coreutils --list

Options:
      --list    lists all defined functions, one per row

Currently defined functions:

    [, arch, b2sum, b3sum, base32, base64, basename, basenc, cat, chgrp, chmod, chown, chroot,
    cksum, comm, cp, csplit, cut, date, dd, df, dir, dircolors, dirname, du, echo, env, expand,
    expr, factor, false, fmt, fold, groups, hashsum, head, hostid, hostname, id, install,
    join, kill, link, ln, logname, ls, md5sum, mkdir, mkfifo, mknod, mktemp, more, mv, nice,
    nl, nohup, nproc, numfmt, od, paste, pathchk, pr, printenv, printf, ptx, pwd, readlink,
    realpath, rm, rmdir, seq, sha1sum, sha224sum, sha256sum, sha3-224sum, sha3-256sum, sha3-
    384sum, sha3-512sum, sha384sum, sha3sum, sha512sum, shake128sum, shake256sum, shred, shuf,
    sleep, sort, split, stat, stty, sum, sync, tac, tail, tee, test, timeout, touch, tr, true,
    truncate, tsort, tty, uname, unexpand, uniq, unlink, vdir, wc, whoami, yes
```

#### Execution environment

```console
$ coreutils uname -a
Linux dsk 6.11.0-21-generic #21~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Feb 24 16:52:15 UTC 2 x86_64 GNU/Linux
```
#### Differences between GNU and Musl versions of Linux

```console
$ ./coreutils-0.0.30-x86_64-unknown-linux-gnu/coreutils --list > /tmp/coreutils-gnu
$ ./coreutils-0.0.30-x86_64-unknown-linux-musl/coreutils --list > /tmp/coreutils-musl
$ diff -urN /tmp/coreutils-gnu /tmp/coreutils-musl
```

```patch
--- /tmp/coreutils-gnu  2025-04-10 18:13:14.014310865 +0900
+++ /tmp/coreutils-musl 2025-04-10 18:13:21.742407130 +0900
@@ -59,7 +59,6 @@
 od
 paste
 pathchk
-pinky
 pr
 printenv
 printf
@@ -88,7 +87,6 @@
 sort
 split
 stat
-stdbuf
 stty
 sum
 sync
@@ -107,10 +105,7 @@
 unexpand
 uniq
 unlink
-uptime
-users
 vdir
 wc
-who
 whoami
 yes
```

If files such as configuration file are needed, please share them.

Reference

- https://uutils.github.io/coreutils/
- https://uutils.github.io/coreutils/docs/
- https://uutils.github.io/coreutils/docs/platforms.html#utility-compatibility-per-platform