### PR TITLE
fix(j178/prek): install on ARM64 Linux

### DIFF
--- a/pkgs/j178/prek/pkg.yaml
+++ b/pkgs/j178/prek/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: j178/prek@v0.1.5
   - name: j178/prek
+    version: v0.0.28
+  - name: j178/prek
     version: v0.0.22
   - name: j178/prek
     version: v0.0.5

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -10,6 +10,9 @@ packages:
         asset: pre-commit-rs-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/pre-commit"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -25,6 +28,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -33,6 +39,9 @@ packages:
         asset: prefligit-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prefligit"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -48,6 +57,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: prefligit
         supported_envs:
           - darwin
           - windows
@@ -56,6 +68,9 @@ packages:
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -71,6 +86,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
         supported_envs:
           - darwin
           - windows
@@ -78,6 +95,9 @@ packages:
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -91,3 +111,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: prek

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -15,9 +15,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/pre-commit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -28,9 +25,6 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -44,9 +38,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/prefligit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -57,9 +48,29 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-                src: prefligit
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.28")
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
           - windows
@@ -67,29 +78,16 @@ packages:
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/prek"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-        supported_envs:
-          - darwin
-          - windows
-          - linux

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -70,6 +70,7 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
@@ -91,4 +92,4 @@ packages:
         supported_envs:
           - darwin
           - windows
-          - amd64
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -42265,9 +42265,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/pre-commit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -42278,9 +42275,6 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -42294,9 +42288,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/prefligit"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -42307,9 +42298,29 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-                src: prefligit
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.28")
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
         supported_envs:
           - darwin
           - windows
@@ -42317,32 +42328,19 @@ packages:
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
-        files:
-          - name: prek
-            src: "{{.AssetWithoutExt}}/prek"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
-            files:
-              - name: prek
-        supported_envs:
-          - darwin
-          - windows
-          - linux
   - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik

--- a/registry.yaml
+++ b/registry.yaml
@@ -42260,6 +42260,9 @@ packages:
         asset: pre-commit-rs-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/pre-commit"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -42275,6 +42278,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: pre-commit
         supported_envs:
           - darwin
           - windows
@@ -42283,6 +42289,9 @@ packages:
         asset: prefligit-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prefligit"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -42298,6 +42307,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
+                src: prefligit
         supported_envs:
           - darwin
           - windows
@@ -42306,6 +42318,9 @@ packages:
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -42321,6 +42336,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: prek
         supported_envs:
           - darwin
           - windows
@@ -42328,6 +42345,9 @@ packages:
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -42341,6 +42361,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: prek
   - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik

--- a/registry.yaml
+++ b/registry.yaml
@@ -42320,6 +42320,7 @@ packages:
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
@@ -42341,7 +42342,7 @@ packages:
         supported_envs:
           - darwin
           - windows
-          - amd64
+          - linux
   - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Allows `prek` to install on `linux/arm64`
