### PR TITLE
fix(bitwarden/clients): disable checksum

### DIFF
--- a/pkgs/bitwarden/clients/pkg.yaml
+++ b/pkgs/bitwarden/clients/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: bitwarden/clients@cli-v2025.5.0
+  - name: bitwarden/clients
+    version: cli-v2025.5.0

--- a/pkgs/bitwarden/clients/registry.yaml
+++ b/pkgs/bitwarden/clients/registry.yaml
@@ -3,8 +3,8 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: clients
-    asset: bw-{{.OS}}-{{trimPrefix "cli-v" .Version}}.zip
-    version_filter: Version startsWith "cli-"
+    asset: bw-{{.OS}}-{{.SemVer}}.zip
+    version_prefix: cli-v
     files:
       - name: bw
     description: Bitwarden CLI
@@ -13,7 +13,11 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    checksum:
-      type: github_release
-      asset: bw-{{.OS}}-sha256-{{trimPrefix "cli-v" .Version}}.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2025.5.0")
+        checksum:
+          type: github_release
+          asset: bw-{{.OS}}-sha256-{{.SemVer}}.txt
+          algorithm: sha256
+      - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -15294,8 +15294,8 @@ packages:
   - type: github_release
     repo_owner: bitwarden
     repo_name: clients
-    asset: bw-{{.OS}}-{{trimPrefix "cli-v" .Version}}.zip
-    version_filter: Version startsWith "cli-"
+    asset: bw-{{.OS}}-{{.SemVer}}.zip
+    version_prefix: cli-v
     files:
       - name: bw
     description: Bitwarden CLI
@@ -15304,10 +15304,14 @@ packages:
     supported_envs:
       - darwin
       - amd64
-    checksum:
-      type: github_release
-      asset: bw-{{.OS}}-sha256-{{trimPrefix "cli-v" .Version}}.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2025.5.0")
+        checksum:
+          type: github_release
+          asset: bw-{{.OS}}-sha256-{{.SemVer}}.txt
+          algorithm: sha256
+      - version_constraint: "true"
   - type: github_release
     repo_owner: bitwarden
     repo_name: sdk-sm


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Fixes https://github.com/aquaproj/aqua-registry/issues/38195.

I tested `cli-v2025.6.0` locally and confirmed it works.