### PR TITLE
feat: add containers/conmon

### DIFF
--- a/pkgs/containers/conmon/pkg.yaml
+++ b/pkgs/containers/conmon/pkg.yaml
@@ -1,6 +1,10 @@
 packages:
-  - name: containers/conmon@v2.1.0
+  - name: containers/conmon@v2.1.13
   - name: containers/conmon
-    version: v2.0.27
+    version: v2.0.32
   - name: containers/conmon
-    version: v2.0.20
+    version: v2.0.23
+  - name: containers/conmon
+    version: v2.0.19
+  - name: containers/conmon
+    version: v2.0.17

--- a/pkgs/containers/conmon/pkg.yaml
+++ b/pkgs/containers/conmon/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: containers/conmon@v2.1.0
+  - name: containers/conmon
+    version: v2.0.27
+  - name: containers/conmon
+    version: v2.0.20

--- a/pkgs/containers/conmon/registry.yaml
+++ b/pkgs/containers/conmon/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: containers
+    repo_name: conmon
+    description: An OCI container runtime monitor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.0.9")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.20")
+      - version_constraint: Version == "v2.0.21"
+        no_asset: true
+      - version_constraint: semver("<= 2.0.27")
+      - version_constraint: semver("<= 2.0.29")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.0")
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/containers/conmon/registry.yaml
+++ b/pkgs/containers/conmon/registry.yaml
@@ -6,14 +6,39 @@ packages:
     description: An OCI container runtime monitor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 2.0.9")
+      - version_constraint: semver("<= 2.0.9") || Version in ["v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
         no_asset: true
-      - version_constraint: semver("<= 2.0.20")
-      - version_constraint: Version == "v2.0.21"
-        no_asset: true
-      - version_constraint: semver("<= 2.0.27")
-      - version_constraint: semver("<= 2.0.29")
-        no_asset: true
-      - version_constraint: semver("<= 2.1.0")
+      - version_constraint: semver("<= 2.0.17") || Version in ["v2.0.20", "v2.0.24"]
+        asset: conmon
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.0.19")
+        asset: conmon-{{trimV .Version}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.0.23") || Version == "v2.0.25"
+        asset: conmon-{{trimV .Version}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux
+        files:
+          - name: conmon
+            src: result/bin/conmon
+      - version_constraint: semver("<= 2.0.32") && semver(">= 2.0.30")
+        asset: conmon-{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux
+        replacements:
+          amd64: x86
+          arm64: arm
+        files:
+          - name: conmon
+            src: bin/conmon
       - version_constraint: "true"
-        no_asset: true
+        asset: conmon.{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -21086,17 +21086,42 @@ packages:
     description: An OCI container runtime monitor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 2.0.9")
+      - version_constraint: semver("<= 2.0.9") || Version in ["v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
         no_asset: true
-      - version_constraint: semver("<= 2.0.20")
-      - version_constraint: Version == "v2.0.21"
-        no_asset: true
-      - version_constraint: semver("<= 2.0.27")
-      - version_constraint: semver("<= 2.0.29")
-        no_asset: true
-      - version_constraint: semver("<= 2.1.0")
+      - version_constraint: semver("<= 2.0.17") || Version in ["v2.0.20", "v2.0.24"]
+        asset: conmon
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.0.19")
+        asset: conmon-{{trimV .Version}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 2.0.23") || Version == "v2.0.25"
+        asset: conmon-{{trimV .Version}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux
+        files:
+          - name: conmon
+            src: result/bin/conmon
+      - version_constraint: semver("<= 2.0.32") && semver(">= 2.0.30")
+        asset: conmon-{{.Arch}}.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux
+        replacements:
+          amd64: x86
+          arm64: arm
+        files:
+          - name: conmon
+            src: bin/conmon
       - version_constraint: "true"
-        no_asset: true
+        asset: conmon.{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
   - type: github_release
     repo_owner: containers
     repo_name: crun

--- a/registry.yaml
+++ b/registry.yaml
@@ -21082,6 +21082,23 @@ packages:
           - windows/amd64
   - type: github_release
     repo_owner: containers
+    repo_name: conmon
+    description: An OCI container runtime monitor
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.0.9")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.20")
+      - version_constraint: Version == "v2.0.21"
+        no_asset: true
+      - version_constraint: semver("<= 2.0.27")
+      - version_constraint: semver("<= 2.0.29")
+        no_asset: true
+      - version_constraint: semver("<= 2.1.0")
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
+    repo_owner: containers
     repo_name: crun
     asset: crun-{{.Version}}-{{.OS}}-{{.Arch}}
     format: raw


### PR DESCRIPTION
[containers/conmon](https://github.com/containers/conmon): An OCI container runtime monitor

```console
$ aqua g -i containers/conmon
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@2076104ac44c:/workspace# conmon -h
Usage:
  conmon.amd64 [OPTION?] - conmon utility

Help Options:
  -h, --help                   Show help options

Application Options:
  --api-version                Conmon API version to use
  -b, --bundle                 Location of the OCI Bundle path
  -c, --cid                    Identification of Container
  -P, --conmon-pidfile         PID file for the conmon process
  -p, --container-pidfile      PID file for the initial pid inside of container
  -u, --cuuid                  Container UUID
  -e, --exec                   Exec a command into a running container
  --exec-attach                Attach to an exec session
  --exec-process-spec          Path to the process spec for execution
  --exit-command               Path to the program to execute when the container terminates its execution
  --exit-command-arg           Additional arg to pass to the exit command.  Can be specified multiple times
  --exit-delay                 Delay before invoking the exit command (in seconds)
  --exit-dir                   Path to the directory where exit files are written
  --leave-stdin-open           Leave stdin open when attached client disconnects
  --log-level                  Print debug logs based on log level
  -l, --log-path               Log file path
  --log-size-max               Maximum size of log file
  --log-global-size-max        Maximum size of all log files
  --log-tag                    Additional tag to use for logging
  -n, --name                   Container name
  --no-new-keyring             Do not create a new session keyring for the container
  --no-pivot                   Do not use pivot_root
  --no-sync-log                Do not manually call sync on logs after container shutdown
  -0, --persist-dir            Persistent directory for a container that can be used for storing container data
  --replace-listen-pid         Replace listen pid if set for oci-runtime pid
  --restore                    Restore a container from a checkpoint
  -r, --runtime                Path to store runtime data for the container
  --runtime-arg                Additional arg to pass to the runtime. Can be specified multiple times
  --runtime-opt                Additional opts to pass to the restore or exec command. Can be specified multiple times
  --sdnotify-socket            Path to the host's sd-notify socket to relay messages to
  --socket-dir-path            Location of container attach sockets
  -i, --stdin                  Open up a pipe to pass stdin to the container
  --sync                       Keep the main conmon process as its child by only forking once
  --syslog                     Log to syslog (use with cgroupfs cgroup manager)
  -s, --systemd-cgroup         Enable systemd cgroup manager, rather then use the cgroupfs directly
  -t, --terminal               Allocate a pseudo-TTY. The default is false
  -T, --timeout                Kill container after specified timeout in seconds.
  --version                    Print the version and exit
  --full-attach                Don't truncate the path to the attach socket. This option causes conmon to ignore --socket-dir-path
  --seccomp-notify-socket      Path to the socket where the seccomp notification fd is received
  --seccomp-notify-plugins     Plugins to use for managing the seccomp notifications
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/containers/conmon
