### PR TITLE
feat: add qnighy/clippy-reviewdog-filter

### DIFF
--- a/pkgs/qnighy/clippy-reviewdog-filter/pkg.yaml
+++ b/pkgs/qnighy/clippy-reviewdog-filter/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: qnighy/clippy-reviewdog-filter@v0.1.6
+  - name: qnighy/clippy-reviewdog-filter
+    version: v0.1.4
+  - name: qnighy/clippy-reviewdog-filter
+    version: v0.1.1

--- a/pkgs/qnighy/clippy-reviewdog-filter/registry.yaml
+++ b/pkgs/qnighy/clippy-reviewdog-filter/registry.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: qnighy
+    repo_name: clippy-reviewdog-filter
+    description: A filter for integrating Clippy with Reviewdog
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.4")
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -57728,6 +57728,55 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: qnighy
+    repo_name: clippy-reviewdog-filter
+    description: A filter for integrating Clippy with Reviewdog
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.4")
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: clippy-reviewdog-filter-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+  - type: github_release
     repo_owner: quantumsheep
     repo_name: sshs
     description: Terminal user interface for SSH


### PR DESCRIPTION
[qnighy/clippy-reviewdog-filter](https://github.com/qnighy/clippy-reviewdog-filter): A filter for integrating Clippy with Reviewdog

```console
$ aqua g -i qnighy/clippy-reviewdog-filter
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@22676a107840:/workspace# clippy-reviewdog-filter -h
Converts cargo check / cargo clippy output into checkstyle-like XML.

Usage: clippy-reviewdog-filter-x86_64-unknown-linux-musl [OPTIONS]

Options:
      --include-rendered  include rendered messages
  -h, --help              Print help
  -V, --version           Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/qnighy/clippy-reviewdog-filter/blob/master/README.md
