### PR TITLE
fix(segmentio/golines): switch the package type to `github_release`

### DIFF
--- a/pkgs/segmentio/golines/pkg.yaml
+++ b/pkgs/segmentio/golines/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: segmentio/golines@v0.12.2
+  - name: segmentio/golines
+    version: v0.11.0

--- a/pkgs/segmentio/golines/registry.yaml
+++ b/pkgs/segmentio/golines/registry.yaml
@@ -11,6 +11,9 @@ packages:
       - version_constraint: "true"
         asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: golines
+            src: "{{.AssetWithoutExt}}/golines"
         checksum:
           type: github_release
           asset: golines_{{trimV .Version}}_checksums.txt
@@ -18,6 +21,5 @@ packages:
         overrides:
           - goos: darwin
             asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
-          - env:
-              - windows
+          - goos: windows
             type: go_install

--- a/pkgs/segmentio/golines/registry.yaml
+++ b/pkgs/segmentio/golines/registry.yaml
@@ -7,7 +7,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.11.0")
-        no_asset: true
+        type: go_install
       - version_constraint: "true"
         asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -18,6 +18,6 @@ packages:
         overrides:
           - goos: darwin
             asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
+          - env:
+              - windows
+            type: go_install

--- a/pkgs/segmentio/golines/registry.yaml
+++ b/pkgs/segmentio/golines/registry.yaml
@@ -1,6 +1,23 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: go_install
+  - type: github_release
     repo_owner: segmentio
     repo_name: golines
     description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.11.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -64367,7 +64367,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.11.0")
-        no_asset: true
+        type: go_install
       - version_constraint: "true"
         asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -64376,11 +64376,18 @@ packages:
           asset: golines_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
+          - goos: linux
+            files:
+              - name: golines
+                src: "{{.AssetWithoutExt}}/golines"
           - goos: darwin
             asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
+            files:
+              - name: golines
+                src: "{{.AssetWithoutExt}}/golines"
+          - goos: windows
+            type: go_install
+            files: []
   - type: go_install
     repo_owner: segmentio
     repo_name: topicctl

--- a/registry.yaml
+++ b/registry.yaml
@@ -64360,10 +64360,27 @@ packages:
           type: github_release
           asset: chamber-{{.Version}}.sha256sums
           algorithm: sha256
-  - type: go_install
+  - type: github_release
     repo_owner: segmentio
     repo_name: golines
     description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.11.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
   - type: go_install
     repo_owner: segmentio
     repo_name: topicctl

--- a/registry.yaml
+++ b/registry.yaml
@@ -64371,23 +64371,18 @@ packages:
       - version_constraint: "true"
         asset: golines_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: golines
+            src: "{{.AssetWithoutExt}}/golines"
         checksum:
           type: github_release
           asset: golines_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            files:
-              - name: golines
-                src: "{{.AssetWithoutExt}}/golines"
           - goos: darwin
             asset: golines_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
-            files:
-              - name: golines
-                src: "{{.AssetWithoutExt}}/golines"
           - goos: windows
             type: go_install
-            files: []
   - type: go_install
     repo_owner: segmentio
     repo_name: topicctl


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Switches the package type from `go_install` to `github_release`.

