### PR TITLE
feat: add KhronosGroup/KTX-Software

### DIFF
--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,15 +1,9 @@
 packages:
   - name: KhronosGroup/KTX-Software@v4.4.0
   - name: KhronosGroup/KTX-Software
-    version: v4.3.2
-  - name: KhronosGroup/KTX-Software
-    version: v4.3.1
-  - name: KhronosGroup/KTX-Software
     version: v4.3.0-beta1
   - name: KhronosGroup/KTX-Software
     version: v4.2.1
-  - name: KhronosGroup/KTX-Software
-    version: v4.2.0
   - name: KhronosGroup/KTX-Software
     version: v4.1.0
   - name: KhronosGroup/KTX-Software

--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: KhronosGroup/KTX-Software@v4.4.0
   - name: KhronosGroup/KTX-Software
-    version: v4.3.0-beta1
+    version: v4.2.1
   - name: KhronosGroup/KTX-Software
     version: v4.1.0
   - name: KhronosGroup/KTX-Software

--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,10 +1,6 @@
 packages:
   - name: KhronosGroup/KTX-Software@v4.4.0
   - name: KhronosGroup/KTX-Software
-    version: v4.3.0-beta1
-  - name: KhronosGroup/KTX-Software
-    version: v4.2.1
-  - name: KhronosGroup/KTX-Software
     version: v4.1.0
   - name: KhronosGroup/KTX-Software
     version: v4.0.0

--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,7 +1,15 @@
 packages:
   - name: KhronosGroup/KTX-Software@v4.4.0
   - name: KhronosGroup/KTX-Software
+    version: v4.3.2
+  - name: KhronosGroup/KTX-Software
+    version: v4.3.1
+  - name: KhronosGroup/KTX-Software
+    version: v4.3.0-beta1
+  - name: KhronosGroup/KTX-Software
     version: v4.2.1
+  - name: KhronosGroup/KTX-Software
+    version: v4.2.0
   - name: KhronosGroup/KTX-Software
     version: v4.1.0
   - name: KhronosGroup/KTX-Software

--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: KhronosGroup/KTX-Software@v4.4.0
+  - name: KhronosGroup/KTX-Software
+    version: v4.3.0-beta1
+  - name: KhronosGroup/KTX-Software
+    version: v4.2.1
+  - name: KhronosGroup/KTX-Software
+    version: v4.1.0
+  - name: KhronosGroup/KTX-Software
+    version: v4.0.0

--- a/pkgs/KhronosGroup/KTX-Software/pkg.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: KhronosGroup/KTX-Software@v4.4.0
   - name: KhronosGroup/KTX-Software
+    version: v4.3.0-beta1
+  - name: KhronosGroup/KTX-Software
     version: v4.1.0
   - name: KhronosGroup/KTX-Software
     version: v4.0.0

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -1,0 +1,122 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: KhronosGroup
+    repo_name: KTX-Software
+    description: KTX (Khronos Texture) Library and Tools
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v4.0.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: pkg
+        replacements:
+          darwin: Darwin
+          linux: Linux
+          windows: win64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v4.1.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: darwin
+            format: pkg
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: Version == "v4.3.0-beta1"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: darwin
+            format: pkg
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+      - version_constraint: semver("<= 4.2.1")
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: pyktx-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
+        format: raw
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            format: pkg
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            goarch: amd64
+            replacements:
+              amd64: amd64
+              windows: win
+          - goos: windows
+            goarch: arm64
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              windows: Windows

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -8,6 +8,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: pkg
         rosetta2: true
         files:
           - name: ktx2check
@@ -20,6 +21,9 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
             src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -27,27 +31,12 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}{{.Arch}}
-            checksum:
-              type: github_release
-              asset: "{{.Asset}}.sha1"
-              algorithm: sha1
-            replacements:
-              windows: win
-              amd64: "64"
         supported_envs:
           - linux/amd64
           - darwin
-          - windows/amd64
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
         files:
           - name: ktx2check
             src: "{{.AssetWithoutExt}}/bin/ktx2check"
@@ -61,6 +50,8 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -68,23 +59,12 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              windows: Windows
-              amd64: x64
         supported_envs:
           - linux/amd64
           - darwin
-          - windows
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
         files:
           - name: ktx
             src: "{{.AssetWithoutExt}}/bin/ktx"
@@ -100,6 +80,8 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -107,14 +89,6 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              windows: Windows
-              amd64: x64
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -62,6 +62,34 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 4.2.1")
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
+        files:
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          amd64: x86_64
+          linux: Linux
+          darwin: Darwin
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: pkg

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -8,115 +8,117 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: pkg
-        replacements:
-          darwin: Darwin
-          linux: Linux
-          windows: win64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
+        rosetta2: true
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         overrides:
           - goos: linux
             format: tar.bz2
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v4.1.0"
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              linux: Linux
           - goos: darwin
             format: pkg
