### PR TITLE
feat: add slok/agebox

### DIFF
--- a/pkgs/slok/agebox/pkg.yaml
+++ b/pkgs/slok/agebox/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: slok/agebox@v0.8.0

--- a/pkgs/slok/agebox/registry.yaml
+++ b/pkgs/slok/agebox/registry.yaml
@@ -5,11 +5,15 @@ packages:
     repo_name: agebox
     description: Age based repository file encryption gitops tool
     version_constraint: "false"
+    files:
+      - name: agebox
     version_overrides:
       - version_constraint: "true"
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
+        files:
+          - name: agebox
         checksum:
           type: github_release
           asset: checksums.txt

--- a/pkgs/slok/agebox/registry.yaml
+++ b/pkgs/slok/agebox/registry.yaml
@@ -10,13 +10,7 @@ packages:
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: agebox-{{.OS}}-{{.Arch}}-v7

--- a/pkgs/slok/agebox/registry.yaml
+++ b/pkgs/slok/agebox/registry.yaml
@@ -5,15 +5,11 @@ packages:
     repo_name: agebox
     description: Age based repository file encryption gitops tool
     version_constraint: "false"
-    files:
-      - name: agebox
     version_overrides:
       - version_constraint: "true"
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        files:
-          - name: agebox
         checksum:
           type: github_release
           asset: checksums.txt

--- a/pkgs/slok/agebox/registry.yaml
+++ b/pkgs/slok/agebox/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: slok
+    repo_name: agebox
+    description: Age based repository file encryption gitops tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: agebox-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: agebox-{{.OS}}-{{.Arch}}-v7

--- a/registry.yaml
+++ b/registry.yaml
@@ -67089,16 +67089,10 @@ packages:
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: agebox-{{.OS}}-{{.Arch}}-v7
   - type: github_release
     repo_owner: slok
     repo_name: sloth

--- a/registry.yaml
+++ b/registry.yaml
@@ -67084,15 +67084,11 @@ packages:
     repo_name: agebox
     description: Age based repository file encryption gitops tool
     version_constraint: "false"
-    files:
-      - name: agebox
     version_overrides:
       - version_constraint: "true"
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        files:
-          - name: agebox
         checksum:
           type: github_release
           asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -67081,6 +67081,26 @@ packages:
             asset: nebula-{{.OS}}.{{.Format}}
   - type: github_release
     repo_owner: slok
+    repo_name: agebox
+    description: Age based repository file encryption gitops tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: agebox-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: agebox-{{.OS}}-{{.Arch}}-v7
+  - type: github_release
+    repo_owner: slok
     repo_name: sloth
     description: Easy and simple Prometheus SLO (service level objectives) generator
     version_filter: not Version startsWith "sloth-helm-chart-"

--- a/registry.yaml
+++ b/registry.yaml
@@ -67084,11 +67084,15 @@ packages:
     repo_name: agebox
     description: Age based repository file encryption gitops tool
     version_constraint: "false"
+    files:
+      - name: agebox
     version_overrides:
       - version_constraint: "true"
         asset: agebox-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
+        files:
+          - name: agebox
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
[slok/agebox](https://github.com/slok/agebox) - Age based repository file encryption gitops tool

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [slok/agebox](https://github.com/slok/agebox/releases).