### PR TITLE
feat: add open-policy-agent/gatekeeper

### DIFF
--- a/pkgs/open-policy-agent/gatekeeper/pkg.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: open-policy-agent/gatekeeper@v3.19.0
-  - name: open-policy-agent/gatekeeper
-    version: v3.12.0-rc.0

--- a/pkgs/open-policy-agent/gatekeeper/pkg.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: open-policy-agent/gatekeeper@v3.19.0
+  - name: open-policy-agent/gatekeeper
+    version: v3.12.0-rc.0

--- a/pkgs/open-policy-agent/gatekeeper/registry.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/registry.yaml
@@ -20,3 +20,5 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: gator

--- a/pkgs/open-policy-agent/gatekeeper/registry.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/registry.yaml
@@ -4,15 +4,17 @@ packages:
     repo_owner: open-policy-agent
     repo_name: gatekeeper
     description: "Gatekeeper - Policy Controller for Kubernetes"
+    files:
+      - name: gator
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v3.12.0-rc.0"
-        no_asset: true
-      - version_constraint: semver("<= 3.7.0-beta.2")
+      - version_constraint: Version == "v3.12.0-rc.0" || semver("<= 3.7.0-beta.2")
         no_asset: true
       - version_constraint: "true"
         asset: gator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gator
         checksum:
           type: github_release
           asset: sha256sums.txt
@@ -20,5 +22,3 @@ packages:
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: gator

--- a/pkgs/open-policy-agent/gatekeeper/registry.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/registry.yaml
@@ -7,10 +7,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v3.12.0-rc.0"
-        checksum:
-          type: github_release
-          asset: sha256sums.txt
-          algorithm: sha256
+        no_asset: true
       - version_constraint: semver("<= 3.7.0-beta.2")
         no_asset: true
       - version_constraint: "true"

--- a/pkgs/open-policy-agent/gatekeeper/registry.yaml
+++ b/pkgs/open-policy-agent/gatekeeper/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: open-policy-agent
+    repo_name: gatekeeper
+    description: "Gatekeeper - Policy Controller for Kubernetes"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v3.12.0-rc.0"
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.7.0-beta.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: gator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -45055,6 +45055,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: gator
   - type: github_release
     repo_owner: open-policy-agent
     repo_name: opa

--- a/registry.yaml
+++ b/registry.yaml
@@ -45042,10 +45042,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v3.12.0-rc.0"
-        checksum:
-          type: github_release
-          asset: sha256sums.txt
-          algorithm: sha256
+        no_asset: true
       - version_constraint: semver("<= 3.7.0-beta.2")
         no_asset: true
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -45060,15 +45060,17 @@ packages:
     repo_owner: open-policy-agent
     repo_name: gatekeeper
     description: "Gatekeeper - Policy Controller for Kubernetes"
+    files:
+      - name: gator
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v3.12.0-rc.0"
-        no_asset: true
-      - version_constraint: semver("<= 3.7.0-beta.2")
+      - version_constraint: Version == "v3.12.0-rc.0" || semver("<= 3.7.0-beta.2")
         no_asset: true
       - version_constraint: "true"
         asset: gator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gator
         checksum:
           type: github_release
           asset: sha256sums.txt
@@ -45076,8 +45078,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: gator
   - type: github_release
     repo_owner: open-policy-agent
     repo_name: opa

--- a/registry.yaml
+++ b/registry.yaml
@@ -45037,6 +45037,29 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: open-policy-agent
+    repo_name: gatekeeper
+    description: "Gatekeeper - Policy Controller for Kubernetes"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v3.12.0-rc.0"
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.7.0-beta.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: gator-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: open-policy-agent
     repo_name: opa
     description: Open Policy Agent (OPA) is an open source, general-purpose policy engine
     version_constraint: "false"


### PR DESCRIPTION
[open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper): Gatekeeper - Policy Controller for Kubernetes

```console
$ aqua g -i open-policy-agent/gatekeeper
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@8e149099f995:/workspace# gator --help
gator is a suite of authorship tools for Gatekeeper

Usage:
  gator [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  expand      expand allow for testing generator resource expansion configs by expanding a generator resource and outputting the resultant resource(s)
  help        Help about any command
  sync        Manage SyncSets and Config
  test        test evaluates resources against policies as defined by constraint templates and constraints. Note: The alpha `gator test` has been renamed to `gator verify`.
  verify      verify suites of tests on Gatekeeper Constraints
  version     Prints the version

Flags:
  -h, --help      help for gator
  -v, --version   version for gator

Use "gator [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://open-policy-agent.github.io/gatekeeper/website/docs/gator
