### PR TITLE
Add `bitwarden/sdk-sm`

### DIFF
--- a/pkgs/bitwarden/sdk-sm/pkg.yaml
+++ b/pkgs/bitwarden/sdk-sm/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/bitwarden/sdk-sm/pkg.yaml
+++ b/pkgs/bitwarden/sdk-sm/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
   - name: bitwarden/sdk-sm@bws-v1.0.0
+  - name: bitwarden/sdk-sm
+    version: bws-v0.5.0
+  - name: bitwarden/sdk-sm
+    version: bws-v0.4.0
+  - name: bitwarden/sdk-sm
+    version: bws-v0.3.1
+  - name: bitwarden/sdk-sm
+    version: bws-v0.3.0
+  - name: bitwarden/sdk-sm
+    version: bws-v0.2.1

--- a/pkgs/bitwarden/sdk-sm/pkg.yaml
+++ b/pkgs/bitwarden/sdk-sm/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: bitwarden/sdk-sm@bws-v1.0.0

--- a/pkgs/bitwarden/sdk-sm/pkg.yaml
+++ b/pkgs/bitwarden/sdk-sm/pkg.yaml
@@ -1,12 +1,6 @@
 packages:
   - name: bitwarden/sdk-sm@bws-v1.0.0
   - name: bitwarden/sdk-sm
-    version: bws-v0.5.0
-  - name: bitwarden/sdk-sm
-    version: bws-v0.4.0
-  - name: bitwarden/sdk-sm
-    version: bws-v0.3.1
-  - name: bitwarden/sdk-sm
     version: bws-v0.3.0
   - name: bitwarden/sdk-sm
     version: bws-v0.2.1

--- a/pkgs/bitwarden/sdk-sm/registry.yaml
+++ b/pkgs/bitwarden/sdk-sm/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: bitwarden
+    repo_name: sdk-sm

--- a/pkgs/bitwarden/sdk-sm/registry.yaml
+++ b/pkgs/bitwarden/sdk-sm/registry.yaml
@@ -7,36 +7,36 @@ packages:
     version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
     asset: bws
     files:
-    - name: bws
-      src: ./bws
+      - name: bws
+        src: ./bws
     format: zip
     overrides:
-    - goos: darwin
-      goarch: amd64
-      asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-    - goos: darwin
-      goarch: arm64
-      asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-    - goos: linux
-      goarch: amd64
-      asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-    - goos: linux
-      goarch: arm64
-      asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-    - goos: windows
-      goarch: amd64
-      asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-    - goos: windows
-      goarch: arm64
-      asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+      - goos: darwin
+        goarch: amd64
+        asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+      - goos: darwin
+        goarch: arm64
+        asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+      - goos: linux
+        goarch: amd64
+        asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+      - goos: linux
+        goarch: arm64
+        asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+      - goos: windows
+        goarch: amd64
+        asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+      - goos: windows
+        goarch: arm64
+        asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
     search_words:
-    - bws
-    - bitwarden-secrets-manager
-    - bitwarden-secrets-manager-cli
+      - bws
+      - bitwarden-secrets-manager
+      - bitwarden-secrets-manager-cli
     supported_envs:
-    - darwin
-    - linux
-    - windows
+      - darwin
+      - linux
+      - windows
     checksum:
       type: github_release
       asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt

--- a/pkgs/bitwarden/sdk-sm/registry.yaml
+++ b/pkgs/bitwarden/sdk-sm/registry.yaml
@@ -3,14 +3,16 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
-    description: Bitwarden Secrets Manager SDK
+    description: Bitwarden Secrets Manager
     version_prefix: bws-v
