### PR TITLE
feat(block/goose): Add block/goose

### DIFF
--- a/pkgs/block/goose/pkg.yaml
+++ b/pkgs/block/goose/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: block/goose@v1.0.19
+  - name: block/goose
+    version: v1.0-beta4
+  - name: block/goose
+    version: v1.0-beta3
+  - name: block/goose
+    version: v1.0.0-alpha.1
+  - name: block/goose
+    version: canary

--- a/pkgs/block/goose/pkg.yaml
+++ b/pkgs/block/goose/pkg.yaml
@@ -1,10 +1,4 @@
 packages:
   - name: block/goose@v1.0.19
   - name: block/goose
-    version: v1.0-beta4
-  - name: block/goose
-    version: v1.0-beta3
-  - name: block/goose
-    version: v1.0.0-alpha.1
-  - name: block/goose
-    version: canary
+    version: v1.0.0

--- a/pkgs/block/goose/registry.yaml
+++ b/pkgs/block/goose/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: block
+    repo_name: goose
+    description: "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.0-alpha.1"
+      - version_constraint: Version == "v1.0-beta3"
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v1.0-beta4"
+      - version_constraint: Version in ["stable", "stable"]
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.9.11")
+        no_asset: true
+      - version_constraint: "true"
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/block/goose/registry.yaml
+++ b/pkgs/block/goose/registry.yaml
@@ -6,35 +6,9 @@ packages:
     description: "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v1.0.0-alpha.1"
-      - version_constraint: Version == "v1.0-beta3"
-        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "v1.0-beta4"
-      - version_constraint: Version in ["stable", "stable"]
-        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.9.11")
-        no_asset: true
+      - version_constraint: semver("< 1.0.0")
+        error_message: |
+          Please use a version later than v1.0.
       - version_constraint: "true"
         asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2

--- a/registry.yaml
+++ b/registry.yaml
@@ -12983,6 +12983,52 @@ packages:
           - name: hwatch
             src: hwatch/hwatch
   - type: github_release
+    repo_owner: block
+    repo_name: goose
+    description: "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.0-alpha.1"
+      - version_constraint: Version == "v1.0-beta3"
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v1.0-beta4"
+      - version_constraint: Version in ["stable", "stable"]
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.9.11")
+        no_asset: true
+      - version_constraint: "true"
+        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: bloznelis
     repo_name: typioca
     asset: typioca-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -12988,35 +12988,9 @@ packages:
     description: "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v1.0.0-alpha.1"
-      - version_constraint: Version == "v1.0-beta3"
-        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "v1.0-beta4"
-      - version_constraint: Version in ["stable", "stable"]
-        asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.9.11")
-        no_asset: true
+      - version_constraint: semver("< 1.0.0")
+        error_message: |
+          Please use a version later than v1.0.
       - version_constraint: "true"
         asset: goose-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Added [block/goose](https://github.com/block/goose).
There is a install script like the following. ([document](https://block.github.io/goose/docs/getting-started/installation/))
```
curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
```
However, if aqua support block/goose, it's more helpful.
I used `cmdx s block/goose`.
However, there were many unstable releases such as beta, alpha.
Therefore, I changed scaffolding template to ignore under v1.0.
Please tell me if it's not good 🙇 

# Test
```console
$ cmdx t block/goose 
+ PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

bash scripts/start.sh
bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry exists
[INFO] Creating a container aqua-registry
[INFO] Get a GitHub Access token by gh auth token
0a6ad5b021d4f1a3217cb8884206b93c95772e77a78580878b3b58f88c997833
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] create a symbolic link                        aqua_version=2.48.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] create a symbolic link                        aqua_version=2.48.2 command=goose env=linux/amd64 package_name=block/goose package_version=v1.0.19 program=aqua
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=block/goose package_version=v1.0.0 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/amd64 package_name=block/goose package_version=v1.0.19 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=block/goose package_version=v1.0.19 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=linux/arm64 package_name=block/goose package_version=v1.0.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=block/goose package_version=v1.0.19 program=aqua registry=standard
INFO[0001] download and unarchive the package            aqua_version=2.48.2 env=darwin/amd64 package_name=block/goose package_version=v1.0.0 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=block/goose package_version=v1.0.19 program=aqua registry=standard
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=darwin/arm64 package_name=block/goose package_version=v1.0.0 program=aqua registry=standard
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Creating a container aqua-registry-windows
[INFO] Get a GitHub Access token by gh auth token
c0a7b96d04c340d299066661176b337420747534ad4774af572f1e50e19719f2
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0001] create a symbolic link                        aqua_version=2.48.2 env=windows/amd64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.48.2 env=windows/arm64 package_name=aqua-proxy package_version=v1.2.8 program=aqua registry=

$ git diff
diff --git a/aqua/test.yaml b/aqua/test.yaml
index 6983d3130..3834b44f7 100644
--- a/aqua/test.yaml
+++ b/aqua/test.yaml
@@ -8,3 +8,4 @@ registries:
     type: local
     path: ../registry.yaml
 packages:
+  - name: block/goose@v1.0.19

$ AQUA_CONFIG=aqua/test.yaml goose --version
 1.0.19
```
