### PR TITLE
fix(crossplane/crossplane): fix bin name

### DIFF
--- a/pkgs/crossplane/crossplane/registry.yaml
+++ b/pkgs/crossplane/crossplane/registry.yaml
@@ -6,8 +6,6 @@ packages:
     format: raw
     url: https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank
     description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
-    files:
-      - name: kubectl-crossplane
     supported_envs:
       - darwin
       - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -24728,8 +24728,6 @@ packages:
     format: raw
     url: https://releases.crossplane.io/stable/{{.Version}}/bin/{{.OS}}_{{.Arch}}/crank
     description: The Crossplane CLI extends kubectl with functionality to build, push, and install Crossplane packages
-    files:
-      - name: kubectl-crossplane
     supported_envs:
       - darwin
       - linux


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

`kubectl-crossplane` has been used as a cli name since the original PR https://github.com/aquaproj/aqua-registry/pull/1339, but they use `crossplane` in the docs.
https://docs.crossplane.io/v2.0/cli/command-reference/

They might have used `kubectl-crossplane` before; at least I can find it in the archived repository ([`crossplane/crossplane-cli`](https://github.com/crossplane/crossplane-cli)).
https://github.com/crossplane/crossplane-cli/blob/f51c0bda333b9b45de8741e61c68344f75d21c86/bootstrap.sh#L17

Also, the asdf plugin uses `kubectl-crossplane`.
https://github.com/joke/asdf-crossplane-cli/blob/dd2a2a62bb049806ad13b514df7563718272d962/lib/utils.bash#L7

This will be a breaking change for users using `kubectl-crossplane`, but I think this was not intended.