### PR TITLE
feat: add sr.ht/charles/rq

### DIFF
--- a/pkgs/sr.ht/~charles/rq/pkg.yaml
+++ b/pkgs/sr.ht/~charles/rq/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/sr.ht/~charles/rq/pkg.yaml
+++ b/pkgs/sr.ht/~charles/rq/pkg.yaml
@@ -1,1 +1,3 @@
-packages: []
+packages:
+  - name: sr.ht/~charles/rq@v0.0.14
+

--- a/pkgs/sr.ht/~charles/rq/pkg.yaml
+++ b/pkgs/sr.ht/~charles/rq/pkg.yaml
@@ -1,3 +1,2 @@
 packages:
   - name: sr.ht/~charles/rq@v0.0.14
-

--- a/pkgs/sr.ht/~charles/rq/registry.yaml
+++ b/pkgs/sr.ht/~charles/rq/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: sr.ht/~charles/rq
+    type: github_release
+    repo_owner: sr.ht
+    repo_name: ~charles

--- a/pkgs/sr.ht/~charles/rq/registry.yaml
+++ b/pkgs/sr.ht/~charles/rq/registry.yaml
@@ -6,4 +6,4 @@ packages:
     format: gz
     files:
       - name: rq
-        src: '{{.AssetWithoutExt}}'
+        src: "{{.AssetWithoutExt}}"

--- a/pkgs/sr.ht/~charles/rq/registry.yaml
+++ b/pkgs/sr.ht/~charles/rq/registry.yaml
@@ -2,6 +2,9 @@
 packages:
   - name: sr.ht/~charles/rq
     type: http
+    description: |
+      rq (Rego Query) is inspired by jq, and aims to offer a similar set of capabilities oriented around running Rego queries
+    link: https://sr.ht/~charles/rq/
     url: https://git.sr.ht/~charles/rq/refs/download/{{.Version}}/rq-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
     format: gz
     files:

--- a/pkgs/sr.ht/~charles/rq/registry.yaml
+++ b/pkgs/sr.ht/~charles/rq/registry.yaml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - name: sr.ht/~charles/rq
-    type: github_release
-    repo_owner: sr.ht
-    repo_name: ~charles
+    type: http
+    url: https://git.sr.ht/~charles/rq/refs/download/{{.Version}}/rq-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    format: gz
+    files:
+      - name: rq
+        src: '{{.AssetWithoutExt}}'

--- a/registry.yaml
+++ b/registry.yaml
@@ -68914,7 +68914,7 @@ packages:
     format: gz
     files:
       - name: rq
-        src: '{{.AssetWithoutExt}}'
+        src: "{{.AssetWithoutExt}}"
   - type: github_release
     repo_owner: srevinsaju
     repo_name: togomak

--- a/registry.yaml
+++ b/registry.yaml
@@ -68910,6 +68910,9 @@ packages:
         complete_windows_ext: false
   - name: sr.ht/~charles/rq
     type: http
+    description: |
+      rq (Rego Query) is inspired by jq, and aims to offer a similar set of capabilities oriented around running Rego queries
+    link: https://sr.ht/~charles/rq/
     url: https://git.sr.ht/~charles/rq/refs/download/{{.Version}}/rq-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
     format: gz
     files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -68908,6 +68908,10 @@ packages:
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+  - name: sr.ht/~charles/rq
+    type: github_release
+    repo_owner: sr.ht
+    repo_name: ~charles
   - type: github_release
     repo_owner: srevinsaju
     repo_name: togomak

--- a/registry.yaml
+++ b/registry.yaml
@@ -68909,9 +68909,12 @@ packages:
         windows_arm_emulation: true
         complete_windows_ext: false
   - name: sr.ht/~charles/rq
-    type: github_release
-    repo_owner: sr.ht
-    repo_name: ~charles
+    type: http
+    url: https://git.sr.ht/~charles/rq/refs/download/{{.Version}}/rq-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+    format: gz
+    files:
+      - name: rq
+        src: '{{.AssetWithoutExt}}'
   - type: github_release
     repo_owner: srevinsaju
     repo_name: togomak


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

This adds [rq / Rego Query](https://git.sr.ht/~charles/rq/), a jq-like that uses the Rego language.

From what I can tell, this is the *first* sr.ht package in aqua, so I'm not sure if the path I chose is good, lmk if any changes are needed there.