### PR TITLE
fix(rest-sh/restish): mark v0.21.0 as no_asset

### DIFF
--- a/pkgs/rest-sh/restish/pkg.yaml
+++ b/pkgs/rest-sh/restish/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: rest-sh/restish@v0.21.0
+  - name: rest-sh/restish@v0.20.0
   - name: rest-sh/restish
     version: v0.17.0
   - name: rest-sh/restish

--- a/pkgs/rest-sh/restish/registry.yaml
+++ b/pkgs/rest-sh/restish/registry.yaml
@@ -55,6 +55,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: Version == "v0.21.0"
+        no_asset: true
       - version_constraint: "true"
         asset: restish-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -63549,6 +63549,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: Version == "v0.21.0"
+        no_asset: true
       - version_constraint: "true"
         asset: restish-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

As you pointed out in https://github.com/rest-sh/restish/issues/290, the release failed for [`v0.21.0`](https://github.com/rest-sh/restish/releases/tag/v0.21.0), and it seems it won't be fixed in the short term.

I was not sure why the `pkg.yaml` update PR had been automatically merged. https://github.com/aquaproj/aqua-registry/pull/37462