### PR TITLE
feat: add tattoy-org/tattoy

### DIFF
--- a/pkgs/tattoy-org/tattoy/pkg.yaml
+++ b/pkgs/tattoy-org/tattoy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tattoy-org/tattoy@v0.1.1

--- a/pkgs/tattoy-org/tattoy/registry.yaml
+++ b/pkgs/tattoy-org/tattoy/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tattoy-org
+    repo_name: tattoy
+    description: A text-based compositor for modern terminals
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tattoy-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: tattoy-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -71144,6 +71144,28 @@ packages:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: tattoy-org
+    repo_name: tattoy
+    description: A text-based compositor for modern terminals
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tattoy-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: tattoy-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - name: tauri-apps/tauri/cargo-tauri
     type: github_release
     repo_owner: tauri-apps


### PR DESCRIPTION
[tattoy-org/tattoy](https://github.com/tattoy-org/tattoy): A text-based compositor for modern terminals

```console
$ aqua g -i tattoy-org/tattoy
```

Close #37623