### PR TITLE
fix(runmedev/runme): update registry

### DIFF
--- a/pkgs/runmedev/runme/pkg.yaml
+++ b/pkgs/runmedev/runme/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: runmedev/runme@v3.15.0
+  - name: runmedev/runme@v3.15.1-rc.3
+  - name: runmedev/runme
+    version: v0.1.12

--- a/pkgs/runmedev/runme/registry.yaml
+++ b/pkgs/runmedev/runme/registry.yaml
@@ -2,24 +2,31 @@
 packages:
   - type: github_release
     repo_owner: runmedev
-    description: Execute commands directly from a README
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.2.0")
-    # https://github.com/stateful/runme/pull/35
     repo_name: runme
-    aliases:
-      - name: stateful/runme
-    asset: runme_{{.OS}}_{{.Arch}}.{{.Format}}
+    description: DevOps Notebooks Built with Markdown
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        repo_name: rdme
+      - version_constraint: semver("<= 0.1.12")
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: runme_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/runmedev/runme/registry.yaml
+++ b/pkgs/runmedev/runme/registry.yaml
@@ -5,10 +5,15 @@ packages:
     repo_name: runme
     description: DevOps Notebooks Built with Markdown
     version_constraint: "false"
+    aliases:
+      - name: stateful/rdme
+      - name: stateful/runme
     version_overrides:
       - version_constraint: semver("<= 0.1.12")
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: rdme
         replacements:
           amd64: x86_64
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -63766,10 +63766,15 @@ packages:
     repo_name: runme
     description: DevOps Notebooks Built with Markdown
     version_constraint: "false"
+    aliases:
+      - name: stateful/rdme
+      - name: stateful/runme
     version_overrides:
       - version_constraint: semver("<= 0.1.12")
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: rdme
         replacements:
           amd64: x86_64
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -63763,27 +63763,34 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: runmedev
-    description: Execute commands directly from a README
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
-    version_constraint: semver(">= 0.2.0")
-    # https://github.com/stateful/runme/pull/35
     repo_name: runme
-    aliases:
-      - name: stateful/runme
-    asset: runme_{{.OS}}_{{.Arch}}.{{.Format}}
+    description: DevOps Notebooks Built with Markdown
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        repo_name: rdme
+      - version_constraint: semver("<= 0.1.12")
         asset: rdme_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: runme_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: rust-cross
     repo_name: cargo-zigbuild


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

This drops support for [`runmedev/rdme`](https://github.com/runmedev/rdme) and adds support for [`stateful/rdme`](https://github.com/stateful/rdme).
Since this matches the GitHub redirect behaviour, I believe this should be a safe change.