### PR TITLE
feat: add encoredev/encore

### DIFF
--- a/pkgs/encoredev/encore/pkg.yaml
+++ b/pkgs/encoredev/encore/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/encoredev/encore/pkg.yaml
+++ b/pkgs/encoredev/encore/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: encoredev/encore@v1.48.6

--- a/pkgs/encoredev/encore/registry.yaml
+++ b/pkgs/encoredev/encore/registry.yaml
@@ -1,10 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: http
     repo_owner: encoredev
     repo_name: encore
     description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
+    files:
+      - name: encore
+        src: bin/encore
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      enabled: false

--- a/pkgs/encoredev/encore/registry.yaml
+++ b/pkgs/encoredev/encore/registry.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: encoredev
+    repo_name: encore
+    description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/encoredev/encore/registry.yaml
+++ b/pkgs/encoredev/encore/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_owner: encoredev
     repo_name: encore
     description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
-    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
+    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
     files:
       - name: encore
         src: bin/encore
@@ -12,6 +12,3 @@ packages:
       - darwin
       - linux
       - amd64
-    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      enabled: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -28281,14 +28281,21 @@ packages:
       - version_constraint: "true"
         rosetta2: true
         asset: kubectl-doctor_{{.OS}}_{{.Arch}}.zip
-  - type: github_release
+  - type: http
     repo_owner: encoredev
     repo_name: encore
     description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        no_asset: true
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
+    files:
+      - name: encore
+        src: bin/encore
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
+    checksum:
+      enabled: false
   - type: github_release
     repo_owner: enokawa
     repo_name: taskdiff

--- a/registry.yaml
+++ b/registry.yaml
@@ -28282,6 +28282,14 @@ packages:
         rosetta2: true
         asset: kubectl-doctor_{{.OS}}_{{.Arch}}.zip
   - type: github_release
+    repo_owner: encoredev
+    repo_name: encore
+    description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: enokawa
     repo_name: taskdiff
     description: Diff tool for ECS Task Definition

--- a/registry.yaml
+++ b/registry.yaml
@@ -28285,7 +28285,7 @@ packages:
     repo_owner: encoredev
     repo_name: encore
     description: Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure
-    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
+    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
     files:
       - name: encore
         src: bin/encore
@@ -28293,9 +28293,6 @@ packages:
       - darwin
       - linux
       - amd64
-    url: https://d2f391esomvqpi.cloudfront.net/encore-{{trimV .Version}}-{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      enabled: false
   - type: github_release
     repo_owner: enokawa
     repo_name: taskdiff


### PR DESCRIPTION
[encoredev/encore](https://github.com/encoredev/encore) - Open Source Development Platform for building robust type-safe distributed systems with declarative infrastructure

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

I copied the URL template from encore's [own homebrew tap](https://github.com/encoredev/homebrew-tap/blob/main/Formula/encore.rb). I couldn't find an URL to properly fetch checksums (I could only find the hardcoded ones), not sure what's the best approach.