### PR TITLE
fix(PowerShell/PowerShell): disable checksum for UTF-16LE files

### DIFF
--- a/pkgs/PowerShell/PowerShell/pkg.yaml
+++ b/pkgs/PowerShell/PowerShell/pkg.yaml
@@ -1,6 +1,18 @@
 packages:
   - name: PowerShell/PowerShell@v7.5.2
   - name: PowerShell/PowerShell
+    version: v7.6.0-preview.4
+  - name: PowerShell/PowerShell
+    version: v7.5.1
+  - name: PowerShell/PowerShell
+    version: v7.5.0-rc.1
+  - name: PowerShell/PowerShell
+    version: v7.5.0-preview.1
+  - name: PowerShell/PowerShell
+    version: v7.4.10
+  - name: PowerShell/PowerShell
+    version: v7.4.7
+  - name: PowerShell/PowerShell
     version: v7.3.12
   - name: PowerShell/PowerShell
     version: v7.3.9

--- a/pkgs/PowerShell/PowerShell/registry.yaml
+++ b/pkgs/PowerShell/PowerShell/registry.yaml
@@ -36,7 +36,10 @@ packages:
           - goos: windows
             format: zip
             asset: PowerShell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: "true"
+      - version_constraint: >-
+          semver("<= 7.4.7") ||
+          (semver(">= 7.5.0-preview.1, <= 7.5.1")) ||
+          (semver(">= 7.6.0-preview.1, <= 7.6.0-preview.4"))
         asset: powershell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -47,6 +50,17 @@ packages:
           type: github_release
           asset: hashes.sha256
           algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            asset: PowerShell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: powershell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -4786,10 +4786,6 @@ packages:
           amd64: x64
           darwin: osx
           windows: win
-        checksum:
-          type: github_release
-          asset: hashes.sha256bu
-          algorithm: sha256
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -4761,7 +4761,10 @@ packages:
           - goos: windows
             format: zip
             asset: PowerShell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: "true"
+      - version_constraint: >-
+          semver("<= 7.4.7") ||
+          (semver(">= 7.5.0-preview.1, <= 7.5.1")) ||
+          (semver(">= 7.6.0-preview.1, <= 7.6.0-preview.4"))
         asset: powershell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -4771,6 +4774,21 @@ packages:
         checksum:
           type: github_release
           asset: hashes.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            asset: PowerShell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: powershell-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        checksum:
+          type: github_release
+          asset: hashes.sha256bu
           algorithm: sha256
         overrides:
           - goos: windows


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Fixes https://github.com/aquaproj/aqua-registry/issues/38179 by disabling checksum validations for releases with UTF-16LE encoded checksum files.

I tested with `cmdx test PowerShell/PowerShell` and confirmed the `version_constraint` is working as expected.

Since tags [v7.4.8](https://github.com/PowerShell/PowerShell/releases/tag/v7.4.8) and [v7.4.9](https://github.com/PowerShell/PowerShell/releases/tag/v7.4.9) don't have releases, I used `semver("<= 7.4.7")` instead of `semver("<= 7.4.9")`.