### PR TITLE
feat(containerd/nerdctl): 2.0.5 update, GH artifact attestations config

### DIFF
--- a/pkgs/containerd/nerdctl/pkg.yaml
+++ b/pkgs/containerd/nerdctl/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: containerd/nerdctl@v2.0.5
   - name: containerd/nerdctl
+    version: v2.0.4
+  - name: containerd/nerdctl
     version: v0.8.1
   - name: containerd/nerdctl
     version: v0.0.1

--- a/pkgs/containerd/nerdctl/pkg.yaml
+++ b/pkgs/containerd/nerdctl/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: containerd/nerdctl@v2.0.4
+  - name: containerd/nerdctl@v2.0.5
   - name: containerd/nerdctl
     version: v0.8.1
   - name: containerd/nerdctl

--- a/pkgs/containerd/nerdctl/registry.yaml
+++ b/pkgs/containerd/nerdctl/registry.yaml
@@ -24,6 +24,17 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux
+      - version_constraint: semver("<= 2.0.4")
+        asset: nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: "true"
         asset: nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -32,6 +43,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: containerd/nerdctl/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -21210,6 +21210,17 @@ packages:
           algorithm: sha256
         supported_envs:
           - linux
+      - version_constraint: semver("<= 2.0.4")
+        asset: nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: "true"
         asset: nerdctl-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -21218,6 +21229,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: containerd/nerdctl/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows/amd64


### PR DESCRIPTION
- https://github.com/containerd/nerdctl/releases
- https://github.com/containerd/nerdctl/attestations

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
