### PR TITLE
feat: add victoriametrics/victoriametrics/vmutils

### DIFF
--- a/pkgs/victoriametrics/victoriametrics/vmutils/pkg.yaml
+++ b/pkgs/victoriametrics/victoriametrics/vmutils/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: victoriametrics/victoriametrics/vmutils@v1.115.0
+  - name: victoriametrics/victoriametrics/vmutils
+    version: v1.103.0

--- a/pkgs/victoriametrics/victoriametrics/vmutils/registry.yaml
+++ b/pkgs/victoriametrics/victoriametrics/vmutils/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: victoriametrics/victoriametrics/vmutils
+    type: github_release
+    repo_owner: victoriametrics
+    repo_name: victoriametrics
+    description: "VictoriaMetrics: fast, cost-effective monitoring solution and time series database"
+    version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.103.0"
+        asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/victoriametrics/victoriametrics/vmutils/registry.yaml
+++ b/pkgs/victoriametrics/victoriametrics/vmutils/registry.yaml
@@ -5,6 +5,9 @@ packages:
     repo_owner: victoriametrics
     repo_name: victoriametrics
     description: "VictoriaMetrics: fast, cost-effective monitoring solution and time series database"
+    files:
+      - name: vmalert-tool
+        src: vmalert-tool-prod
     version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")
     version_constraint: "false"
     version_overrides:
@@ -29,3 +32,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: vmalert-tool
+                src: vmalert-tool-windows-{{.Arch}}-prod.exe

--- a/pkgs/victoriametrics/victoriametrics/vmutils/scaffold.yaml
+++ b/pkgs/victoriametrics/victoriametrics/vmutils/scaffold.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: victoriametrics/victoriametrics/vmutils
+# version_filter: not (Version matches "-rc$")
+# version_prefix: cli-
+all_assets_filter:  (Asset matches "vmutils-") and not (Asset matches "-enterprise") and not (Asset matches "-arm-")
+version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")

--- a/pkgs/victoriametrics/victoriametrics/vmutils/scaffold.yaml
+++ b/pkgs/victoriametrics/victoriametrics/vmutils/scaffold.yaml
@@ -6,5 +6,5 @@
 name: victoriametrics/victoriametrics/vmutils
 # version_filter: not (Version matches "-rc$")
 # version_prefix: cli-
-all_assets_filter:  (Asset matches "vmutils-") and not (Asset matches "-enterprise") and not (Asset matches "-arm-")
+all_assets_filter: (Asset matches "vmutils-") and not (Asset matches "-enterprise") and not (Asset matches "-arm-")
 version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -70053,6 +70053,9 @@ packages:
     repo_owner: victoriametrics
     repo_name: victoriametrics
     description: "VictoriaMetrics: fast, cost-effective monitoring solution and time series database"
+    files:
+      - name: vmalert-tool
+        src: vmalert-tool-prod
     version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")
     version_constraint: "false"
     version_overrides:
@@ -70077,6 +70080,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: vmalert-tool
+                src: vmalert-tool-windows-{{.Arch}}-prod.exe
   - type: github_release
     repo_owner: vishaltelangre
     repo_name: ff

--- a/registry.yaml
+++ b/registry.yaml
@@ -70048,6 +70048,35 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - name: victoriametrics/victoriametrics/vmutils
+    type: github_release
+    repo_owner: victoriametrics
+    repo_name: victoriametrics
+    description: "VictoriaMetrics: fast, cost-effective monitoring solution and time series database"
+    version_filter: semver("> 1.78.1") and not (Version endsWith "-victorialogs") and (Version endsWith ".0")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.103.0"
+        asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: vmutils-{{.OS}}-{{.Arch}}-{{.Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: vishaltelangre
     repo_name: ff


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## Description

This PR adds vmalert-tool command from [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics). It's included in vmutils distributed on VictoriaMetrics GitHub release pages (like [this](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.115.0)). The versioning system of VictoriaMetrics isn't straightforward, and I'm not too sure about it, but after some trials I found that using only vX.Y.0 should be reasonable for aqua. And too old assets don't have common file structures as the current ones, so I intentionally omit <=v1.78.1 versions.

## How to confirm if this package works well
Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well. Please confirm if this package works well yourself as much as possible.

Command and output

```
❯ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@180c4de61856:/workspace# vmalert-tool --version
vmalert-tool version vmalert-tool-20250404-141114-tags-v1.115.0-0-g123f373537
2025/04/28 04:20:14 Total time: 85.833µs
root@180c4de61856:/workspace# vmalert-tool --help   
NAME:
   vmalert-tool - VMAlert command-line tool

USAGE:
   More info in https://docs.victoriametrics.com/vmalert-tool.html

VERSION:
   vmalert-tool-20250404-141114-tags-v1.115.0-0-g123f373537

COMMANDS:
   unittest  Run unittest for alerting and recording rules.
   help, h   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
2025/04/28 04:20:33 Total time: 963.575µs
root@180c4de61856:/workspace#
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/VictoriaMetrics/VictoriaMetrics
- https://docs.victoriametrics.com/victoriametrics/vmalert-tool/