### PR TITLE
fix(sharkdp/hexyl): Re-scaffold the registry file

### DIFF
--- a/pkgs/sharkdp/hexyl/pkg.yaml
+++ b/pkgs/sharkdp/hexyl/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: sharkdp/hexyl@v0.16.0
+  - name: sharkdp/hexyl
+    version: v0.15.0
+  - name: sharkdp/hexyl
+    version: v0.8.0

--- a/pkgs/sharkdp/hexyl/registry.yaml
+++ b/pkgs/sharkdp/hexyl/registry.yaml
@@ -17,6 +17,9 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
       - version_constraint: semver("<= 0.15.0")
         asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -26,6 +29,9 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
         overrides:
           - goos: linux
             goarch: amd64
@@ -47,6 +53,9 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
         overrides:
           - goos: linux
             goarch: amd64

--- a/pkgs/sharkdp/hexyl/registry.yaml
+++ b/pkgs/sharkdp/hexyl/registry.yaml
@@ -3,27 +3,58 @@ packages:
   - type: github_release
     repo_owner: sharkdp
     repo_name: hexyl
-    asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: A command-line hex viewer
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    format: tar.gz
-    replacements:
-      darwin: apple-darwin
-      windows: pc-windows-msvc
-      linux: unknown-linux-musl
-      arm64: aarch64
-      amd64: x86_64
-    overrides:
-      - goos: linux
-        goarch: arm64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
-          linux: unknown-linux-gnu
-      - goos: windows
-        format: zip
-    files:
-      - name: hexyl
-        src: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}/hexyl
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.15.0")
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -63996,6 +63996,9 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
       - version_constraint: semver("<= 0.15.0")
         asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -64005,6 +64008,9 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
         overrides:
           - goos: linux
             goarch: amd64
@@ -64026,6 +64032,9 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
+        files:
+          - name: hexyl
+            src: "{{.AssetWithoutExt}}/hexyl"
         overrides:
           - goos: linux
             goarch: amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -63982,30 +63982,61 @@ packages:
   - type: github_release
     repo_owner: sharkdp
     repo_name: hexyl
-    asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     description: A command-line hex viewer
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    format: tar.gz
-    replacements:
-      darwin: apple-darwin
-      windows: pc-windows-msvc
-      linux: unknown-linux-musl
-      arm64: aarch64
-      amd64: x86_64
-    overrides:
-      - goos: linux
-        goarch: arm64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
-          linux: unknown-linux-gnu
-      - goos: windows
-        format: zip
-    files:
-      - name: hexyl
-        src: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}/hexyl
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.15.0")
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hexyl-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: sharkdp
     repo_name: hyperfine


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

## Description
<!-- Please write the description here -->
`sharkdp/hexyl` currently supports ARM64 natively on macOS. However, the registry file still requires Rosetta 2. So I re-scaffolded the registry file.

Related PR: https://github.com/aquaproj/aqua-registry/pull/35610