### PR TITLE
feat: add project-zot/zot

### DIFF
--- a/pkgs/project-zot/zot/pkg.yaml
+++ b/pkgs/project-zot/zot/pkg.yaml
@@ -4,5 +4,3 @@ packages:
     version: v2.0.1
   - name: project-zot/zot
     version: v1.3.7
-  - name: project-zot/zot
-    version: v1.3.4

--- a/pkgs/project-zot/zot/pkg.yaml
+++ b/pkgs/project-zot/zot/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: project-zot/zot@v2.1.2
+  - name: project-zot/zot
+    version: v1.3.7
+  - name: project-zot/zot
+    version: v1.3.4

--- a/pkgs/project-zot/zot/pkg.yaml
+++ b/pkgs/project-zot/zot/pkg.yaml
@@ -4,3 +4,5 @@ packages:
     version: v2.0.1
   - name: project-zot/zot
     version: v1.3.7
+  - name: project-zot/zot
+    version: v1.3.5

--- a/pkgs/project-zot/zot/pkg.yaml
+++ b/pkgs/project-zot/zot/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: project-zot/zot@v2.1.2
   - name: project-zot/zot
+    version: v2.0.1
+  - name: project-zot/zot
     version: v1.3.7
   - name: project-zot/zot
     version: v1.3.4

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: project-zot
+    repo_name: zot
+    description: "zot - A scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification)"
+    version_filter: not (Version matches "-rc[0-9]+$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.3.7"
+      - version_constraint: semver("<= 1.3.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.3.4")
+      - version_constraint: semver("<= 1.3.6")
+        no_asset: true
+      - version_constraint: "true"
+        asset: zot-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -8,9 +8,17 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
       - version_constraint: "true"

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -8,9 +8,17 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
       - version_constraint: semver("<= 2.0.1")

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -7,8 +7,15 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version in ["1.3.2", "1.3.6"]
+        no_asset: true
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
+      - version_constraint: semver("<= 1.3.5")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.7")
         asset: zot-{{.Arch}}
         format: raw

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -4,26 +4,28 @@ packages:
     repo_owner: project-zot
     repo_name: zot
     description: "zot - A scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification)"
-    version_filter: not (Version matches "-rc[0-9]+$")
+    version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
-        asset: zot
-        format: raw
-        supported_envs:
-          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
+      - version_constraint: semver("<= 2.0.1")
+        asset: zot-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw
+        checksum:
+          type: github_release
+          asset: checksums.sha256.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - darwin

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -10,6 +10,10 @@ packages:
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
       - version_constraint: semver("<= 1.3.7")
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -7,20 +7,9 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v1.3.7"
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
-      - version_constraint: semver("<= 1.3.2")
+      - version_constraint: semver("<= 1.2.1")
         no_asset: true
-      - version_constraint: semver("<= 1.3.4")
-        asset: zot
-        format: raw
-        supported_envs:
-          - linux/amd64
-      - version_constraint: semver("<= 1.3.6")
-        no_asset: true
+      - version_constraint: semver("<= 1.3.7")
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -10,10 +10,6 @@ packages:
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
       - version_constraint: semver("<= 1.3.7")
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/project-zot/zot/registry.yaml
+++ b/pkgs/project-zot/zot/registry.yaml
@@ -7,9 +7,7 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["1.3.2", "1.3.6"]
-        no_asset: true
-      - version_constraint: semver("<= 1.2.1")
+      - version_constraint: semver("<= 1.2.1") or Version in ["1.3.2", "1.3.6"]
         no_asset: true
       - version_constraint: semver("<= 1.3.5")
         asset: zot

--- a/pkgs/project-zot/zot/scaffold.yaml
+++ b/pkgs/project-zot/zot/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: project-zot/zot
+version_filter: not (Version matches "-rc[0-9]+$")
+# version_prefix: cli-
+all_assets_filter: ((Asset matches "^zot-") and (not (Asset matches "-(debug|minimal)")))

--- a/pkgs/project-zot/zot/scaffold.yaml
+++ b/pkgs/project-zot/zot/scaffold.yaml
@@ -6,4 +6,4 @@
 name: project-zot/zot
 version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
 # version_prefix: cli-
-all_assets_filter: (Asset matches "checksum") or ((Asset matches "^zot") and (not (Asset matches "-(debug|exporter|minimal)")))
+all_assets_filter: (Asset matches "checksum") or ((Asset matches "^zot") and (not (Asset matches "-(debug|exporter|minimal)$")))

--- a/pkgs/project-zot/zot/scaffold.yaml
+++ b/pkgs/project-zot/zot/scaffold.yaml
@@ -6,4 +6,4 @@
 name: project-zot/zot
 version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
 # version_prefix: cli-
-all_assets_filter: (Asset matches "checksum") or ((Asset matches "^zot-") and (not (Asset matches "-(debug|minimal)")))
+all_assets_filter: (Asset matches "checksum") or ((Asset matches "^zot") and (not (Asset matches "-(debug|exporter|minimal)")))

--- a/pkgs/project-zot/zot/scaffold.yaml
+++ b/pkgs/project-zot/zot/scaffold.yaml
@@ -4,6 +4,6 @@
 # https://aquaproj.github.io/
 # Other than name is optional. All initial values are just examples.
 name: project-zot/zot
-version_filter: not (Version matches "-rc[0-9]+$")
+version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
 # version_prefix: cli-
-all_assets_filter: ((Asset matches "^zot-") and (not (Asset matches "-(debug|minimal)")))
+all_assets_filter: (Asset matches "checksum") or ((Asset matches "^zot-") and (not (Asset matches "-(debug|minimal)")))

--- a/registry.yaml
+++ b/registry.yaml
@@ -50806,9 +50806,17 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
       - version_constraint: semver("<= 2.0.1")

--- a/registry.yaml
+++ b/registry.yaml
@@ -50808,10 +50808,6 @@ packages:
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
       - version_constraint: semver("<= 1.3.7")
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -50802,26 +50802,28 @@ packages:
     repo_owner: project-zot
     repo_name: zot
     description: "zot - A scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification)"
-    version_filter: not (Version matches "-rc[0-9]+$")
+    version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
-        asset: zot
-        format: raw
-        supported_envs:
-          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
+      - version_constraint: semver("<= 2.0.1")
+        asset: zot-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw
+        checksum:
+          type: github_release
+          asset: checksums.sha256.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -50806,9 +50806,17 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.7"
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.3.2")
         no_asset: true
       - version_constraint: semver("<= 1.3.4")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.6")
         no_asset: true
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -50805,8 +50805,15 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version in ["1.3.2", "1.3.6"]
+        no_asset: true
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
+      - version_constraint: semver("<= 1.3.5")
+        asset: zot
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 1.3.7")
         asset: zot-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -50805,9 +50805,7 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["1.3.2", "1.3.6"]
-        no_asset: true
-      - version_constraint: semver("<= 1.2.1")
+      - version_constraint: semver("<= 1.2.1") or Version in ["1.3.2", "1.3.6"]
         no_asset: true
       - version_constraint: semver("<= 1.3.5")
         asset: zot

--- a/registry.yaml
+++ b/registry.yaml
@@ -50808,6 +50808,10 @@ packages:
       - version_constraint: semver("<= 1.2.1")
         no_asset: true
       - version_constraint: semver("<= 1.3.7")
+        asset: zot-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -50798,6 +50798,25 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+  - type: github_release
+    repo_owner: project-zot
+    repo_name: zot
+    description: "zot - A scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification)"
+    version_filter: not (Version matches "-rc[0-9]+$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.3.7"
+      - version_constraint: semver("<= 1.3.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.3.4")
+      - version_constraint: semver("<= 1.3.6")
+        no_asset: true
+      - version_constraint: "true"
+        asset: zot-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
   - name: projectcalico/calico/calicoctl
     type: github_release
     repo_owner: projectcalico

--- a/registry.yaml
+++ b/registry.yaml
@@ -50805,20 +50805,9 @@ packages:
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v1.3.7"
-        asset: zot-{{.Arch}}
-        format: raw
-        supported_envs:
-          - linux
-      - version_constraint: semver("<= 1.3.2")
+      - version_constraint: semver("<= 1.2.1")
         no_asset: true
-      - version_constraint: semver("<= 1.3.4")
-        asset: zot
-        format: raw
-        supported_envs:
-          - linux/amd64
-      - version_constraint: semver("<= 1.3.6")
-        no_asset: true
+      - version_constraint: semver("<= 1.3.7")
       - version_constraint: semver("<= 2.0.1")
         asset: zot-{{.OS}}-{{.Arch}}
         format: raw


### PR DESCRIPTION
[project-zot/zot](https://github.com/project-zot/zot): zot - A scale-out production-ready vendor-neutral OCI-native container image/artifact registry (purely based on OCI Distribution Specification)

```console
$ aqua g -i project-zot/zot
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ zot -h
`zot`

Usage:
  zot [flags]
  zot [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  scrub       `scrub` checks manifest/blob integrity
  serve       `serve` stores and distributes OCI images
  verify      `verify` validates a zot config file

Flags:
  -h, --help      help for zot
  -v, --version   show the version and exit

Use "zot [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

```json:config.json
{
    "distSpecVersion": "1.0.1",
    "storage": {
        "rootDirectory": "/tmp/zot"
    },
    "http": {
        "address": "127.0.0.1",
        "port": "8080"
    },
    "log": {
        "level": "debug"
    }
}
```

Running server

```console
$ zot serve config.json
{"level":"warn","config version":"1.0.1","supported version":"1.1.0","goroutine":1,"caller":"zotregistry.dev/zot/pkg/cli/server/root.go:769","time":"2025-04-22T17:27:37.916807329Z","message":"config dist-spec version differs from version actually used"}
...snip...
```

Reference

- https://zotregistry.dev/v2.1.2/general/releases/
- https://zotregistry.dev/v2.1.2/install-guides/install-guide-linux/
- https://zotregistry.dev/v2.1.2/admin-guide/admin-getting-started/
- https://zotregistry.dev/v2.1.2/admin-guide/admin-configuration/
