### PR TITLE
fix(kubernetes-sigs/kubebuilder): rescaffold

### DIFF
--- a/pkgs/kubernetes-sigs/kubebuilder/pkg.yaml
+++ b/pkgs/kubernetes-sigs/kubebuilder/pkg.yaml
@@ -1,2 +1,14 @@
 packages:
   - name: kubernetes-sigs/kubebuilder@v4.8.0
+  - name: kubernetes-sigs/kubebuilder
+    version: v3.3.0
+  - name: kubernetes-sigs/kubebuilder
+    version: v2.3.2
+  - name: kubernetes-sigs/kubebuilder
+    version: v2.0.0
+  - name: kubernetes-sigs/kubebuilder
+    version: v1beta1.2
+  - name: kubernetes-sigs/kubebuilder
+    version: v0.1.12
+  - name: kubernetes-sigs/kubebuilder
+    version: release-0.1.6

--- a/pkgs/kubernetes-sigs/kubebuilder/registry.yaml
+++ b/pkgs/kubernetes-sigs/kubebuilder/registry.yaml
@@ -11,6 +11,9 @@ packages:
       - version_constraint: Version == "release-0.1.6"
         asset: kubebuilder_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -22,6 +25,9 @@ packages:
       - version_constraint: Version == "v1beta1.2"
         asset: kubebuilder-release-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "kubebuilder/bin/kubebuilder"
         rosetta2: true
         supported_envs:
           - linux/amd64
@@ -29,6 +35,9 @@ packages:
       - version_constraint: semver("<= 0.1.12")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -42,6 +51,9 @@ packages:
       - version_constraint: semver("<= 2.0.0")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -53,6 +65,9 @@ packages:
       - version_constraint: semver("<= 2.3.2")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release

--- a/pkgs/kubernetes-sigs/kubebuilder/registry.yaml
+++ b/pkgs/kubernetes-sigs/kubebuilder/registry.yaml
@@ -3,13 +3,82 @@ packages:
   - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: kubebuilder
-    description: Kubebuilder - SDK for building Kubernetes APIs using CRDs
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-    asset: kubebuilder_{{.OS}}_{{.Arch}}
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: "Kubebuilder - SDK for building Kubernetes APIs using CRDs"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.9-alpha.30"
+        no_asset: true
+      - version_constraint: Version == "release-0.1.6"
+        asset: kubebuilder_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v1beta1.2"
+        asset: kubebuilder-release-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.12")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.0-beta1.1")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.0")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.3.2")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.3.0")
+        asset: kubebuilder_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: kubebuilder_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -48057,16 +48057,85 @@ packages:
   - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: kubebuilder
-    description: Kubebuilder - SDK for building Kubernetes APIs using CRDs
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux
-    asset: kubebuilder_{{.OS}}_{{.Arch}}
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: "Kubebuilder - SDK for building Kubernetes APIs using CRDs"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.9-alpha.30"
+        no_asset: true
+      - version_constraint: Version == "release-0.1.6"
+        asset: kubebuilder_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v1beta1.2"
+        asset: kubebuilder-release-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.12")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.0.0-beta1.1")
+        no_asset: true
+      - version_constraint: semver("<= 2.0.0")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.3.2")
+        asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.3.0")
+        asset: kubebuilder_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: kubebuilder_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: kubernetes-sigs
     repo_name: kustomize

--- a/registry.yaml
+++ b/registry.yaml
@@ -48065,6 +48065,9 @@ packages:
       - version_constraint: Version == "release-0.1.6"
         asset: kubebuilder_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -48076,6 +48079,9 @@ packages:
       - version_constraint: Version == "v1beta1.2"
         asset: kubebuilder-release-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "kubebuilder/bin/kubebuilder"
         rosetta2: true
         supported_envs:
           - linux/amd64
@@ -48083,6 +48089,9 @@ packages:
       - version_constraint: semver("<= 0.1.12")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -48096,6 +48105,9 @@ packages:
       - version_constraint: semver("<= 2.0.0")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release
@@ -48107,6 +48119,9 @@ packages:
       - version_constraint: semver("<= 2.3.2")
         asset: kubebuilder_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubebuilder
+            src: "{{.AssetWithoutExt}}/bin/kubebuilder"
         rosetta2: true
         checksum:
           type: github_release


### PR DESCRIPTION
[kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder): Kubebuilder - SDK for building Kubernetes APIs using CRDs

```console
$ aqua g -i kubernetes-sigs/kubebuilder
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

The main change is removing `rosetta2` since [v3.4.0](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v3.4.0), which started releasing MacOS arm build.

ref: https://github.com/jdx/mise/discussions/6258