### PR TITLE
feat: add j178/prek

### DIFF
--- a/pkgs/j178/prek/pkg.yaml
+++ b/pkgs/j178/prek/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: j178/prek@v0.0.24
+  - name: j178/prek
+    version: v0.0.22
+  - name: j178/prek
+    version: v0.0.5

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -15,6 +15,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/pre-commit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -25,6 +28,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "pre-commit.exe"
         supported_envs:
           - darwin
           - windows
@@ -38,6 +44,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prefligit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -48,6 +57,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "prefligit.exe"
         supported_envs:
           - darwin
           - windows
@@ -61,6 +73,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -71,6 +86,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "prek.exe"
         supported_envs:
           - darwin
           - windows

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: j178
+    repo_name: prek
+    description: Better `pre-commit`, re-engineered in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: pre-commit-rs-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.22")
+        asset: prefligit-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -30,7 +30,7 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "pre-commit.exe"
+                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -59,7 +59,7 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "prefligit.exe"
+                src: prefligit
         supported_envs:
           - darwin
           - windows
@@ -88,7 +88,6 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "prek.exe"
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -41435,6 +41435,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/pre-commit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -41445,6 +41448,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "pre-commit.exe"
         supported_envs:
           - darwin
           - windows
@@ -41458,6 +41464,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prefligit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -41468,6 +41477,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "prefligit.exe"
         supported_envs:
           - darwin
           - windows
@@ -41481,6 +41493,9 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -41491,6 +41506,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: "prek.exe"
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -41421,6 +41421,81 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: j178
+    repo_name: prek
+    description: Better `pre-commit`, re-engineered in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: pre-commit-rs-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.22")
+        asset: prefligit-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik
     description: Process Interactive Kill

--- a/registry.yaml
+++ b/registry.yaml
@@ -41450,7 +41450,7 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "pre-commit.exe"
+                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -41479,7 +41479,7 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "prefligit.exe"
+                src: prefligit
         supported_envs:
           - darwin
           - windows
@@ -41508,7 +41508,6 @@ packages:
             format: zip
             files:
               - name: prek
-                src: "prek.exe"
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
[j178/prek](https://github.com/j178/prek) - Better `pre-commit`, re-engineered in Rust

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
