### PR TITLE
Excluded envtest from controller-gen package

### DIFF
--- a/pkgs/kubernetes-sigs/controller-tools/controller-gen/registry.yaml
+++ b/pkgs/kubernetes-sigs/controller-tools/controller-gen/registry.yaml
@@ -8,5 +8,6 @@ packages:
     repo_owner: kubernetes-sigs
     repo_name: controller-tools
     description: controller-gen - Generate Kubernetes API extension resources and code
+    version_filter: 'not (Version startsWith "envtest-")'
     files:
       - name: controller-gen

--- a/registry.yaml
+++ b/registry.yaml
@@ -44906,6 +44906,7 @@ packages:
     repo_owner: kubernetes-sigs
     repo_name: controller-tools
     description: controller-gen - Generate Kubernetes API extension resources and code
+    version_filter: 'not (Version startsWith "envtest-")'
     files:
       - name: controller-gen
   - type: github_release


### PR DESCRIPTION
`aqua -g` or `aqua update` may select envtest as the controller-gen version.
https://github.com/kubernetes-sigs/controller-tools/releases/tag/envtest-v1.33.0

This PR excludes envtest releases.