### PR TITLE
feat(kubecolor/kubecolor): GitHub artifact attestations config

### DIFF
--- a/pkgs/kubecolor/kubecolor/pkg.yaml
+++ b/pkgs/kubecolor/kubecolor/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: kubecolor/kubecolor@v0.5.0
+  - name: kubecolor/kubecolor@v0.5.1
+  - name: kubecolor/kubecolor
+    version: v0.5.0
   - name: kubecolor/kubecolor
     version: v0.0.21

--- a/pkgs/kubecolor/kubecolor/registry.yaml
+++ b/pkgs/kubecolor/kubecolor/registry.yaml
@@ -21,6 +21,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 0.5.1")
+        asset: kubecolor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: kubecolor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -28,6 +38,8 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: kubecolor/kubecolor/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43210,6 +43210,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 0.5.1")
+        asset: kubecolor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: kubecolor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -43217,6 +43227,8 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: kubecolor/kubecolor/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
- https://github.com/kubecolor/kubecolor/releases/tag/v0.5.1
- https://github.com/kubecolor/kubecolor/attestations

No test coverage yet as registry's kubecolor is still at 0.5.0 at time of writing.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
