### PR TITLE
fix 1password cli version

### DIFF
--- a/pkgs/1password/cli/pkg.yaml
+++ b/pkgs/1password/cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: 1password/cli@v2.30.3
+  - name: 1password/cli@v2.31.1


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

1password cli installation is always failed since the version is incorrect.
ref: https://formulae.brew.sh/cask/1password-cli#default