### PR TITLE
fix(sqldef/sqldef): psqdef support windows/amd64

### DIFF
--- a/pkgs/sqldef/sqldef/psqldef/pkg.yaml
+++ b/pkgs/sqldef/sqldef/psqldef/pkg.yaml
@@ -1,6 +1,10 @@
 packages:
   - name: sqldef/sqldef/psqldef@v2.4.0
   - name: sqldef/sqldef/psqldef
-    version: v0.1.1
+    version: v0.17.19
+  - name: sqldef/sqldef/psqldef
+    version: v0.12.8
+  - name: sqldef/sqldef/psqldef
+    version: v0.9.0
   - name: sqldef/sqldef/psqldef
     version: v0.1.0

--- a/pkgs/sqldef/sqldef/psqldef/registry.yaml
+++ b/pkgs/sqldef/sqldef/psqldef/registry.yaml
@@ -1,32 +1,58 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - name: sqldef/sqldef/psqldef
-    aliases:
-      - name: k0kubun/sqldef/psqldef
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for PostgreSQL
-    asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
-    files:
-      - name: psqldef
-    format: zip
-    overrides:
-      - goos: linux
-        format: tar.gz
-    version_constraint: semver(">= 0.9.1")
-    # darwin/arm64 is supported
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.1.1")
+      - version_constraint: Version == "v0.1.0"
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        # windows/amd64 is supported
-        # linux/arm64 is supported
-      - version_constraint: "true"
-        rosetta2: true
+        overrides:
+          - goos: darwin
+            format: zip
         supported_envs:
-          - darwin
           - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.9.0")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: semver("<= 0.12.8")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: semver("<= 0.17.19")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+            replacements:
+              arm64: arm
+          - goos: windows
+            asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz

--- a/pkgs/sqldef/sqldef/psqldef/registry.yaml
+++ b/pkgs/sqldef/sqldef/psqldef/registry.yaml
@@ -39,8 +39,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
-            replacements:
-              arm64: arm
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/pkgs/sqldef/sqldef/psqldef/registry.yaml
+++ b/pkgs/sqldef/sqldef/psqldef/registry.yaml
@@ -6,7 +6,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for PostgreSQL
     asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
     files:
       - name: psqldef
@@ -19,9 +19,11 @@ packages:
     supported_envs:
       - darwin
       - linux
+      - windows/amd64
     version_overrides:
       - version_constraint: semver(">= 0.1.1")
         rosetta2: true
+        # windows/amd64 is supported
         # linux/arm64 is supported
       - version_constraint: "true"
         rosetta2: true

--- a/pkgs/sqldef/sqldef/psqldef/registry.yaml
+++ b/pkgs/sqldef/sqldef/psqldef/registry.yaml
@@ -4,7 +4,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for PostgreSQL
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -22,8 +22,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz
@@ -31,8 +29,6 @@ packages:
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz
@@ -45,14 +41,10 @@ packages:
             format: tar.gz
             replacements:
               arm64: arm
-          - goos: windows
-            asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
       - version_constraint: "true"
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz

--- a/pkgs/sqldef/sqldef/sqlite3def/registry.yaml
+++ b/pkgs/sqldef/sqldef/sqlite3def/registry.yaml
@@ -6,7 +6,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for SQLite3
     asset: sqlite3def_{{.OS}}_{{.Arch}}.{{.Format}}
     files:
       - name: sqlite3def

--- a/registry.yaml
+++ b/registry.yaml
@@ -70984,7 +70984,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for PostgreSQL
     asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
     files:
       - name: psqldef
@@ -70997,9 +70997,11 @@ packages:
     supported_envs:
       - darwin
       - linux
+      - windows/amd64
     version_overrides:
       - version_constraint: semver(">= 0.1.1")
         rosetta2: true
+        # windows/amd64 is supported
         # linux/arm64 is supported
       - version_constraint: "true"
         rosetta2: true
@@ -71012,7 +71014,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for SQLite3
     asset: sqlite3def_{{.OS}}_{{.Arch}}.{{.Format}}
     files:
       - name: sqlite3def

--- a/registry.yaml
+++ b/registry.yaml
@@ -71017,8 +71017,9 @@ packages:
         overrides:
           - goos: linux
             format: tar.gz
-            replacements:
-              arm64: arm
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -70979,35 +70979,61 @@ packages:
           - darwin
           - linux/amd64
   - name: sqldef/sqldef/psqldef
-    aliases:
-      - name: k0kubun/sqldef/psqldef
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for PostgreSQL
-    asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
-    files:
-      - name: psqldef
-    format: zip
-    overrides:
-      - goos: linux
-        format: tar.gz
-    version_constraint: semver(">= 0.9.1")
-    # darwin/arm64 is supported
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.1.1")
+      - version_constraint: Version == "v0.1.0"
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        # windows/amd64 is supported
-        # linux/arm64 is supported
-      - version_constraint: "true"
-        rosetta2: true
+        overrides:
+          - goos: darwin
+            format: zip
         supported_envs:
-          - darwin
           - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.9.0")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: semver("<= 0.12.8")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: semver("<= 0.17.19")
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+            replacements:
+              arm64: arm
+          - goos: windows
+            asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: "true"
+        asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+        overrides:
+          - goos: linux
+            format: tar.gz
   - name: sqldef/sqldef/sqlite3def
     aliases:
       - name: k0kubun/sqldef/sqlite3def

--- a/registry.yaml
+++ b/registry.yaml
@@ -70982,7 +70982,7 @@ packages:
     type: github_release
     repo_owner: sqldef
     repo_name: sqldef
-    description: Idempotent schema management for MySQL, PostgreSQL, and more
+    description: Idempotent schema management for PostgreSQL
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -71000,8 +71000,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz
@@ -71009,8 +71007,6 @@ packages:
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz
@@ -71023,14 +71019,10 @@ packages:
             format: tar.gz
             replacements:
               arm64: arm
-          - goos: windows
-            asset: mssqldef_{{.OS}}_{{.Arch}}.{{.Format}}
       - version_constraint: "true"
         asset: psqldef_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        replacements:
-          arm64: arm
         overrides:
           - goos: linux
             format: tar.gz


### PR DESCRIPTION
and update description for psqldef & sqlite3def

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

1. `psqldef` support windows/amd64 since [v0.1.1](https://github.com/sqldef/sqldef/releases/tag/v0.1.1)
2. Update `psqldef`'s `sqlite3def`'sdescription to a specific one, not the repository description
