### PR TITLE
feat: add Shopify/shadowenv

### DIFF
--- a/pkgs/Shopify/shadowenv/pkg.yaml
+++ b/pkgs/Shopify/shadowenv/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: Shopify/shadowenv@3.0.3
+  - name: Shopify/shadowenv
+    version: 2.1.1
+  - name: Shopify/shadowenv
+    version: 2.1.0
+  - name: Shopify/shadowenv
+    version: 2.0.7
+  - name: Shopify/shadowenv
+    version: 2.0.5
+  - name: Shopify/shadowenv
+    version: 2.0.0
+  - name: Shopify/shadowenv
+    version: 1.2.1

--- a/pkgs/Shopify/shadowenv/registry.yaml
+++ b/pkgs/Shopify/shadowenv/registry.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Shopify
+    repo_name: shadowenv
+    description: reversible directory-local environment variable manipulations
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.2.1"
+        asset: shadowenv-{{.OS}}-10.14
+        format: raw
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "2.1.0"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "2.1.1"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.0")
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2.0.5")
+        asset: shadowenv-{{.OS}}-latest
+        format: raw
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2.0.7")
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -4986,6 +4986,83 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: Shopify
+    repo_name: shadowenv
+    description: reversible directory-local environment variable manipulations
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.2.1"
+        asset: shadowenv-{{.OS}}-10.14
+        format: raw
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "2.1.0"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "2.1.1"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.0.0")
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2.0.5")
+        asset: shadowenv-{{.OS}}-latest
+        format: raw
+        replacements:
+          darwin: macOS
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2.0.7")
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: shadowenv-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: Shopify
     repo_name: toxiproxy
     description: A TCP proxy to simulate network and system conditions for chaos and resiliency testing
     files:


### PR DESCRIPTION
[Shopify/shadowenv](https://github.com/Shopify/shadowenv): reversible directory-local environment variable manipulations

```console
$ aqua g -i Shopify/shadowenv
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@f9c87a0090f0:/workspace# shadowenv -h
shadowenv 3.0.3

USAGE:
    shadowenv-x86_64-unknown-linux-gnu <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    diff             Display a diff of changed environment variables.
    exec             Execute a command after loading the environment from the current directory.
    help             Prints this message or the help of the given subcommand(s)
    hook             Runs the shell hook. You shouldn't need to run this manually.
    init             Prints a script which can be eval'd to set up shadowenv in various shells.
    prompt-widget    Print a little glyph you can include in a shell prompt to indicate that shadowenv is active.
    trust            Mark the closest shadowenv directory as 'trusted', allowing its programs to be run. The closest
                     shadowenv directory is found by traversing the file system upwards, starting at the current
                     directory.
```

If files such as configuration file are needed, please share them.

Reference

- https://shopify.github.io/shadowenv/
- https://shopify.github.io/shadowenv/getting-started/
