### PR TITLE
Add ianlewis/todos

### DIFF
--- a/pkgs/ianlewis/todos/pkg.yaml
+++ b/pkgs/ianlewis/todos/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: ianlewis/todos@v0.12.0
+  - name: ianlewis/todos
+    version: v0.3.0
+  - name: ianlewis/todos
+    version: v0.0.1

--- a/pkgs/ianlewis/todos/registry.yaml
+++ b/pkgs/ianlewis/todos/registry.yaml
@@ -13,15 +13,16 @@ packages:
         slsa_provenance:
           type: github_release
           asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
-      - version_constraint: Version == "v0.3.0"
-        asset: todos-{{.OS}}-{{.Arch}}
-        format: raw
-        slsa_provenance:
-          type: github_release
-          asset: github-issue-reopener-{{.OS}}-{{.Arch}}.intoto.jsonl
       - version_constraint: "true"
         asset: todos-{{.OS}}-{{.Arch}}
         format: raw
         slsa_provenance:
           type: github_release
           asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
+        overrides:
+          - goos: windows
+            complete_windows_ext: false
+            asset: todos-{{.OS}}-{{.Arch}}.exe
+            slsa_provenance:
+              type: github_release
+              asset: todos-{{.OS}}-{{.Arch}}.exe.intoto.jsonl

--- a/pkgs/ianlewis/todos/registry.yaml
+++ b/pkgs/ianlewis/todos/registry.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ianlewis
+    repo_name: todos
+    description: Parse TODO and FIXME comments from code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        complete_windows_ext: false
+        slsa_provenance:
+          type: github_release
+          asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
+      - version_constraint: Version == "v0.3.0"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        slsa_provenance:
+          type: github_release
+          asset: github-issue-reopener-{{.OS}}-{{.Arch}}.intoto.jsonl
+      - version_constraint: "true"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        slsa_provenance:
+          type: github_release
+          asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -37007,18 +37007,19 @@ packages:
         slsa_provenance:
           type: github_release
           asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
-      - version_constraint: Version == "v0.3.0"
-        asset: todos-{{.OS}}-{{.Arch}}
-        format: raw
-        slsa_provenance:
-          type: github_release
-          asset: github-issue-reopener-{{.OS}}-{{.Arch}}.intoto.jsonl
       - version_constraint: "true"
         asset: todos-{{.OS}}-{{.Arch}}
         format: raw
         slsa_provenance:
           type: github_release
           asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
+        overrides:
+          - goos: windows
+            complete_windows_ext: false
+            asset: todos-{{.OS}}-{{.Arch}}.exe
+            slsa_provenance:
+              type: github_release
+              asset: todos-{{.OS}}-{{.Arch}}.exe.intoto.jsonl
   - type: github_release
     repo_owner: iann0036
     repo_name: iamlive

--- a/registry.yaml
+++ b/registry.yaml
@@ -36995,6 +36995,31 @@ packages:
           - name: packer
             src: pkenv-{{trimV .Version}}/bin/packer
   - type: github_release
+    repo_owner: ianlewis
+    repo_name: todos
+    description: Parse TODO and FIXME comments from code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        complete_windows_ext: false
+        slsa_provenance:
+          type: github_release
+          asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
+      - version_constraint: Version == "v0.3.0"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        slsa_provenance:
+          type: github_release
+          asset: github-issue-reopener-{{.OS}}-{{.Arch}}.intoto.jsonl
+      - version_constraint: "true"
+        asset: todos-{{.OS}}-{{.Arch}}
+        format: raw
+        slsa_provenance:
+          type: github_release
+          asset: todos-{{.OS}}-{{.Arch}}.intoto.jsonl
+  - type: github_release
     repo_owner: iann0036
     repo_name: iamlive
     asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[ianlewis/todos](https://github.com/ianlewis/todos) - Parse TODO and FIXME comments from code

Add [`ianlewis/todos`](https://github.com/ianlewis/todos) to the registry. `todos` is distributed as a static binary and is installed from GitHub releases.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
