### PR TITLE
fix(luau-lang/luau): restrict darwin support to arm64

### DIFF
--- a/pkgs/luau-lang/luau/pkg.yaml
+++ b/pkgs/luau-lang/luau/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: luau-lang/luau@0.671
+  - name: luau-lang/luau
+    version: 0.644
+  - name: luau-lang/luau
+    version: 0.622

--- a/pkgs/luau-lang/luau/registry.yaml
+++ b/pkgs/luau-lang/luau/registry.yaml
@@ -13,7 +13,7 @@ packages:
           darwin: macos
           linux: ubuntu
         supported_envs:
-          - darwin
+          - darwin/arm64
           - linux
           - windows/amd64
         files:

--- a/pkgs/luau-lang/luau/registry.yaml
+++ b/pkgs/luau-lang/luau/registry.yaml
@@ -6,6 +6,34 @@ packages:
     description: A fast, small, safe, gradually typed embeddable scripting language derived from Lua
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.622")
+        asset: luau-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+          linux: ubuntu
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+        files:
+          - name: luau
+          - name: luau-analyze
+          - name: luau-compile
+      - version_constraint: semver("<= 0.644")
+        asset: luau-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+          linux: ubuntu
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows
+        files:
+          - name: luau
+          - name: luau-analyze
+          - name: luau-compile
       - version_constraint: "true"
         asset: luau-{{.OS}}.{{.Format}}
         format: zip
@@ -15,7 +43,7 @@ packages:
         supported_envs:
           - darwin/arm64
           - linux
-          - windows/amd64
+          - windows
         files:
           - name: luau
           - name: luau-analyze

--- a/registry.yaml
+++ b/registry.yaml
@@ -47182,7 +47182,7 @@ packages:
           darwin: macos
           linux: ubuntu
         supported_envs:
-          - darwin
+          - darwin/arm64
           - linux
           - windows/amd64
         files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -47175,6 +47175,34 @@ packages:
     description: A fast, small, safe, gradually typed embeddable scripting language derived from Lua
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.622")
+        asset: luau-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+          linux: ubuntu
+        supported_envs:
+          - darwin
+          - linux
+          - windows/amd64
+        files:
+          - name: luau
+          - name: luau-analyze
+          - name: luau-compile
+      - version_constraint: semver("<= 0.644")
+        asset: luau-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+          linux: ubuntu
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows
+        files:
+          - name: luau
+          - name: luau-analyze
+          - name: luau-compile
       - version_constraint: "true"
         asset: luau-{{.OS}}.{{.Format}}
         format: zip
@@ -47184,7 +47212,7 @@ packages:
         supported_envs:
           - darwin/arm64
           - linux
-          - windows/amd64
+          - windows
         files:
           - name: luau
           - name: luau-analyze


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Install and execute the package and confirm if the package works well
- [X] Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

The "macos" release for luau-lang/luau apparently is arm64-only.