### PR TITLE
fix(hadolint/hadolint): regenerate the setting

### DIFF
--- a/pkgs/hadolint/hadolint/pkg.yaml
+++ b/pkgs/hadolint/hadolint/pkg.yaml
@@ -1,12 +1,12 @@
 packages:
-  - name: hadolint/hadolint@v2.12.0
+  - name: hadolint/hadolint@v2.13.1
+  - name: hadolint/hadolint
+    version: v2.12.1-beta
   - name: hadolint/hadolint
     version: v2.10.0
   - name: hadolint/hadolint
     version: v2.9.3
   - name: hadolint/hadolint
     version: v2.7.0
-  - name: hadolint/hadolint
-    version: v2.6.1
   - name: hadolint/hadolint
     version: v1.2.2

--- a/pkgs/hadolint/hadolint/registry.yaml
+++ b/pkgs/hadolint/hadolint/registry.yaml
@@ -6,6 +6,8 @@ packages:
     description: Dockerfile linter, validate inline bash, written in Haskell
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v1.0"
+        no_asset: true
       - version_constraint: Version == "v2.7.0"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
@@ -17,8 +19,16 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.0")
-        no_asset: true
+      - version_constraint: Version == "v2.10.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
       - version_constraint: semver("<= 1.2.2")
         asset: hadolint_{{.OS}}_{{.Arch}}
         format: raw
@@ -42,7 +52,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "v2.10.0"
+      - version_constraint: semver("<= 2.12.1-beta")
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
@@ -52,16 +62,17 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
       - version_constraint: "true"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
+          darwin: macos
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -38434,6 +38434,8 @@ packages:
     description: Dockerfile linter, validate inline bash, written in Haskell
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v1.0"
+        no_asset: true
       - version_constraint: Version == "v2.7.0"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
@@ -38445,8 +38447,16 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 1.0")
-        no_asset: true
+      - version_constraint: Version == "v2.10.0"
+        asset: hadolint-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
       - version_constraint: semver("<= 1.2.2")
         asset: hadolint_{{.OS}}_{{.Arch}}
         format: raw
@@ -38470,7 +38480,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "v2.10.0"
+      - version_constraint: semver("<= 2.12.1-beta")
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
@@ -38480,16 +38490,17 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
       - version_constraint: "true"
         asset: hadolint-{{.OS}}-{{.Arch}}
         format: raw
-        rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
+          darwin: macos
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

The release assets have been changed in the latest version v2.13.1, so I regenerated the settings with `cmdx s`.
https://github.com/hadolint/hadolint/issues/1120