### PR TITLE
fix(ducaale/xh): Re-scaffold the registry file

### DIFF
--- a/pkgs/ducaale/xh/pkg.yaml
+++ b/pkgs/ducaale/xh/pkg.yaml
@@ -1,4 +1,12 @@
 packages:
   - name: ducaale/xh@v0.24.1
   - name: ducaale/xh
+    version: v0.21.0
+  - name: ducaale/xh
     version: v0.14.1
+  - name: ducaale/xh
+    version: v0.7.0
+  - name: ducaale/xh
+    version: v0.6.0
+  - name: ducaale/xh
+    version: v0.3.3

--- a/pkgs/ducaale/xh/registry.yaml
+++ b/pkgs/ducaale/xh/registry.yaml
@@ -3,29 +3,103 @@ packages:
   - type: github_release
     repo_owner: ducaale
     repo_name: xh
-    rosetta2: true
-    asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: Friendly and fast tool for sending HTTP requests
-    files:
-      - name: xh
-        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
-    replacements:
-      windows: pc-windows-msvc
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      amd64: x86_64
-      arm64: aarch64
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    version_constraint: semver(">= 0.15.0")
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.7.0"
+        asset: xh-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 0.3.3")
+        asset: ht-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.0")
+        asset: ht-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.14.1")
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.21.0")
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/ducaale/xh/registry.yaml
+++ b/pkgs/ducaale/xh/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: ducaale
     repo_name: xh
     description: Friendly and fast tool for sending HTTP requests
+    files:
+      - name: xh
+        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.7.0"
@@ -11,6 +14,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: xh
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -28,6 +34,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: ht
+            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -45,6 +54,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: ht
+            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/pkgs/ducaale/xh/registry.yaml
+++ b/pkgs/ducaale/xh/registry.yaml
@@ -4,9 +4,6 @@ packages:
     repo_owner: ducaale
     repo_name: xh
     description: Friendly and fast tool for sending HTTP requests
-    files:
-      - name: xh
-        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.7.0"
@@ -16,7 +13,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: xh
-            src: xh
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -36,7 +32,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: ht
-            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -56,7 +51,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: ht
-            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -74,6 +68,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -91,6 +88,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -106,6 +106,9 @@ packages:
         asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/pkgs/ducaale/xh/registry.yaml
+++ b/pkgs/ducaale/xh/registry.yaml
@@ -93,13 +93,11 @@ packages:
             src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -27144,9 +27144,6 @@ packages:
     repo_owner: ducaale
     repo_name: xh
     description: Friendly and fast tool for sending HTTP requests
-    files:
-      - name: xh
-        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.7.0"
@@ -27156,7 +27153,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: xh
-            src: xh
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27176,7 +27172,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: ht
-            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27196,7 +27191,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: ht
-            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27214,6 +27208,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27231,6 +27228,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27246,6 +27246,9 @@ packages:
         asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -27144,6 +27144,9 @@ packages:
     repo_owner: ducaale
     repo_name: xh
     description: Friendly and fast tool for sending HTTP requests
+    files:
+      - name: xh
+        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.7.0"
@@ -27151,6 +27154,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: xh
+            src: xh
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27168,6 +27174,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: ht
+            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -27185,6 +27194,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: ht
+            src: ht
         replacements:
           amd64: x86_64
           darwin: apple-darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -27143,32 +27143,106 @@ packages:
   - type: github_release
     repo_owner: ducaale
     repo_name: xh
-    rosetta2: true
-    asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: Friendly and fast tool for sending HTTP requests
-    files:
-      - name: xh
-        src: xh-{{.Version}}-{{.Arch}}-{{.OS}}/xh
-    replacements:
-      windows: pc-windows-msvc
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      amd64: x86_64
-      arm64: aarch64
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    version_constraint: semver(">= 0.15.0")
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.7.0"
+        asset: xh-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 0.3.3")
+        asset: ht-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.0")
+        asset: ht-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.14.1")
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.21.0")
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: xh-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: duckdb
     repo_name: duckdb

--- a/registry.yaml
+++ b/registry.yaml
@@ -27233,13 +27233,11 @@ packages:
             src: "{{.AssetWithoutExt}}/xh"
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
       - version_constraint: "true"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

`ducaale/xh` currently supports ARM64 natively on macOS. However, the registry file still requires Rosetta 2.
Therefore, I re-scaffolded the registry file.
Related PR: https://github.com/aquaproj/aqua-registry/pull/35049