### PR TITLE
feat: add ohkrab/krab

### DIFF
--- a/pkgs/ohkrab/krab/pkg.yaml
+++ b/pkgs/ohkrab/krab/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: ohkrab/krab@v0.9.0
+  - name: ohkrab/krab
+    version: v0.3.1

--- a/pkgs/ohkrab/krab/pkg.yaml
+++ b/pkgs/ohkrab/krab/pkg.yaml
@@ -1,4 +1,33 @@
 packages:
-  - name: ohkrab/krab@v0.9.0
+  - name: ohkrab/krab
+    version: v0.9.0
+  - name: ohkrab/krab
+    version: v0.8.0
+  - name: ohkrab/krab
+    version: v0.7.0
+  - name: ohkrab/krab
+    version: v0.6.2
+  - name: ohkrab/krab
+    version: v0.6.1
+  - name: ohkrab/krab
+    version: v0.6.0
+  - name: ohkrab/krab
+    version: v0.5.0
+  - name: ohkrab/krab
+    version: v0.4.2
+  - name: ohkrab/krab
+    version: v0.4.1
+  - name: ohkrab/krab
+    version: v0.4.0
   - name: ohkrab/krab
     version: v0.3.1
+  - name: ohkrab/krab
+    version: v0.3.0
+  - name: ohkrab/krab
+    version: v0.2.4
+  - name: ohkrab/krab
+    version: v0.2.3
+  - name: ohkrab/krab
+    version: v0.2.2
+  - name: ohkrab/krab
+    version: v0.2.1

--- a/pkgs/ohkrab/krab/pkg.yaml
+++ b/pkgs/ohkrab/krab/pkg.yaml
@@ -1,33 +1,4 @@
 packages:
-  - name: ohkrab/krab
-    version: v0.9.0
-  - name: ohkrab/krab
-    version: v0.8.0
-  - name: ohkrab/krab
-    version: v0.7.0
-  - name: ohkrab/krab
-    version: v0.6.2
-  - name: ohkrab/krab
-    version: v0.6.1
-  - name: ohkrab/krab
-    version: v0.6.0
-  - name: ohkrab/krab
-    version: v0.5.0
-  - name: ohkrab/krab
-    version: v0.4.2
-  - name: ohkrab/krab
-    version: v0.4.1
-  - name: ohkrab/krab
-    version: v0.4.0
+  - name: ohkrab/krab@v0.9.0
   - name: ohkrab/krab
     version: v0.3.1
-  - name: ohkrab/krab
-    version: v0.3.0
-  - name: ohkrab/krab
-    version: v0.2.4
-  - name: ohkrab/krab
-    version: v0.2.3
-  - name: ohkrab/krab
-    version: v0.2.2
-  - name: ohkrab/krab
-    version: v0.2.1

--- a/pkgs/ohkrab/krab/registry.yaml
+++ b/pkgs/ohkrab/krab/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ohkrab
+    repo_name: krab
+    description: Krab is a migration and automation tool for PostgreSQL based on HCL syntax
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.3.1")
+        asset: krab_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: krab_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: krab_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: krab_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -55691,6 +55691,36 @@ packages:
       - name: exa
         src: bin/exa
   - type: github_release
+    repo_owner: ohkrab
+    repo_name: krab
+    description: Krab is a migration and automation tool for PostgreSQL based on HCL syntax
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.3.1")
+        asset: krab_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: krab_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: krab_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: krab_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: oknozor
     repo_name: toml-bombadil
     description: A dotfile manager with templating


### PR DESCRIPTION
[ohkrab/krab](https://github.com/ohkrab/krab) - Krab is a migration and automation tool for PostgreSQL based on HCL syntax

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds [ohkrab/krab](https://github.com/ohkrab/krab). ([Releases](https://github.com/ohkrab/krab/releases))

It has only 19 stars, so feel free to close this issue if you think Aqua doesn't have to support it.