### PR TITLE
feat(moby/buildkit): support buildkitd

### DIFF
--- a/pkgs/moby/buildkit/pkg.yaml
+++ b/pkgs/moby/buildkit/pkg.yaml
@@ -1,6 +1,4 @@
 packages:
-  - name: moby/buildkit@v0.13.1
-  - name: moby/buildkit
-    version: v0.11.0-rc2
+  - name: moby/buildkit@v0.21.1
   - name: moby/buildkit
     version: v0.8.3

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    files:
+      - name: buildctl
+        src: bin/{{.FileName}}
     version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
@@ -12,6 +15,114 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-aarch64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-x86_64
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-aarch64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-x86_64
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: windows
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}

--- a/pkgs/moby/buildkit/registry.yaml
+++ b/pkgs/moby/buildkit/registry.yaml
@@ -4,8 +4,7 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
-    files:
-      - name: buildctl
+    version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -13,19 +12,6 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: buildctl
-            src: bin/buildctl
-      - version_constraint: semver("<= 0.11.0-rc2")
-        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buildctl
-            src: bin/buildctl
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
-        files:
-          - name: buildctl
-            src: bin/buildctl

--- a/pkgs/moby/buildkit/scaffold.yaml
+++ b/pkgs/moby/buildkit/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: moby/buildkit
+version_filter: not (Version matches "-(alpha|beta|rc)")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -49735,6 +49735,9 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
+    files:
+      - name: buildctl
+        src: bin/{{.FileName}}
     version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
@@ -49743,9 +49746,117 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-aarch64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-x86_64
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: linux
+            goarch: amd64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-aarch64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: linux
+            goarch: arm64
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-bridge
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-firewall
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-host-local
+                src: bin/{{.FileName}}
+              - name: buildkit-cni-loopback
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-arm
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-i386
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-ppc64le
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-riscv64
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-s390x
+                src: bin/{{.FileName}}
+              - name: buildkit-qemu-x86_64
+                src: bin/{{.FileName}}
+              - name: buildkit-runc
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
+          - goos: windows
+            files:
+              - name: buildctl
+                src: bin/{{.FileName}}
+              - name: buildkitd
+                src: bin/{{.FileName}}
   - type: github_release
     repo_owner: momaek
     repo_name: authy

--- a/registry.yaml
+++ b/registry.yaml
@@ -49735,8 +49735,7 @@ packages:
     repo_owner: moby
     repo_name: buildkit
     description: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
-    files:
-      - name: buildctl
+    version_filter: not (Version matches "-(alpha|beta|rc)")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.3")
@@ -49744,22 +49743,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: buildctl
-            src: bin/buildctl
-      - version_constraint: semver("<= 0.11.0-rc2")
-        asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: buildctl
-            src: bin/buildctl
       - version_constraint: "true"
         asset: buildkit-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        complete_windows_ext: false
-        files:
-          - name: buildctl
-            src: bin/buildctl
   - type: github_release
     repo_owner: momaek
     repo_name: authy


### PR DESCRIPTION
[moby/buildkit](https://github.com/moby/buildkit): concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit

```console
$ aqua g -i moby/buildkit
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@a6484b52730e:/workspace# buildkitd --help
NAME:
   buildkitd - build daemon

USAGE:
   buildkitd [global options] command [command options] [arguments...]

VERSION:
   v0.21.1

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --rootless                                  set all the default options to be compatible with rootless containers
   --config value                              path to config file (default: "/etc/buildkit/buildkitd.toml")
   --debug                                     enable debug output in logs
   --trace                                     enable trace output in logs (highly verbose, could affect performance)
   --root value                                path to state directory (default: "/var/lib/buildkit")
   --addr value                                listening address (socket or tcp) (default: "unix:///run/buildkit/buildkitd.sock")
   --log-format value                          log formatter: json or text (default: "text")
   --group value                               group (name or gid) which will own all Unix socket listening addresses
   --debugaddr value                           debugging address (eg. 0.0.0.0:6060) [$BUILDKITD_DEBUGADDR]
   --tlscert value                             certificate file to use
   --tlskey value                              key file to use
   --tlscacert value                           ca certificate to verify clients
   --allow-insecure-entitlement value          allows insecure entitlements e.g. network.host, security.insecure
   --otel-socket-path value                    OTEL collector trace socket path
   --cdi-disabled                              disables support of the Container Device Interface (CDI)
   --cdi-spec-dir value                        list of directories to scan for CDI spec files
   --containerd-worker value                   enable containerd workers (true/false/auto) (default: "auto")
   --containerd-worker-addr value              containerd socket (default: "/run/containerd/containerd.sock")
   --containerd-worker-labels value            user-specific annotation labels (com.example.foo=bar)
   --containerd-worker-net value               worker network type (auto, bridge, cni or host) (default: "auto")
   --containerd-cni-config-path value          path of cni config file (default: "/etc/buildkit/cni.json")
   --containerd-cni-binary-dir value           path of cni binary files (default: "/opt/cni/bin")
   --containerd-cni-pool-size value            size of cni network namespace pool (default: 0)
   --containerd-worker-snapshotter value       snapshotter name to use (default: "overlayfs")
   --containerd-worker-apparmor-profile value  set the name of the apparmor profile applied to containers
   --containerd-worker-selinux                 apply SELinux labels
   --containerd-worker-rootless                enable rootless mode
   --containerd-worker-gc                      Enable automatic garbage collection on worker
   --containerd-worker-gc-keepstorage value    Amount of storage GC keep locally, format "Reserved[,Free[,Maximum]]" (MB) (default: "2000,2000,2000")
   --oci-worker value                          enable oci workers (true/false/auto) (default: "auto")
   --oci-worker-labels value                   user-specific annotation labels (com.example.foo=bar)
   --oci-worker-snapshotter value              name of snapshotter (overlayfs, native, etc.) (default: "auto")
   --oci-worker-proxy-snapshotter-path value   address of proxy snapshotter socket (do not include 'unix://' prefix)
   --oci-worker-platform value                 override supported platforms for worker
   --oci-worker-net value                      worker network type (auto, bridge, cni or host) (default: "auto")
   --oci-cni-config-path value                 path of cni config file (default: "/etc/buildkit/cni.json")
   --oci-cni-binary-dir value                  path of cni binary files (default: "/opt/cni/bin")
   --oci-cni-pool-size value                   size of cni network namespace pool (default: 0)
   --oci-worker-binary value                   name of specified oci worker binary
   --oci-worker-apparmor-profile value         set the name of the apparmor profile applied to containers
   --oci-worker-selinux                        apply SELinux labels
   --oci-worker-rootless                       enable rootless mode
   --oci-worker-no-process-sandbox             use the host PID namespace and procfs (WARNING: allows build containers to kill (and potentially ptrace) an arbitrary process in the host namespace)
   --oci-worker-gc                             Enable automatic garbage collection on worker
   --oci-worker-gc-keepstorage value           Amount of storage GC keep locally, format "Reserved[,Free[,Maximum]]" (MB) (default: "2000,2000,2000")
   --help, -h                                  show help
   --version, -v                               print the version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/moby/buildkit/blob/master/README.md#quick-start
- https://github.com/moby/buildkit/blob/master/docs/rootless.md
