### PR TITLE
feat: add inovex/CalendarSync

### DIFF
--- a/pkgs/inovex/CalendarSync/pkg.yaml
+++ b/pkgs/inovex/CalendarSync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: inovex/CalendarSync@v0.10.1

--- a/pkgs/inovex/CalendarSync/registry.yaml
+++ b/pkgs/inovex/CalendarSync/registry.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: inovex
+    repo_name: CalendarSync
+    description: Stateless CLI tool to sync calendars across different calendaring systems
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: CalendarSync_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -39274,6 +39274,20 @@ packages:
           asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
   - type: github_release
+    repo_owner: inovex
+    repo_name: CalendarSync
+    description: Stateless CLI tool to sync calendars across different calendaring systems
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: CalendarSync_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: instrumenta
     repo_name: kubeval
     description: Validate your Kubernetes configuration files, supports multiple Kubernetes versions


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [inovex/CalendarSync](https://github.com/inovex/CalendarSync/releases).

For Windows, they don't have `arm64`, so `windows_arm_emulation` is enabled.
- `CalendarSync_0.10.1_windows_amd64.tar.gz`
- `CalendarSync_0.10.1_windows_armv6.tar.gz`
- `CalendarSync_0.10.1_windows_armv7.tar.gz`