### PR TITLE
feat: add dimonomid/nerdlog

### DIFF
--- a/pkgs/dimonomid/nerdlog/pkg.yaml
+++ b/pkgs/dimonomid/nerdlog/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: dimonomid/nerdlog@v1.8.1
+  - name: dimonomid/nerdlog
+    version: v1.5.0

--- a/pkgs/dimonomid/nerdlog/registry.yaml
+++ b/pkgs/dimonomid/nerdlog/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dimonomid
+    repo_name: nerdlog
+    description: "Nerdlog: fast, remote-first, multi-host TUI log viewer with timeline histogram and no central server"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: nerdlog_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: nerdlog_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -25309,6 +25309,34 @@ packages:
               arm64: aarch64
               linux: unknown-linux-gnu
   - type: github_release
+    repo_owner: dimonomid
+    repo_name: nerdlog
+    description: "Nerdlog: fast, remote-first, multi-host TUI log viewer with timeline histogram and no central server"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: nerdlog_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: nerdlog_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: dineshba
     repo_name: tf-summarize
     description: A command-line utility to print the summary of the terraform plan


### PR DESCRIPTION
[dimonomid/nerdlog](https://github.com/dimonomid/nerdlog): Nerdlog: fast, remote-first, multi-host TUI log viewer with timeline histogram and no central server

```console
$ aqua g -i dimonomid/nerdlog
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Do only one thing in one Pull Request
- [X] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [X] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.


Command and output

Execute `nerdlog` and configure it through TUI : 
![{2C7BDC3E-2929-4938-AECD-2F81EBCF89FD}](https://github.com/user-attachments/assets/dbcc3903-1c4c-48c9-9811-434b19e7082b)


```console
$ nerdlog --help
Usage of nerdlog:
      --loglevel string                This is NOT about the logs that nerdlog fetches from the remote servers, it's rather about nerdlog's own log. Valid values are: error, warning, info, verbose1, verbose2 or verbose3 (default "error")
  -h, --lstreams string                Logstreams to connect to, as comma-separated glob patterns, e.g. 'foo-*,bar-*'
      --no-journalctl-access-warning   Suppress the warning when journalctl is being used by the user who can't read all system logs
  -p, --pattern string                 Initial awk pattern to use
  -s, --selquery string                SELECT-like query to specify which fields to show, like 'time STICKY, message, lstream, level_name AS level, *'
      --ssh-config string              ssh config file to use; set to an empty string to disable reading ssh config (default "/home/nikitac/.ssh/config")
      --ssh-key strings                ssh keys to use; only the first existing file will be used (default [/home/nikitac/.ssh/id_ed25519,/home/nikitac/.ssh/id_ecdsa,/home/nikitac/.ssh/id_rsa])
  -t, --time string                    Time range in the same format as accepted by the UI. Examples: '1h', 'Mar27 12:00'
  -v, --version                        Print version info and exit
pflag: help requested
```

### To work properly, this package may require certain system dependencies. These dependencies could be listed when the program is run, for example using the --version flag :
```console
$ nerdlog --version
Nerdlog 1.8.1
Commit: 9ea01409b142bc2dceb31364ec79749b597a0357
Build time: 2025-05-20T15:09:09Z
Built by: goreleaser
GOOS: linux
CGO: enabled
Clipboard support: no (clipboard unavailable: Failed to initialize the X11 display, and the clipboard package
will not work properly. Install the following dependency may help:

        apt install -y libx11-dev

If the clipboard package is in an environment without a frame buffer,
such as a cloud server, it may also be necessary to install xvfb:

        apt install -y xvfb

and initialize a virtual frame buffer:

        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
        export DISPLAY=:99.0

Then this package should be ready to use.
)

Written by Dmitry Frank (https://dmitryfrank.com)
```

## 🆘 Help needed to enable cosign
This package provides releases signed with Cosign via a GitHub Action during the release process :
![{B39FE08A-23D1-41F9-8285-D45A10BCC5DE}](https://github.com/user-attachments/assets/b736ff6e-aee0-40aa-a8f9-cb75d2527bbf)

Each OS and architecture has its own signed binary along with an associated signature and certificate. However, the issue is that only the binary itself is signed — not the archive that contains it.

Is it possible to configure Cosign (via the registry or otherwise) to validate the binary after it has been extracted from the archive?

Extract of there `.goreleaser.yaml` : 
```yaml
binary_signs:
  - cmd: cosign
    args:
      - sign-blob
      - --output-signature=${signature}
      - --output-certificate=${certificate}
      - ${artifact}
      - --yes
    certificate: '${artifact}_{{- tolower .Version }}_{{- tolower .Os }}_{{- if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}.pem'
    signature: '${artifact}_{{- tolower .Version }}_{{- tolower .Os }}_{{- if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}.sig'
    output: true
```

Cosign step during release where the artefact is signed : https://github.com/dimonomid/nerdlog/actions/runs/15141194358/job/42565490613#step:6:319

Do you think Aqua could/would support this? Or should we consider creating a pull request to update the .goreleaser.yaml and add:
```yaml
binary_signs:
  - cmd: cosign
    artifacts:  '${artifact}_{{- tolower .Version }}_{{- tolower .Os }}_{{- if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}.{{ .Format }}'
...
```
