### PR TITLE
feat: add ytdl-org/ytdl-nightly

### DIFF
--- a/pkgs/ytdl-org/ytdl-nightly/pkg.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: ytdl-org/ytdl-nightly@2025.05.05
+  - name: ytdl-org/ytdl-nightly
+    version: 2024.03.28

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -11,6 +11,7 @@ packages:
         format: tar.gz
         files:
           - name: youtube-dl
+            src: youtube-dl/youtube-dl
         supported_envs:
           - linux
           - darwin
@@ -19,6 +20,7 @@ packages:
         format: tar.gz
         files:
           - name: youtube-dl
+            src: youtube-dl/youtube-dl
         overrides:
           - goos: windows
             asset: youtube-dl

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Nightly builds for youtube-dl
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "2024.03.28" 
+      - version_constraint: Version == "2024.03.28"
         asset: youtube-dl-{{.Version}}.{{.Format}}
         format: tar.gz
         files:

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: ytdl-org
     repo_name: ytdl-nightly
     description: Nightly builds for youtube-dl
+    files:
+      - name: youtube-dl
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "2024.03.28"

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ytdl-org
+    repo_name: ytdl-nightly
+    description: Nightly builds for youtube-dl
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "2024.03.28"
+      - version_constraint: "true"
+        asset: youtube-dl
+        format: raw
+        supported_envs:
+          - windows/amd64

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -6,9 +6,16 @@ packages:
     description: Nightly builds for youtube-dl
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "2024.03.28"
-      - version_constraint: "true"
-        asset: youtube-dl
-        format: raw
+      - version_constraint: Version == "2024.03.28" 
+        asset: youtube-dl-{{.Version}}.{{.Format}}
+        format: tar.gz
         supported_envs:
-          - windows/amd64
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: youtube-dl-{{.Version}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            asset: youtube-dl
+            format: raw

--- a/pkgs/ytdl-org/ytdl-nightly/registry.yaml
+++ b/pkgs/ytdl-org/ytdl-nightly/registry.yaml
@@ -9,12 +9,16 @@ packages:
       - version_constraint: Version == "2024.03.28" 
         asset: youtube-dl-{{.Version}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: youtube-dl
         supported_envs:
           - linux
           - darwin
       - version_constraint: "true"
         asset: youtube-dl-{{.Version}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: youtube-dl
         overrides:
           - goos: windows
             asset: youtube-dl

--- a/registry.yaml
+++ b/registry.yaml
@@ -78855,6 +78855,18 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: ytdl-org
+    repo_name: ytdl-nightly
+    description: Nightly builds for youtube-dl
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "2024.03.28"
+      - version_constraint: "true"
+        asset: youtube-dl
+        format: raw
+        supported_envs:
+          - windows/amd64
+  - type: github_release
     repo_owner: yudai
     repo_name: gotty
     asset: gotty_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -78865,6 +78865,7 @@ packages:
         format: tar.gz
         files:
           - name: youtube-dl
+            src: youtube-dl/youtube-dl
         supported_envs:
           - linux
           - darwin
@@ -78873,6 +78874,7 @@ packages:
         format: tar.gz
         files:
           - name: youtube-dl
+            src: youtube-dl/youtube-dl
         overrides:
           - goos: windows
             asset: youtube-dl

--- a/registry.yaml
+++ b/registry.yaml
@@ -78860,7 +78860,7 @@ packages:
     description: Nightly builds for youtube-dl
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "2024.03.28" 
+      - version_constraint: Version == "2024.03.28"
         asset: youtube-dl-{{.Version}}.{{.Format}}
         format: tar.gz
         files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -78858,6 +78858,8 @@ packages:
     repo_owner: ytdl-org
     repo_name: ytdl-nightly
     description: Nightly builds for youtube-dl
+    files:
+      - name: youtube-dl
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "2024.03.28"

--- a/registry.yaml
+++ b/registry.yaml
@@ -78860,12 +78860,23 @@ packages:
     description: Nightly builds for youtube-dl
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "2024.03.28"
-      - version_constraint: "true"
-        asset: youtube-dl
-        format: raw
+      - version_constraint: Version == "2024.03.28" 
+        asset: youtube-dl-{{.Version}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: youtube-dl
         supported_envs:
-          - windows/amd64
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: youtube-dl-{{.Version}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: youtube-dl
+        overrides:
+          - goos: windows
+            asset: youtube-dl
+            format: raw
   - type: github_release
     repo_owner: yudai
     repo_name: gotty


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [ytdl-org/ytdl-nightly](https://github.com/ytdl-org/ytdl-nightly/releases).

---

Never mind, it also worked for Windows when I installed Visual C++ 2010 and restared the system.

<details>
For Windows, I tested it locally and on GitHub Actions (https://github.com/risu729/aqua-registry-test/pull/7), but both failed.

`aqua info`
```json
{
  "version": "2.53.4",
  "commit_hash": "bf6676796512254e5a2e2361b81724d99d6bea8a",
  "os": "windows",
  "arch": "amd64",
  "pwd": "C:\\Users\\(USER)",
  "root_dir": "C:\\Users\\(USER)\\AppData\\Local\\aquaproj-aqua",
  "env": {
    "AQUA_DISABLE_POLICY": "true"
  },
  "config_files": [
    {
      "path": "C:\\Users\\(USER)\\aqua.yaml"
    }
  ]
}
```


```
> aqua which youtube-dl
C:\Users\risu\AppData\Local\aquaproj-aqua\pkgs\github_release\github.com\ytdl-org\ytdl-nightly\2025.05.05\youtube-dl.exe\youtube-dl.exe
> youtube-dl --version
> youtube-dl.exe --version
```

`C:\Users\risu\AppData\Local\aquaproj-aqua\pkgs\github_release\github.com\ytdl-org\ytdl-nightly\2025.05.05\youtube-dl.exe\youtube-dl.exe --version` shows this error.
Since this is the same for a directly downloaded `.exe` file, it might be broken.

<img width="1483" height="822" alt="image" src="https://github.com/user-attachments/assets/d021c25e-aa71-40d6-b0f9-cb506ffef49d" />
</details>