### PR TITLE
fix(oven-sh/bun): support bunx

### DIFF
--- a/pkgs/oven-sh/bun/registry.yaml
+++ b/pkgs/oven-sh/bun/registry.yaml
@@ -6,6 +6,9 @@ packages:
     aliases:
       - name: Jarred-Sumner/bun
     description: Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one
+    files:
+      - name: bun
+      - name: bunx
     version_prefix: bun-v
     version_constraint: "false"
     version_overrides:
@@ -21,6 +24,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
       - version_constraint: semver("<= 1.0.36")
         asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
@@ -33,6 +39,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
       - version_constraint: "true"
         asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
@@ -40,6 +49,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
         overrides:
           - goos: linux
             asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -60301,6 +60301,9 @@ packages:
     aliases:
       - name: Jarred-Sumner/bun
     description: Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one
+    files:
+      - name: bun
+      - name: bunx
     version_prefix: bun-v
     version_constraint: "false"
     version_overrides:
@@ -60316,6 +60319,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
       - version_constraint: semver("<= 1.0.36")
         asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
@@ -60328,6 +60334,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
       - version_constraint: "true"
         asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
@@ -60335,6 +60344,9 @@ packages:
         files:
           - name: bun
             src: "{{.AssetWithoutExt}}/bun"
+          - name: bunx
+            src: "{{.AssetWithoutExt}}/bun"
+            link: bunx
         overrides:
           - goos: linux
             asset: bun-{{.OS}}-{{.Arch}}.{{.Format}}


### PR DESCRIPTION
Close #40816

```console
$ bunx --help
Usage: bunx [flags] <package><@version> [flags and arguments for the package]
Execute an npm package executable (CLI), automatically installing into a global shared cache if not installed in node_modules.

Flags:
  --bun                  Force the command to run with Bun instead of Node.js
  -p, --package <package>    Specify package to install when binary name differs from package name
  --no-install           Skip installation if package is not already installed
  --verbose              Enable verbose output during installation
  --silent               Suppress output during installation

Examples:
  bunx prisma migrate
  bunx prettier foo.js
  bunx -p @angular/cli ng new my-app
  bunx --bun vite dev foo.js
```

I tried https://bun.com/install .
It installed bun and bunx into ~/.bun/bin/bun.
And bunx is a symbolic link to bun.

```console
$ curl -fsSL https://bun.com/install | bash
######################################################################## 100.0%
bun was installed successfully to ~/.bun/bin/bun 
Run 'bun --help' to get started

$ ls ~/.bun/bin 
bun  bunx

$ ls -lh ~/.bun/bin/bunx 
lrwxr-xr-x 1 shunsukesuzuki staff 34  9  2 06:12 /Users/shunsukesuzuki/.bun/bin/bunx -> /Users/shunsukesuzuki/.bun/bin/bun
```

In case of aqua, `.files[].link` is available.

https://aquaproj.github.io/docs/reference/registry-config/files#link