### PR TITLE
greymd/teip: replace arm64 to aarch64

### DIFF
--- a/pkgs/greymd/teip/registry.yaml
+++ b/pkgs/greymd/teip/registry.yaml
@@ -7,6 +7,7 @@ packages:
     format: tar.gz
     description: Highly efficient "Masking tape" for Shell
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl

--- a/registry.yaml
+++ b/registry.yaml
@@ -34372,6 +34372,7 @@ packages:
     format: tar.gz
     description: Highly efficient "Masking tape" for Shell
     replacements:
+      arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
       linux: unknown-linux-musl


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

arm64 needs to be replaced by aarch64. See https://github.com/greymd/teip/releases/tag/v2.3.2
