### PR TITLE
feat: add sourcemeta/jsonschema

### DIFF
--- a/pkgs/sourcemeta/jsonschema/pkg.yaml
+++ b/pkgs/sourcemeta/jsonschema/pkg.yaml
@@ -8,5 +8,3 @@ packages:
     version: v7.2.2
   - name: sourcemeta/jsonschema
     version: v0.4.1
-  - name: sourcemeta/jsonschema
-    version: continuous

--- a/pkgs/sourcemeta/jsonschema/pkg.yaml
+++ b/pkgs/sourcemeta/jsonschema/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: sourcemeta/jsonschema@v10.0.0
+  - name: sourcemeta/jsonschema
+    version: v9.3.2
+  - name: sourcemeta/jsonschema
+    version: v7.3.0
+  - name: sourcemeta/jsonschema
+    version: v7.2.2
+  - name: sourcemeta/jsonschema
+    version: v0.4.1
+  - name: sourcemeta/jsonschema
+    version: continuous

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -7,15 +7,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "continuous"
-        asset: jsonschema-10.0.0-28881f25-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-        checksum:
-          type: github_release
-          asset: CHECKSUMS.txt
-          algorithm: sha256
+        error_message: "The version 'continuous' is not supported. Please use a specific version."
       - version_constraint: semver("<= 0.4.1")
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -47,12 +47,6 @@ packages:
           - goos: linux
             replacements:
               arm64: aarch64
-      - version_constraint: semver("<= 9.3.2")
-        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
       - version_constraint: "true"
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -20,7 +20,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin/arm64
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 7.2.2")
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -56,7 +56,3 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
-        checksum:
-          type: github_release
-          asset: CHECKSUMS.txt
-          algorithm: sha256

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sourcemeta
+    repo_name: jsonschema
+    description: The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "continuous"
+        asset: jsonschema-10.0.0-28881f25-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.1")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 7.2.2")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 7.3.0")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 9.3.2")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+      - version_constraint: "true"
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256

--- a/pkgs/sourcemeta/jsonschema/registry.yaml
+++ b/pkgs/sourcemeta/jsonschema/registry.yaml
@@ -12,6 +12,9 @@ packages:
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         supported_envs:
@@ -22,6 +25,9 @@ packages:
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         supported_envs:
@@ -32,6 +38,9 @@ packages:
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         overrides:
@@ -48,6 +57,9 @@ packages:
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -68016,29 +68016,27 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "continuous"
-        asset: jsonschema-10.0.0-28881f25-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-        checksum:
-          type: github_release
-          asset: CHECKSUMS.txt
-          algorithm: sha256
+        error_message: "The version 'continuous' is not supported. Please use a specific version."
       - version_constraint: semver("<= 0.4.1")
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         supported_envs:
           - linux/amd64
           - darwin/arm64
-          - windows/amd64
+          - windows
       - version_constraint: semver("<= 7.2.2")
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         supported_envs:
@@ -68049,28 +68047,24 @@ packages:
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
         overrides:
           - goos: linux
             replacements:
               arm64: aarch64
-      - version_constraint: semver("<= 9.3.2")
-        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
       - version_constraint: "true"
         asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jsonschema
+            src: "{{.AssetWithoutExt}}/bin/jsonschema"
         replacements:
           amd64: x86_64
-        checksum:
-          type: github_release
-          asset: CHECKSUMS.txt
-          algorithm: sha256
   - type: github_release
     repo_owner: spacelift-io
     repo_name: spacectl

--- a/registry.yaml
+++ b/registry.yaml
@@ -68010,6 +68010,68 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: sourcemeta
+    repo_name: jsonschema
+    description: The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "continuous"
+        asset: jsonschema-10.0.0-28881f25-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.1")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 7.2.2")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 7.3.0")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 9.3.2")
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+      - version_constraint: "true"
+        asset: jsonschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: spacelift-io
     repo_name: spacectl
     description: Spacelift client and CLI


### PR DESCRIPTION
[sourcemeta/jsonschema](https://github.com/sourcemeta/jsonschema): The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines

```console
$ aqua g -i sourcemeta/jsonschema
```

Close #39064

⚠️ The version `continuous` isn't supported.