### PR TITLE
fix(concourse/concourse): support checksum

### DIFF
--- a/pkgs/concourse/concourse/concourse/registry.yaml
+++ b/pkgs/concourse/concourse/concourse/registry.yaml
@@ -14,8 +14,10 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      algorithm: sha1
     files:
       - name: concourse
         src: concourse/bin/concourse

--- a/pkgs/concourse/concourse/fly/registry.yaml
+++ b/pkgs/concourse/concourse/fly/registry.yaml
@@ -14,7 +14,9 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      algorithm: sha1
     files:
       - name: fly


### PR DESCRIPTION
<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables \`Require signed commits\`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute \`cmdx s\` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Resolves TODO to support `sha1` checksums.