### PR TITLE
Re-scaffold k0sproject/k0s (support cosign)

### DIFF
--- a/pkgs/k0sproject/k0s/pkg.yaml
+++ b/pkgs/k0sproject/k0s/pkg.yaml
@@ -1,6 +1,14 @@
 packages:
   - name: k0sproject/k0s@v1.32.3+k0s.0
   - name: k0sproject/k0s
+    version: v1.31.7+k0s.0
+  - name: k0sproject/k0s
+    version: v1.30.11+k0s.0
+  - name: k0sproject/k0s
+    version: v1.29.15+k0s.0
+  - name: k0sproject/k0s
+    version: v1.28.15+k0s.0
+  - name: k0sproject/k0s
     version: v1.27.16+k0s.0
   - name: k0sproject/k0s
     version: v0.8.1

--- a/pkgs/k0sproject/k0s/pkg.yaml
+++ b/pkgs/k0sproject/k0s/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: k0sproject/k0s@v1.32.3+k0s.0
+  - name: k0sproject/k0s
+    version: v1.27.16+k0s.0
+  - name: k0sproject/k0s
+    version: v0.8.1

--- a/pkgs/k0sproject/k0s/registry.yaml
+++ b/pkgs/k0sproject/k0s/registry.yaml
@@ -19,7 +19,22 @@ packages:
         supported_envs:
           - linux
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.28.15+k0s.0")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - windows
+      - version_constraint: >-
+          (semver("<= 1.32.3+k0s.0") && semver(">= 1.32.0+k0s.0")) ||
+          (semver("<= 1.31.7+k0s.0") && semver(">= 1.31.0+k0s.0")) ||
+          (semver("<= 1.30.11+k0s.0") && semver(">= 1.30.0+k0s.0")) ||
+          semver("<= 1.29.15+k0s.0")
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -36,8 +51,28 @@ packages:
             asset: "cosign.pub"
           opts:
             # `--insecure-ignore-tlog` is required because it is signed with `--tlog-upload=false` option
-            # see also: https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L106
+            # see also:
+            # https://github.com/k0sproject/k0s/pull/5724
+            # https://github.com/k0sproject/k0s/commit/a01579db2dc7916194e6fd95949b6b4fbbfa2252
             - --insecure-ignore-tlog
+        supported_envs:
+          - linux
+          - windows
+      - version_constraint: "true"
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        cosign:
+          signature:
+            type: github_release
+            asset: "{{.Asset}}.sig"
+          key:
+            type: github_release
+            asset: "cosign.pub"
         supported_envs:
           - linux
           - windows

--- a/pkgs/k0sproject/k0s/registry.yaml
+++ b/pkgs/k0sproject/k0s/registry.yaml
@@ -3,13 +3,24 @@ packages:
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0s
-    asset: k0s-{{.Version}}-{{.Arch}}
-    format: raw
-    description: k0s - Zero Friction Kubernetes
-    supported_envs:
-      - linux
-    replacements:
-      x86_64: amd64
-      aarch64: arm64
-      armv7l: arm
-      armv8l: arm
+    description: "k0s - The Zero Friction Kubernetes"
+    version_filter: not (Version matches "-(alpha|beta|rc)")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.1")
+      - version_constraint: semver("<= 1.27.16+k0s.0")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: "true"
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64

--- a/pkgs/k0sproject/k0s/registry.yaml
+++ b/pkgs/k0sproject/k0s/registry.yaml
@@ -3,17 +3,22 @@ packages:
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0s
-    description: "k0s - The Zero Friction Kubernetes"
+    description: k0s - The Zero Friction Kubernetes
     version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.1")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.27.16+k0s.0")
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         supported_envs:
-          - windows/amd64
+          - linux
+          - windows
       - version_constraint: "true"
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
@@ -22,5 +27,17 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        cosign:
+          signature:
+            type: github_release
+            asset: "{{.Asset}}.sig"
+          key:
+            type: github_release
+            asset: "cosign.pub"
+          opts:
+            # `--insecure-ignore-tlog` is required because it is signed with `--tlog-upload=false` option
+            # see also: https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L106
+            - --insecure-ignore-tlog
         supported_envs:
-          - windows/amd64
+          - linux
+          - windows

