### PR TITLE
Add scaffold bytecodealliance/wrpc/wit-bindgen-wrpc

### DIFF
--- a/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/pkg.yaml
+++ b/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bytecodealliance/wrpc/wit-bindgen-wrpc@v0.14.0

--- a/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/registry.yaml
+++ b/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: bytecodealliance/wrpc/wit-bindgen-wrpc
+    type: github_release
+    repo_owner: bytecodealliance
+    repo_name: wrpc
+    description: Wasm component-native RPC framework
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: wit-bindgen-wrpc-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu

--- a/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/scaffold.yaml
+++ b/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/scaffold.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: bytecodealliance/wrpc/wit-bindgen-wrpc

--- a/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/scaffold.yaml
+++ b/pkgs/bytecodealliance/wrpc/wit-bindgen-wrpc/scaffold.yaml
@@ -1,2 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-name: bytecodealliance/wrpc/wit-bindgen-wrpc

--- a/registry.yaml
+++ b/registry.yaml
@@ -16504,6 +16504,23 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - name: bytecodealliance/wrpc/wit-bindgen-wrpc
+    type: github_release
+    repo_owner: bytecodealliance
+    repo_name: wrpc
+    description: Wasm component-native RPC framework
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: wit-bindgen-wrpc-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
   - type: github_release
     repo_owner: c-bata
     repo_name: kube-prompt


### PR DESCRIPTION
[bytecodealliance/wrpc/wit-bindgen-wrpc](https://github.com/bytecodealliance/wrpc) - Wasm component-native RPC framework

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
Fourth of four packages, This time a dependency for using wash to deploy a wasmCloud provider