### PR TITLE
feat: add psastras/sarif-rs/shellcheck-sarif

### DIFF
--- a/pkgs/psastras/sarif-rs/shellcheck-sarif/pkg.yaml
+++ b/pkgs/psastras/sarif-rs/shellcheck-sarif/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: psastras/sarif-rs/shellcheck-sarif@shellcheck-sarif-v0.8.0
+  - name: psastras/sarif-rs/shellcheck-sarif
+    version: shellcheck-sarif-v0.4.2
+  - name: psastras/sarif-rs/shellcheck-sarif
+    version: shellcheck-sarif-v0.2.24
+  - name: psastras/sarif-rs/shellcheck-sarif
+    version: shellcheck-sarif-v0.2.23

--- a/pkgs/psastras/sarif-rs/shellcheck-sarif/registry.yaml
+++ b/pkgs/psastras/sarif-rs/shellcheck-sarif/registry.yaml
@@ -17,6 +17,9 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/amd64
+        files:
+          - name: shellcheck-sarif
+            src: target/release/{{.FileName}}-{{.Arch}}-{{.OS}}
       - version_constraint: Version in ["shellcheck-sarif-v0.2.24", "shellcheck-sarif-v0.6.2"]
         asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
         format: raw

--- a/pkgs/psastras/sarif-rs/shellcheck-sarif/registry.yaml
+++ b/pkgs/psastras/sarif-rs/shellcheck-sarif/registry.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: psastras/sarif-rs/shellcheck-sarif
+    type: github_release
+    repo_owner: psastras
+    repo_name: sarif-rs
+    description: A group of Rust projects for interacting with the SARIF format
+    version_filter: not (Version matches "-latest$")
+    version_prefix: shellcheck-sarif-
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "shellcheck-sarif-v0.2.23"
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tgz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version in ["shellcheck-sarif-v0.2.24", "shellcheck-sarif-v0.6.2"]
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.2")
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64

--- a/pkgs/psastras/sarif-rs/shellcheck-sarif/scaffold.yaml
+++ b/pkgs/psastras/sarif-rs/shellcheck-sarif/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: psastras/sarif-rs/shellcheck-sarif
+version_filter: not (Version matches "-latest$")
+version_prefix: shellcheck-sarif-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -57554,6 +57554,9 @@ packages:
           linux: unknown-linux-gnu
         supported_envs:
           - linux/amd64
+        files:
+          - name: shellcheck-sarif
+            src: target/release/{{.FileName}}-{{.Arch}}-{{.OS}}
       - version_constraint: Version in ["shellcheck-sarif-v0.2.24", "shellcheck-sarif-v0.6.2"]
         asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -57537,6 +57537,58 @@ packages:
     overrides:
       - goos: windows
         asset: protoc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+  - name: psastras/sarif-rs/shellcheck-sarif
+    type: github_release
+    repo_owner: psastras
+    repo_name: sarif-rs
+    description: A group of Rust projects for interacting with the SARIF format
+    version_filter: not (Version matches "-latest$")
+    version_prefix: shellcheck-sarif-
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "shellcheck-sarif-v0.2.23"
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tgz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version in ["shellcheck-sarif-v0.2.24", "shellcheck-sarif-v0.6.2"]
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.4.2")
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: shellcheck-sarif-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
   - type: github_release
     repo_owner: pseudomuto
     repo_name: protoc-gen-doc


### PR DESCRIPTION
[psastras/sarif-rs/shellcheck-sarif](https://github.com/psastras/sarif-rs): A group of Rust projects for interacting with the SARIF format

```console
$ aqua g -i psastras/sarif-rs/shellcheck-sarif
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@e33419e0b715:/workspace# shellcheck-sarif -h
Convert shellcheck warnings into SARIF

Usage: shellcheck-sarif-x86_64-unknown-linux-gnu [OPTIONS]

Options:
  -i, --input <INPUT>    input file; reads from stdin if none is given
  -f, --format <FORMAT>  input format; json or json1; defaults to 'json' [default: json]
  -o, --output <OUTPUT>  output file; writes to stdout if none is given
  -h, --help             Print help
  -V, --version          Print version

The expected input is generated by running 'shellcheck -f json'.
```

If files such as configuration file are needed, please share them.

Reference

- https://psastras.github.io/sarif-rs/
