### PR TITLE
feat: add str4d/rage

### DIFF
--- a/pkgs/str4d/rage/pkg.yaml
+++ b/pkgs/str4d/rage/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: str4d/rage@v0.11.1
+  - name: str4d/rage
+    version: v0.10.1
+  - name: str4d/rage
+    version: v0.1.1

--- a/pkgs/str4d/rage/registry.yaml
+++ b/pkgs/str4d/rage/registry.yaml
@@ -4,6 +4,11 @@ packages:
     repo_owner: str4d
     repo_name: rage
     description: A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability
+    files:
+      - name: rage
+        src: rage/{{.FileName}}
+      - name: rage-keygen
+        src: rage/{{.FileName}}
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -18,6 +23,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}
         supported_envs:
           - darwin
           - windows
@@ -32,6 +46,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}
       - version_constraint: "true"
         asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -41,3 +64,12 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}

--- a/pkgs/str4d/rage/registry.yaml
+++ b/pkgs/str4d/rage/registry.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: str4d
+    repo_name: rage
+    description: A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: Version == "v0.1.1"
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.1")
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/str4d/rage/scaffold.yaml
+++ b/pkgs/str4d/rage/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: str4d/rage
+# version_filter: not (Version matches "-rc$")
+# version_prefix: cli-
+all_assets_filter: not (Asset matches ".deb$")

--- a/registry.yaml
+++ b/registry.yaml
@@ -61343,6 +61343,11 @@ packages:
     repo_owner: str4d
     repo_name: rage
     description: A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability
+    files:
+      - name: rage
+        src: rage/{{.FileName}}
+      - name: rage-keygen
+        src: rage/{{.FileName}}
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -61357,6 +61362,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}
         supported_envs:
           - darwin
           - windows
@@ -61371,6 +61385,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}
       - version_constraint: "true"
         asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -61380,6 +61403,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: rage
+                src: rage/{{.FileName}}
+              - name: rage-keygen
+                src: rage/{{.FileName}}
+              - name: rage-mount
+                src: rage/{{.FileName}}
   - type: github_release
     repo_owner: streamdal
     repo_name: plumber

--- a/registry.yaml
+++ b/registry.yaml
@@ -61340,6 +61340,47 @@ packages:
           - goos: windows
             asset: spectral
   - type: github_release
+    repo_owner: str4d
+    repo_name: rage
+    description: A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: Version == "v0.1.1"
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.1")
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: rage-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: streamdal
     repo_name: plumber
     aliases:


### PR DESCRIPTION
[str4d/rage](https://github.com/str4d/rage): A simple, secure and modern file encryption tool (and Rust library) with small explicit keys, no config options, and UNIX-style composability

```console
$ aqua g -i str4d/rage
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@0a5e11844b34:/workspace# rage -h
Usage: rage [--encrypt] (-r RECIPIENT | -R PATH)... [-i IDENTITY] [-a] [-o OUTPUT] [INPUT]
       rage [--encrypt] --passphrase [-a] [-o OUTPUT] [INPUT]
       rage --decrypt [-i IDENTITY] [-o OUTPUT] [INPUT]

Arguments:
  [INPUT]  Path to a file to read from.

Options:
  -h, --help                    Print this help message and exit.
  -V, --version                 Print version info and exit.
  -e, --encrypt                 Encrypt the input (the default).
  -d, --decrypt                 Decrypt the input.
  -p, --passphrase              Encrypt with a passphrase instead of recipients.
      --max-work-factor <WF>    Maximum work factor to allow for passphrase decryption.
  -a, --armor                   Encrypt to a PEM encoded format.
  -r, --recipient <RECIPIENT>   Encrypt to the specified RECIPIENT. May be repeated.
  -R, --recipients-file <PATH>  Encrypt to the recipients listed at PATH. May be repeated.
  -i, --identity <IDENTITY>     Use the identity file at IDENTITY. May be repeated.
  -j <PLUGIN-NAME>              Use age-plugin-PLUGIN-NAME in its default mode as an identity.
  -o, --output <OUTPUT>         Write the result to the file at path OUTPUT.

INPUT defaults to standard input, and OUTPUT defaults to standard output.
If OUTPUT exists, it will be overwritten.

RECIPIENT can be:
- An age public key, as generated by rage-keygen ("age1...").
- An SSH public key ("ssh-ed25519 AAAA...", "ssh-rsa AAAA...").

PATH is a path to a file containing age recipients, one per line
(ignoring "#" prefixed comments and empty lines). "-" may be used to
read recipients from standard input.

IDENTITY is a path to a file with age identities, one per line
(ignoring "#" prefixed comments and empty lines), or to an SSH key file.
Passphrase-encrypted age identity files can be used as identity files.
Multiple identities may be provided, and any unused ones will be ignored.
"-" may be used to read identities from standard input.

Example:
  $ rage-keygen -o key.txt
  Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
  $ tar cvz ~/data | rage -r age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p > data.tar.gz.age
  $ rage -d -i key.txt -o data.tar.gz data.tar.gz.age
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/C2SP/C2SP/blob/main/age.md
