### PR TITLE
feat: add arduino/arduino-language-server

### DIFF
--- a/pkgs/arduino/arduino-language-server/pkg.yaml
+++ b/pkgs/arduino/arduino-language-server/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: arduino/arduino-language-server@0.7.7
+  - name: arduino/arduino-language-server
+    version: 0.7.1

--- a/pkgs/arduino/arduino-language-server/registry.yaml
+++ b/pkgs/arduino/arduino-language-server/registry.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: arduino
+    repo_name: arduino-language-server
+    description: An Arduino Language Server based on Clangd to Arduino code autocompletion
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.7.1")
+        asset: arduino-language-server_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-checksums.txt"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: ARM64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: arduino-language-server_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-checksums.txt"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/arduino/arduino-language-server/registry.yaml
+++ b/pkgs/arduino/arduino-language-server/registry.yaml
@@ -13,6 +13,7 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: 64bit
+          arm64: ARM64
           darwin: macOS
           linux: Linux
           windows: Windows
@@ -21,9 +22,6 @@ packages:
           asset: "{{.Version}}-checksums.txt"
           algorithm: sha256
         overrides:
-          - goos: linux
-            replacements:
-              arm64: ARM64
           - goos: windows
             format: zip
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12314,6 +12314,7 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: 64bit
+          arm64: ARM64
           darwin: macOS
           linux: Linux
           windows: Windows
@@ -12322,9 +12323,6 @@ packages:
           asset: "{{.Version}}-checksums.txt"
           algorithm: sha256
         overrides:
-          - goos: linux
-            replacements:
-              arm64: ARM64
           - goos: windows
             format: zip
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12302,6 +12302,49 @@ packages:
           asset: "{{trimV .Version}}-checksums.txt"
           algorithm: sha256
   - type: github_release
+    repo_owner: arduino
+    repo_name: arduino-language-server
+    description: An Arduino Language Server based on Clangd to Arduino code autocompletion
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.7.1")
+        asset: arduino-language-server_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-checksums.txt"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: ARM64
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: arduino-language-server_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Version}}-checksums.txt"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: argoproj-labs
     repo_name: argocd-autopilot
     description: Argo-CD Autopilot


### PR DESCRIPTION
[arduino/arduino-language-server](https://github.com/arduino/arduino-language-server): An Arduino Language Server based on Clangd to Arduino code autocompletion

```console
$ aqua g -i arduino/arduino-language-server
```

Close #40192