### PR TITLE
fix(bazelbuild/bazel-watcher): update registry for V prefixed and latest version

### DIFF
--- a/pkgs/bazelbuild/bazel-watcher/pkg.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/pkg.yaml
@@ -1,7 +1,13 @@
 packages:
   - name: bazelbuild/bazel-watcher@v0.26.8
   - name: bazelbuild/bazel-watcher
+    version: v0.26.7
+  - name: bazelbuild/bazel-watcher
+    version: V0.26.6
+  - name: bazelbuild/bazel-watcher
     version: V0.26.4
+  - name: bazelbuild/bazel-watcher
+    version: V0.25.1
   - name: bazelbuild/bazel-watcher
     version: v0.25.1
   - name: bazelbuild/bazel-watcher

--- a/pkgs/bazelbuild/bazel-watcher/registry.yaml
+++ b/pkgs/bazelbuild/bazel-watcher/registry.yaml
@@ -59,6 +59,11 @@ packages:
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
+      - version_constraint: Version == "V0.25.1"
+        version_prefix: V
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
       - version_constraint: Version == "V0.26.4"
         version_prefix: V
         asset: ibazel_{{.OS}}_{{.Arch}}
@@ -68,7 +73,8 @@ packages:
           - linux/amd64
           - darwin/arm64
           - windows
-      - version_constraint: "true"
+      - version_constraint: Version == "V0.26.6"
+        version_prefix: V
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -76,3 +82,15 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: semver("<= 0.26.7")
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -14771,6 +14771,11 @@ packages:
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
+      - version_constraint: Version == "V0.25.1"
+        version_prefix: V
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
       - version_constraint: Version == "V0.26.4"
         version_prefix: V
         asset: ibazel_{{.OS}}_{{.Arch}}
@@ -14780,7 +14785,8 @@ packages:
           - linux/amd64
           - darwin/arm64
           - windows
-      - version_constraint: "true"
+      - version_constraint: Version == "V0.26.6"
+        version_prefix: V
         asset: ibazel_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -14788,6 +14794,18 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: semver("<= 0.26.7")
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: ibazel_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: bazelbuild
     repo_name: bazelisk


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

- Adds large `V` prefixes to the registry for [V0.25.1](https://github.com/bazelbuild/bazel-watcher/releases/tag/V0.25.1) and [V0.26.6](https://github.com/bazelbuild/bazel-watcher/releases/tag/V0.26.6).
  Both [V0.25.1](https://github.com/bazelbuild/bazel-watcher/releases/tag/V0.25.1) and [v0.25.1](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.25.1) exist. I think they created a new release to fix the prefix without any changes.

- [v0.26.8](https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.26.8) has an asset for `darwin/arm64` again.
  They fixed the build issue in https://github.com/bazelbuild/bazel-watcher/pull/780, so this should continue for the following releases.
  `version_overrides` of `semver("<= 0.25.1")` and `"true"` are identical, but I think merging them makes the registry unclear.

Sorry for making this one PR. If it's better to separate the PR, I will make another PR.