### PR TITLE
feat(IBM-Cloud/redli): scaffold IBM-Cloud/redli

### DIFF
--- a/pkgs/IBM-Cloud/redli/pkg.yaml
+++ b/pkgs/IBM-Cloud/redli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: IBM-Cloud/redli@v0.15.0
+  - name: IBM-Cloud/redli
+    version: v0.10.0

--- a/pkgs/IBM-Cloud/redli/pkg.yaml
+++ b/pkgs/IBM-Cloud/redli/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: IBM-Cloud/redli@v0.15.0
   - name: IBM-Cloud/redli
+    version: v0.14.0
+  - name: IBM-Cloud/redli
     version: v0.10.0

--- a/pkgs/IBM-Cloud/redli/registry.yaml
+++ b/pkgs/IBM-Cloud/redli/registry.yaml
@@ -23,6 +23,20 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: redli
+            src: redli_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            goarch: amd64
+            files:
+              - name: redli.exe
+                src: redli.exe
+          - goos: windows
+            goarch: arm64
+            files:
+              - name: redli.exe
+                src: redli_{{.Arch}}.exe
         format: tar.gz
         checksum:
           type: github_release

--- a/pkgs/IBM-Cloud/redli/registry.yaml
+++ b/pkgs/IBM-Cloud/redli/registry.yaml
@@ -23,22 +23,21 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         files:
           - name: redli
             src: redli_{{.OS}}_{{.Arch}}
-        overrides:
-          - goos: windows
-            goarch: amd64
-            files:
-              - name: redli.exe
-                src: redli.exe
-          - goos: windows
-            goarch: arm64
-            files:
-              - name: redli.exe
-                src: redli_{{.Arch}}.exe
-        format: tar.gz
         checksum:
           type: github_release
           asset: redli_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            goarch: amd64
+            files:
+              - name: redli
+          - goos: windows
+            goarch: arm64
+            files:
+              - name: redli
+                src: redli_{{.Arch}}.exe

--- a/pkgs/IBM-Cloud/redli/registry.yaml
+++ b/pkgs/IBM-Cloud/redli/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: IBM-Cloud
+    repo_name: redli
+    description: "Redli - A humane alternative to the Redis-cli and TLS"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.11.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.10.0")
+        asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: redli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: redli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -3133,6 +3133,20 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: redli
+            src: redli_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            goarch: amd64
+            files:
+              - name: redli.exe
+                src: redli.exe
+          - goos: windows
+            goarch: arm64
+            files:
+              - name: redli.exe
+                src: redli_{{.Arch}}.exe
         format: tar.gz
         checksum:
           type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -3133,25 +3133,24 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         files:
           - name: redli
             src: redli_{{.OS}}_{{.Arch}}
-        overrides:
-          - goos: windows
-            goarch: amd64
-            files:
-              - name: redli.exe
-                src: redli.exe
-          - goos: windows
-            goarch: arm64
-            files:
-              - name: redli.exe
-                src: redli_{{.Arch}}.exe
-        format: tar.gz
         checksum:
           type: github_release
           asset: redli_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            goarch: amd64
+            files:
+              - name: redli
+          - goos: windows
+            goarch: arm64
+            files:
+              - name: redli
+                src: redli_{{.Arch}}.exe
   - type: github_release
     repo_owner: IxDay
     repo_name: mruby

--- a/registry.yaml
+++ b/registry.yaml
@@ -3111,6 +3111,34 @@ packages:
       - linux
       - amd64
   - type: github_release
+    repo_owner: IBM-Cloud
+    repo_name: redli
+    description: "Redli - A humane alternative to the Redis-cli and TLS"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.11.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.10.0")
+        asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: redli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: redli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: redli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: IxDay
     repo_name: mruby
     description: Lightweight Ruby


### PR DESCRIPTION
[IBM-Cloud/redli](https://github.com/IBM-Cloud/redli): Redli - A humane alternative to the Redis-cli and TLS

```console
$ aqua g -i IBM-Cloud/redli
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Do only one thing in one Pull Request
- [X] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [X] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ root@6f479981193a:/workspace# redli --help
usage: redli_linux_amd64 [<flags>] [<commands>...]

Flags:
      --help                   Show context-sensitive help (also try --help-long and --help-man).
      --debug                  Enable debug mode.
      --long                   Enable long prompt with host/port
  -u, --uri=URI                URI to connect to
  -h, --host="127.0.0.1"       Host to connect to
  -p, --port=6379              Port to connect to
  -r, --redisuser=""           Username to use when connecting. Supported since Redis 6.
  -a, --auth=AUTH              Password to use when connecting
  -n, --ndb=0                  Redis database to access
      --tls                    Enable TLS/SSL
  -s, --servername=SERVERNAME  ServerName is used to verify the hostname on the returned certificates unless skipverify is set.
      --skipverify             Don't validate certificates
      --certfile=CERTFILE      Self-signed certificate file for validation
      --certb64=CERTB64        Self-signed certificate string as base64 for validation
      --raw                    Produce raw output
      --eval=EVAL              Evaluate a Lua script file, follow with keys a , and args
      --version                Show application version.

Args:
  [<commands>]  Redis commands and values
```

If files such as configuration file are needed, please share them.

> [!Warning]
> Tests on Windows containers (created with `cmdx con windows arm64` and `amd64`) are not working. I'm not sure if this is expected behavior or not
> ```
>cmdx con windows amd64
>+ bash scripts/connect.sh
>[INFO] Connecting to the container aqua-registry-windows (windows/amd64)
>
>root@5b1198b36e4f:/workspace# redli   
>bash: redli: command not found
>
>root@5b1198b36e4f:/workspace# aqua which redli
>/root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/IBM-Cloud/redli/v0.10.0/redli_0.10.0_windows_amd64.tar.gz/redli.exe
>
>root@5b1198b36e4f:/workspace# /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/IBM-Cloud/redli/v0.10.0/redli_0.10.0_windows_amd64.tar.gz/redli.exe
>bash: /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/IBM-Cloud/redli/v0.10.0/>redli_0.10.0_windows_amd64.tar.gz/redli.exe: cannot execute: required file not found
> ```
