### PR TITLE
feat: add stunnel/static-curl

### DIFF
--- a/pkgs/stunnel/static-curl/pkg.yaml
+++ b/pkgs/stunnel/static-curl/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: stunnel/static-curl@8.13.0
+  - name: stunnel/static-curl
+    version: 8.6.0
+  - name: stunnel/static-curl
+    version: 8.6.0-1
+  - name: stunnel/static-curl
+    version: 8.5.0
+  - name: stunnel/static-curl
+    version: 8.2.0

--- a/pkgs/stunnel/static-curl/registry.yaml
+++ b/pkgs/stunnel/static-curl/registry.yaml
@@ -4,11 +4,16 @@ packages:
     repo_owner: stunnel
     repo_name: static-curl
     description: static builds cURL with HTTP3
+    files:
+      - name: curl
+      - name: curl-config
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "8.6.0-1"
         asset: curl-{{.OS}}-{{.Arch}}-8.6.0.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -17,39 +22,42 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
-        files:
-          - name: curl
       - version_constraint: Version == "8.6.0"
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           darwin: macos
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: curl
       - version_constraint: semver("<= 8.2.0")
         asset: curl-static-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
-        supported_envs:
-          - linux
         files:
           - name: curl
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 8.5.0")
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           linux: static
           darwin: macos
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: curl
       - version_constraint: "true"
         asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
+            src: curl-{{.Arch}}/bin/curl
+          - name: curl-config
+            src: curl-{{.Arch}}/bin/curl-config
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -58,8 +66,3 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
-        files:
-          - name: curl
-            src: curl-{{.Arch}}/bin/curl
-          - name: curl-config
-            src: curl-{{.Arch}}/bin/curl-config

--- a/pkgs/stunnel/static-curl/registry.yaml
+++ b/pkgs/stunnel/static-curl/registry.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: stunnel
+    repo_name: static-curl
+    description: static builds cURL with HTTP3
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "8.6.0-1"
+        asset: curl-{{.OS}}-{{.Arch}}-8.6.0.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: arm64
+      - version_constraint: Version == "8.6.0"
+        asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 8.2.0")
+      - version_constraint: semver("<= 8.5.0")
+        asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: arm64

--- a/pkgs/stunnel/static-curl/registry.yaml
+++ b/pkgs/stunnel/static-curl/registry.yaml
@@ -17,6 +17,8 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
+        files:
+          - name: curl
       - version_constraint: Version == "8.6.0"
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
@@ -25,14 +27,26 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: curl
       - version_constraint: semver("<= 8.2.0")
+        asset: curl-static-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        supported_envs:
+          - linux
+        files:
+          - name: curl
       - version_constraint: semver("<= 8.5.0")
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
         replacements:
+          linux: static
           darwin: macos
         supported_envs:
+          - linux
           - darwin
+        files:
+          - name: curl
       - version_constraint: "true"
         asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
         format: tar.xz
@@ -44,3 +58,8 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
+        files:
+          - name: curl
+            src: curl-{{.Arch}}/bin/curl
+          - name: curl-config
+            src: curl-{{.Arch}}/bin/curl-config

--- a/registry.yaml
+++ b/registry.yaml
@@ -58425,11 +58425,16 @@ packages:
     repo_owner: stunnel
     repo_name: static-curl
     description: static builds cURL with HTTP3
+    files:
+      - name: curl
+      - name: curl-config
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "8.6.0-1"
         asset: curl-{{.OS}}-{{.Arch}}-8.6.0.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -58438,39 +58443,42 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
-        files:
-          - name: curl
       - version_constraint: Version == "8.6.0"
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           darwin: macos
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: curl
       - version_constraint: semver("<= 8.2.0")
         asset: curl-static-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
-        supported_envs:
-          - linux
         files:
           - name: curl
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 8.5.0")
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
         replacements:
           linux: static
           darwin: macos
         supported_envs:
           - linux
           - darwin
-        files:
-          - name: curl
       - version_constraint: "true"
         asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
         format: tar.xz
+        files:
+          - name: curl
+            src: curl-{{.Arch}}/bin/curl
+          - name: curl-config
+            src: curl-{{.Arch}}/bin/curl-config
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -58479,11 +58487,6 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
-        files:
-          - name: curl
-            src: curl-{{.Arch}}/bin/curl
-          - name: curl-config
-            src: curl-{{.Arch}}/bin/curl-config
   - type: github_release
     repo_owner: subtrace
     repo_name: subtrace

--- a/registry.yaml
+++ b/registry.yaml
@@ -58438,6 +58438,8 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
+        files:
+          - name: curl
       - version_constraint: Version == "8.6.0"
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
@@ -58446,14 +58448,26 @@ packages:
         supported_envs:
           - linux
           - darwin
+        files:
+          - name: curl
       - version_constraint: semver("<= 8.2.0")
+        asset: curl-static-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        supported_envs:
+          - linux
+        files:
+          - name: curl
       - version_constraint: semver("<= 8.5.0")
         asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.xz
         replacements:
+          linux: static
           darwin: macos
         supported_envs:
+          - linux
           - darwin
+        files:
+          - name: curl
       - version_constraint: "true"
         asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
         format: tar.xz
@@ -58465,6 +58479,11 @@ packages:
           - goos: darwin
             replacements:
               arm64: arm64
+        files:
+          - name: curl
+            src: curl-{{.Arch}}/bin/curl
+          - name: curl-config
+            src: curl-{{.Arch}}/bin/curl-config
   - type: github_release
     repo_owner: subtrace
     repo_name: subtrace

--- a/registry.yaml
+++ b/registry.yaml
@@ -58422,6 +58422,50 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: stunnel
+    repo_name: static-curl
+    description: static builds cURL with HTTP3
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "8.6.0-1"
+        asset: curl-{{.OS}}-{{.Arch}}-8.6.0.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: arm64
+      - version_constraint: Version == "8.6.0"
+        asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 8.2.0")
+      - version_constraint: semver("<= 8.5.0")
+        asset: curl-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: curl-{{.OS}}-{{.Arch}}-dev-{{.Version}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: arm64
+  - type: github_release
     repo_owner: subtrace
     repo_name: subtrace
     description: Wireshark for Docker containers


### PR DESCRIPTION
[stunnel/static-curl](https://github.com/stunnel/static-curl): static builds cURL with HTTP3

```console
$ aqua g -i stunnel/static-curl
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@691d1fbcb71f:/workspace# curl -V
curl 8.13.0 (x86_64-pc-linux-gnu) libcurl/8.13.0 OpenSSL/3.4.1 zlib/1.3.1 brotli/1.1.0 zstd/1.5.7 c-ares/1.34.4 libidn2/2.3.8 libpsl/0.21.5 libssh2/1.11.1 nghttp2/1.65.0 nghttp3/1.8.0
Release-Date: 2025-04-02
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Largefile libz NTLM PSL SSL SSLS-EXPORT threadsafe TLS-SRP TrackMemory UnixSockets zstd
root@691d1fbcb71f:/workspace# curl https://google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
```

If files such as configuration file are needed, please share them.

Reference

- https://curl.se/download.html#Linux
- https://github.com/stunnel/static-curl/blob/8.13.0/README.md#known-issue
  - > For Linux glibc versions, if your system’s /etc/nsswitch.conf file is configured with passwd: compat, glibc will attempt to load libnss_compat.so, libnss_nis.so, libpthread.so, etc. These libraries may not be compatible with the statically linked glibc, and the program might crash.
      Currently, there is no good solution for this issue, except for compiling glibc within the script.
In this case, it is recommended to use the musl version.
