### PR TITLE
fix: rename `rust-lang/rustup/rustup-init` to `rust-lang/rustup`

### DIFF
--- a/pkgs/rust-lang/rustup/pkg.yaml
+++ b/pkgs/rust-lang/rustup/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rust-lang/rustup@1.28.1

--- a/pkgs/rust-lang/rustup/registry.yaml
+++ b/pkgs/rust-lang/rustup/registry.yaml
@@ -1,10 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - name: rust-lang/rustup/rustup-init
+  - name: rust-lang/rustup
+    aliases:
+      - name: rust-lang/rustup/rustup-init
     type: http
     repo_owner: rust-lang
     repo_name: rustup
-    description: The installer for rustup
+    files:
+      - name: rustup
+        link: rustup
+      - name: rustup-init
+    description: The Rust toolchain installer
     version_source: github_tag
     version_constraint: "false"
     version_overrides:

--- a/pkgs/rust-lang/rustup/rustup-init/pkg.yaml
+++ b/pkgs/rust-lang/rustup/rustup-init/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: rust-lang/rustup/rustup-init@1.28.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -59574,11 +59574,17 @@ packages:
             format: zip
             files:
               - name: rust-analyzer
-  - name: rust-lang/rustup/rustup-init
+  - name: rust-lang/rustup
+    aliases:
+      - name: rust-lang/rustup/rustup-init
     type: http
     repo_owner: rust-lang
     repo_name: rustup
-    description: The installer for rustup
+    files:
+      - name: rustup
+        link: rustup
+      - name: rustup-init
+    description: The Rust toolchain installer
     version_source: github_tag
     version_constraint: "false"
     version_overrides:


### PR DESCRIPTION
## About

The `rustup-init` binary behaves differently depending on its filename.
Below are the `rustup-init` source code comments:

https://github.com/rust-lang/rustup/blob/f9edccde032ea3109e0b78c891dd74852c0b25ff/src/bin/rustup-init.rs#L1C1-L12C20

```rust
//! The main Rustup command-line interface
//!
//! The rustup binary is a chimera, changing its behavior based on the
//! name of the binary. This is used most prominently to enable
//! Rustup's tool 'proxies' - that is, rustup itself and the rustup
//! proxies are the same binary: when the binary is called 'rustup' or
//! 'rustup.exe' it offers the Rustup command-line interface, and
//! when it is called 'rustc' it behaves as a proxy to 'rustc'.
//!
//! This scheme is further used to distinguish the Rustup installer,
//! called 'rustup-init', which is again just the rustup binary under a
//! different name.
```

## Testing

for `rustup`:

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@a860315c15f9:/workspace# which rustup
/root/.local/share/aquaproj-aqua/bin/rustup
root@a860315c15f9:/workspace# aqua which rustup
/root/.local/share/aquaproj-aqua/pkgs/http/static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-gnu/rustup-init/rustup
root@a860315c15f9:/workspace# rustup -h
rustup 1.28.1 (f9edccde0 2025-03-05)

The Rust toolchain installer

Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]

Commands:
  show         Show the active and installed toolchains or profiles
  update       Update Rust toolchains and rustup
  check        Check for updates to Rust toolchains and rustup
  default      Set the default toolchain
  toolchain    Modify or query the installed toolchains
  target       Modify a toolchain's supported targets
  component    Modify a toolchain's installed components
  override     Modify toolchain overrides for directories
  run          Run a command with an environment configured for a given toolchain
  which        Display which binary will be run for a given command
  doc          Open the documentation for the current toolchain
  man          View the man page for a given command
  self         Modify the rustup installation
  set          Alter rustup settings
  completions  Generate tab-completion scripts for your shell
  help         Print this message or the help of the given subcommand(s)

Arguments:
  [+toolchain]  Release channel (e.g. +stable) or custom toolchain to set override

Options:
  -v, --verbose  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
  -q, --quiet    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
  -h, --help     Print help
  -V, --version  Print version

Discussion:
    Rustup installs The Rust Programming Language from the official
    release channels, enabling you to easily switch between stable,
    beta, and nightly compilers and keep them updated. It makes
    cross-compiling simpler with binary builds of the standard library
    for common platforms.

    If you are new to Rust consider running `rustup doc --book` to
    learn Rust.
```

for `rustup-init`:

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@433e1f7da58f:/workspace# which rustup-init
/root/.local/share/aquaproj-aqua/bin/rustup-init
root@433e1f7da58f:/workspace# aqua which rustup-init
/root/.local/share/aquaproj-aqua/pkgs/http/static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-gnu/rustup-init/rustup-init
root@433e1f7da58f:/workspace# rustup-init -h
rustup-init 1.28.1 (f9edccde0 2025-03-05)

The installer for rustup

Usage: rustup-init[EXE] [OPTIONS]

Options:
  -v, --verbose                                Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
  -q, --quiet                                  Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
  -y                                           Disable confirmation prompt
      --default-host <DEFAULT_HOST>            Choose a default host triple
      --default-toolchain <DEFAULT_TOOLCHAIN>  Choose a default toolchain to install. Use 'none' to not install any
                                               toolchains at all
      --profile <PROFILE>                      [default: default] [possible values: minimal, default, complete]
  -c, --component <COMPONENT>                  Comma-separated list of component names to also install
  -t, --target <TARGET>                        Comma-separated list of target names to also install
      --no-update-default-toolchain            Don't update any existing default toolchain after install
      --no-modify-path                         Don't configure the PATH environment variable
  -h, --help                                   Print help
  -V, --version                                Print version
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
