### PR TITLE
feat: add syumai/sbx

### DIFF
--- a/pkgs/syumai/sbx/pkg.yaml
+++ b/pkgs/syumai/sbx/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: syumai/sbx@v0.0.3
+  - name: syumai/sbx
+    version: v0.0.2

--- a/pkgs/syumai/sbx/registry.yaml
+++ b/pkgs/syumai/sbx/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: syumai
+    repo_name: sbx
+    description: an easy-to-use command-line tool for running commands with macOS sandbox-exec policies using flag-based interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        no_asset: true
+      - version_constraint: Version == "v0.0.2"
+        asset: sbx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sbx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: sbx-{{.Arch}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sbx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -64167,6 +64167,36 @@ packages:
       asset: kube-psp-advisor_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: syumai
+    repo_name: sbx
+    description: an easy-to-use command-line tool for running commands with macOS sandbox-exec policies using flag-based interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        no_asset: true
+      - version_constraint: Version == "v0.0.2"
+        asset: sbx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: sbx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: sbx-{{.Arch}}-{{.OS}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sbx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: t-kikuc
     repo_name: ecstop
     description: Stop your running resources of Amazon ECS easily


### PR DESCRIPTION
[syumai/sbx](https://github.com/syumai/sbx): an easy-to-use command-line tool for running commands with macOS sandbox-exec policies using flag-based interface

```console
$ aqua g -i syumai/sbx
```