### PR TITLE
feat: add wren-lang/wren-cli

### DIFF
--- a/pkgs/wren-lang/wren-cli/pkg.yaml
+++ b/pkgs/wren-lang/wren-cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: wren-lang/wren-cli@0.4.0
+  - name: wren-lang/wren-cli
+    version: 0.3.0

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: wren-lang
     repo_name: wren-cli
     description: A command line tool for the Wren programming language
+    files:
+      - name: wren_cli
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.3.0"

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -28,12 +28,8 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        overrides:
-          - goos: darwin
-            files:
-              - name: wren_cli
-            replacements:
-              darwin: mac
+        replacements:
+          darwin: mac
         supported_envs:
           - darwin
           - windows

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: wren-lang
+    repo_name: wren-cli
+    description: A command line tool for the Wren programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.3.0"
+        asset: wren_cli-{{.OS}}-{{.Version}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: wren-cli-{{.OS}}-{{.Version}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -18,6 +18,10 @@ packages:
               - name: wren_cli
             replacements:
               darwin: mac
+          - goos: windows
+            files:
+              - name: wren_cli
+                src: wren_cli-{{.Version}}.exe
         supported_envs:
           - darwin
           - windows

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: Version == "0.3.0"
         asset: wren_cli-{{.OS}}-{{.Version}}.{{.Format}}
         format: zip
+        files:
+          - name: wren_cli
+            src: "{{.AssetWithoutExt}}/wren_cli"
         replacements:
           darwin: mac
         supported_envs:
@@ -18,6 +21,9 @@ packages:
       - version_constraint: "true"
         asset: wren-cli-{{.OS}}-{{.Version}}.{{.Format}}
         format: zip
+        files:
+          - name: wren_cli
+            src: "{{.AssetWithoutExt}}/wren_cli"
         replacements:
           darwin: mac
         supported_envs:

--- a/pkgs/wren-lang/wren-cli/registry.yaml
+++ b/pkgs/wren-lang/wren-cli/registry.yaml
@@ -12,8 +12,12 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        replacements:
-          darwin: mac
+        overrides:
+          - goos: darwin
+            files:
+              - name: wren_cli
+            replacements:
+              darwin: mac
         supported_envs:
           - darwin
           - windows
@@ -24,8 +28,12 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        replacements:
-          darwin: mac
+        overrides:
+          - goos: darwin
+            files:
+              - name: wren_cli
+            replacements:
+              darwin: mac
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -77822,6 +77822,8 @@ packages:
     repo_owner: wren-lang
     repo_name: wren-cli
     description: A command line tool for the Wren programming language
+    files:
+      - name: wren_cli
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.3.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -77827,6 +77827,9 @@ packages:
       - version_constraint: Version == "0.3.0"
         asset: wren_cli-{{.OS}}-{{.Version}}.{{.Format}}
         format: zip
+        files:
+          - name: wren_cli
+            src: "{{.AssetWithoutExt}}/wren_cli"
         replacements:
           darwin: mac
         supported_envs:
@@ -77836,6 +77839,9 @@ packages:
       - version_constraint: "true"
         asset: wren-cli-{{.OS}}-{{.Version}}.{{.Format}}
         format: zip
+        files:
+          - name: wren_cli
+            src: "{{.AssetWithoutExt}}/wren_cli"
         replacements:
           darwin: mac
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -77830,8 +77830,12 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        replacements:
-          darwin: mac
+        overrides:
+          - goos: darwin
+            files:
+              - name: wren_cli
+            replacements:
+              darwin: mac
         supported_envs:
           - darwin
           - windows
@@ -77842,8 +77846,12 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        replacements:
-          darwin: mac
+        overrides:
+          - goos: darwin
+            files:
+              - name: wren_cli
+            replacements:
+              darwin: mac
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -77846,12 +77846,8 @@ packages:
         files:
           - name: wren_cli
             src: "{{.AssetWithoutExt}}/wren_cli"
-        overrides:
-          - goos: darwin
-            files:
-              - name: wren_cli
-            replacements:
-              darwin: mac
+        replacements:
+          darwin: mac
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -77819,6 +77819,30 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: wren-lang
+    repo_name: wren-cli
+    description: A command line tool for the Wren programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.3.0"
+        asset: wren_cli-{{.OS}}-{{.Version}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: wren-cli-{{.OS}}-{{.Version}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: wtetsu
     repo_name: gaze
     asset: gaze_{{.OS}}_{{.Version}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -77836,6 +77836,10 @@ packages:
               - name: wren_cli
             replacements:
               darwin: mac
+          - goos: windows
+            files:
+              - name: wren_cli
+                src: wren_cli-{{.Version}}.exe
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [wren-lang/wren-cli](https://github.com/wren-lang/wren-cli/releases).



They only have two releases, `0.3.0` and `0.4.0`.
The registry seems to be the same, but it's using `wren_cli` for `0.3.0` and `wren-cli` for `0.4.0`.