### PR TITLE
feat: add apple/container

### DIFF
--- a/pkgs/apple/container/pkg.yaml
+++ b/pkgs/apple/container/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: apple/container@0.1.0

--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: apple
+    repo_name: container
+    description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It's written in Swift, and optimized for Apple silicon
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: container-{{.Version}}-installer-signed.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin

--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -9,5 +9,8 @@ packages:
       - version_constraint: "true"
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
+        files:
+          - name: container
+            src: Payload/bin/container
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -10347,6 +10347,17 @@ packages:
             format: zip
   - type: github_release
     repo_owner: apple
+    repo_name: container
+    description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It's written in Swift, and optimized for Apple silicon
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: container-{{.Version}}-installer-signed.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+  - type: github_release
+    repo_owner: apple
     repo_name: pkl
     description: A configuration as code language with rich validation and tooling
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -10354,6 +10354,9 @@ packages:
       - version_constraint: "true"
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
+        files:
+          - name: container
+            src: Payload/bin/container
         supported_envs:
           - darwin
   - type: github_release


### PR DESCRIPTION
[apple/container](https://github.com/apple/container): A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It's written in Swift, and optimized for Apple silicon

```console
$ aqua g -i apple/container
```