### PR TITLE
fix(zizmorcore/zizmor): support v1.12.0 which don't have assets

### DIFF
--- a/pkgs/zizmorcore/zizmor/pkg.yaml
+++ b/pkgs/zizmorcore/zizmor/pkg.yaml
@@ -3,4 +3,4 @@ packages:
   - name: zizmorcore/zizmor
     version: v1.8.0-rc3
   - name: zizmorcore/zizmor
-    version: v1.8.0-rc2
+    version: v1.12.0

--- a/pkgs/zizmorcore/zizmor/registry.yaml
+++ b/pkgs/zizmorcore/zizmor/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Static analysis for GitHub Actions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.0-rc2")
+      - version_constraint: semver("<= 1.8.0-rc2") || Version == "v1.12.0"
         type: cargo
         crate: zizmor
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -81713,7 +81713,7 @@ packages:
     description: Static analysis for GitHub Actions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.0-rc2")
+      - version_constraint: semver("<= 1.8.0-rc2") || Version == "v1.12.0"
         type: cargo
         crate: zizmor
       - version_constraint: "true"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Fixes the failing test in https://github.com/aquaproj/aqua-registry/pull/40166.

[v1.12.0](https://github.com/zizmorcore/zizmor/releases/tag/v1.12.0) doesn't have assets, so fallback to `type: cargo`.
[v1.12.1](https://github.com/zizmorcore/zizmor/releases/tag/v1.12.1) doesn't have `zizmor-i686-pc-windows-msvc.zip`, but we're not using it.