+            replacements:
+              darwin: Darwin
           - goos: windows
-            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}{{.Arch}}
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              windows: win
+              amd64: "64"
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v4.1.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            replacements:
+              darwin: Darwin
+          - goos: windows
             asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
             replacements:
+              windows: Windows
               amd64: x64
         supported_envs:
           - linux/amd64
           - darwin
           - windows
-      - version_constraint: Version == "v4.3.0-beta1"
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.bz2
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: darwin
-            format: pkg
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              amd64: x64
-      - version_constraint: semver("<= 4.2.1")
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: linux
-            format: tar.bz2
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              amd64: x64
       - version_constraint: "true"
-        asset: pyktx-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
-        format: raw
-        complete_windows_ext: false
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
         overrides:
           - goos: linux
             format: tar.bz2
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              linux: Linux
           - goos: darwin
             format: pkg
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            goarch: amd64
             replacements:
-              amd64: amd64
-              windows: win
+              darwin: Darwin
           - goos: windows
-            goarch: arm64
             asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
             replacements:
               windows: Windows
+              amd64: x64

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -11,17 +11,17 @@ packages:
         rosetta2: true
         files:
           - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
+            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         overrides:
           - goos: linux
             format: tar.bz2
@@ -52,17 +52,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
+            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:
@@ -91,17 +91,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
+            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -139,6 +139,8 @@ packages:
           - goos: linux
             format: tar.bz2
             files:
+              - name: ktx
+                src: "{{.AssetWithoutExt}}/bin/ktx"
               - name: ktx2check
                 src: "{{.AssetWithoutExt}}/bin/ktx2check"
               - name: ktxinfo
@@ -158,6 +160,8 @@ packages:
           - goos: darwin
             format: pkg
             files:
+              - name: ktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx"
               - name: ktx2check
                 src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
               - name: ktxinfo

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -10,8 +10,6 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
         rosetta2: true
         files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
             src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
@@ -51,8 +49,6 @@ packages:
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
             src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -8,115 +8,168 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: pkg
         rosetta2: true
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 4.2.1")
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux
           - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux
           - darwin

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: KhronosGroup
     repo_name: KTX-Software
     description: KTX (Khronos Texture) Library and Tools
+    search_words:
+      - Linux Only
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v4.0.0"
@@ -29,24 +31,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux/amd64
-          - darwin
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -71,24 +57,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux/amd64
-          - darwin
       - version_constraint: semver("<= 4.2.1")
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -113,24 +83,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux
-          - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -157,23 +111,5 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx"
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux
-          - darwin

--- a/pkgs/KhronosGroup/KTX-Software/registry.yaml
+++ b/pkgs/KhronosGroup/KTX-Software/registry.yaml
@@ -11,17 +11,17 @@ packages:
         rosetta2: true
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         overrides:
           - goos: linux
             format: tar.bz2
@@ -52,17 +52,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:
@@ -91,17 +91,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -3404,17 +3404,17 @@ packages:
         rosetta2: true
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         overrides:
           - goos: linux
             format: tar.bz2
@@ -3445,17 +3445,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:
@@ -3484,17 +3484,17 @@ packages:
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
           - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
           - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
+            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
         replacements:
           amd64: x86_64
         overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -3455,6 +3455,34 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 4.2.1")
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
+        files:
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          amd64: x86_64
+          linux: Linux
+          darwin: Darwin
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: pkg

--- a/registry.yaml
+++ b/registry.yaml
@@ -3397,6 +3397,8 @@ packages:
     repo_owner: KhronosGroup
     repo_name: KTX-Software
     description: KTX (Khronos Texture) Library and Tools
+    search_words:
+      - Linux Only
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v4.0.0"
@@ -3422,24 +3424,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux/amd64
-          - darwin
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -3464,24 +3450,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux/amd64
-          - darwin
       - version_constraint: semver("<= 4.2.1")
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -3506,24 +3476,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux
-          - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -3550,26 +3504,8 @@ packages:
               algorithm: sha1
             replacements:
               linux: Linux
-          - goos: darwin
-            format: pkg
-            files:
-              - name: ktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx"
-              - name: ktx2check
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
-              - name: ktxinfo
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
-              - name: ktx2ktx2
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
-              - name: ktxsc
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
-              - name: toktx
-                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
-            replacements:
-              darwin: Darwin
         supported_envs:
           - linux
