### PR TITLE
feat: add reproio/terraform-j2md

### DIFF
--- a/pkgs/reproio/terraform-j2md/pkg.yaml
+++ b/pkgs/reproio/terraform-j2md/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: reproio/terraform-j2md@v0.0.9
+  - name: reproio/terraform-j2md
+    version: v0.0.3

--- a/pkgs/reproio/terraform-j2md/registry.yaml
+++ b/pkgs/reproio/terraform-j2md/registry.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: reproio
+    repo_name: terraform-j2md
+    description: create readable terraform plan as markdown text from json plan output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+        asset: terraform-j2md_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: terraform-j2md_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -58417,6 +58417,38 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: reproio
+    repo_name: terraform-j2md
+    description: create readable terraform plan as markdown text from json plan output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+        asset: terraform-j2md_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: terraform-j2md_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: rest-sh
     repo_name: restish
     aliases:


### PR DESCRIPTION
[reproio/terraform-j2md](https://github.com/reproio/terraform-j2md): create readable terraform plan as markdown text from json plan output

```console
$ aqua g -i reproio/terraform-j2md
```


- https://github.com/aquaproj/aqua-registry/pull/35644