### PR TITLE
feat: add kubernetes/node-problem-detector

### DIFF
--- a/pkgs/kubernetes/node-problem-detector/pkg.yaml
+++ b/pkgs/kubernetes/node-problem-detector/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: kubernetes/node-problem-detector@v0.8.20
+  - name: kubernetes/node-problem-detector
+    version: v0.8.15
+  - name: kubernetes/node-problem-detector
+    version: v0.8.13
+  - name: kubernetes/node-problem-detector
+    version: v0.8.12
+  - name: kubernetes/node-problem-detector
+    version: v0.8.10
+  - name: kubernetes/node-problem-detector
+    version: v0.8.8
+  - name: kubernetes/node-problem-detector
+    version: v0.8.7

--- a/pkgs/kubernetes/node-problem-detector/registry.yaml
+++ b/pkgs/kubernetes/node-problem-detector/registry.yaml
@@ -4,6 +4,13 @@ packages:
     repo_owner: kubernetes
     repo_name: node-problem-detector
     description: This is a place for various problem detectors running on the Kubernetes nodes
+    files:
+      - name: node-problem-detector
+        src: bin/{{.FileName}}
+      - name: health-checker
+        src: bin/{{.FileName}}
+      - name: log-counter
+        src: bin/{{.FileName}}
     version_filter: not (Version matches "-(alpha|beta|rc)$")
     version_constraint: "false"
     version_overrides:
@@ -15,7 +22,14 @@ packages:
         windows_arm_emulation: true
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: Version == "v0.8.12"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -26,22 +40,47 @@ packages:
           algorithm: sha512
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: Version == "v0.8.13"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: semver("<= 0.8.7")
+        asset: node-problem-detector-{{.Version}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.8.10")
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: semver("<= 0.8.15")
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -52,11 +91,25 @@ packages:
           algorithm: sha512
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: "true"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}

--- a/pkgs/kubernetes/node-problem-detector/registry.yaml
+++ b/pkgs/kubernetes/node-problem-detector/registry.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kubernetes
+    repo_name: node-problem-detector
+    description: This is a place for various problem detectors running on the Kubernetes nodes
+    version_filter: not (Version matches "-(alpha|beta|rc)$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.11"
+        no_asset: true
+      - version_constraint: Version == "v0.8.8"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.8.12"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: Version == "v0.8.13"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.8.7")
+      - version_constraint: semver("<= 0.8.10")
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.8.15")
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: "true"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64

--- a/pkgs/kubernetes/node-problem-detector/scaffold.yaml
+++ b/pkgs/kubernetes/node-problem-detector/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: kubernetes/node-problem-detector
+version_filter: not (Version matches "-(alpha|beta|rc)$")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -44274,6 +44274,13 @@ packages:
     repo_owner: kubernetes
     repo_name: node-problem-detector
     description: This is a place for various problem detectors running on the Kubernetes nodes
+    files:
+      - name: node-problem-detector
+        src: bin/{{.FileName}}
+      - name: health-checker
+        src: bin/{{.FileName}}
+      - name: log-counter
+        src: bin/{{.FileName}}
     version_filter: not (Version matches "-(alpha|beta|rc)$")
     version_constraint: "false"
     version_overrides:
@@ -44285,7 +44292,14 @@ packages:
         windows_arm_emulation: true
         supported_envs:
           - linux/amd64
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: Version == "v0.8.12"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -44296,22 +44310,47 @@ packages:
           algorithm: sha512
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: Version == "v0.8.13"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: semver("<= 0.8.7")
+        asset: node-problem-detector-{{.Version}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.8.10")
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: semver("<= 0.8.15")
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -44322,14 +44361,28 @@ packages:
           algorithm: sha512
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
       - version_constraint: "true"
         asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         supported_envs:
           - linux
-          - windows/amd64
+          - windows
+        overrides:
+          - goos: windows
+            files:
+              - name: node-problem-detector.exe
+                src: bin/{{.FileName}}
+              - name: health-checker.exe
+                src: bin/{{.FileName}}
   - type: github_release
     repo_owner: kubescape
     repo_name: kubescape

--- a/registry.yaml
+++ b/registry.yaml
@@ -44271,6 +44271,66 @@ packages:
       - amd64
     url: https://storage.googleapis.com/minikube/releases/{{.Version}}/minikube-{{.OS}}-{{.Arch}}
   - type: github_release
+    repo_owner: kubernetes
+    repo_name: node-problem-detector
+    description: This is a place for various problem detectors running on the Kubernetes nodes
+    version_filter: not (Version matches "-(alpha|beta|rc)$")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.11"
+        no_asset: true
+      - version_constraint: Version == "v0.8.8"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "v0.8.12"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: Version == "v0.8.13"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.8.7")
+      - version_constraint: semver("<= 0.8.10")
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.8.15")
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: "true"
+        asset: node-problem-detector-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - windows/amd64
+  - type: github_release
     repo_owner: kubescape
     repo_name: kubescape
     description: Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources


### PR DESCRIPTION
[kubernetes/node-problem-detector](https://github.com/kubernetes/node-problem-detector): This is a place for various problem detectors running on the Kubernetes nodes

```console
$ aqua g -i kubernetes/node-problem-detector
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@88c8c36f0ff7:/workspace# node-problem-detector -h
Usage of node-problem-detector:
      --address string                           The address to bind the node problem detector server. (default "127.0.0.1")
      --apiserver-override string                Custom URI used to connect to Kubernetes ApiServer. This is ignored if --enable-k8s-exporter is false.
      --apiserver-wait-interval duration         The interval between the checks on the readiness of kube-apiserver. This is ignored if --enable-k8s-exporter is false. (default 5s)
      --apiserver-wait-timeout duration          The timeout on waiting for kube-apiserver to be ready. This is ignored if --enable-k8s-exporter is false. (default 5m0s)
      --config.custom-plugin-monitor strings     Comma separated configurations for custom-plugin-monitor monitor. Set to config file paths.
      --config.system-log-monitor strings        Comma separated configurations for system-log-monitor monitor. Set to config file paths.
      --config.system-stats-monitor strings      Comma separated configurations for system-stats-monitor monitor. Set to config file paths.
      --enable-k8s-exporter                      Enables reporting to Kubernetes API server. (default true)
      --event-namespace string                   Namespace for recorded Kubernetes events.
      --exporter.stackdriver string              Configuration for Stackdriver exporter. Set to config file path.
      --hostname-override string                 Custom node name used to override hostname
      --k8s-exporter-heartbeat-period duration   The period at which k8s-exporter does forcibly sync with apiserver. (default 5m0s)
      --port int                                 The port to bind the node problem detector server. Use 0 to disable. (default 20256)
      --prometheus-address string                The address to bind the Prometheus scrape endpoint. (default "127.0.0.1")
      --prometheus-port int                      The port to bind the Prometheus scrape endpoint. Prometheus exporter is enabled by default at port 20257. Use 0 to disable. (default 20257)
  -v, --v Level                                  number for the log level verbosity
      --version                                  Print version information and quit
pflag: help requested
```

If files such as configuration file are needed, please share them.

Reference

- https://kubernetes.io/docs/tasks/debug/debug-cluster/monitor-node-health/

Note

My needs are met by the following `Problem Maker`, but if the command is executed incorrectly, it can cause serious problems in the system, so only those who need it can copy the binary with the command below and perform abnormality testing on the system.

README:
https://github.com/kubernetes/node-problem-detector/blob/master/test/e2e/problemmaker/README.md

Command:
```console
$ cp "$(dirname "$(dirname "$(aqua which node-problem-detector)")")"/test/bin/problem-maker .
```