### PR TITLE
feat: add kubernetes-sigs/controller-runtime/setup-envtest

### DIFF
--- a/pkgs/kubernetes-sigs/controller-runtime/setup-envtest/pkg.yaml
+++ b/pkgs/kubernetes-sigs/controller-runtime/setup-envtest/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubernetes-sigs/controller-runtime/setup-envtest@v0.20.4

--- a/pkgs/kubernetes-sigs/controller-runtime/setup-envtest/registry.yaml
+++ b/pkgs/kubernetes-sigs/controller-runtime/setup-envtest/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: kubernetes-sigs/controller-runtime/setup-envtest
+    type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: controller-runtime
+    description: Repo for the controller-runtime subproject of kubebuilder (sig-apimachinery)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.18.7")
+        no_asset: true
+      - version_constraint: "true"
+        asset: setup-envtest-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -39687,6 +39687,19 @@ packages:
       - darwin
       - linux
       - amd64
+  - name: kubernetes-sigs/controller-runtime/setup-envtest
+    type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: controller-runtime
+    description: Repo for the controller-runtime subproject of kubebuilder (sig-apimachinery)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.18.7")
+        no_asset: true
+      - version_constraint: "true"
+        asset: setup-envtest-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: go_install
     name: kubernetes-sigs/controller-tools/controller-gen
     search_words:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

This pull request adds setup-envtest to the registry. The source URL is https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest.

I verified the installation with the following command:

```
$ cmdx con
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@e222d44c89f7:/workspace# setup-envtest version
setup-envtest version: v0.20.4
root@e222d44c89f7:/workspace#
```

---

I apologize for force pushing while this was still in Draft pull request...