### PR TITLE
feat: add hashicorp/terraform-mcp-server

### DIFF
--- a/pkgs/hashicorp/terraform-mcp-server/pkg.yaml
+++ b/pkgs/hashicorp/terraform-mcp-server/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/hashicorp/terraform-mcp-server/pkg.yaml
+++ b/pkgs/hashicorp/terraform-mcp-server/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: hashicorp/terraform-mcp-server@v0.2.3

--- a/pkgs/hashicorp/terraform-mcp-server/registry.yaml
+++ b/pkgs/hashicorp/terraform-mcp-server/registry.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: go_install
     repo_owner: hashicorp
     repo_name: terraform-mcp-server
     description: The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        no_asset: true
+        path: github.com/hashicorp/terraform-mcp-server/cmd/terraform-mcp-server

--- a/pkgs/hashicorp/terraform-mcp-server/registry.yaml
+++ b/pkgs/hashicorp/terraform-mcp-server/registry.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: hashicorp
+    repo_name: terraform-mcp-server
+    description: The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -38812,14 +38812,14 @@ packages:
           asset: terraform-ls_{{trimV .Version}}_SHA256SUMS
           algorithm: sha256
       - version_constraint: "true"
-  - type: github_release
+  - type: go_install
     repo_owner: hashicorp
     repo_name: terraform-mcp-server
     description: The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        no_asset: true
+        path: github.com/hashicorp/terraform-mcp-server/cmd/terraform-mcp-server
   - type: github_release
     repo_owner: hashicorp
     repo_name: terraform-plugin-docs

--- a/registry.yaml
+++ b/registry.yaml
@@ -38814,6 +38814,14 @@ packages:
       - version_constraint: "true"
   - type: github_release
     repo_owner: hashicorp
+    repo_name: terraform-mcp-server
+    description: The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
+    repo_owner: hashicorp
     repo_name: terraform-plugin-docs
     description: Generate and validate Terraform plugin/provider documentation
     asset: tfplugindocs_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip


### PR DESCRIPTION
[hashicorp/terraform-mcp-server](https://github.com/hashicorp/terraform-mcp-server): The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development

```console
$ aqua g -i hashicorp/terraform-mcp-server
```

Close #40610