### PR TITLE
feat: add nil0x42/dnsanity

### DIFF
--- a/pkgs/nil0x42/dnsanity/pkg.yaml
+++ b/pkgs/nil0x42/dnsanity/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: nil0x42/dnsanity@v1.1.0

--- a/pkgs/nil0x42/dnsanity/registry.yaml
+++ b/pkgs/nil0x42/dnsanity/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: nil0x42
+    repo_name: dnsanity
+    description: High-performance DNS validator using template-based verification
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dnsanity-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -52518,6 +52518,21 @@ packages:
     repo_name: go-cover-treemap
     description: Go code coverage to SVG treemap
   - type: github_release
+    repo_owner: nil0x42
+    repo_name: dnsanity
+    description: High-performance DNS validator using template-based verification
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dnsanity-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        replacements:
+          amd64: x64
+          darwin: mac
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: ninja-build
     repo_name: ninja
     description: a small build system with a focus on speed


### PR DESCRIPTION
[nil0x42/dnsanity](https://github.com/nil0x42/dnsanity): High-performance DNS validator using template-based verification

```console
$ aqua g -i nil0x42/dnsanity
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@4cccded67283:/workspace# dnsanity -h

DNSanity is a high-performance DNS validator using template-based verification

Usage:      dnsanity [flags]
Example:    dnsanity -list /tmp/untrusted-dns.txt -o /tmp/trusted-dns.txt

GENERIC OPTIONS:
   -o string                  file to write output (defaults to STDOUT)
   -global-ratelimit int      global max requests per second (default 500)
   -threads int               max concurrency (default: -global-ratelimit * 2)

SERVERS SANITIZATION:
   -list string               list of DNS servers to sanitize (file or comma separated or STDIN)
   -timeout int               timeout in seconds for DNS queries (default 4)
   -ratelimit int             max requests per second per DNS server (default 2)
   -max-attempts int          max attempts before marking a mismatching DNS test as failed (default 2)
   -max-mismatches int        max allowed mismatching DNS tests per server (default 0)

TEMPLATE VALIDATION:
   -template string           path to the DNSanity validation template (-verbose to show)
   -trusted-list string       list of TRUSTED servers (defaults to "8.8.8.8, 1.1.1.1, 9.9.9.9")
   -trusted-timeout int       timeout in seconds for TRUSTED servers (default 2)
   -trusted-ratelimit int     max requests per second per TRUSTED server (default 10)
   -trusted-max-attempts int  max attempts before marking a mismatching TRUSTED test as failed (default 2)

DEBUG:
   -h, --help                 show help
   -version                   display version of dnsanity
   -verbose                   show detailed servers status
   -debug                     enable debugging information
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/nil0x42/dnsanity/blob/master/README.md
