### PR TITLE
feat: add liquidmetal-dev/flintlock/flintlockd

### DIFF
--- a/pkgs/liquidmetal-dev/flintlock/flintlockd/pkg.yaml
+++ b/pkgs/liquidmetal-dev/flintlock/flintlockd/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: liquidmetal-dev/flintlock/flintlockd@v0.8.1

--- a/pkgs/liquidmetal-dev/flintlock/flintlockd/registry.yaml
+++ b/pkgs/liquidmetal-dev/flintlock/flintlockd/registry.yaml
@@ -9,3 +9,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
+        asset: flintlockd_{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux

--- a/pkgs/liquidmetal-dev/flintlock/flintlockd/registry.yaml
+++ b/pkgs/liquidmetal-dev/flintlock/flintlockd/registry.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: liquidmetal-dev/flintlock/flintlockd
+    type: github_release
+    repo_owner: liquidmetal-dev
+    repo_name: flintlock
+    description: Lock, Stock, and Two Smoking MicroVMs. Create and manage the lifecycle of MicroVMs backed by containerd
+    version_filter: not (Version matches "-alpha")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"

--- a/pkgs/liquidmetal-dev/flintlock/flintlockd/scaffold.yaml
+++ b/pkgs/liquidmetal-dev/flintlock/flintlockd/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: liquidmetal-dev/flintlock/flintlockd
+version_filter: not (Version matches "-alpha")
+# version_prefix: cli-
+all_assets_filter: not (Asset matches "-metrics")

--- a/registry.yaml
+++ b/registry.yaml
@@ -44804,6 +44804,10 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
+        asset: flintlockd_{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
   - type: github_release
     repo_owner: livebud
     repo_name: bud

--- a/registry.yaml
+++ b/registry.yaml
@@ -44795,6 +44795,15 @@ packages:
         checksum:
           enabled: false
       - version_constraint: "true"
+  - name: liquidmetal-dev/flintlock/flintlockd
+    type: github_release
+    repo_owner: liquidmetal-dev
+    repo_name: flintlock
+    description: Lock, Stock, and Two Smoking MicroVMs. Create and manage the lifecycle of MicroVMs backed by containerd
+    version_filter: not (Version matches "-alpha")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
   - type: github_release
     repo_owner: livebud
     repo_name: bud


### PR DESCRIPTION
[liquidmetal-dev/flintlock/flintlockd](https://github.com/liquidmetal-dev/flintlock): Lock, Stock, and Two Smoking MicroVMs. Create and manage the lifecycle of MicroVMs backed by containerd

```console
$ aqua g -i liquidmetal-dev/flintlock/flintlockd
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@94cf37a714fb:/workspace# flintlockd -h
The flintlock API

Usage:
  flintlockd [flags]
  flintlockd [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  run         Start running the flintlock API
  version     Print the version number of flintlock

Flags:
  -h, --help                help for flintlockd
      --log-format string   The format of the logging output. Can be 'text' or 'json'. (default "text")
      --log-output string   The output for logging. Supply a file path or one of the special values of 'stdout' and 'stderr'. (default "stderr")
  -v, --verbosity int       The verbosity level of the logging. A level of 2 and above is debug logging. A level of 9 and above is tracing.

Use "flintlockd [command] --help" for more information about a command.
```

If files such as configuration file are needed, please share them.

Reference

- https://flintlock.liquidmetal.dev/
- https://flintlock.liquidmetal.dev/docs/getting-started/
