### PR TITLE
feat: add pypa/pipx

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,3 +13,4 @@ packages:
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: jqlang/jq@jq-1.8.1
   - name: cli/cli@v2.76.2
+  - name: pypa/pipx@1.7.1

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,4 +13,3 @@ packages:
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: jqlang/jq@jq-1.8.1
   - name: cli/cli@v2.76.2
-  - name: pypa/pipx@1.7.1

--- a/pkgs/pypa/pipx/pkg.yaml
+++ b/pkgs/pypa/pipx/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: pypa/pipx@1.2.1
+  - name: pypa/pipx@1.7.1

--- a/pkgs/pypa/pipx/pkg.yaml
+++ b/pkgs/pypa/pipx/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pypa/pipx@1.2.1

--- a/pkgs/pypa/pipx/registry.yaml
+++ b/pkgs/pypa/pipx/registry.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: pypa
+    repo_name: pipx
+    description: Install and Run Python Applications in Isolated Environments
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.1")
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/pypa/pipx/registry.yaml
+++ b/pkgs/pypa/pipx/registry.yaml
@@ -8,6 +8,13 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 1.1.0")
         no_asset: true
-      - version_constraint: semver("<= 1.2.1")
-      - version_constraint: "true"
+      - version_constraint: semver("1.3.0")
         no_asset: true
+      - version_constraint: "true"
+        asset: pipx.pyz
+        format: raw
+        files:
+          - name: pipx
+        supported_envs:
+          - darwin
+          - linux

--- a/pkgs/pypa/pipx/registry.yaml
+++ b/pkgs/pypa/pipx/registry.yaml
@@ -6,15 +6,11 @@ packages:
     description: Install and Run Python Applications in Isolated Environments
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.1.0")
-        no_asset: true
-      - version_constraint: semver("1.3.0")
+      - version_constraint: semver("<= 1.1.0") or Version == "1.3.0"
         no_asset: true
       - version_constraint: "true"
         asset: pipx.pyz
         format: raw
-        files:
-          - name: pipx
         supported_envs:
           - darwin
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -62230,6 +62230,17 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: pypa
+    repo_name: pipx
+    description: Install and Run Python Applications in Isolated Environments
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.2.1")
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: qarmin
     repo_name: czkawka
     description: Multi functional app to find duplicates, empty folders, similar images etc

--- a/registry.yaml
+++ b/registry.yaml
@@ -62235,15 +62235,11 @@ packages:
     description: Install and Run Python Applications in Isolated Environments
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.1.0")
-        no_asset: true
-      - version_constraint: semver("1.3.0")
+      - version_constraint: semver("<= 1.1.0") or Version == "1.3.0"
         no_asset: true
       - version_constraint: "true"
         asset: pipx.pyz
         format: raw
-        files:
-          - name: pipx
         supported_envs:
           - darwin
           - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -62237,9 +62237,16 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 1.1.0")
         no_asset: true
-      - version_constraint: semver("<= 1.2.1")
-      - version_constraint: "true"
+      - version_constraint: semver("1.3.0")
         no_asset: true
+      - version_constraint: "true"
+        asset: pipx.pyz
+        format: raw
+        files:
+          - name: pipx
+        supported_envs:
+          - darwin
+          - linux
   - type: github_release
     repo_owner: qarmin
     repo_name: czkawka


### PR DESCRIPTION
[pipx](https://github.com/pypa/pipx) is a tool that helps you install and run Python applications in isolated environments.

Windows is excluded from `supported_envs` because it requires an exe file to be generated, which is not included in the releases.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