--- a/pkgs/k0sproject/k0s/scaffold.yaml
+++ b/pkgs/k0sproject/k0s/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: k0sproject/k0s
+version_filter: not (Version matches "-(alpha|beta|rc)")
+# version_prefix: cli-
+all_assets_filter: not (Asset matches "^(airgap-images-|k0s-airgap-bundle-|sonobuoy-conformance-results-)")

--- a/registry.yaml
+++ b/registry.yaml
@@ -39848,17 +39848,22 @@ packages:
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0s
-    description: "k0s - The Zero Friction Kubernetes"
+    description: k0s - The Zero Friction Kubernetes
     version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.1")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
       - version_constraint: semver("<= 1.27.16+k0s.0")
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         supported_envs:
-          - windows/amd64
+          - linux
+          - windows
       - version_constraint: "true"
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
@@ -39867,8 +39872,20 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        cosign:
+          signature:
+            type: github_release
+            asset: "{{.Asset}}.sig"
+          key:
+            type: github_release
+            asset: "cosign.pub"
+          opts:
+            # `--insecure-ignore-tlog` is required because it is signed with `--tlog-upload=false` option
+            # see also: https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L106
+            - --insecure-ignore-tlog
         supported_envs:
-          - windows/amd64
+          - linux
+          - windows
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0sctl

--- a/registry.yaml
+++ b/registry.yaml
@@ -39864,7 +39864,22 @@ packages:
         supported_envs:
           - linux
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.28.15+k0s.0")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - windows
+      - version_constraint: >-
+          (semver("<= 1.32.3+k0s.0") && semver(">= 1.32.0+k0s.0")) ||
+          (semver("<= 1.31.7+k0s.0") && semver(">= 1.31.0+k0s.0")) ||
+          (semver("<= 1.30.11+k0s.0") && semver(">= 1.30.0+k0s.0")) ||
+          semver("<= 1.29.15+k0s.0")
         asset: k0s-{{.Version}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -39881,8 +39896,28 @@ packages:
             asset: "cosign.pub"
           opts:
             # `--insecure-ignore-tlog` is required because it is signed with `--tlog-upload=false` option
-            # see also: https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L106
+            # see also:
+            # https://github.com/k0sproject/k0s/pull/5724
+            # https://github.com/k0sproject/k0s/commit/a01579db2dc7916194e6fd95949b6b4fbbfa2252
             - --insecure-ignore-tlog
+        supported_envs:
+          - linux
+          - windows
+      - version_constraint: "true"
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        cosign:
+          signature:
+            type: github_release
+            asset: "{{.Asset}}.sig"
+          key:
+            type: github_release
+            asset: "cosign.pub"
         supported_envs:
           - linux
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -39848,16 +39848,27 @@ packages:
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0s
-    asset: k0s-{{.Version}}-{{.Arch}}
-    format: raw
-    description: k0s - Zero Friction Kubernetes
-    supported_envs:
-      - linux
-    replacements:
-      x86_64: amd64
-      aarch64: arm64
-      armv7l: arm
-      armv8l: arm
+    description: "k0s - The Zero Friction Kubernetes"
+    version_filter: not (Version matches "-(alpha|beta|rc)")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.1")
+      - version_constraint: semver("<= 1.27.16+k0s.0")
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - windows/amd64
+      - version_constraint: "true"
+        asset: k0s-{{.Version}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sha256sums.txt
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
   - type: github_release
     repo_owner: k0sproject
     repo_name: k0sctl


### PR DESCRIPTION
[k0sproject/k0s](https://github.com/k0sproject/k0s): k0s - The Zero Friction Kubernetes

```console
$ aqua g -i k0sproject/k0s
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@bec87e916077:/workspace# k0s version
v1.32.3+k0s.0
```

If files such as configuration file are needed, please share them.

Reference

- https://docs.k0sproject.io/stable/
- https://docs.k0sproject.io/stable/verifying-signs/
- https://docs.k0sproject.io/stable/install/

Note

Please note the registry comments below:

> `--insecure-ignore-tlog` is required because it is signed with `--tlog-upload=false` option

- sign for linux/amd64
  - https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L106
- sign for linux/arm64
  - https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L266
- sign for windows/amd64
  - https://github.com/k0sproject/k0s/blob/v1.32.3%2Bk0s.0/.github/workflows/release.yml#L198
