### PR TITLE
fix(cloudflare/gokey): switch the package type to `github_release`

### DIFF
--- a/pkgs/cloudflare/gokey/pkg.yaml
+++ b/pkgs/cloudflare/gokey/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: cloudflare/gokey@a7a2ab980535f783b88740e46b9281fc2f08e629
+  - name: cloudflare/gokey@v0.1.3

--- a/pkgs/cloudflare/gokey/registry.yaml
+++ b/pkgs/cloudflare/gokey/registry.yaml
@@ -1,7 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: go_install
+  - type: github_release
     repo_owner: cloudflare
     repo_name: gokey
     description: A simple vaultless password manager in Go
-    path: github.com/cloudflare/gokey/cmd/gokey
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: gokey-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -20003,11 +20003,17 @@ packages:
     overrides:
       - goos: darwin
         asset: cloudflared-{{.OS}}-{{.Arch}}.tgz
-  - type: go_install
+  - type: github_release
     repo_owner: cloudflare
     repo_name: gokey
     description: A simple vaultless password manager in Go
-    path: github.com/cloudflare/gokey/cmd/gokey
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: gokey-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
   - type: github_release
     repo_owner: cloudflare
     repo_name: pint


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Switches the package type from `go_install` to `github_release`.

It seems they didn't have releases when this package is added in https://github.com/aquaproj/aqua-registry/commit/6ceed9b8632f278019c12bdbd29b52fa418a2602.