### PR TITLE
feat: add takumin/zizmor-bin

### DIFF
--- a/pkgs/takumin/zizmor-bin/pkg.yaml
+++ b/pkgs/takumin/zizmor-bin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: takumin/zizmor-bin@v1.7.0

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -39,3 +39,5 @@ packages:
               - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: takumin/zizmor-bin/.github/workflows/wc-sign.yml

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: takumin
     repo_name: zizmor-bin
     description: Static build of `zizmor`
+    files:
+      - name: zizmor
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: takumin
+    repo_name: zizmor-bin
+    description: Static build of `zizmor`
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: zizmor-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.cert
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: zizmor-{{.Arch}}-{{.OS}}llvm

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -18,13 +18,13 @@ packages:
         cosign:
           opts:
             - --certificate
-            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert"
+            - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert
             - --signature
-            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig"
+            - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate-identity
-            - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+            - https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main
             - --certificate-oidc-issuer
-            - "https://token.actions.githubusercontent.com"
+            - https://token.actions.githubusercontent.com
         checksum:
           type: github_release
           asset: SHA256SUMS
@@ -32,12 +32,12 @@ packages:
           cosign:
             opts:
               - --certificate
-              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert"
+              - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert
               - --signature
-              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig"
+              - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig
               - --certificate-identity
-              - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+              - https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main
               - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
+              - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           signer_workflow: takumin/zizmor-bin/.github/workflows/wc-sign.yml

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -14,11 +14,8 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
-          windows: pc-windows-gnu
+          windows: pc-windows-gnullvm
         checksum:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: zizmor-{{.Arch}}-{{.OS}}llvm

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -15,6 +15,16 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-gnullvm
+        cosign:
+          opts:
+            - --certificate
+            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert"
+            - --signature
+            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig"
+            - --certificate-identity
+            - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+            - --certificate-oidc-issuer
+            - "https://token.actions.githubusercontent.com"
         checksum:
           type: github_release
           asset: SHA256SUMS

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -19,3 +19,13 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert"
+              - --signature
+              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig"
+              - --certificate-identity
+              - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"

--- a/pkgs/takumin/zizmor-bin/registry.yaml
+++ b/pkgs/takumin/zizmor-bin/registry.yaml
@@ -17,7 +17,7 @@ packages:
           windows: pc-windows-gnu
         checksum:
           type: github_release
-          asset: SHA256SUMS.cert
+          asset: SHA256SUMS
           algorithm: sha256
         overrides:
           - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -69167,6 +69167,8 @@ packages:
               - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: takumin/zizmor-bin/.github/workflows/wc-sign.yml
   - type: github_release
     repo_owner: tamasfe
     repo_name: taplo

--- a/registry.yaml
+++ b/registry.yaml
@@ -69146,13 +69146,13 @@ packages:
         cosign:
           opts:
             - --certificate
-            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert"
+            - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert
             - --signature
-            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig"
+            - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate-identity
-            - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+            - https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main
             - --certificate-oidc-issuer
-            - "https://token.actions.githubusercontent.com"
+            - https://token.actions.githubusercontent.com
         checksum:
           type: github_release
           asset: SHA256SUMS
@@ -69160,13 +69160,13 @@ packages:
           cosign:
             opts:
               - --certificate
-              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert"
+              - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert
               - --signature
-              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig"
+              - https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig
               - --certificate-identity
-              - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+              - https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main
               - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
+              - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           signer_workflow: takumin/zizmor-bin/.github/workflows/wc-sign.yml
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -69142,14 +69142,11 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
-          windows: pc-windows-gnu
+          windows: pc-windows-gnullvm
         checksum:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: zizmor-{{.Arch}}-{{.OS}}llvm
   - type: github_release
     repo_owner: tamasfe
     repo_name: taplo

--- a/registry.yaml
+++ b/registry.yaml
@@ -69145,7 +69145,7 @@ packages:
           windows: pc-windows-gnu
         checksum:
           type: github_release
-          asset: SHA256SUMS.cert
+          asset: SHA256SUMS
           algorithm: sha256
         overrides:
           - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -69129,6 +69129,28 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: takumin
