### PR TITLE
fix(ariga/atlas): add exe extension to download url

### DIFF
--- a/pkgs/ariga/atlas/registry.yaml
+++ b/pkgs/ariga/atlas/registry.yaml
@@ -18,6 +18,7 @@ packages:
       algorithm: sha256
     overrides:
       - goos: windows
+        url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe
         checksum:
           type: http
           url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -11587,6 +11587,7 @@ packages:
       algorithm: sha256
     overrides:
       - goos: windows
+        url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe
         checksum:
           type: http
           url: https://release.ariga.io/atlas/atlas-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

From [a discussion on /dev/tty discord](https://discord.com/channels/1141777454164365382/1142142009117777940/1374467471494352967) the download URL for this tool on Windows expects a `.exe` suffix