### PR TITLE
feat: add sst/opencode

### DIFF
--- a/pkgs/sst/opencode/pkg.yaml
+++ b/pkgs/sst/opencode/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sst/opencode@v0.0.52

--- a/pkgs/sst/opencode/registry.yaml
+++ b/pkgs/sst/opencode/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sst
+    repo_name: opencode
+    description: AI coding agent, built for the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: opencode-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -67309,6 +67309,25 @@ packages:
           asset: togomak_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: sst
+    repo_name: opencode
+    description: AI coding agent, built for the terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: opencode-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: sstadick
     repo_name: crabz
     description: Like pigz, but rust


### PR DESCRIPTION
[sst/opencode](https://github.com/sst/opencode): AI coding agent, built for the terminal

```console
$ aqua g -i sst/opencode
```
