### PR TITLE
fix(zizmorcore/zizmor): use cargo for v1.13.0

### DIFF
--- a/pkgs/zizmorcore/zizmor/registry.yaml
+++ b/pkgs/zizmorcore/zizmor/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Static analysis for GitHub Actions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.0-rc2") || Version == "v1.12.0"
+      - version_constraint: semver("<= 1.8.0-rc2") || Version in ["v1.12.0", "v1.13.0"]
         type: cargo
         crate: zizmor
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -83263,7 +83263,7 @@ packages:
     description: Static analysis for GitHub Actions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.0-rc2") || Version == "v1.12.0"
+      - version_constraint: semver("<= 1.8.0-rc2") || Version in ["v1.12.0", "v1.13.0"]
         type: cargo
         crate: zizmor
       - version_constraint: "true"


### PR DESCRIPTION
[v1.13.0](https://github.com/zizmorcore/zizmor/releases/tag/v1.13.0) doesn't have assets. Since it's immutable, the assets won't be added.
Fixes https://github.com/aquaproj/aqua-registry/pull/41364