### PR TITLE
feat: add hytromo/mimosa

### DIFF
--- a/pkgs/hytromo/mimosa/pkg.yaml
+++ b/pkgs/hytromo/mimosa/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: hytromo/mimosa@v0.0.9
+  - name: hytromo/mimosa
+    version: v0.0.7

--- a/pkgs/hytromo/mimosa/registry.yaml
+++ b/pkgs/hytromo/mimosa/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: hytromo
+    repo_name: mimosa
+    description: Zero-config docker image promotion
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.7")
+        asset: mimosa_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: mimosa_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: mimosa_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: mimosa_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -38926,6 +38926,27 @@ packages:
         files:
           - name: terraformify
             src: terraformify_{{.OS}}_{{.Arch}}/terraformify
+  - type: github_release
+    repo_owner: hytromo
+    repo_name: mimosa
+    description: Zero-config docker image promotion
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.7")
+        asset: mimosa_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: mimosa_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: mimosa_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: mimosa_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_archive
     repo_owner: iamhsa
     repo_name: pkenv


### PR DESCRIPTION
[hytromo/mimosa](https://github.com/hytromo/mimosa) - Zero-config docker image promotion

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

This adds [hytromo/mimosa](https://github.com/hytromo/mimosa), a single Go binary that enables seamless docker image promotion in CI.

- :white_check_mark: `cmdx gr`
- :white_check_mark: `cmdx t hytromo/mimosa`
- :white_check_mark: `aqua install` and testing of the `mimosa` binary