+    search_words:
+      - secret manager
     files:
       - name: bws
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "bws-v0.2.1"
-        asset: bws-{{.Arch}}-{{.OS}}-0.2.1.{{.Format}}
+      - version_constraint: Version in ["bws-v0.2.1", "bws-v0.3.0"]
+        asset: bws-{{.Arch}}-{{.OS}}-{{.SemVer}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
         replacements:
@@ -20,7 +22,7 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: bws-sha256-checksums-0.2.1.txt
+          asset: bws-sha256-checksums-{{.SemVer}}.txt
           algorithm: sha256
         overrides:
           - goos: darwin
@@ -30,68 +32,8 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "bws-v0.3.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.3.0.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.3.0.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "bws-v0.3.1"
-        asset: bws-{{.Arch}}-{{.OS}}-0.3.1.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.3.1.txt
-          algorithm: sha256
-      - version_constraint: Version == "bws-v0.4.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.4.0.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.4.0.txt
-          algorithm: sha256
-      - version_constraint: Version == "bws-v0.5.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.5.0.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.5.0.txt
-          algorithm: sha256
       - version_constraint: "true"
-        asset: bws-{{.Arch}}-{{.OS}}-1.0.0.{{.Format}}
+        asset: bws-{{.Arch}}-{{.OS}}-{{.SemVer}}.{{.Format}}
         format: zip
         replacements:
           amd64: x86_64
@@ -101,5 +43,5 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: bws-sha256-checksums-1.0.0.txt
+          asset: bws-sha256-checksums-{{.SemVer}}.txt
           algorithm: sha256

--- a/pkgs/bitwarden/sdk-sm/registry.yaml
+++ b/pkgs/bitwarden/sdk-sm/registry.yaml
@@ -3,41 +3,103 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
-    description: Bitwarden Secrets Manager CLI.
-    version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
-    asset: bws
+    description: Bitwarden Secrets Manager SDK
+    version_prefix: bws-v
     files:
       - name: bws
-        src: ./bws
-    format: zip
-    overrides:
-      - goos: darwin
-        goarch: amd64
-        asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-      - goos: darwin
-        goarch: arm64
-        asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-      - goos: linux
-        goarch: amd64
-        asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-      - goos: linux
-        goarch: arm64
-        asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-      - goos: windows
-        goarch: amd64
-        asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-      - goos: windows
-        goarch: arm64
-        asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-    search_words:
-      - bws
-      - bitwarden-secrets-manager
-      - bitwarden-secrets-manager-cli
-    supported_envs:
-      - darwin
-      - linux
-      - windows
-    checksum:
-      type: github_release
-      asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "bws-v0.2.1"
+        asset: bws-{{.Arch}}-{{.OS}}-0.2.1.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.2.1.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "bws-v0.3.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.3.0.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.3.0.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "bws-v0.3.1"
+        asset: bws-{{.Arch}}-{{.OS}}-0.3.1.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.3.1.txt
+          algorithm: sha256
+      - version_constraint: Version == "bws-v0.4.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.4.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.4.0.txt
+          algorithm: sha256
+      - version_constraint: Version == "bws-v0.5.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.5.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.5.0.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: bws-{{.Arch}}-{{.OS}}-1.0.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-1.0.0.txt
+          algorithm: sha256

--- a/pkgs/bitwarden/sdk-sm/registry.yaml
+++ b/pkgs/bitwarden/sdk-sm/registry.yaml
@@ -3,3 +3,41 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
+    description: Bitwarden Secrets Manager CLI.
+    version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
+    asset: bws
+    files:
+    - name: bws
+      src: ./bws
+    format: zip
+    overrides:
+    - goos: darwin
+      goarch: amd64
+      asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+    - goos: darwin
+      goarch: arm64
+      asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+    - goos: linux
+      goarch: amd64
+      asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+    - goos: linux
+      goarch: arm64
+      asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+    - goos: windows
+      goarch: amd64
+      asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+    - goos: windows
+      goarch: arm64
+      asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+    search_words:
+    - bws
+    - bitwarden-secrets-manager
+    - bitwarden-secrets-manager-cli
+    supported_envs:
+    - darwin
+    - linux
+    - windows
+    checksum:
+      type: github_release
+      asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt
+      algorithm: sha256

--- a/pkgs/bitwarden/sdk-sm/scaffold.yaml
+++ b/pkgs/bitwarden/sdk-sm/scaffold.yaml
@@ -1,0 +1,4 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: bitwarden/sdk-sm
+version_prefix: bws-v

--- a/registry.yaml
+++ b/registry.yaml
@@ -15125,44 +15125,106 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
-    description: Bitwarden Secrets Manager CLI.
-    version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
-    asset: bws
+    description: Bitwarden Secrets Manager SDK
+    version_prefix: bws-v
     files:
       - name: bws
-        src: ./bws
-    format: zip
-    overrides:
-      - goos: darwin
-        goarch: amd64
-        asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-      - goos: darwin
-        goarch: arm64
-        asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-      - goos: linux
-        goarch: amd64
-        asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-      - goos: linux
-        goarch: arm64
-        asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-      - goos: windows
-        goarch: amd64
-        asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-      - goos: windows
-        goarch: arm64
-        asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-    search_words:
-      - bws
-      - bitwarden-secrets-manager
-      - bitwarden-secrets-manager-cli
-    supported_envs:
-      - darwin
-      - linux
-      - windows
-    checksum:
-      type: github_release
-      asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "bws-v0.2.1"
+        asset: bws-{{.Arch}}-{{.OS}}-0.2.1.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.2.1.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "bws-v0.3.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.3.0.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.3.0.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "bws-v0.3.1"
+        asset: bws-{{.Arch}}-{{.OS}}-0.3.1.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.3.1.txt
+          algorithm: sha256
+      - version_constraint: Version == "bws-v0.4.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.4.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.4.0.txt
+          algorithm: sha256
+      - version_constraint: Version == "bws-v0.5.0"
+        asset: bws-{{.Arch}}-{{.OS}}-0.5.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-0.5.0.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: bws-{{.Arch}}-{{.OS}}-1.0.0.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: bws-sha256-checksums-1.0.0.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: bjesus
     repo_name: pipet

--- a/registry.yaml
+++ b/registry.yaml
@@ -15125,14 +15125,16 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
-    description: Bitwarden Secrets Manager SDK
+    description: Bitwarden Secrets Manager
     version_prefix: bws-v
+    search_words:
+      - secret manager
     files:
       - name: bws
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "bws-v0.2.1"
-        asset: bws-{{.Arch}}-{{.OS}}-0.2.1.{{.Format}}
+      - version_constraint: Version in ["bws-v0.2.1", "bws-v0.3.0"]
+        asset: bws-{{.Arch}}-{{.OS}}-{{.SemVer}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
         replacements:
@@ -15142,7 +15144,7 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: bws-sha256-checksums-0.2.1.txt
+          asset: bws-sha256-checksums-{{.SemVer}}.txt
           algorithm: sha256
         overrides:
           - goos: darwin
@@ -15152,68 +15154,8 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "bws-v0.3.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.3.0.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.3.0.txt
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "bws-v0.3.1"
-        asset: bws-{{.Arch}}-{{.OS}}-0.3.1.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.3.1.txt
-          algorithm: sha256
-      - version_constraint: Version == "bws-v0.4.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.4.0.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.4.0.txt
-          algorithm: sha256
-      - version_constraint: Version == "bws-v0.5.0"
-        asset: bws-{{.Arch}}-{{.OS}}-0.5.0.{{.Format}}
-        format: zip
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: bws-sha256-checksums-0.5.0.txt
-          algorithm: sha256
       - version_constraint: "true"
-        asset: bws-{{.Arch}}-{{.OS}}-1.0.0.{{.Format}}
+        asset: bws-{{.Arch}}-{{.OS}}-{{.SemVer}}.{{.Format}}
         format: zip
         replacements:
           amd64: x86_64
@@ -15223,7 +15165,7 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: bws-sha256-checksums-1.0.0.txt
+          asset: bws-sha256-checksums-{{.SemVer}}.txt
           algorithm: sha256
   - type: github_release
     repo_owner: bjesus

--- a/registry.yaml
+++ b/registry.yaml
@@ -15129,36 +15129,36 @@ packages:
     version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
     asset: bws
     files:
-    - name: bws
-      src: ./bws
+      - name: bws
+        src: ./bws
     format: zip
     overrides:
-    - goos: darwin
-      goarch: amd64
-      asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-    - goos: darwin
-      goarch: arm64
-      asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
-    - goos: linux
-      goarch: amd64
-      asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-    - goos: linux
-      goarch: arm64
-      asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
-    - goos: windows
-      goarch: amd64
-      asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
-    - goos: windows
-      goarch: arm64
-      asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+      - goos: darwin
+        goarch: amd64
+        asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+      - goos: darwin
+        goarch: arm64
+        asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+      - goos: linux
+        goarch: amd64
+        asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+      - goos: linux
+        goarch: arm64
+        asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+      - goos: windows
+        goarch: amd64
+        asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+      - goos: windows
+        goarch: arm64
+        asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
     search_words:
-    - bws
-    - bitwarden-secrets-manager
-    - bitwarden-secrets-manager-cli
+      - bws
+      - bitwarden-secrets-manager
+      - bitwarden-secrets-manager-cli
     supported_envs:
-    - darwin
-    - linux
-    - windows
+      - darwin
+      - linux
+      - windows
     checksum:
       type: github_release
       asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -15123,6 +15123,9 @@ packages:
       asset: bw-{{.OS}}-sha256-{{trimPrefix "cli-v" .Version}}.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: bitwarden
+    repo_name: sdk-sm
+  - type: github_release
     repo_owner: bjesus
     repo_name: pipet
     description: a swiss-army tool for scraping and extracting data from online assets, made for hackers

--- a/registry.yaml
+++ b/registry.yaml
@@ -15125,6 +15125,44 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm
+    description: Bitwarden Secrets Manager CLI.
+    version_constraint: 'semverWithVersion(">= 1.0.0", trimPrefix(Version, "bws-"))'
+    asset: bws
+    files:
+    - name: bws
+      src: ./bws
+    format: zip
+    overrides:
+    - goos: darwin
+      goarch: amd64
+      asset: bws-x86_64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+    - goos: darwin
+      goarch: arm64
+      asset: bws-aarch64-apple-darwin-{{trimPrefix "bws-v" .Version}}
+    - goos: linux
+      goarch: amd64
+      asset: bws-x86_64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+    - goos: linux
+      goarch: arm64
+      asset: bws-aarch64-unknown-linux-gnu-{{trimPrefix "bws-v" .Version}}
+    - goos: windows
+      goarch: amd64
+      asset: bws-x86_64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+    - goos: windows
+      goarch: arm64
+      asset: bws-aarch64-pc-windows-msvc-{{trimPrefix "bws-v" .Version}}
+    search_words:
+    - bws
+    - bitwarden-secrets-manager
+    - bitwarden-secrets-manager-cli
+    supported_envs:
+    - darwin
+    - linux
+    - windows
+    checksum:
+      type: github_release
+      asset: bws-sha256-checksums-{{trimPrefix "bws-v" .Version}}.txt
+      algorithm: sha256
   - type: github_release
     repo_owner: bjesus
     repo_name: pipet


### PR DESCRIPTION
[bitwarden/sdk-sm](https://github.com/bitwarden/sdk-sm) - Bitwarden Secrets Manager CLI

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

- This provides bitwarden secrets manager CLI (which is different from the already supported bitwarden password manager CLI).
- Tested locally:
```bash
$ cmdx con
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/arm64)
root@d75e8725b640:/workspace# bws help
Bitwarden Secrets CLI

Usage: bws [OPTIONS] [COMMAND]

Commands:
  config       Configure the CLI
  completions  Generate shell completion files
  project      Commands available on Projects
  secret       Commands available on Secrets
  run          Run a command with secrets injected
  help         Print this message or the help of the given subcommand(s)

Options:
  -o, --output <OUTPUT>              Output format [default: json] [possible values: json, yaml, env, table, tsv, none]
  -c, --color <COLOR>                Use colors in the output [default: auto] [possible values: no, yes, auto]
  -t, --access-token <ACCESS_TOKEN>  Specify access token for the service account [env: BWS_ACCESS_TOKEN]
  -f, --config-file <CONFIG_FILE>    [default: ~/.config/bws/config] Config file to use [env: BWS_CONFIG_FILE=]
  -p, --profile <PROFILE>            Profile to use from the config file [env: BWS_PROFILE=]
  -u, --server-url <SERVER_URL>      Override the server URL from the config file [env: BWS_SERVER_URL=]
  -h, --help                         Print help
  -V, --version                      Print version
  ```