### PR TITLE
feat: add yarnpkg/berry

### DIFF
--- a/pkgs/yarnpkg/berry/pkg.yaml
+++ b/pkgs/yarnpkg/berry/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yarnpkg/berry@

--- a/pkgs/yarnpkg/berry/pkg.yaml
+++ b/pkgs/yarnpkg/berry/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: yarnpkg/berry@
+  - name: yarnpkg/berry@@yarnpkg/cli/4.9.2

--- a/pkgs/yarnpkg/berry/registry.yaml
+++ b/pkgs/yarnpkg/berry/registry.yaml
@@ -1,7 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: http
     repo_owner: yarnpkg
     repo_name: berry
     description: Active development trunk for Yarn
-    no_asset: true
+    files:
+      - name: yarn
+    version_constraint: "false"
+    version_prefix: "@yarnpkg/cli/"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://repo.yarnpkg.com/{{.SemVer}}/packages/yarnpkg-cli/bin/yarn.js
+        format: raw
+        complete_windows_ext: false

--- a/pkgs/yarnpkg/berry/registry.yaml
+++ b/pkgs/yarnpkg/berry/registry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: yarnpkg
+    repo_name: berry
+    description: Active development trunk for Yarn
+    no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -79284,11 +79284,19 @@ packages:
         overrides:
           - goos: windows
             format: zip
-  - type: github_release
+  - type: http
     repo_owner: yarnpkg
     repo_name: berry
     description: Active development trunk for Yarn
-    no_asset: true
+    files:
+      - name: yarn
+    version_constraint: "false"
+    version_prefix: "@yarnpkg/cli/"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://repo.yarnpkg.com/{{.SemVer}}/packages/yarnpkg-cli/bin/yarn.js
+        format: raw
+        complete_windows_ext: false
   - type: github_release
     repo_owner: yarnpkg
     repo_name: yarn

--- a/registry.yaml
+++ b/registry.yaml
@@ -79286,6 +79286,11 @@ packages:
             format: zip
   - type: github_release
     repo_owner: yarnpkg
+    repo_name: berry
+    description: Active development trunk for Yarn
+    no_asset: true
+  - type: github_release
+    repo_owner: yarnpkg
     repo_name: yarn
     search_words:
       - v1 only


### PR DESCRIPTION
[yarnpkg/berry](https://github.com/yarnpkg/berry): Active development trunk for Yarn

```console
$ aqua g -i yarnpkg/berry
```

Close #39120

## ⚠️ This package is for yarn berry

yarn has two lines.

- v1 https://github.com/yarnpkg/yarn
- v2 ~ (berry) https://github.com/yarnpkg/berry

This package is for yarn berry.
If you want to install yarn v1, please use the package `yarnpkg/yarn`

- https://github.com/aquaproj/aqua-registry/pull/32360

## ⚠️ yarn global

If you want to install packages globally by yarn, you need to add `$(yarn global bin)` to `$PATH`.
aqua can't change `$PATH` dynamically, so `$(yarn global bin)` must be static.
If `$(yarn global bin)` depends on the yarn version, you need to fix it.

e.g.

```sh
yarn config set prefix ~/.yarn
export PATH=$HOME/.yarn/bin:$PATH
```