### PR TITLE
feat: add GoogleCloudPlatform/kubectl-ai

### DIFF
--- a/pkgs/GoogleCloudPlatform/kubectl-ai/pkg.yaml
+++ b/pkgs/GoogleCloudPlatform/kubectl-ai/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: GoogleCloudPlatform/kubectl-ai@v0.0.6

--- a/pkgs/GoogleCloudPlatform/kubectl-ai/registry.yaml
+++ b/pkgs/GoogleCloudPlatform/kubectl-ai/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: GoogleCloudPlatform
+    repo_name: kubectl-ai
+    description: AI powered Kubernetes Assistant
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kubectl-ai_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kubectl-ai_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -2972,6 +2972,27 @@ packages:
             url: https://storage.googleapis.com/cloudsql-proxy/{{.Version}}/cloud_sql_proxy_x64.exe
   - type: github_release
     repo_owner: GoogleCloudPlatform
+    repo_name: kubectl-ai
+    description: AI powered Kubernetes Assistant
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kubectl-ai_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kubectl-ai_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: GoogleCloudPlatform
     repo_name: terraformer
     description: CLI tool to generate terraform files from existing infrastructure (reverse Terraform). Infrastructure to Code
     version_constraint: "false"


### PR DESCRIPTION
[GoogleCloudPlatform/kubectl-ai](https://github.com/GoogleCloudPlatform/kubectl-ai): AI powered Kubernetes Assistant

```console
$ aqua g -i GoogleCloudPlatform/kubectl-ai
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@88c8c36f0ff7:/workspace# kubectl-ai -h
Usage of kubectl-ai:
  -add_dir_header
        If true, adds the file directory to the header of the log messages
  -alsologtostderr
        log to standard error as well as files (no effect when -logtostderr=true)
  -enable-tool-use-shim
        enable tool use shim
  -kubeconfig string
        path to the kubeconfig file
  -llm-provider string
        language model provider (default "gemini")
  -log_backtrace_at value
        when logging hits line file:N, emit a stack trace
  -log_dir string
        If non-empty, write log files in this directory (no effect when -logtostderr=true)
  -log_file string
        If non-empty, use this log file (no effect when -logtostderr=true)
  -log_file_max_size uint
        Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
  -logtostderr
        log to standard error instead of files (default true)
  -max-iterations int
        maximum number of iterations agent will try before giving up (default 20)
  -mcp-server
        run in MCP server mode
  -model string
        language model e.g. gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-flash (default "gemini-2.5-pro-preview-03-25")
  -one_output
        If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
  -prompt-template-file string
        path to custom prompt template file
  -quiet
        run in non-interactive mode, requires a query to be provided as a positional argument
  -remove-workdir
        remove the temporary working directory after execution
  -skip-permissions
        (dangerous) skip asking for confirmation before executing kubectl commands that modify resources
  -skip_headers
        If true, avoid header prefixes in the log messages
  -skip_log_headers
        If true, avoid headers when opening log files (no effect when -logtostderr=true)
  -stderrthreshold value
        logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
  -trace-path string
        path to the trace file (default "trace.log")
  -v value
        number for the log level verbosity
  -vmodule value
        comma-separated list of pattern=N settings for file-filtered logging
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/GoogleCloudPlatform/kubectl-ai/blob/main/README.md
