### PR TITLE
feat: add Nukesor/pueue/pueued

### DIFF
--- a/pkgs/Nukesor/pueue/pueued/pkg.yaml
+++ b/pkgs/Nukesor/pueue/pueued/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: Nukesor/pueue/pueued@v4.0.0
+  - name: Nukesor/pueue/pueued
+    version: v3.4.1
+  - name: Nukesor/pueue/pueued
+    version: v2.1.0
+  - name: Nukesor/pueue/pueued
+    version: v0.12.2
+  - name: Nukesor/pueue/pueued
+    version: v0.10.2
+  - name: Nukesor/pueue/pueued
+    version: v0.7.0
+  - name: Nukesor/pueue/pueued
+    version: v0.2.0
+  - name: Nukesor/pueue/pueued
+    version: v0.1.4

--- a/pkgs/Nukesor/pueue/pueued/registry.yaml
+++ b/pkgs/Nukesor/pueue/pueued/registry.yaml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: Nukesor/pueue/pueued
+    type: github_release
+    repo_owner: Nukesor
+    repo_name: pueue
+    description: ":stars: Manage your shell commands"
+    version_filter: not (Version matches "-rc")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.4")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.0")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.2")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.11.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.12.2")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.29.0")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.0")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 3.4.1")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              darwin: macos
+          - goos: windows
+            replacements: {}
+      - version_constraint: "true"
+        asset: pueue-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc

--- a/pkgs/Nukesor/pueue/pueued/registry.yaml
+++ b/pkgs/Nukesor/pueue/pueued/registry.yaml
@@ -4,7 +4,10 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: ":stars: Manage your shell commands"
+    description: |
+      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
+
+      *Daemon version*
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/pkgs/Nukesor/pueue/pueued/registry.yaml
+++ b/pkgs/Nukesor/pueue/pueued/registry.yaml
@@ -4,7 +4,10 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: ":stars: Manage your shell commands"
+    description: |-
+      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
+
+      *Daemon version*
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/pkgs/Nukesor/pueue/pueued/registry.yaml
+++ b/pkgs/Nukesor/pueue/pueued/registry.yaml
@@ -4,15 +4,12 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: |
-      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
-
-      *Daemon version*
+    description: ":stars: Manage your shell commands"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         replacements:
@@ -21,7 +18,7 @@ packages:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 0.1.4")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         replacements:
@@ -30,7 +27,7 @@ packages:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 0.7.0")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -41,7 +38,7 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 0.10.2")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -55,7 +52,7 @@ packages:
       - version_constraint: semver("<= 0.11.1")
         no_asset: true
       - version_constraint: semver("<= 0.12.2")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -69,7 +66,7 @@ packages:
       - version_constraint: semver("<= 0.29.0")
         no_asset: true
       - version_constraint: semver("<= 2.1.0")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -81,7 +78,7 @@ packages:
             replacements:
               arm64: aarch64
       - version_constraint: semver("<= 3.4.1")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         replacements:
@@ -95,7 +92,7 @@ packages:
           - goos: windows
             replacements: {}
       - version_constraint: "true"
-        asset: pueue-{{.Arch}}-{{.OS}}
+        asset: pueued-{{.Arch}}-{{.OS}}
         format: raw
         windows_arm_emulation: true
         replacements:

--- a/pkgs/Nukesor/pueue/pueued/scaffold.yaml
+++ b/pkgs/Nukesor/pueue/pueued/scaffold.yaml
@@ -6,4 +6,4 @@
 name: Nukesor/pueue/pueued
 version_filter: not (Version matches "-rc")
 # version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")
+all_assets_filter: Asset matches "^pueued-"

--- a/pkgs/Nukesor/pueue/pueued/scaffold.yaml
+++ b/pkgs/Nukesor/pueue/pueued/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: Nukesor/pueue/pueued
+version_filter: not (Version matches "-rc")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -4041,7 +4041,10 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: ":stars: Manage your shell commands"
+    description: |
+      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
+
+      *Daemon version*
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -4041,15 +4041,12 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: |
-      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
-
-      *Daemon version*
+    description: ":stars: Manage your shell commands"
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         replacements:
@@ -4058,7 +4055,7 @@ packages:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 0.1.4")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         replacements:
@@ -4067,7 +4064,7 @@ packages:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 0.7.0")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -4078,7 +4075,7 @@ packages:
           - windows
           - amd64
       - version_constraint: semver("<= 0.10.2")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -4092,7 +4089,7 @@ packages:
       - version_constraint: semver("<= 0.11.1")
         no_asset: true
       - version_constraint: semver("<= 0.12.2")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -4106,7 +4103,7 @@ packages:
       - version_constraint: semver("<= 0.29.0")
         no_asset: true
       - version_constraint: semver("<= 2.1.0")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         windows_arm_emulation: true
@@ -4118,7 +4115,7 @@ packages:
             replacements:
               arm64: aarch64
       - version_constraint: semver("<= 3.4.1")
-        asset: pueue-{{.OS}}-{{.Arch}}
+        asset: pueued-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         replacements:
@@ -4132,7 +4129,7 @@ packages:
           - goos: windows
             replacements: {}
       - version_constraint: "true"
-        asset: pueue-{{.Arch}}-{{.OS}}
+        asset: pueued-{{.Arch}}-{{.OS}}
         format: raw
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -4041,7 +4041,10 @@ packages:
     type: github_release
     repo_owner: Nukesor
     repo_name: pueue
-    description: ":stars: Manage your shell commands"
+    description: |-
+      Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
+
+      *Daemon version*
     version_filter: not (Version matches "-rc")
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -4037,6 +4037,107 @@ packages:
           type: github_release
           asset: ice_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+  - name: Nukesor/pueue/pueued
+    type: github_release
+    repo_owner: Nukesor
+    repo_name: pueue
+    description: ":stars: Manage your shell commands"
+    version_filter: not (Version matches "-rc")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.4")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.0")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.2")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.11.1")
+        no_asset: true
+      - version_constraint: semver("<= 0.12.2")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.29.0")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.0")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 3.4.1")
+        asset: pueue-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              darwin: macos
+          - goos: windows
+            replacements: {}
+      - version_constraint: "true"
+        asset: pueue-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
   - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl


### PR DESCRIPTION
[Nukesor/pueue/pueued](https://github.com/Nukesor/pueue): Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.

*Daemon version*

```console
$ aqua g -i Nukesor/pueue/pueued
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@c8d1bec8146f:/workspace# pueued -h
Start the Pueue daemon

Usage: pueued-x86_64-unknown-linux-musl [OPTIONS]

Options:
  -v, --verbose...         Verbose mode (-v, -vv, -vvv)
  -d, --daemonize          If this flag is set, the daemon will start and fork itself into the background
  -c, --config <CONFIG>    If provided, Pueue only uses this config file
  -p, --profile <PROFILE>  The name of the profile that should be loaded from your config file
  -h, --help               Print help (see more with '--help')
  -V, --version            Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/Nukesor/pueue/wiki/Get-started
- https://github.com/aquaproj/aqua-registry/pull/21533
- https://github.com/Nukesor/pueue/issues/522#issuecomment-2187590693