They started releasing assets from [v0.12.0](https://github.com/segmentio/golines/releases/tag/v0.12.0). PR: https://github.com/segmentio/golines/pull/117

---

`cmdx t segmentio/golines` fails for Windows (even without this change). I couldn't figure it out, so could you take a look?

I manually commented out the Windows test in `cmdx.yaml`, and it passed.
The following log is Windows-only.

```
$ cmdx t segmentio/golines
+ PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

# bash scripts/start.sh
# bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry-windows exists
[INFO] Creating a container aqua-registry-windows
05a6f4355901de9fbdd539dedefda0c9141e40b2c8943c64cbb7a03fa87e2d48
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=aqua-proxy package_version=v1.2.9 program=aqua program_version=2.53.3 registry=
INFO[0001] create a symbolic link                        env=windows/amd64 package_name=aqua-proxy package_version=v1.2.9 program=aqua program_version=2.53.3 registry=
INFO[0001] create a symbolic link                        command=golines env=windows/amd64 package_name=segmentio/golines package_version=v0.12.2 program=aqua program_version=2.53.3
INFO[0001] Installing a Go tool                          env=windows/amd64 go_package_path=github.com/segmentio/golines@v0.11.0 gobin=/root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.11.0/bin package_name=segmentio/golines package_version=v0.11.0 program=aqua program_version=2.53.3 registry=standard
INFO[0001] Installing a Go tool                          env=windows/amd64 go_package_path=github.com/segmentio/golines@v0.12.2 gobin=/root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.12.2/bin package_name=segmentio/golines package_version=v0.12.2 program=aqua program_version=2.53.3 registry=standard
go: downloading github.com/segmentio/golines v0.11.0
go: downloading github.com/segmentio/golines v0.12.2
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/sirupsen/logrus v1.9.3
go: downloading golang.org/x/term v0.16.0
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading github.com/dave/dst v0.27.3
go: downloading github.com/x-cray/logrus-prefixed-formatter v0.5.2
go: downloading github.com/fatih/structtag v1.2.0
go: downloading github.com/fatih/structtag v1.2.0
go: downloading github.com/dave/dst v0.27.0
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/x-cray/logrus-prefixed-formatter v0.5.2
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
go: downloading github.com/sirupsen/logrus v1.4.2
go: downloading golang.org/x/crypto v0.18.0
go: downloading github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
go: downloading golang.org/x/sys v0.16.0
go: downloading github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
go: downloading github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading golang.org/x/sys v0.0.0-20220318055525-2edf467146b5
go: downloading github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading github.com/mattn/go-colorable v0.1.4
go: downloading github.com/mattn/go-colorable v0.1.13
go: downloading golang.org/x/tools v0.1.10
go: downloading github.com/mattn/go-isatty v0.0.10
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
go: downloading golang.org/x/tools v0.17.0
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
go: downloading golang.org/x/mod v0.14.0
ERRO[0022] check file_src is correct                     env=windows/amd64 error="check file_src is correct: exe_path isn't found: stat /root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.11.0/bin/golines.exe: no such file or directory" exe_path=/root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.11.0/bin/golines.exe file_name=golines package_name=segmentio/golines package_version=v0.11.0 program=aqua program_version=2.53.3 registry=standard
ERRO[0022] executable files aren't found
Files in the unarchived package:
golines
   env=windows/amd64 package_name=segmentio/golines package_version=v0.11.0 program=aqua program_version=2.53.3 registry=standard
ERRO[0022] install the package                           env=windows/amd64 error="check file_src is correct" package_name=segmentio/golines package_version=v0.11.0 program=aqua program_version=2.53.3 registry=standard
ERRO[0022] check file_src is correct                     env=windows/amd64 error="check file_src is correct: exe_path isn't found: stat /root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.12.2/bin/golines.exe: no such file or directory" exe_path=/root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/segmentio/golines/v0.12.2/bin/golines.exe file_name=golines package_name=segmentio/golines package_version=v0.12.2 program=aqua program_version=2.53.3 registry=standard
ERRO[0022] executable files aren't found
Files in the unarchived package:
golines
   env=windows/amd64 package_name=segmentio/golines package_version=v0.12.2 program=aqua program_version=2.53.3 registry=standard
ERRO[0022] install the package                           env=windows/amd64 error="check file_src is correct" package_name=segmentio/golines package_version=v0.12.2 program=aqua program_version=2.53.3 registry=standard
FATA[0022] aqua failed                                   env=windows/amd64 error="it failed to install some packages" program=aqua program_version=2.53.3
[ERROR] Build failed windows/amd64
        If you want to look into the container, please run 'cmdx con windows amd64'
exit status 1
```