### PR TITLE
fix(jesseduffield/lazygit): re-scaffold registry

### DIFF
--- a/pkgs/jesseduffield/lazygit/pkg.yaml
+++ b/pkgs/jesseduffield/lazygit/pkg.yaml
@@ -1,2 +1,22 @@
 packages:
-  - name: jesseduffield/lazygit@v0.53.0
+  - name: jesseduffield/lazygit@v0.54.0
+  - name: jesseduffield/lazygit
+    version: v0.53.0
+  - name: jesseduffield/lazygit
+    version: v0.34
+  - name: jesseduffield/lazygit
+    version: v0.24.2
+  - name: jesseduffield/lazygit
+    version: v0.16.2
+  - name: jesseduffield/lazygit
+    version: v0.1.29
+  - name: jesseduffield/lazygit
+    version: v0.1.25
+  - name: jesseduffield/lazygit
+    version: v0.1.22
+  - name: jesseduffield/lazygit
+    version: v0.1.16
+  - name: jesseduffield/lazygit
+    version: v0.1.11
+  - name: jesseduffield/lazygit
+    version: v0.1.7

--- a/pkgs/jesseduffield/lazygit/registry.yaml
+++ b/pkgs/jesseduffield/lazygit/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: simple terminal UI for git commands
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.1.12", "v0.1.77"]
+      - version_constraint: semver("<= 0.1.6") || Version in ["v0.1.12", "v0.1.77"]
         no_asset: true
       - version_constraint: Version == "v0.1.7"
         asset: lazygit_{{.OS}}_{{.Arch}}
@@ -17,6 +17,22 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.1.11")
+        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.16")
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
       - version_constraint: Version == "v0.1.22"
         asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -46,24 +62,6 @@ packages:
         supported_envs:
           - linux/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.1.6")
-        no_asset: true
-      - version_constraint: semver("<= 0.1.11")
-        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.1.16")
-        asset: lazygit_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
       - version_constraint: semver("<= 0.1.29")
         asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/jesseduffield/lazygit/registry.yaml
+++ b/pkgs/jesseduffield/lazygit/registry.yaml
@@ -4,22 +4,156 @@ packages:
     repo_owner: jesseduffield
     repo_name: lazygit
     description: simple terminal UI for git commands
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: 32-bit
-      amd64: x86_64
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.1.12", "v0.1.77"]
+        no_asset: true
+      - version_constraint: Version == "v0.1.7"
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.22"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.1.25"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 0.1.6")
+        no_asset: true
+      - version_constraint: semver("<= 0.1.11")
+        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.16")
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 0.1.29")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.16.2")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.17.2")
+        no_asset: true
+      - version_constraint: semver("<= 0.24.2")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.34.0")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.53.0")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -41894,7 +41894,7 @@ packages:
     description: simple terminal UI for git commands
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.1.12", "v0.1.77"]
+      - version_constraint: semver("<= 0.1.6") || Version in ["v0.1.12", "v0.1.77"]
         no_asset: true
       - version_constraint: Version == "v0.1.7"
         asset: lazygit_{{.OS}}_{{.Arch}}
@@ -41905,6 +41905,22 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.1.11")
+        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.16")
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
       - version_constraint: Version == "v0.1.22"
         asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -41934,24 +41950,6 @@ packages:
         supported_envs:
           - linux/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.1.6")
-        no_asset: true
-      - version_constraint: semver("<= 0.1.11")
-        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.1.16")
-        asset: lazygit_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
       - version_constraint: semver("<= 0.1.29")
         asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -41892,25 +41892,159 @@ packages:
     repo_owner: jesseduffield
     repo_name: lazygit
     description: simple terminal UI for git commands
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: 32-bit
-      amd64: x86_64
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.1.12", "v0.1.77"]
+        no_asset: true
+      - version_constraint: Version == "v0.1.7"
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.22"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.1.25"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 0.1.6")
+        no_asset: true
+      - version_constraint: semver("<= 0.1.11")
+        asset: lazygit_{{.OS}}_{{.Arch}}_{{.Version}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.16")
+        asset: lazygit_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 0.1.29")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.16.2")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.17.2")
+        no_asset: true
+      - version_constraint: semver("<= 0.24.2")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.34.0")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.53.0")
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lazygit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: jesseduffield
     repo_name: lazynpm


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

They changed `.goreleaser.yml` since [v0.54.0](https://github.com/jesseduffield/lazygit/releases/tag/v0.54.0) so they no longer use the title-cased `Darwin` or `Linux`.
https://github.com/jesseduffield/lazygit/pull/4703/files#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689
This PR adds support for that version.
This would fix the failing test in https://github.com/aquaproj/aqua-registry/pull/39654.

This also adds old versions, but I think they are unnecessary.