### PR TITLE
chore(kubernetes/kubernetes): remove unused scaffold.yaml

### DIFF
--- a/pkgs/kubernetes/kubelet/scaffold.yaml
+++ b/pkgs/kubernetes/kubelet/scaffold.yaml
@@ -1,4 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-name: kubernetes/kubernetes/kubelet
-version_filter: not (Version matches "-(alpha|beta|rc)")

--- a/pkgs/kubernetes/kubernetes/apiextensions-apiserver/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/apiextensions-apiserver/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/apiextensions-apiserver
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-aggregator/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-aggregator/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-aggregator
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-apiserver/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-apiserver/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-apiserver
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-controller-manager/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-controller-manager/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-controller-manager
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-log-runner/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-log-runner/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-log-runner
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-proxy/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-proxy/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-proxy
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kube-scheduler/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kube-scheduler/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kube-scheduler
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kubeadm/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kubeadm/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kubeadm
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kubectl-convert/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kubectl-convert/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kubectl-convert
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/kubernetes/kubernetes/kubectl/scaffold.yaml
+++ b/pkgs/kubernetes/kubernetes/kubectl/scaffold.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
-name: kubernetes/kubernetes/kubectl
-version_filter: not (Version matches "-(alpha|beta|rc)")
-# version_prefix: cli-
-# all_assets_filter: not (Asset matches "-cli")


### PR DESCRIPTION
cmdx s (scaffold.yaml) supports only github_release type package.

see also: https://github.com/aquaproj/aqua-registry/pull/35734#discussion_r2069798489

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## About

Fllow-up PR Comment:
https://github.com/aquaproj/aqua-registry/pull/35734#discussion_r2069798489