### PR TITLE
feat: add openfga/cli

### DIFF
--- a/pkgs/openfga/cli/pkg.yaml
+++ b/pkgs/openfga/cli/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: openfga/cli@v0.6.6
+  - name: openfga/cli
+    version: v0.4.0
+  - name: openfga/cli
+    version: v0.1.0-beta1

--- a/pkgs/openfga/cli/registry.yaml
+++ b/pkgs/openfga/cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: openfga
     repo_name: cli
     description: A cross-platform CLI to interact with an OpenFGA server
+    files:
+      - name: fga
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0-beta1"
@@ -40,10 +42,6 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
       - version_constraint: "true"
         asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -64,7 +62,3 @@ packages:
         slsa_provenance:
           type: github_release
           asset: fga.intoto.jsonl
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}

--- a/pkgs/openfga/cli/registry.yaml
+++ b/pkgs/openfga/cli/registry.yaml
@@ -19,8 +19,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -36,8 +36,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -53,8 +53,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature

--- a/pkgs/openfga/cli/registry.yaml
+++ b/pkgs/openfga/cli/registry.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: openfga
+    repo_name: cli
+    description: A cross-platform CLI to interact with an OpenFGA server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-beta1"
+        asset: openfga-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+      - version_constraint: semver("<= 0.4.0")
+        asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+      - version_constraint: "true"
+        asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: fga.intoto.jsonl
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -50449,8 +50449,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -50466,8 +50466,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -50483,8 +50483,8 @@ packages:
             opts:
               - --certificate
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - "https://github.com/openfga/cli/.github/workflows/main.yaml@refs/tags/{{.Version}}"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature

--- a/registry.yaml
+++ b/registry.yaml
@@ -50431,6 +50431,74 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
   - type: github_release
+    repo_owner: openfga
+    repo_name: cli
+    description: A cross-platform CLI to interact with an OpenFGA server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-beta1"
+        asset: openfga-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+      - version_constraint: semver("<= 0.4.0")
+        asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+      - version_constraint: "true"
+        asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openfga/cli/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: fga.intoto.jsonl
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+  - type: github_release
     repo_owner: openshift-online
     repo_name: ocm-cli
     description: CLI for the Red Hat OpenShift Cluster Manager

--- a/registry.yaml
+++ b/registry.yaml
@@ -50434,6 +50434,8 @@ packages:
     repo_owner: openfga
     repo_name: cli
     description: A cross-platform CLI to interact with an OpenFGA server
+    files:
+      - name: fga
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0-beta1"
@@ -50470,10 +50472,6 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/openfga/cli/releases/download/{{.Version}}/checksums.txt.sig
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
       - version_constraint: "true"
         asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -50494,10 +50492,6 @@ packages:
         slsa_provenance:
           type: github_release
           asset: fga.intoto.jsonl
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: fga_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
   - type: github_release
     repo_owner: openshift-online
     repo_name: ocm-cli


### PR DESCRIPTION
Added [openfga/cli](https://github.com/openfga/cli) - A cross-platform CLI to interact with an OpenFGA server

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

### Confirmation

```
$ cmdx con
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/arm64)
root@ed9214bb1769:/workspace# fga
OpenFGA CLI

Usage:
  fga [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  model       Interact with Authorization Models
  query       Run Queries
  store       Interact with OpenFGA Stores
  tuple       Interact with Relationship Tuples
  version     Reports the FGA CLI version

Flags:
      --api-audience string       API Audience. Used when performing the Client Credentials flow
      --api-scopes stringArray    API Scopes (repeat option for multiple values). Used in the Client Credentials flow
      --api-token string          API Token. Will be sent in as a Bearer in the Authorization header
      --api-token-issuer string   API Token Issuer. API responsible for issuing the API Token. Used in the Client Credentials flow
      --api-url string            OpenFGA API URI e.g. https://api.fga.example:8080 (default "http://localhost:8080")
      --client-id string          Client ID. Sent to the Token Issuer during the Client Credentials flow
      --client-secret string      Client Secret. Sent to the Token Issuer during the Client Credentials flow
      --config string             config file (default is $HOME/.fga.yaml)
      --debug                     Enable debug mode - can print more detailed information for debugging
  -h, --help                      help for fga
  -v, --version                   version for fga

Use "fga [command] --help" for more information about a command.
```
