### PR TITLE
feat: add zmap/zlint

### DIFF
--- a/pkgs/zmap/zlint/pkg.yaml
+++ b/pkgs/zmap/zlint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: zmap/zlint@v3.6.5

--- a/pkgs/zmap/zlint/registry.yaml
+++ b/pkgs/zmap/zlint/registry.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: zmap
+    repo_name: zlint
+    description: X.509 Certificate Linter focused on Web PKI standards and requirements
+    version_filter: not (Version matches "-rc")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: zlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: zlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/zmap/zlint/registry.yaml
+++ b/pkgs/zmap/zlint/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: zmap
     repo_name: zlint
     description: X.509 Certificate Linter focused on Web PKI standards and requirements
+    files:
+      - name: zlint
+        src: "{{.AssetWithoutExt}}/{{.FileName}}"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/pkgs/zmap/zlint/registry.yaml
+++ b/pkgs/zmap/zlint/registry.yaml
@@ -4,9 +4,6 @@ packages:
     repo_owner: zmap
     repo_name: zlint
     description: X.509 Certificate Linter focused on Web PKI standards and requirements
-    files:
-      - name: zlint
-        src: "{{.AssetWithoutExt}}/{{.FileName}}"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:
@@ -17,6 +14,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: zlint
+            src: "{{.AssetWithoutExt}}/{{.FileName}}"
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/zmap/zlint/scaffold.yaml
+++ b/pkgs/zmap/zlint/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: zmap/zlint
+version_filter: not (Version matches "-rc")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -68839,6 +68839,9 @@ packages:
     repo_owner: zmap
     repo_name: zlint
     description: X.509 Certificate Linter focused on Web PKI standards and requirements
+    files:
+      - name: zlint
+        src: "{{.AssetWithoutExt}}/{{.FileName}}"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -68836,6 +68836,33 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: zmap
+    repo_name: zlint
+    description: X.509 Certificate Linter focused on Web PKI standards and requirements
+    version_filter: not (Version matches "-rc")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: zlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: zlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: zmwangx
     repo_name: ets
     description: Command output timestamper

--- a/registry.yaml
+++ b/registry.yaml
@@ -68839,9 +68839,6 @@ packages:
     repo_owner: zmap
     repo_name: zlint
     description: X.509 Certificate Linter focused on Web PKI standards and requirements
-    files:
-      - name: zlint
-        src: "{{.AssetWithoutExt}}/{{.FileName}}"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:
@@ -68852,6 +68849,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: zlint
+            src: "{{.AssetWithoutExt}}/{{.FileName}}"
         replacements:
           amd64: x86_64
           darwin: Darwin


### PR DESCRIPTION
[zmap/zlint](https://github.com/zmap/zlint): X.509 Certificate Linter focused on Web PKI standards and requirements

```console
$ aqua g -i zmap/zlint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ zlint -h
ZLint version 3.6.5

Usage: zlint [flags] file...
  -config string
        A path to valid a TOML file that is to service as the configuration for a single run of ZLint. Providing a configuration file allows for modifying the behavior of select lints. For an example configuration, please see '-exampleConfig'
  -exampleConfig
        Prints a complete example of a configuration that is usable via the '-config' flag and exit. All values listed in this example will be set to their default.
  -excludeNames string
        Comma-separated list of lints to exclude by name. The names provided must be precise. If you wish to use a pattern instead, please see -nameFilter
  -excludeSources string
        Comma-separated list of lint sources to exclude. For a list of sources, please see '-list-lints-source'
  -format string
        Informs ZLint of the format of the incoming file. One of {pem, der, base64}. Default: pem (default "pem")
  -includeNames string
        Comma-separated list of lints to include by name. The names provided must be precise. If you wish to use a pattern instead, please see -nameFilter
  -includeSources string
        Comma-separated list of lint sources to include. For a list of sources, please see '-list-lints-source'
  -list-lints-json
        Prints a line delimited list of JSON. Each line prints the name, description, and source of the given lint
  -list-lints-source
        Prints a line-delimited list of lint sources. A lint source is a governing body, or document, such as CABF or an individual RFC.
  -list-profiles
        Prints a line delimited list of JSON. Each line the prints name, description, source, and a list of all lints that comprise the profile
  -longSummary
        Prints a tabular, human-readable, summary report in place of the default JSON report. This prints the same contents as '-summary', but with the additional detail of what lints produced a non-PASS code
  -nameFilter string
        Only run lints with a name matching the provided regex. The regex syntax used is that used in the Golang regexp package (please see https://pkg.go.dev/regexp/syntax) (Can not be used with -includeNames/-excludeNames)
  -pretty
        Pretty-print JSON output
  -profile string
        Name of the linting profile to use. Only the lints falling under this profile will be ran. For a list of lints per-profile, please see '-list-profiles'
  -summary
        Prints a succinct, tabular, human-readable, summary report in place of the default JSON report. Only the counts of info/warn/error/fatal occurrences are reported
  -version
        Print ZLint version and exit
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/zmap/zlint/blob/master/README.md#command-line-usage