-          - darwin
   - type: github_release
     repo_owner: Kong
     repo_name: deck

--- a/registry.yaml
+++ b/registry.yaml
@@ -3532,6 +3532,8 @@ packages:
           - goos: linux
             format: tar.bz2
             files:
+              - name: ktx
+                src: "{{.AssetWithoutExt}}/bin/ktx"
               - name: ktx2check
                 src: "{{.AssetWithoutExt}}/bin/ktx2check"
               - name: ktxinfo
@@ -3551,6 +3553,8 @@ packages:
           - goos: darwin
             format: pkg
             files:
+              - name: ktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx"
               - name: ktx2check
                 src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
               - name: ktxinfo

--- a/registry.yaml
+++ b/registry.yaml
@@ -3402,6 +3402,19 @@ packages:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: pkg
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           darwin: Darwin
           linux: Linux
@@ -3423,6 +3436,19 @@ packages:
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -3447,6 +3473,19 @@ packages:
       - version_constraint: Version == "v4.3.0-beta1"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -3467,6 +3506,19 @@ packages:
       - version_constraint: semver("<= 4.2.1")
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: pkg
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -3485,34 +3537,48 @@ packages:
             replacements:
               amd64: x64
       - version_constraint: "true"
-        asset: pyktx-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
-        format: raw
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         complete_windows_ext: false
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
         overrides:
           - goos: linux
             format: tar.bz2
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: darwin
-            format: pkg
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+          # - goos: darwin
+          #   format: pkg
           - goos: windows
             goarch: amd64
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe
             replacements:
               amd64: amd64
               windows: win
           - goos: windows
             goarch: arm64
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe
             replacements:
               windows: Windows
+        supported_envs:
+          - linux
+          - windows
   - type: github_release
     repo_owner: Kong
     repo_name: deck

--- a/registry.yaml
+++ b/registry.yaml
@@ -3401,7 +3401,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: pkg
+        rosetta2: true
         files:
           - name: ktx
             src: "{{.AssetWithoutExt}}/bin/ktx"
@@ -3415,147 +3415,6 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
             src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          darwin: Darwin
-          linux: Linux
-          windows: win64
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: linux
-            format: tar.bz2
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "v4.1.0"
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.bz2
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: darwin
-            format: pkg
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              amd64: x64
-        supported_envs:
-          - linux/amd64
-          - darwin
-          - windows
-      - version_constraint: Version == "v4.3.0-beta1"
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.bz2
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: darwin
-            format: pkg
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              amd64: x64
-      - version_constraint: semver("<= 4.2.1")
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-        overrides:
-          - goos: linux
-            format: tar.bz2
-          - goos: windows
-            format: raw
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              amd64: x64
-      - version_constraint: "true"
-        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        complete_windows_ext: false
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
         overrides:
           - goos: linux
             format: tar.bz2
@@ -3563,22 +3422,99 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-          # - goos: darwin
-          #   format: pkg
-          - goos: windows
-            goarch: amd64
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe
             replacements:
-              amd64: amd64
-              windows: win
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            replacements:
+              darwin: Darwin
           - goos: windows
-            goarch: arm64
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.exe
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}{{.Arch}}
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              windows: win
+              amd64: "64"
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows/amd64
+      - version_constraint: Version == "v4.1.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            replacements:
+              darwin: Darwin
+          - goos: windows
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
             replacements:
               windows: Windows
+              amd64: x64
         supported_envs:
-          - linux
+          - linux/amd64
+          - darwin
           - windows
+      - version_constraint: "true"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+          - name: ktx
+            src: "{{.AssetWithoutExt}}/bin/ktx"
+          - name: ktx2check
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
+          - name: ktxinfo
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+          - name: ktx2ktx2
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+          - name: ktxsc
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
+          - name: toktx
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha1"
+              algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            replacements:
+              darwin: Darwin
+          - goos: windows
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              windows: Windows
+              amd64: x64
   - type: github_release
     repo_owner: Kong
     repo_name: deck

--- a/registry.yaml
+++ b/registry.yaml
@@ -3394,6 +3394,126 @@ packages:
           - darwin
           - windows
   - type: github_release
