### PR TITLE
feat: add Kotlin/kotlin-interactive-shell

### DIFF
--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Kotlin/kotlin-interactive-shell@v0.4.0
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.3.3
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.3.2

--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -1,6 +1,29 @@
 packages:
-  - name: Kotlin/kotlin-interactive-shell@v0.4.0
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.5.2
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.5.1
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.5.0
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.5
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.4
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.3
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.2
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.1
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.4.0
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.3
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.2
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2.3
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2.1
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2

--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -1,29 +1,6 @@
 packages:
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.5.2
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.5.1
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.5.0
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.5
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.4
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.3
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.2
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.1
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.4.0
+  - name: Kotlin/kotlin-interactive-shell@v0.4.0
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.3
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.2
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2.3
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2.1
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2

--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: Kotlin/kotlin-interactive-shell@v0.4.0
+  - name: Kotlin/kotlin-interactive-shell@v0.5.2
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.3
   - name: Kotlin/kotlin-interactive-shell

--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -21,9 +21,3 @@ packages:
     version: v0.3.3
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.2
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2.3
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2.1
-  - name: Kotlin/kotlin-interactive-shell
-    version: v0.2

--- a/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/pkg.yaml
@@ -21,3 +21,9 @@ packages:
     version: v0.3.3
   - name: Kotlin/kotlin-interactive-shell
     version: v0.3.2
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2.3
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2.1
+  - name: Kotlin/kotlin-interactive-shell
+    version: v0.2

--- a/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Kotlin
+    repo_name: kotlin-interactive-shell
+    description: Kotlin Language Interactive Shell
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        no_asset: true
+      - version_constraint: Version == "v0.3.2"
+      - version_constraint: Version == "v0.3.3"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"

--- a/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: Kotlin
     repo_name: kotlin-interactive-shell
     description: Kotlin Language Interactive Shell
+    files:
+      - name: ki
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.3")
@@ -12,18 +14,18 @@ packages:
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat
       - version_constraint: Version == "v0.3.3"
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         checksum:
           type: github_release
@@ -32,13 +34,13 @@ packages:
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat
       - version_constraint: "true"
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         checksum:
           type: github_release
@@ -47,5 +49,5 @@ packages:
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat

--- a/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
+++ b/pkgs/Kotlin/kotlin-interactive-shell/registry.yaml
@@ -8,10 +8,44 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.2.3")
         no_asset: true
-      - version_constraint: Version == "v0.3.2"
+      - version_constraint: Version in ["v0.3.2", "v0.4.0"]
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat
       - version_constraint: Version == "v0.3.3"
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat
       - version_constraint: "true"
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
+        checksum:
+          type: github_release
+          asset: checksums_sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat

--- a/registry.yaml
+++ b/registry.yaml
@@ -3554,13 +3554,47 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.2.3")
         no_asset: true
-      - version_constraint: Version == "v0.3.2"
+      - version_constraint: Version in ["v0.3.2", "v0.4.0"]
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat
       - version_constraint: Version == "v0.3.3"
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat
       - version_constraint: "true"
+        asset: ki-archive.{{.Format}}
+        format: zip
+        files:
+          - name: ki.sh
+            src: ki/bin/ki.sh
+        checksum:
+          type: github_release
+          asset: checksums_sha256.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            files:
+              - name: ki.bat
+                src: ki/bin/ki.bat
   - type: github_release
     repo_owner: KusionStack
     repo_name: kusion

--- a/registry.yaml
+++ b/registry.yaml
@@ -3547,6 +3547,21 @@ packages:
           - goos: darwin
             asset: deck_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
   - type: github_release
+    repo_owner: Kotlin
+    repo_name: kotlin-interactive-shell
+    description: Kotlin Language Interactive Shell
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        no_asset: true
+      - version_constraint: Version == "v0.3.2"
+      - version_constraint: Version == "v0.3.3"
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+  - type: github_release
     repo_owner: KusionStack
     repo_name: kusion
     description: Deliver intentions to Kubernetes and Clouds

--- a/registry.yaml
+++ b/registry.yaml
@@ -3550,6 +3550,8 @@ packages:
     repo_owner: Kotlin
     repo_name: kotlin-interactive-shell
     description: Kotlin Language Interactive Shell
+    files:
+      - name: ki
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.3")
@@ -3558,18 +3560,18 @@ packages:
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat
       - version_constraint: Version == "v0.3.3"
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         checksum:
           type: github_release
@@ -3578,13 +3580,13 @@ packages:
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat
       - version_constraint: "true"
         asset: ki-archive.{{.Format}}
         format: zip
         files:
-          - name: ki.sh
+          - name: ki
             src: ki/bin/ki.sh
         checksum:
           type: github_release
@@ -3593,7 +3595,7 @@ packages:
         overrides:
           - goos: windows
             files:
-              - name: ki.bat
+              - name: ki
                 src: ki/bin/ki.bat
   - type: github_release
     repo_owner: KusionStack


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [Kotlin/kotlin-interactive-shell](https://github.com/Kotlin/kotlin-interactive-shell/releases).

As mentioned in the [README](https://github.com/Kotlin/kotlin-interactive-shell?tab=readme-ov-file#manual), we need to use `ki.sh` or `ki.bat` instead of the binary `ki`.
So I added the scripts to `files`.

> Launch bin/ki.sh for Linux/Mac or bin\ki.bat for Windows

I confirmed both `ki.sh --version` and `ki.bat --version` work fine. ([test repo](https://github.com/risu729/aqua-registry-test/pull/8))