### PR TITLE
fix(jdx/mise): add no_asset to broken releases

### DIFF
--- a/pkgs/jdx/mise/registry.yaml
+++ b/pkgs/jdx/mise/registry.yaml
@@ -36,6 +36,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver(">= 2025.7.13, <= 2025.7.15")
+        no_asset: true
       - version_constraint: "true"
         asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -40784,6 +40784,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver(">= 2025.7.13, <= 2025.7.15")
+        no_asset: true
       - version_constraint: "true"
         asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

[v2025.7.13](https://github.com/jdx/mise/releases/tag/v2025.7.13), [v2025.7.14](https://github.com/jdx/mise/releases/tag/v2025.7.14), and [v2025.7.15](https://github.com/jdx/mise/releases/tag/v2025.7.15) don't have assets because the release workflow have been broken.