### PR TITLE
fix(biomejs/biome): ignore broken version

### DIFF
--- a/pkgs/biomejs/biome/pkg.yaml
+++ b/pkgs/biomejs/biome/pkg.yaml
@@ -4,5 +4,3 @@ packages:
     version: "@biomejs/biome@2.0.0-beta.5"
   - name: biomejs/biome
     version: "@biomejs/biome@2.0.0-beta"
-  - name: biomejs/biome
-    version: "@biomejs/biome@2.0.4"

--- a/pkgs/biomejs/biome/pkg.yaml
+++ b/pkgs/biomejs/biome/pkg.yaml
@@ -4,3 +4,5 @@ packages:
     version: "@biomejs/biome@2.0.0-beta.5"
   - name: biomejs/biome
     version: "@biomejs/biome@2.0.0-beta"
+  - name: biomejs/biome
+    version: "@biomejs/biome@2.0.4"

--- a/pkgs/biomejs/biome/registry.yaml
+++ b/pkgs/biomejs/biome/registry.yaml
@@ -6,6 +6,8 @@ packages:
     description: A toolchain for web projects, aimed to provide functionalities to maintain them. Biome offers formatter and linter, usable via CLI and LSP
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "@biomejs/biome@2.0.1"
+        no_asset: true
       - version_constraint: 'Version startsWith "@biomejs/biome@"'
         version_prefix: "@biomejs/biome@"
         asset: biome-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -15013,6 +15013,8 @@ packages:
     description: A toolchain for web projects, aimed to provide functionalities to maintain them. Biome offers formatter and linter, usable via CLI and LSP
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "@biomejs/biome@2.0.1"
+        no_asset: true
       - version_constraint: 'Version startsWith "@biomejs/biome@"'
         version_prefix: "@biomejs/biome@"
         asset: biome-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

`biome@2.0.1` is released to GitHub, but it doesn't contain the binaries. (Maybe removed?)
`2.0.2` and `2.0.3` are also broken, but they're not in the GitHub releases.

https://github.com/biomejs/biome/issues/6446, https://github.com/biomejs/biome/issues/6435