### PR TITLE
feat: add mackee/go-readability

### DIFF
--- a/pkgs/mackee/go-readability/pkg.yaml
+++ b/pkgs/mackee/go-readability/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mackee/go-readability@v0.3.1

--- a/pkgs/mackee/go-readability/registry.yaml
+++ b/pkgs/mackee/go-readability/registry.yaml
@@ -17,3 +17,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: readability

--- a/pkgs/mackee/go-readability/registry.yaml
+++ b/pkgs/mackee/go-readability/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mackee
+    repo_name: go-readability
+    description: "Extract readable content from web pages - Mozilla’s and Mizchi Readability ported to Go"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-readability_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/mackee/go-readability/registry.yaml
+++ b/pkgs/mackee/go-readability/registry.yaml
@@ -4,12 +4,16 @@ packages:
     repo_owner: mackee
     repo_name: go-readability
     description: "Extract readable content from web pages - Mozilla’s and Mizchi Readability ported to Go"
+    files:
+      - name: readability
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: go-readability_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: readability
         checksum:
           type: github_release
           asset: checksums.txt
@@ -17,5 +21,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        files:
-          - name: readability

--- a/registry.yaml
+++ b/registry.yaml
@@ -40151,12 +40151,16 @@ packages:
     repo_owner: mackee
     repo_name: go-readability
     description: "Extract readable content from web pages - Mozilla’s and Mizchi Readability ported to Go"
+    files:
+      - name: readability
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: go-readability_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: readability
         checksum:
           type: github_release
           asset: checksums.txt
@@ -40164,8 +40168,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        files:
-          - name: readability
   - type: github_release
     repo_owner: maddyblue
     repo_name: sqlfmt

--- a/registry.yaml
+++ b/registry.yaml
@@ -40148,6 +40148,23 @@ packages:
       asset: slides_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: mackee
+    repo_name: go-readability
+    description: "Extract readable content from web pages - Mozilla’s and Mizchi Readability ported to Go"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-readability_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: maddyblue
     repo_name: sqlfmt
     aliases:

--- a/registry.yaml
+++ b/registry.yaml
@@ -40164,6 +40164,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        files:
+          - name: readability
   - type: github_release
     repo_owner: maddyblue
     repo_name: sqlfmt


### PR DESCRIPTION
[mackee/go-readability](https://github.com/mackee/go-readability): Extract readable content from web pages - Mozilla’s and Mizchi Readability ported to Go

```console
$ aqua g -i mackee/go-readability
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ readability --help
Usage: readability [options] <url|file_path>

readability is a command-line tool that extracts the main content from a web page.
The web page to be processed can be specified as a URL, a file path, or stdin.

Options:
  --format <format>  Output format: html or markdown (default: html)
  --metadata         Output metadata as JSON instead of content
  --help             Show this help message

Examples:
  readability https://example.com/article
  readability ./article.html
  readability --format markdown https://example.com/article
  readability --metadata https://example.com/article
  cat ./article.html | readability --format markdown
```

https://github.com/mackee/go-readability/blob/main/README.md#using-the-cli-tool

```
# Extract content from a URL
readability https://example.com/article

# Save the extracted content to a file
readability https://example.com/article > article.html

# Output as markdown
readability --format markdown https://example.com/article > article.md

# Output metadata as JSON
readability --metadata https://example.com/article
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/mozilla/readability
- https://github.com/mizchi/readability
- https://github.com/mackee/go-readability
