### PR TITLE
fix(theseus-rs/postgresql-binaries): replace musl with gnu

### DIFF
--- a/pkgs/theseus-rs/postgresql-binaries/registry.yaml
+++ b/pkgs/theseus-rs/postgresql-binaries/registry.yaml
@@ -19,7 +19,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu # https://github.com/aquaproj/aqua-registry/issues/34136
           windows: pc-windows-msvc
         overrides:
           - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -58896,7 +58896,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu # https://github.com/aquaproj/aqua-registry/issues/34136
           windows: pc-windows-msvc
         overrides:
           - goos: windows


### PR DESCRIPTION
Close #34136

- https://github.com/aquaproj/aqua-registry/issues/34136