### PR TITLE
feat: add werf/nelm

### DIFF
--- a/pkgs/werf/nelm/pkg.yaml
+++ b/pkgs/werf/nelm/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/werf/nelm/pkg.yaml
+++ b/pkgs/werf/nelm/pkg.yaml
@@ -1,1 +1,8 @@
-packages: []
+packages:
+  - name: werf/nelm@v1.3.0
+  - name: werf/nelm
+    version: v1.1.1
+  - name: werf/nelm
+    version: v1.1.0
+  - name: werf/nelm
+    version: v1.0.0

--- a/pkgs/werf/nelm/registry.yaml
+++ b/pkgs/werf/nelm/registry.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: werf
+    repo_name: nelm
+    description: Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/werf/nelm/registry.yaml
+++ b/pkgs/werf/nelm/registry.yaml
@@ -1,10 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: http
     repo_owner: werf
     repo_name: nelm
     description: Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 1.1.1")
+        url: https://storage.googleapis.com/nelm-tuf/targets/releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/bin/nelm
+        format: raw
+        windows_arm_emulation: true
       - version_constraint: "true"
-        no_asset: true
+        url: https://tuf.nelm.sh/targets/releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/bin/nelm
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -74691,14 +74691,20 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: github_release
+  - type: http
     repo_owner: werf
     repo_name: nelm
     description: Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 1.1.1")
+        url: https://storage.googleapis.com/nelm-tuf/targets/releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/bin/nelm
+        format: raw
+        windows_arm_emulation: true
       - version_constraint: "true"
-        no_asset: true
+        url: https://tuf.nelm.sh/targets/releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/bin/nelm
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: wfxr
     repo_name: csview

--- a/registry.yaml
+++ b/registry.yaml
@@ -74692,6 +74692,14 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: werf
+    repo_name: nelm
+    description: Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: wfxr
     repo_name: csview
     description: Pretty and fast csv viewer for cli with cjk/emoji support


### PR DESCRIPTION
[werf/nelm](https://github.com/werf/nelm): Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes

```console
$ aqua g -i werf/nelm
```

Close #36389