### PR TITLE
fix(bazelbuild/bazel-watcher): support recent versions

### DIFF
--- a/pkgs/bazelbuild/bazel-watcher/pkg.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/pkg.yaml
@@ -1,4 +1,5 @@
 packages:
+  - name: bazelbuild/bazel-watcher@v0.26.2
   - name: bazelbuild/bazel-watcher
     version: V0.26.4
   - name: bazelbuild/bazel-watcher

--- a/pkgs/bazelbuild/bazel-watcher/pkg.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: bazelbuild/bazel-watcher@v0.26.3
   - name: bazelbuild/bazel-watcher
+    version: V0.26.4
+  - name: bazelbuild/bazel-watcher
     version: v0.25.1
   - name: bazelbuild/bazel-watcher
     version: v0.23.1

--- a/pkgs/bazelbuild/bazel-watcher/pkg.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/pkg.yaml
@@ -1,5 +1,4 @@
 packages:
-  - name: bazelbuild/bazel-watcher@v0.26.3
   - name: bazelbuild/bazel-watcher
     version: V0.26.4
   - name: bazelbuild/bazel-watcher

--- a/pkgs/bazelbuild/bazel-watcher/registry.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/registry.yaml
@@ -8,7 +8,7 @@ packages:
       - name: ibazel
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.4.0") || Version == "v0.15.1"
+      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3"]
         no_asset: true
       - version_constraint: semver("<= 0.9.1")
         asset: ibazel_{{.OS}}_{{.Arch}}
@@ -59,6 +59,15 @@ packages:
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
+      - version_constraint: Version == "V0.26.4"
+        version_prefix: V
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows
       - version_constraint: "true"
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -14208,7 +14208,7 @@ packages:
       - name: ibazel
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.4.0") || Version == "v0.15.1"
+      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3"]
         no_asset: true
       - version_constraint: semver("<= 0.9.1")
         asset: ibazel_{{.OS}}_{{.Arch}}
@@ -14259,6 +14259,15 @@ packages:
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
+      - version_constraint: Version == "V0.26.4"
+        version_prefix: V
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows
       - version_constraint: "true"
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Fix the registry to support these weird releases:

- [v0.26.0](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.26.0) and [v0.26.3](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.26.3) don't have the assets.

- [V0.26.4](https://github.com/bazelbuild/bazel-watcher/releases/tag/V0.26.4) is prefixed with a large `V`, and doesn't include the `linux/arm` bin.