### PR TITLE
feat: add containerd/stargz-snapshotter

### DIFF
--- a/pkgs/containerd/stargz-snapshotter/pkg.yaml
+++ b/pkgs/containerd/stargz-snapshotter/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: containerd/stargz-snapshotter@v0.16.3
+  - name: containerd/stargz-snapshotter
+    version: v0.3.0

--- a/pkgs/containerd/stargz-snapshotter/registry.yaml
+++ b/pkgs/containerd/stargz-snapshotter/registry.yaml
@@ -13,10 +13,11 @@ packages:
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
-      - name: "containerd-stargz-grpc"
-      - name: "ctr-remote"
-      - name: "stargz-store"
-      - name: "stargz-store-helper"
+      - name: containerd-stargz-grpc
+      - name: ctr
+        src: ctr-remote
+      - name: stargz-store
+      - name: stargz-store-helper
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.3.0")

--- a/pkgs/containerd/stargz-snapshotter/registry.yaml
+++ b/pkgs/containerd/stargz-snapshotter/registry.yaml
@@ -14,8 +14,7 @@ packages:
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
       - name: containerd-stargz-grpc
-      - name: ctr
-        src: ctr-remote
+      - name: ctr-remote
       - name: stargz-store
       - name: stargz-store-helper
     version_constraint: "false"
@@ -30,8 +29,8 @@ packages:
         supported_envs:
           - linux/amd64
         files:
-          - name: "containerd-stargz-grpc"
-          - name: "ctr-remote"
+          - name: containerd-stargz-grpc
+          - name: ctr-remote
       - version_constraint: "true"
         asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/containerd/stargz-snapshotter/registry.yaml
+++ b/pkgs/containerd/stargz-snapshotter/registry.yaml
@@ -4,6 +4,11 @@ packages:
     repo_owner: containerd
     repo_name: stargz-snapshotter
     description: Fast container image distribution plugin with lazy pulling
+    files:
+      - name: "containerd-stargz-grpc"
+      - name: "ctr-remote"
+      - name: "stargz-store"
+      - name: "stargz-store-helper"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.3.0")
@@ -15,6 +20,9 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux/amd64
+        files:
+          - name: "containerd-stargz-grpc"
+          - name: "ctr-remote"
       - version_constraint: "true"
         asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/containerd/stargz-snapshotter/registry.yaml
+++ b/pkgs/containerd/stargz-snapshotter/registry.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: containerd
+    repo_name: stargz-snapshotter
+    description: Fast container image distribution plugin with lazy pulling
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux

--- a/pkgs/containerd/stargz-snapshotter/registry.yaml
+++ b/pkgs/containerd/stargz-snapshotter/registry.yaml
@@ -3,7 +3,15 @@ packages:
   - type: github_release
     repo_owner: containerd
     repo_name: stargz-snapshotter
-    description: Fast container image distribution plugin with lazy pulling
+    description: |-
+      Fast container image distribution plugin with lazy pulling
+
+      ## How to set up
+
+      Please see:
+
+      https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
+      https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
       - name: "containerd-stargz-grpc"
       - name: "ctr-remote"

--- a/registry.yaml
+++ b/registry.yaml
@@ -21078,10 +21078,11 @@ packages:
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
-      - name: "containerd-stargz-grpc"
-      - name: "ctr-remote"
-      - name: "stargz-store"
-      - name: "stargz-store-helper"
+      - name: containerd-stargz-grpc
+      - name: ctr
+        src: ctr-remote
+      - name: stargz-store
+      - name: stargz-store-helper
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.3.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -21069,6 +21069,11 @@ packages:
     repo_owner: containerd
     repo_name: stargz-snapshotter
     description: Fast container image distribution plugin with lazy pulling
+    files:
+      - name: "containerd-stargz-grpc"
+      - name: "ctr-remote"
+      - name: "stargz-store"
+      - name: "stargz-store-helper"
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.3.0")
@@ -21080,6 +21085,9 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux/amd64
+        files:
+          - name: "containerd-stargz-grpc"
+          - name: "ctr-remote"
       - version_constraint: "true"
         asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -21066,6 +21066,30 @@ packages:
           - linux
           - windows/amd64
   - type: github_release
+    repo_owner: containerd
+    repo_name: stargz-snapshotter
+    description: Fast container image distribution plugin with lazy pulling
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.0")
+        asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+  - type: github_release
     repo_owner: containers
     repo_name: crun
     asset: crun-{{.Version}}-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -21068,7 +21068,15 @@ packages:
   - type: github_release
     repo_owner: containerd
     repo_name: stargz-snapshotter
-    description: Fast container image distribution plugin with lazy pulling
+    description: |-
+      Fast container image distribution plugin with lazy pulling
+
+      ## How to set up
+
+      Please see:
+
+      https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
+      https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
       - name: "containerd-stargz-grpc"
       - name: "ctr-remote"

--- a/registry.yaml
+++ b/registry.yaml
@@ -21079,8 +21079,7 @@ packages:
       https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
     files:
       - name: containerd-stargz-grpc
-      - name: ctr
-        src: ctr-remote
+      - name: ctr-remote
       - name: stargz-store
       - name: stargz-store-helper
     version_constraint: "false"
@@ -21095,8 +21094,8 @@ packages:
         supported_envs:
           - linux/amd64
         files:
-          - name: "containerd-stargz-grpc"
-          - name: "ctr-remote"
+          - name: containerd-stargz-grpc
+          - name: ctr-remote
       - version_constraint: "true"
         asset: stargz-snapshotter-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[containerd/stargz-snapshotter](https://github.com/containerd/stargz-snapshotter): Fast container image distribution plugin with lazy pulling

## How to set up

Please see:

https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md

```console
$ aqua g -i containerd/stargz-snapshotter
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@c63615f0a509:/workspace# stargz-store -h
Usage of stargz-store:
  -addr string
        path to the socket listened by this snapshotter (default "/var/lib/stargz-store/store.sock")
  -config string
        path to the configuration file (default "/etc/stargz-store/config.toml")
  -log-level string
        set the logging level [trace, debug, info, warn, error, fatal, panic] (default "info")
  -root string
        path to the root directory for this snapshotter (default "/var/lib/stargz-store")
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/containerd/stargz-snapshotter/blob/main/docs/INSTALL.md
- https://github.com/containerd/stargz-snapshotter/blob/main/docs/rootless.md
