### PR TITLE
feat: add zk-org/zk

### DIFF
--- a/pkgs/zk-org/zk/pkg.yaml
+++ b/pkgs/zk-org/zk/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: zk-org/zk@v0.15.1
+  - name: zk-org/zk
+    version: v0.15.0
+  - name: zk-org/zk
+    version: v0.14.1
+  - name: zk-org/zk
+    version: v0.14.0
+  - name: zk-org/zk
+    version: v0.11.0
+  - name: zk-org/zk
+    version: v0.2.1

--- a/pkgs/zk-org/zk/registry.yaml
+++ b/pkgs/zk-org/zk/registry.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: zk-org
+    repo_name: zk
+    description: A plain text note-taking assistant
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.11.0"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v0.14.1"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            format: zip
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.2.1")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.14.0")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.15.0")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: arm64
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}_86.{{.Format}}
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos

--- a/pkgs/zk-org/zk/registry.yaml
+++ b/pkgs/zk-org/zk/registry.yaml
@@ -17,12 +17,12 @@ packages:
       - version_constraint: Version == "v0.14.1"
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: macos
         overrides:
           - goos: darwin
             format: zip
+            replacements:
+              amd64: x86_64
+              darwin: macos
         supported_envs:
           - linux
           - darwin
@@ -43,13 +43,12 @@ packages:
           - darwin
       - version_constraint: semver("<= 0.14.0")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
+        format: tar.gz
         replacements:
           darwin: macos
         overrides:
-          - goos: linux
-            format: tar.gz
           - goos: darwin
+            format: zip
             replacements:
               amd64: x86_64
         supported_envs:
@@ -70,13 +69,19 @@ packages:
             goarch: arm64
             asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
-            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}_86.{{.Format}}
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
-              amd64: x64
+              amd64: x64_86
       - version_constraint: "true"
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         replacements:
-          amd64: x86_64
           darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            replacements:
+              amd64: x86_64

--- a/pkgs/zk-org/zk/registry.yaml
+++ b/pkgs/zk-org/zk/registry.yaml
@@ -14,34 +14,21 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: Version == "v0.14.1"
+      - version_constraint: semver("<= 0.2.1")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
         overrides:
           - goos: darwin
             format: zip
             replacements:
               amd64: x86_64
-              darwin: macos
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.2.1")
-        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        replacements:
-          darwin: macos
-        overrides:
-          - goos: linux
-            format: tar.gz
-          - goos: darwin
-            replacements:
-              amd64: x86_64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.14.0")
+      - version_constraint: semver("<= 0.14.1")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -77921,6 +77921,86 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: zk-org
+    repo_name: zk
+    description: A plain text note-taking assistant
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.11.0"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: Version == "v0.14.1"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            format: zip
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.2.1")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.14.0")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.15.0")
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: arm64
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}_86.{{.Format}}
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+  - type: github_release
     repo_owner: zmap
     repo_name: zlint
     description: X.509 Certificate Linter focused on Web PKI standards and requirements

--- a/registry.yaml
+++ b/registry.yaml
@@ -77937,12 +77937,12 @@ packages:
       - version_constraint: Version == "v0.14.1"
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: macos
         overrides:
           - goos: darwin
             format: zip
+            replacements:
+              amd64: x86_64
+              darwin: macos
         supported_envs:
           - linux
           - darwin
@@ -77963,13 +77963,12 @@ packages:
           - darwin
       - version_constraint: semver("<= 0.14.0")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
+        format: tar.gz
         replacements:
           darwin: macos
         overrides:
-          - goos: linux
-            format: tar.gz
           - goos: darwin
+            format: zip
             replacements:
               amd64: x86_64
         supported_envs:
@@ -77990,16 +77989,22 @@ packages:
             goarch: arm64
             asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
-            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}_86.{{.Format}}
+            asset: zk-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
-              amd64: x64
+              amd64: x64_86
       - version_constraint: "true"
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         replacements:
-          amd64: x86_64
           darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            replacements:
+              amd64: x86_64
   - type: github_release
     repo_owner: zmap
     repo_name: zlint

--- a/registry.yaml
+++ b/registry.yaml
@@ -77934,34 +77934,21 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: Version == "v0.14.1"
+      - version_constraint: semver("<= 0.2.1")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
         overrides:
           - goos: darwin
             format: zip
             replacements:
               amd64: x86_64
-              darwin: macos
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.2.1")
-        asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        replacements:
-          darwin: macos
-        overrides:
-          - goos: linux
-            format: tar.gz
-          - goos: darwin
-            replacements:
-              amd64: x86_64
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.14.0")
+      - version_constraint: semver("<= 0.14.1")
         asset: zk-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:


### PR DESCRIPTION
[zk-org/zk](https://github.com/zk-org/zk) - A plain text note-taking assistant

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Works on my machine™:
```
$ cmdx con
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@eb2166badf0d:/workspace# zk --version
zk 0.15.1
```