### PR TITLE
feat: add takaishi/tfdiff

### DIFF
--- a/pkgs/takaishi/tfdiff/pkg.yaml
+++ b/pkgs/takaishi/tfdiff/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: takaishi/tfdiff@v0.0.2

--- a/pkgs/takaishi/tfdiff/registry.yaml
+++ b/pkgs/takaishi/tfdiff/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: takaishi
+    repo_name: tfdiff
+    description: A CLI that shows attribute-level diffs between Terraform modules with clean, diff-like output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tfdiff_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -73462,6 +73462,24 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: takaishi
+    repo_name: tfdiff
+    description: A CLI that shows attribute-level diffs between Terraform modules with clean, diff-like output
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tfdiff_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: takumin
     repo_name: gjson
     description: Golang JSON Tool


### PR DESCRIPTION
[takaishi/tfdiff](https://github.com/takaishi/tfdiff): A CLI that shows attribute-level diffs between Terraform modules with clean, diff-like output

```console
$ aqua g -i takaishi/tfdiff
```