### PR TITLE
feat: add containerd/containerd/static

### DIFF
--- a/pkgs/containerd/containerd/static/pkg.yaml
+++ b/pkgs/containerd/containerd/static/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: containerd/containerd/static@v2.0.5

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -5,6 +5,15 @@ packages:
     repo_owner: containerd
     repo_name: containerd
     description: An open and reliable container runtime (static binary)
+    files:
+      - name: containerd
+        src: bin/{{.FileName}}
+      - name: containerd-shim-runc-v2
+        src: bin/{{.FileName}}
+      - name: containerd-stress
+        src: bin/{{.FileName}}
+      - name: ctr
+        src: bin/{{.FileName}}
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -24,7 +24,7 @@ packages:
         format: tar.gz
         checksum:
           type: github_release
-          asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
         supported_envs:
           - linux

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -19,9 +19,20 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 1.6.38")
         no_asset: true
+      - version_constraint: semver("<= 2.0.0")
+        asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        supported_envs:
+          - linux
       - version_constraint: "true"
         asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        github_artifact_attestations:
+          signer-workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -4,7 +4,7 @@ packages:
     type: github_release
     repo_owner: containerd
     repo_name: containerd
-    description: An open and reliable container runtime
+    description: An open and reliable container runtime (static binary)
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: containerd/containerd/static
+    type: github_release
+    repo_owner: containerd
+    repo_name: containerd
+    description: An open and reliable container runtime
+    version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.38")
+        no_asset: true
+      - version_constraint: "true"
+        asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux

--- a/pkgs/containerd/containerd/static/scaffold.yaml
+++ b/pkgs/containerd/containerd/static/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: containerd/containerd/static
+version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
+# version_prefix: cli-
+all_assets_filter: Asset matches "^containerd-static-[0-9]+"

--- a/registry.yaml
+++ b/registry.yaml
@@ -20804,9 +20804,20 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 1.6.38")
         no_asset: true
+      - version_constraint: semver("<= 2.0.0")
+        asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256sum"
+          algorithm: sha256
+        supported_envs:
+          - linux
       - version_constraint: "true"
         asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        github_artifact_attestations:
+          signer-workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"

--- a/registry.yaml
+++ b/registry.yaml
@@ -20809,7 +20809,7 @@ packages:
         format: tar.gz
         checksum:
           type: github_release
-          asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
         supported_envs:
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -20789,7 +20789,7 @@ packages:
     type: github_release
     repo_owner: containerd
     repo_name: containerd
-    description: An open and reliable container runtime
+    description: An open and reliable container runtime (static binary)
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -20790,6 +20790,15 @@ packages:
     repo_owner: containerd
     repo_name: containerd
     description: An open and reliable container runtime (static binary)
+    files:
+      - name: containerd
+        src: bin/{{.FileName}}
+      - name: containerd-shim-runc-v2
+        src: bin/{{.FileName}}
+      - name: containerd-stress
+        src: bin/{{.FileName}}
+      - name: ctr
+        src: bin/{{.FileName}}
     version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -20785,6 +20785,25 @@ packages:
         supported_envs:
           - linux
           - windows
+  - name: containerd/containerd/static
+    type: github_release
+    repo_owner: containerd
+    repo_name: containerd
+    description: An open and reliable container runtime
+    version_filter: Version matches "^v[0-9]+.[0-9]+.[0-9]+$"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.38")
+        no_asset: true
+      - version_constraint: "true"
+        asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
   - type: github_release
     repo_owner: containerd
     repo_name: fuse-overlayfs-snapshotter


### PR DESCRIPTION
[containerd/containerd/static](https://github.com/containerd/containerd): An open and reliable container runtime (static binary)

```console
$ aqua g -i containerd/containerd/static
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@0da0ad9f25a4:/workspace# containerd -h
NAME:
   containerd -
                                    __        _                     __
                  _________  ____  / /_____ _(_)___  ___  _________/ /
                 / ___/ __ \/ __ \/ __/ __ `/ / __ \/ _ \/ ___/ __  /
                / /__/ /_/ / / / / /_/ /_/ / / / / /  __/ /  / /_/ /
                \___/\____/_/ /_/\__/\__,_/_/_/ /_/\___/_/   \__,_/

                high performance container runtime


USAGE:
   containerd [global options] command [command options]

VERSION:
   v2.0.5

DESCRIPTION:

   containerd is a high performance container runtime whose daemon can be started
   by using this command. If none of the *config*, *publish*, *oci-hook*, or *help* commands
   are specified, the default action of the **containerd** command is to start the
   containerd daemon in the foreground.


   A default configuration is used if no TOML configuration is specified or located
   at the default file location. The *containerd config* command can be used to
   generate the default configuration for containerd. The output of that command
   can be used and modified as necessary as a custom configuration.

COMMANDS:
   config    Information on the containerd config
   publish   Binary to publish events to containerd
   oci-hook  Provides a base for OCI runtime hooks to allow arguments to be injected.
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value     Path to the configuration file (default: "/etc/containerd/config.toml")
   --log-level value, -l value  Set the logging level [trace, debug, info, warn, error, fatal, panic]
   --address value, -a value    Address for containerd's GRPC server
   --root value                 containerd root directory
   --state value                containerd state directory
   --help, -h                   Show help (default: false)
   --version, -v                Print the version (default: false)
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/containerd/containerd/blob/main/docs/getting-started.md