### PR TITLE
fix(hashicorp/nomad): exclude ent-changelog versions

### DIFF
--- a/pkgs/hashicorp/nomad/registry.yaml
+++ b/pkgs/hashicorp/nomad/registry.yaml
@@ -9,6 +9,7 @@ packages:
       - darwin
       - linux
       - amd64
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     checksum:
       type: http
       url: https://releases.hashicorp.com/nomad/{{trimV .Version}}/nomad_{{trimV .Version}}_SHA256SUMS

--- a/registry.yaml
+++ b/registry.yaml
@@ -37621,6 +37621,7 @@ packages:
       - darwin
       - linux
       - amd64
+    version_filter: Version matches "^v\\d+\\.\\d+\\.\\d+"
     checksum:
       type: http
       url: https://releases.hashicorp.com/nomad/{{trimV .Version}}/nomad_{{trimV .Version}}_SHA256SUMS


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

As in https://github.com/aquaproj/aqua-registry/pull/29189, adds `version_filter` to exclude `ent-changelog-*` versions.

I looked for other hashicorp tools, but others didn't have `ent-changelog-*` versions.