+    repo_name: zizmor-bin
+    description: Static build of `zizmor`
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: zizmor-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.cert
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: zizmor-{{.Arch}}-{{.OS}}llvm
+  - type: github_release
     repo_owner: tamasfe
     repo_name: taplo
     description: A TOML toolkit written in Rust

--- a/registry.yaml
+++ b/registry.yaml
@@ -69147,6 +69147,16 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.cert"
+              - --signature
+              - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/SHA256SUMS.sig"
+              - --certificate-identity
+              - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
   - type: github_release
     repo_owner: tamasfe
     repo_name: taplo

--- a/registry.yaml
+++ b/registry.yaml
@@ -69132,6 +69132,8 @@ packages:
     repo_owner: takumin
     repo_name: zizmor-bin
     description: Static build of `zizmor`
+    files:
+      - name: zizmor
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -69143,6 +69143,16 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-gnullvm
+        cosign:
+          opts:
+            - --certificate
+            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.cert"
+            - --signature
+            - "https://github.com/takumin/zizmor-bin/releases/download/{{.Version}}/{{.Asset}}.sig"
+            - --certificate-identity
+            - "https://github.com/takumin/zizmor-bin/.github/workflows/wc-sign.yml@refs/heads/main"
+            - --certificate-oidc-issuer
+            - "https://token.actions.githubusercontent.com"
         checksum:
           type: github_release
           asset: SHA256SUMS


### PR DESCRIPTION
[takumin/zizmor-bin](https://github.com/takumin/zizmor-bin): Static build of `zizmor`

```console
$ aqua g -i takumin/zizmor-bin
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con linux amd64
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@36c5901ada5b:/workspace# zizmor -h
Static analysis for GitHub Actions

Usage: zizmor-x86_64-unknown-linux-musl [OPTIONS] <INPUTS>...

Arguments:
  <INPUTS>...  The inputs to audit

Options:
  -p, --pedantic
          Emit 'pedantic' findings
      --persona <PERSONA>
          The persona to use while auditing [default: regular] [possible values: auditor, pedantic, regular]
  -o, --offline
          Perform only offline operations [env: ZIZMOR_OFFLINE=]
      --gh-token <GH_TOKEN>
          The GitHub API token to use [env: GH_TOKEN=]
      --gh-hostname <GH_HOSTNAME>
          The GitHub Server Hostname. Defaults to github.com [env: GH_HOST=] [default: github.com]
      --no-online-audits
          Perform only offline audits [env: ZIZMOR_NO_ONLINE_AUDITS=]
  -v, --verbose...
          Increase logging verbosity
  -q, --quiet...
          Decrease logging verbosity
      --no-progress
          Don't show progress bars, even if the terminal supports them
      --format <FORMAT>
          The output format to emit. By default, cargo-style diagnostics will be emitted [default: plain] [possible values: plain, json, json-v1, sarif, github]
      --color <MODE>
          Control the use of color in output [possible values: auto, always, never]
  -c, --config <CONFIG>
          The configuration file to load. By default, any config will be discovered relative to $CWD
      --no-config
          Disable all configuration loading
      --no-exit-codes
          Disable all error codes besides success and tool failure
      --min-severity <MIN_SEVERITY>
          Filter all results below this severity [possible values: unknown, informational, low, medium, high]
      --min-confidence <MIN_CONFIDENCE>
          Filter all results below this confidence [possible values: unknown, low, medium, high]
      --cache-dir <CACHE_DIR>
          The directory to use for HTTP caching. By default, a host-appropriate user-caching directory will be used
      --collect <COLLECT>
          Control which kinds of inputs are collected for auditing [default: default] [possible values: all, default, workflows-only, actions-only]
      --strict-collection
          Fail instead of warning on syntax and schema errors in collected inputs
      --completions <SHELL>
          Generate tab completion scripts for the specified shell [possible values: bash, elvish, fish, powershell, zsh]
  -h, --help
          Print help (see more with '--help')
  -V, --version
          Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://docs.zizmor.sh
- https://github.com/zizmorcore/zizmor
