### PR TITLE
fix(bazelbuild/bazel-watcher): mark v0.26.5 as no_asset

### DIFF
--- a/pkgs/bazelbuild/bazel-watcher/registry.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/registry.yaml
@@ -8,7 +8,7 @@ packages:
       - name: ibazel
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3"]
+      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3", "v0.26.5"]
         no_asset: true
       - version_constraint: semver("<= 0.9.1")
         asset: ibazel_{{.OS}}_{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -14565,7 +14565,7 @@ packages:
       - name: ibazel
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3"]
+      - version_constraint: semver("<= 0.4.0") || Version in ["v0.15.1", "v0.26.0", "v0.26.3", "v0.26.5"]
         no_asset: true
       - version_constraint: semver("<= 0.9.1")
         asset: ibazel_{{.OS}}_{{.Arch}}


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

[v0.26.5](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.26.5) doesn't have the assets again.
Fixes https://github.com/aquaproj/aqua-registry/pull/39049.