### PR TITLE
fix(tree-sitter/tree-sitter): regenerate to support Windows

### DIFF
--- a/pkgs/tree-sitter/tree-sitter/pkg.yaml
+++ b/pkgs/tree-sitter/tree-sitter/pkg.yaml
@@ -1,6 +1,12 @@
 packages:
   - name: tree-sitter/tree-sitter@v0.25.9
   - name: tree-sitter/tree-sitter
-    version: v0.18.1
+    version: v0.24.7
   - name: tree-sitter/tree-sitter
-    version: 0.14.0-beta2
+    version: v0.24.4
+  - name: tree-sitter/tree-sitter
+    version: v0.20.8
+  - name: tree-sitter/tree-sitter
+    version: v0.20.7
+  - name: tree-sitter/tree-sitter
+    version: 0.18.0

--- a/pkgs/tree-sitter/tree-sitter/registry.yaml
+++ b/pkgs/tree-sitter/tree-sitter/registry.yaml
@@ -4,30 +4,66 @@ packages:
     repo_owner: tree-sitter
     repo_name: tree-sitter
     description: An incremental parsing system for programming tools
-    asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: gz
-    replacements:
-      amd64: x64
-      darwin: macos
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    files:
-      - name: tree-sitter
-        src: tree-sitter-{{.OS}}-{{.Arch}}
-    version_constraint: semver(">= 0.20.8")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.18.1")
-        supported_envs:
-          - darwin
-          - amd64
+      - version_constraint: Version == "v0.20.8"
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm
+      - version_constraint: semver("<= 0.18.0")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
         rosetta2: true
-      - version_constraint: semver("< 0.18.1")
+        windows_arm_emulation: true
         replacements:
           amd64: x64
           darwin: osx
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 0.20.7")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.4")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm
+      - version_constraint: semver("<= 0.24.7")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: "true"
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm

--- a/pkgs/tree-sitter/tree-sitter/registry.yaml
+++ b/pkgs/tree-sitter/tree-sitter/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: tree-sitter
     repo_name: tree-sitter
     description: An incremental parsing system for programming tools
+    files:
+      - name: tree-sitter
+        src: tree-sitter-{{.OS}}-{{.Arch}}
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.20.8"

--- a/pkgs/tree-sitter/tree-sitter/registry.yaml
+++ b/pkgs/tree-sitter/tree-sitter/registry.yaml
@@ -16,10 +16,6 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm
       - version_constraint: semver("<= 0.18.0")
         asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
         format: gz
@@ -50,10 +46,6 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm
       - version_constraint: semver("<= 0.24.7")
         asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
         format: gz
@@ -66,7 +58,3 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm

--- a/registry.yaml
+++ b/registry.yaml
@@ -77728,6 +77728,9 @@ packages:
     repo_owner: tree-sitter
     repo_name: tree-sitter
     description: An incremental parsing system for programming tools
+    files:
+      - name: tree-sitter
+        src: tree-sitter-{{.OS}}-{{.Arch}}
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.20.8"

--- a/registry.yaml
+++ b/registry.yaml
@@ -77740,10 +77740,6 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm
       - version_constraint: semver("<= 0.18.0")
         asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
         format: gz
@@ -77774,10 +77770,6 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm
       - version_constraint: semver("<= 0.24.7")
         asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
         format: gz
@@ -77790,10 +77782,6 @@ packages:
         replacements:
           amd64: x64
           darwin: macos
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: arm
   - type: github_release
     repo_owner: trufflesecurity
     repo_name: driftwood

--- a/registry.yaml
+++ b/registry.yaml
@@ -77728,33 +77728,69 @@ packages:
     repo_owner: tree-sitter
     repo_name: tree-sitter
     description: An incremental parsing system for programming tools
-    asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: gz
-    replacements:
-      amd64: x64
-      darwin: macos
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    files:
-      - name: tree-sitter
-        src: tree-sitter-{{.OS}}-{{.Arch}}
-    version_constraint: semver(">= 0.20.8")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.18.1")
-        supported_envs:
-          - darwin
-          - amd64
+      - version_constraint: Version == "v0.20.8"
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm
+      - version_constraint: semver("<= 0.18.0")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
         rosetta2: true
-      - version_constraint: semver("< 0.18.1")
+        windows_arm_emulation: true
         replacements:
           amd64: x64
           darwin: osx
         supported_envs:
           - darwin
+          - windows
           - amd64
+      - version_constraint: semver("<= 0.20.7")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.24.4")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm
+      - version_constraint: semver("<= 0.24.7")
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+      - version_constraint: "true"
+        asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: arm
   - type: github_release
     repo_owner: trufflesecurity
     repo_name: driftwood


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