+    repo_owner: KhronosGroup
+    repo_name: KTX-Software
+    description: KTX (Khronos Texture) Library and Tools
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v4.0.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: pkg
+        replacements:
+          darwin: Darwin
+          linux: Linux
+          windows: win64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v4.1.0"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: darwin
+            format: pkg
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: Version == "v4.3.0-beta1"
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: darwin
+            format: pkg
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+      - version_constraint: semver("<= 4.2.1")
+        asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+          - goos: windows
+            format: raw
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: pyktx-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
+        format: raw
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+        overrides:
+          - goos: linux
+            format: tar.bz2
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: darwin
+            format: pkg
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            goarch: amd64
+            replacements:
+              amd64: amd64
+              windows: win
+          - goos: windows
+            goarch: arm64
+            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+            replacements:
+              windows: Windows
+  - type: github_release
     repo_owner: Kong
     repo_name: deck
     description: "decK: Configuration management and drift detection for Kong"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3401,20 +3401,22 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        format: pkg
         rosetta2: true
         files:
-          - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
+        replacements:
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -3422,42 +3424,27 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}{{.Arch}}
-            checksum:
-              type: github_release
-              asset: "{{.Asset}}.sha1"
-              algorithm: sha1
-            replacements:
-              windows: win
-              amd64: "64"
         supported_envs:
           - linux/amd64
           - darwin
-          - windows/amd64
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
         files:
-          - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -3465,38 +3452,29 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              windows: Windows
-              amd64: x64
         supported_envs:
           - linux/amd64
           - darwin
-          - windows
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: pkg
         files:
           - name: ktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx"
+            src: "{{.AssetWithoutExt}}/bin/ktx"
           - name: ktx2check
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2check"
+            src: "{{.AssetWithoutExt}}/bin/ktx2check"
           - name: ktxinfo
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxinfo"
+            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
           - name: ktx2ktx2
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktx2ktx2"
+            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
           - name: ktxsc
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/ktxsc"
+            src: "{{.AssetWithoutExt}}/bin/ktxsc"
           - name: toktx
-            src: "KTX-Software-{{trimV .Version}}-{{.OS}}/bin/toktx"
+            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
+          linux: Linux
+          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
@@ -3504,17 +3482,9 @@ packages:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
-            replacements:
-              linux: Linux
-          - goos: darwin
-            format: pkg
-            replacements:
-              darwin: Darwin
-          - goos: windows
-            asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}
-            replacements:
-              windows: Windows
-              amd64: x64
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: Kong
     repo_name: deck

--- a/registry.yaml
+++ b/registry.yaml
@@ -3401,115 +3401,168 @@ packages:
     version_overrides:
       - version_constraint: Version == "v4.0.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: pkg
         rosetta2: true
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
-        replacements:
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: Version == "v4.1.0"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 4.2.1")
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux
           - darwin
       - version_constraint: "true"
         asset: KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: pkg
-        files:
-          - name: ktx
-            src: "{{.AssetWithoutExt}}/bin/ktx"
-          - name: ktx2check
-            src: "{{.AssetWithoutExt}}/bin/ktx2check"
-          - name: ktxinfo
-            src: "{{.AssetWithoutExt}}/bin/ktxinfo"
-          - name: ktx2ktx2
-            src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
-          - name: ktxsc
-            src: "{{.AssetWithoutExt}}/bin/ktxsc"
-          - name: toktx
-            src: "{{.AssetWithoutExt}}/bin/toktx"
         replacements:
           amd64: x86_64
-          linux: Linux
-          darwin: Darwin
         overrides:
           - goos: linux
             format: tar.bz2
+            files:
+              - name: ktx2check
+                src: "{{.AssetWithoutExt}}/bin/ktx2check"
+              - name: ktxinfo
+                src: "{{.AssetWithoutExt}}/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "{{.AssetWithoutExt}}/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "{{.AssetWithoutExt}}/bin/ktxsc"
+              - name: toktx
+                src: "{{.AssetWithoutExt}}/bin/toktx"
             checksum:
               type: github_release
               asset: "{{.Asset}}.sha1"
               algorithm: sha1
+            replacements:
+              linux: Linux
+          - goos: darwin
+            format: pkg
+            files:
+              - name: ktx2check
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2check"
+              - name: ktxinfo
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxinfo"
+              - name: ktx2ktx2
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktx2ktx2"
+              - name: ktxsc
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/ktxsc"
+              - name: toktx
+                src: "KTX-Software-{{trimV .Version}}-{{.OS}}-{{.Arch}}-tools.{{.Format}}/Payload/usr/local/bin/toktx"
+            replacements:
+              darwin: Darwin
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [KhronosGroup/KTX-Software](https://github.com/KhronosGroup/KTX-Software/releases).

The list of binaries is in its [cmake/ReadMe.txt](https://github.com/KhronosGroup/KTX-Software/blob/main/cmake/ReadMe.txt). `ktx` binary is added from `v4.3.0-beta1`.

Windows `.exe` assets are installer, so we need to exclude them.