### PR TITLE
chore: unpin lima (#36953)

### DIFF
--- a/pkgs/lima-vm/lima/pkg.yaml
+++ b/pkgs/lima-vm/lima/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: lima-vm/lima@v1.2.1
+  # - name: lima-vm/lima@v1.2.1
+  - name: lima-vm/lima
+    version: v1.1.0
   - name: lima-vm/lima
     version: v0.22.0
   - name: lima-vm/lima

--- a/pkgs/lima-vm/lima/pkg.yaml
+++ b/pkgs/lima-vm/lima/pkg.yaml
@@ -1,6 +1,5 @@
 packages:
-  - name: lima-vm/lima
-    version: v1.0.7
+  - name: lima-vm/lima@v1.2.1
   - name: lima-vm/lima
     version: v0.22.0
   - name: lima-vm/lima

--- a/pkgs/lima-vm/lima/registry.yaml
+++ b/pkgs/lima-vm/lima/registry.yaml
@@ -11,6 +11,12 @@ packages:
         src: bin/limactl
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v1.1.1"
+        error_message: |
+          aqua doesn't support this version.
+          Please update this package.
+          https://github.com/aquaproj/aqua-registry/issues/36874
+          https://github.com/lima-vm/lima/pull/3621
       - version_constraint: Version == "v0.7.0"
         no_asset: true
       - version_constraint: Version == "v0.1.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -49150,6 +49150,12 @@ packages:
         src: bin/limactl
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v1.1.1"
+        error_message: |
+          aqua doesn't support this version.
+          Please update this package.
+          https://github.com/aquaproj/aqua-registry/issues/36874
+          https://github.com/lima-vm/lima/pull/3621
       - version_constraint: Version == "v0.7.0"
         no_asset: true
       - version_constraint: Version == "v0.1.0"


### PR DESCRIPTION
This reverts commit b1ae176863f309016a38c0003597af7e691fe13d (#36953) and updates lima to 1.2.1.

The pin happened because guest agent lookup broke in lima 1.1.1; that got fixed in 1.2.0:

https://github.com/lima-vm/lima/pull/3621

Although the question of what to do about additional guest agents is still left open, the package isn't completely broken anymore, so it makes sense to unpin it now.

Ref: #36874

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
