### PR TITLE
feat: add cloudfoundry/uaa-cli

### DIFF
--- a/pkgs/cloudfoundry/uaa-cli/pkg.yaml
+++ b/pkgs/cloudfoundry/uaa-cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: cloudfoundry/uaa-cli@0.16.0
+  - name: cloudfoundry/uaa-cli
+    version: 0.10.0

--- a/pkgs/cloudfoundry/uaa-cli/registry.yaml
+++ b/pkgs/cloudfoundry/uaa-cli/registry.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: cloudfoundry
+    repo_name: uaa-cli
+    description: CLI for UAA written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.0.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.10.0")
+        asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/cloudfoundry/uaa-cli/registry.yaml
+++ b/pkgs/cloudfoundry/uaa-cli/registry.yaml
@@ -5,6 +5,8 @@ packages:
     repo_name: uaa-cli
     description: CLI for UAA written in Go
     version_constraint: "false"
+    files:
+      - name: uaa
     version_overrides:
       - version_constraint: Version == "0.0.1"
         no_asset: true
@@ -13,6 +15,8 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: uaa
         supported_envs:
           - darwin
           - windows
@@ -21,6 +25,8 @@ packages:
         asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
         format: raw
         windows_arm_emulation: true
+        files:
+          - name: uaa
         supported_envs:
           - darwin
           - windows

--- a/pkgs/cloudfoundry/uaa-cli/registry.yaml
+++ b/pkgs/cloudfoundry/uaa-cli/registry.yaml
@@ -4,9 +4,9 @@ packages:
     repo_owner: cloudfoundry
     repo_name: uaa-cli
     description: CLI for UAA written in Go
-    version_constraint: "false"
     files:
       - name: uaa
+    version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.0.1"
         no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -20427,9 +20427,9 @@ packages:
     repo_owner: cloudfoundry
     repo_name: uaa-cli
     description: CLI for UAA written in Go
-    version_constraint: "false"
     files:
       - name: uaa
+    version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.0.1"
         no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -20423,6 +20423,31 @@ packages:
       - version_constraint: semver("< 2.9.21")
         asset: credhub-{{.OS}}-{{.Version}}.{{.Format}}
         rosetta2: true
+  - type: github_release
+    repo_owner: cloudfoundry
+    repo_name: uaa-cli
+    description: CLI for UAA written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.0.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.10.0")
+        asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
   - name: cloudnative-pg/cloudnative-pg/kubectl-cnpg
     type: github_release
     repo_owner: cloudnative-pg

--- a/registry.yaml
+++ b/registry.yaml
@@ -20428,6 +20428,8 @@ packages:
     repo_name: uaa-cli
     description: CLI for UAA written in Go
     version_constraint: "false"
+    files:
+      - name: uaa
     version_overrides:
       - version_constraint: Version == "0.0.1"
         no_asset: true
@@ -20436,6 +20438,8 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: uaa
         supported_envs:
           - darwin
           - windows
@@ -20444,6 +20448,8 @@ packages:
         asset: uaa-{{.OS}}-{{.Arch}}-{{.Version}}
         format: raw
         windows_arm_emulation: true
+        files:
+          - name: uaa
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
#39081 [cloudfoundry/uaa-cli](https://github.com/cloudfoundry/uaa-cli) - CLI for UAA written in Go

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [cloudfoundry/uaa-cli](https://github.com/cloudfoundry/uaa-cli/releases).

The bin name `uaa` is written in the example.

> uaa -h

https://github.com/cloudfoundry/uaa-cli?tab=readme-ov-file#trying-out-the-latest-code

It has only 21 stars, so feel free to close this issue if you think Aqua doesn't have to support it.