### PR TITLE
feat(tailwindlabs/tailwindcss): scaffold tailwindlabs/tailwindcss

### DIFF
--- a/pkgs/tailwindlabs/tailwindcss/pkg.yaml
+++ b/pkgs/tailwindlabs/tailwindcss/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: tailwindlabs/tailwindcss@v4.1.3
+  - name: tailwindlabs/tailwindcss
+    version: v3.4.17
+  - name: tailwindlabs/tailwindcss
+    version: v3.2.7
+  - name: tailwindlabs/tailwindcss
+    version: v3.2.4
+  - name: tailwindlabs/tailwindcss
+    version: v3.0.7

--- a/pkgs/tailwindlabs/tailwindcss/registry.yaml
+++ b/pkgs/tailwindlabs/tailwindcss/registry.yaml
@@ -53,3 +53,6 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl

--- a/pkgs/tailwindlabs/tailwindcss/registry.yaml
+++ b/pkgs/tailwindlabs/tailwindcss/registry.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tailwindlabs
+    repo_name: tailwindcss
+    description: A utility-first CSS framework for rapid UI development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.0.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.0.7")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 3.2.4")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: semver("<= 3.2.7")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: semver("<= 3.4.17")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -57039,6 +57039,9 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl
   - type: github_release
     repo_owner: takaishi
     repo_name: awscost

--- a/registry.yaml
+++ b/registry.yaml
@@ -56987,6 +56987,59 @@ packages:
       - linux
       - darwin
   - type: github_release
+    repo_owner: tailwindlabs
+    repo_name: tailwindcss
+    description: A utility-first CSS framework for rapid UI development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.0.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.0.7")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 3.2.4")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: semver("<= 3.2.7")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: semver("<= 3.4.17")
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: tailwindcss-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: takaishi
     repo_name: awscost
     description: Print AWS costs to text or graph image


### PR DESCRIPTION
[tailwindlabs/tailwindcss](https://github.com/tailwindlabs/tailwindcss) - A utility-first CSS framework for rapid UI development

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adding support for https://github.com/tailwindlabs/tailwindcss/releases/ 

Blogpost: https://tailwindcss.com/blog/standalone-cli

Using binary release would allow developers to use tailwindcss without having to install node.


> linux: use the asset for not gnu but musl if both of them are supported

This release has both, but the `musl` part is at the end of the asset name, so 

```yaml
replacements:
  linux: linux-musl
```

like i've seen in other packages, wouldn't work. Should I add `{{.Format}}` at the end and override that? Or is there a less hacky way of fixing this?
