### PR TITLE
fix(cloudflare/cfssl/cfssljson): add checksum validation for old versions

### DIFF
--- a/pkgs/cloudflare/cfssl/cfssljson/registry.yaml
+++ b/pkgs/cloudflare/cfssl/cfssljson/registry.yaml
@@ -14,6 +14,10 @@ packages:
         windows_arm_emulation: true
         replacements:
           arm64: arm
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
       - version_constraint: semver("<= 1.3.4")
         no_asset: true
       - version_constraint: semver("<= 1.6.3")

--- a/pkgs/cloudflare/cfssl/cfssljson/scaffold.yaml
+++ b/pkgs/cloudflare/cfssl/cfssljson/scaffold.yaml
@@ -4,4 +4,6 @@
 # https://aquaproj.github.io/
 # Other than name is optional. All initial values are just examples.
 name: cloudflare/cfssl/cfssljson
-all_assets_filter: (Asset matches "cfssljson") or (Asset matches "checksums.txt")
+all_assets_filter: |
+  let words = ["cfssljson", "checksums.txt", "SHA256SUMS"];
+  any(words, {Asset matches #})

--- a/registry.yaml
+++ b/registry.yaml
@@ -20925,6 +20925,10 @@ packages:
         windows_arm_emulation: true
         replacements:
           arm64: arm
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
       - version_constraint: semver("<= 1.3.4")
         no_asset: true
       - version_constraint: semver("<= 1.6.3")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

As in https://github.com/aquaproj/aqua-registry/pull/40149#discussion_r2277954659, I removed it in https://github.com/aquaproj/aqua-registry/pull/40104. This PR reverts it.