### PR TITLE
fix: Update registry.yaml for zigtools/zls

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -12,6 +12,7 @@ packages:
   - import: pkgs/golang/go/pkg.yaml
   - import: pkgs/suzuki-shunsuke/ghcp/pkg.yaml
   - import: pkgs/zizmorcore/zizmor/pkg.yaml
+  - import: pkgs/zigtools/zls/pkg.yaml
   - import: pkgs/*/*/pkg.yaml
   - import: pkgs/*/*/*/pkg.yaml
   - import: pkgs/*/*/*/*/pkg.yaml

--- a/pkgs/zigtools/zls/pkg.yaml
+++ b/pkgs/zigtools/zls/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
-  - name: zigtools/zls@0.14.0
+  - name: zigtools/zls@0.15.0
   - name: zigtools/zls
-    version: 0.15.0-dev.129+bb6d6473
+    version: 0.14.0
   - name: zigtools/zls
     version: 0.13.0
   - name: zigtools/zls

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -46,12 +46,27 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.14.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
           url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
+        replacements:
+          darwin: macos
+          arm64: aarch64
+          amd64: x86_64
+        format: tar.xz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
+        windows_arm_emulation: true
+        minisign:
+          type: http
+          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -27,7 +27,7 @@ packages:
           - darwin
           - windows
           - amd64
-       - version_constraint: "true"
+      - version_constraint: "true"
         url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -7,7 +7,7 @@ packages:
     link: https://zigtools.org/
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.9.0")
+      - version_constraint: semver("<= 0.14.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         rosetta2: true
         windows_arm_emulation: true
@@ -27,31 +27,12 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "0.10.0"
-        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+       - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
-          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
-          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
-        replacements:
-          darwin: macos
-          arm64: aarch64
-          amd64: x86_64
-        format: tar.xz
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: "true"
-        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
-        windows_arm_emulation: true
-        minisign:
-          type: http
-          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -7,7 +7,7 @@ packages:
     link: https://zigtools.org/
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.14.0")
+      - version_constraint: semver("<= 0.9.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         rosetta2: true
         windows_arm_emulation: true
@@ -27,12 +27,31 @@ packages:
           - darwin
           - windows
           - amd64
-       - version_constraint: "true"
-        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
+      - version_constraint: Version == "0.10.0"
+        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
-          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
+          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
+        replacements:
+          darwin: macos
+          arm64: aarch64
+          amd64: x86_64
+        format: tar.xz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        windows_arm_emulation: true
+        minisign:
+          type: http
+          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos

--- a/pkgs/zigtools/zls/registry.yaml
+++ b/pkgs/zigtools/zls/registry.yaml
@@ -27,7 +27,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+       - version_constraint: "true"
         url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:

--- a/registry.yaml
+++ b/registry.yaml
@@ -82495,7 +82495,7 @@ packages:
     link: https://zigtools.org/
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.14.0")
+      - version_constraint: semver("<= 0.9.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         rosetta2: true
         windows_arm_emulation: true
@@ -82515,12 +82515,31 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
-        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
+      - version_constraint: Version == "0.10.0"
+        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
-          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
+          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
+        replacements:
+          darwin: macos
+          arm64: aarch64
+          amd64: x86_64
+        format: tar.xz
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        windows_arm_emulation: true
+        minisign:
+          type: http
+          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos

--- a/registry.yaml
+++ b/registry.yaml
@@ -82495,7 +82495,7 @@ packages:
     link: https://zigtools.org/
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.9.0")
+      - version_constraint: semver("<= 0.14.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         rosetta2: true
         windows_arm_emulation: true
@@ -82515,31 +82515,12 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "0.10.0"
-        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
-        windows_arm_emulation: true
-        minisign:
-          type: http
-          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
-          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
-        replacements:
-          darwin: macos
-          arm64: aarch64
-          amd64: x86_64
-        format: tar.xz
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: "true"
-        url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
-          url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos

--- a/registry.yaml
+++ b/registry.yaml
@@ -82534,12 +82534,27 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.14.0")
         url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         windows_arm_emulation: true
         minisign:
           type: http
           url: https://builds.zigtools.org/zls-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}.minisig
+          public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
+        replacements:
+          darwin: macos
+          arm64: aarch64
+          amd64: x86_64
+        format: tar.xz
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}
+        windows_arm_emulation: true
+        minisign:
+          type: http
+          url: https://builds.zigtools.org/zls-{{.Arch}}-{{.OS}}-{{.Version}}.{{.Format}}.minisig
           public_key: "RWR+9B91GBZ0zOjh6Lr17+zKf5BoSuFvrx2xSeDE57uIYvnKBGmMjOex"
         replacements:
           darwin: macos


### PR DESCRIPTION
Close #40533

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

https://zigtools.org/zls/releases/0.15.0/

> Release filenames have changed
> The operating system and cpu archtecture in the filename have been swapped to match the equivalent change that happened in Zig’s tarballs. armv7a also has been renamed to arm for the same reason.