### PR TITLE
fix(helm): add 'v' prefix to Helm download URLs

### DIFF
--- a/pkgs/helm/helm/registry.yaml
+++ b/pkgs/helm/helm/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: http
     repo_owner: helm
     repo_name: helm
-    url: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
+    url: https://get.helm.sh/helm-v{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz
     description: The Kubernetes Package Manager
     files:
       - name: helm
@@ -14,7 +14,7 @@ packages:
       - amd64
     checksum:
       type: http
-      url: https://get.helm.sh/helm-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
+      url: https://get.helm.sh/helm-v{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz.sha256sum
       algorithm: sha256
     version_constraint: semver(">= 3.6.0")
     version_overrides:


### PR DESCRIPTION
There is an issue with the current URL templates used for Helm downloads in this registry.

The registry currently points to:
```
https://get.helm.sh/helm-<version>-<os>-<arch>.tar.gz
```
However, Helm officially publishes release artifacts with a v prefix in the version string:
Example (works):
```
https://get.helm.sh/helm-v3.13.3-linux-amd64.tar.gz.sha256sum
```
Current URL (fails with 404):
```
https://get.helm.sh/helm-3.13.3-linux-amd64.tar.gz.sha256sum
```
This PR updates both the archive and checksum URLs to use the correct format with v{{.Version}}, allowing Helm installations via aqua/mise to work properly.