### PR TITLE
Add `juanfont/headscale`

### DIFF
--- a/pkgs/juanfont/headscale/pkg.yaml
+++ b/pkgs/juanfont/headscale/pkg.yaml
@@ -1,4 +1,5 @@
 packages:
+  - name: juanfont/headscale@v0.26.0
   - name: juanfont/headscale@v0.15.0-beta2
   - name: juanfont/headscale
     version: v0.10.2

--- a/pkgs/juanfont/headscale/pkg.yaml
+++ b/pkgs/juanfont/headscale/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: juanfont/headscale@v0.15.0-beta2
+  - name: juanfont/headscale
+    version: v0.10.2
+  - name: juanfont/headscale
+    version: v0.3.2
+  - name: juanfont/headscale
+    version: v0.1.0

--- a/pkgs/juanfont/headscale/pkg.yaml
+++ b/pkgs/juanfont/headscale/pkg.yaml
@@ -1,6 +1,5 @@
 packages:
   - name: juanfont/headscale@v0.26.0
-  - name: juanfont/headscale@v0.15.0-beta2
   - name: juanfont/headscale
     version: v0.10.2
   - name: juanfont/headscale

--- a/pkgs/juanfont/headscale/registry.yaml
+++ b/pkgs/juanfont/headscale/registry.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: juanfont
+    repo_name: headscale
+    description: An open source, self-hosted implementation of the Tailscale control server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.2")
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.10.2")
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -41419,6 +41419,58 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: juanfont
+    repo_name: headscale
+    description: An open source, self-hosted implementation of the Tailscale control server
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.3.2")
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.10.2")
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: headscale_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: jubako
     repo_name: arx
     description: Store files and directory in an archive. Like tar, but faster and with direct random access


### PR DESCRIPTION
[juanfont/headscale](https://github.com/juanfont/headscale) - An open source, self-hosted implementation of the Tailscale control server

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

The `headscale` CLI provides commands to interact with a running headscale server.

