### PR TITLE
fix(helix-editor/helix): rescaffold

### DIFF
--- a/pkgs/helix-editor/helix/pkg.yaml
+++ b/pkgs/helix-editor/helix/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: helix-editor/helix@25.07.1
   - name: helix-editor/helix
+    version: 22.08.1
+  - name: helix-editor/helix
     version: "22.05"
   - name: helix-editor/helix
     version: v0.6.0

--- a/pkgs/helix-editor/helix/registry.yaml
+++ b/pkgs/helix-editor/helix/registry.yaml
@@ -3,33 +3,64 @@ packages:
   - type: github_release
     repo_owner: helix-editor
     repo_name: helix
-    asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.xz
     description: A post-modern modal text editor
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: macos
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    files:
-      - name: hx
-        src: helix-{{.Version}}-{{.Arch}}-{{.OS}}/hx
-    version_constraint: semver(">= 22.08")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 22.03")
+      - version_constraint: semver("<= 0.6.0")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 22.5.0")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 22.8.1")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
           - amd64
       - version_constraint: "true"
-        rosetta2: true
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}

--- a/pkgs/helix-editor/helix/registry.yaml
+++ b/pkgs/helix-editor/helix/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: helix-editor
     repo_name: helix
     description: A post-modern modal text editor
+    files:
+      - name: hx
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.0")
@@ -11,6 +13,9 @@ packages:
         format: tar.xz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -25,6 +30,9 @@ packages:
         format: tar.xz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -39,6 +47,9 @@ packages:
         asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -56,6 +67,9 @@ packages:
         asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -38802,6 +38802,8 @@ packages:
     repo_owner: helix-editor
     repo_name: helix
     description: A post-modern modal text editor
+    files:
+      - name: hx
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.0")
@@ -38809,6 +38811,9 @@ packages:
         format: tar.xz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -38823,6 +38828,9 @@ packages:
         format: tar.xz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -38837,6 +38845,9 @@ packages:
         asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           darwin: macos
@@ -38854,6 +38865,9 @@ packages:
         asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: hx
+            src: "{{.AssetWithoutExt}}/hx"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -38801,36 +38801,67 @@ packages:
   - type: github_release
     repo_owner: helix-editor
     repo_name: helix
-    asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.xz
     description: A post-modern modal text editor
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: macos
-    overrides:
-      - goos: windows
-        format: zip
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    files:
-      - name: hx
-        src: helix-{{.Version}}-{{.Arch}}-{{.OS}}/hx
-    version_constraint: semver(">= 22.08")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 22.03")
+      - version_constraint: semver("<= 0.6.0")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 22.5.0")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 22.8.1")
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
           - amd64
       - version_constraint: "true"
-        rosetta2: true
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        asset: helix-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
   - type: github_release
     repo_owner: hellux
     repo_name: jotdown


### PR DESCRIPTION
[helix-editor/helix](https://github.com/helix-editor/helix): A post-modern modal text editor.

```console
$ aqua g -i helix-editor/helix
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ aqua exec hx -- --version
helix 25.07.1 (a05c151b)
```

If files such as configuration file are needed, please share them.

Reference

It now has macOS ARM binaries. ref: https://github.com/jdx/mise/discussions/6115
