### PR TITLE
feat(k1LoW/octocov): Add linux/arm64 package

### DIFF
--- a/pkgs/k1LoW/octocov/pkg.yaml
+++ b/pkgs/k1LoW/octocov/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: k1LoW/octocov@v0.66.0
   - name: k1LoW/octocov
+    version: v0.51.1
+  - name: k1LoW/octocov
     version: v0.40.1

--- a/pkgs/k1LoW/octocov/registry.yaml
+++ b/pkgs/k1LoW/octocov/registry.yaml
@@ -10,16 +10,20 @@ packages:
       - goos: linux
         format: tar.gz
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
-    checksum:
-      type: github_release
-      asset: checksums-{{.OS}}.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.41.0")
+    version_constraint: semver(">= 0.51.1")
     version_overrides:
+      - version_constraint: semver(">= 0.41.0")
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
       - version_constraint: "true"
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -35939,19 +35939,23 @@ packages:
       - goos: linux
         format: tar.gz
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
-    checksum:
-      type: github_release
-      asset: checksums-{{.OS}}.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.41.0")
+    version_constraint: semver(">= 0.51.1")
     version_overrides:
+      - version_constraint: semver(">= 0.41.0")
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
       - version_constraint: "true"
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
   - type: github_release
     repo_owner: k1LoW
     repo_name: oldstable


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Add linux/arm64 package for k1LoW/octocov.
From v0.51.1, octocov supports linux/arm64 package.

https://github.com/k1LoW/octocov/releases/tag/v0.51.1

```console
$ cmdx t k1LoW/octocov 
+ PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

bash scripts/start.sh
bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry exists
[INFO] Creating a container aqua-registry
[INFO] Get a GitHub Access token by gh auth token
800615ab1d104130327ce21ad3bdb4b4a61d0bb3410eb6c1a0762808dc0e9a9e
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] create a symbolic link                        aqua_version=2.48.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] create a symbolic link                        aqua_version=2.48.2 command=octocov env=linux/amd64 package_name=k1LoW/octocov package_version=v0.66.0 program=aqua
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=k1LoW/octocov package_version=v0.66.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=k1LoW/octocov package_version=v0.51.1 program=aqua registry=standard
INFO[0001] downloading a checksum file                   aqua_version=2.48.2 env=linux/amd64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=k1LoW/octocov package_version=v0.51.1 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=k1LoW/octocov package_version=v0.66.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=k1LoW/octocov package_version=v0.51.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=k1LoW/octocov package_version=v0.66.0 program=aqua registry=standard
INFO[0002] downloading a checksum file                   aqua_version=2.48.2 env=darwin/amd64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=k1LoW/octocov package_version=v0.51.1 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=k1LoW/octocov package_version=v0.66.0 program=aqua registry=standard
INFO[0002] downloading a checksum file                   aqua_version=2.48.2 env=darwin/arm64 package_name=k1LoW/octocov package_version=v0.40.1 program=aqua registry=standard
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Creating a container aqua-registry-windows
[INFO] Get a GitHub Access token by gh auth token
faeddcd5768e82e0367a174eac5a6083c3f1658a73d30650d48ae84d5832eb14
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] create a symbolic link                        aqua_version=2.48.2 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=windows/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
```
