### PR TITLE
feat: add mozilla/grcov

### DIFF
--- a/pkgs/mozilla/grcov/pkg.yaml
+++ b/pkgs/mozilla/grcov/pkg.yaml
@@ -1,0 +1,26 @@
+packages:
+  - name: mozilla/grcov@v0.9.1
+  - name: mozilla/grcov
+    version: v0.8.6
+  - name: mozilla/grcov
+    version: v0.8.2
+  - name: mozilla/grcov
+    version: v0.7.1
+  - name: mozilla/grcov
+    version: v0.7.0
+  - name: mozilla/grcov
+    version: v0.6.1
+  - name: mozilla/grcov
+    version: v0.5.15
+  - name: mozilla/grcov
+    version: v0.4.2
+  - name: mozilla/grcov
+    version: v0.4.0
+  - name: mozilla/grcov
+    version: v0.3.2
+  - name: mozilla/grcov
+    version: v0.1.28
+  - name: mozilla/grcov
+    version: v0.1.5
+  - name: mozilla/grcov
+    version: v0.1.1

--- a/pkgs/mozilla/grcov/registry.yaml
+++ b/pkgs/mozilla/grcov/registry.yaml
@@ -1,0 +1,149 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mozilla
+    repo_name: grcov
+    description: Rust tool to collect and aggregate code coverage data for multiple source files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.4.0"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v0.7.0"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.7.1"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.1")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.1.5")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.1.28")
+        asset: grcov-{{.OS}}-standalone-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        overrides:
+          - goos: windows
+            asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.3.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.5.15")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.1")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.8.6")
+        asset: grcov-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: grcov-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -50418,6 +50418,153 @@ packages:
               - name: proto
   - type: github_release
     repo_owner: mozilla
+    repo_name: grcov
+    description: Rust tool to collect and aggregate code coverage data for multiple source files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.4.0"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v0.7.0"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.7.1"
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.1")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.1.5")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.1.28")
+        asset: grcov-{{.OS}}-standalone-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        overrides:
+          - goos: windows
+            asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.3.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          windows: win
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.5.15")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+          windows: win
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.1")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.2")
+        asset: grcov-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.8.6")
+        asset: grcov-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: grcov-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: mozilla
     repo_name: sccache
     description: sccache is ccache with cloud storage
     asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
[mozilla/grcov](https://github.com/mozilla/grcov): Rust tool to collect and aggregate code coverage data for multiple source files

```console
$ aqua g -i mozilla/grcov
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@2aba3e2df5fa:/workspace# grcov --help
grcov
Marco Castelluccio <mcastelluccio@mozilla.com>
Parse, collect and aggregate code coverage data for multiple source files

Usage: grcov [OPTIONS] <PATHS>...

Arguments:
  <PATHS>...
          Sets the input paths to use

Options:
  -b, --binary-path <PATH>
          Sets the path to the compiled binary to be used

      --llvm-path <PATH>
          Sets the path to the LLVM bin directory

  -t, --output-types <OUTPUT TYPE>
          Comma separated list of custom output types:
          - *html* for a HTML coverage report;
          - *coveralls* for the Coveralls specific format;
          - *lcov* for the lcov INFO format;
          - *covdir* for the covdir recursive JSON format;
          - *coveralls+* for the Coveralls specific format with function information;
          - *ade* for the ActiveData-ETL specific format;
          - *files* to only return a list of files.
          - *markdown* for human easy read.
          - *cobertura* for output in cobertura format.
          - *cobertura-pretty* to pretty-print in cobertura format.


          [default: lcov]

  -o, --output-path <PATH>
          Specifies the output path. This is a file for a single output type and must be a folder
          for multiple output types

      --output-config-file <PATH>
          Specifies the output config file

  -s, --source-dir <DIRECTORY>
          Specifies the root directory of the source files

  -p, --prefix-dir <PATH>
          Specifies a prefix to remove from the paths (e.g. if grcov is run on a different machine
          than the one that generated the code coverage information)

      --ignore-not-existing
          Ignore source files that can't be found on the disk

      --ignore <PATH>
          Ignore files/directories specified as globs

      --keep-only <PATH>
          Keep only files/directories specified as globs

      --path-mapping <PATH>


      --branch
          Enables parsing branch coverage information

      --filter <FILTER>
          Filters out covered/uncovered files. Use 'covered' to only return covered files,
          'uncovered' to only return uncovered files

          [possible values: covered, uncovered]

      --sort-output-types <OUTPUT TYPES>
          Comma separated list of output types to sort files lexicographically for

          [default: markdown]

      --llvm
          Speeds-up parsing, when the code coverage information is exclusively coming from a llvm
          build

      --token <TOKEN>
          Sets the repository token from Coveralls, required for the 'coveralls' and 'coveralls+'
          formats

      --commit-sha <COMMIT HASH>
          Sets the hash of the commit used to generate the code coverage data

      --service-name <SERVICE NAME>
          Sets the service name

      --service-number <SERVICE NUMBER>
          Sets the service number

      --service-job-id <SERVICE JOB ID>
          Sets the service job id

          [aliases: service-job-number]

      --service-pull-request <SERVICE PULL REQUEST>
          Sets the service pull request number

      --service-flag-name <SERVICE FLAG NAME>
          Sets the service flag name for coveralls parallel/carryover mode

      --parallel
          Sets the build type to be parallel for 'coveralls' and 'coveralls+' formats

      --threads <NUMBER>


      --precision <NUMBER>
          Sets coverage decimal point precision on output reports

          [default: 2]

      --guess-directory-when-missing


      --vcs-branch <VCS BRANCH>
          Set the branch for coveralls report. Defaults to 'master'

          [default: master]

      --log <LOG>
          Set the file where to log (or stderr or stdout). Defaults to 'stderr'

          [default: stderr]

      --log-level <LEVEL>
          Set the log level

          [default: ERROR]
          [possible values: OFF, ERROR, WARN, INFO, DEBUG, TRACE]

      --excl-line <regex>
          Lines in covered files containing this marker will be excluded

      --excl-start <regex>
          Marks the beginning of an excluded section. The current line is part of this section

      --excl-stop <regex>
          Marks the end of an excluded section. The current line is part of this section

      --excl-br-line <regex>
          Lines in covered files containing this marker will be excluded from branch coverage

      --excl-br-start <regex>
          Marks the beginning of a section excluded from branch coverage. The current line is part
          of this section

      --excl-br-stop <regex>
          Marks the end of a section excluded from branch coverage. The current line is part of this
          section

      --no-demangle
          No symbol demangling

      --abs-link-prefix <LINK PREFIX>
          Generate absolute HTML links with the given prefix

      --no-date
          Do not include the current date in the HTML report

      --html-resources <SOURCE>
          Where to retrieve the CSS files used to style the HTML reports

          [default: bundled]
          [possible values: bundled, cdn]

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/mozilla/grcov/blob/master/README.md#usage
