### PR TITLE
feat: add actions/go-versions

### DIFF
--- a/pkgs/actions/go-versions/pkg.yaml
+++ b/pkgs/actions/go-versions/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: actions/go-versions@

--- a/pkgs/actions/go-versions/pkg.yaml
+++ b/pkgs/actions/go-versions/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: actions/go-versions@
+  - name: actions/go-versions@1.24.2-14210955142

--- a/pkgs/actions/go-versions/registry.yaml
+++ b/pkgs/actions/go-versions/registry.yaml
@@ -4,14 +4,23 @@ packages:
     repo_owner: actions
     repo_name: go-versions
     description: Go releases for Actions Runner Images
-    asset: go-1.24.2-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x64
-    supported_envs:
-      - linux
-      - darwin
-    checksum:
-      type: github_release
-      asset: hashes.sha256
-      algorithm: sha256
+    files:
+      - name: go
+        src: bin/go
+      - name: gofmt
+        src: bin/gofmt
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-{{.Version | regexFind "^[^-]+"}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: hashes.sha256
+          algorithm: sha256

--- a/pkgs/actions/go-versions/registry.yaml
+++ b/pkgs/actions/go-versions/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: actions
+    repo_name: go-versions
+    description: Go releases for Actions Runner Images
+    asset: go-1.24.2-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x64
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: hashes.sha256
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -8064,6 +8064,21 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: actions
+    repo_name: go-versions
+    description: Go releases for Actions Runner Images
+    asset: go-1.24.2-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x64
+    supported_envs:
+      - linux
+      - darwin
+    checksum:
+      type: github_release
+      asset: hashes.sha256
+      algorithm: sha256
+  - type: github_release
     repo_owner: adhocteam
     repo_name: ssm
     description: AWS SSM Paramater Store CLI

--- a/registry.yaml
+++ b/registry.yaml
@@ -8067,17 +8067,26 @@ packages:
     repo_owner: actions
     repo_name: go-versions
     description: Go releases for Actions Runner Images
-    asset: go-1.24.2-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x64
-    supported_envs:
-      - linux
-      - darwin
-    checksum:
-      type: github_release
-      asset: hashes.sha256
-      algorithm: sha256
+    files:
+      - name: go
+        src: bin/go
+      - name: gofmt
+        src: bin/gofmt
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: go-{{.Version | regexFind "^[^-]+"}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: hashes.sha256
+          algorithm: sha256
   - type: github_release
     repo_owner: adhocteam
     repo_name: ssm


### PR DESCRIPTION
[actions/go-versions](https://github.com/actions/go-versions): Go releases for Actions Runner Images

```console
$ aqua g -i actions/go-versions
```

Close #35928