### PR TITLE
feat: add rmitchellscott/rm-version-switcher

### DIFF
--- a/pkgs/rmitchellscott/rm-version-switcher/pkg.yaml
+++ b/pkgs/rmitchellscott/rm-version-switcher/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/rmitchellscott/rm-version-switcher/pkg.yaml
+++ b/pkgs/rmitchellscott/rm-version-switcher/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: rmitchellscott/rm-version-switcher@v0.3.0

--- a/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
+++ b/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
@@ -13,4 +13,3 @@ packages:
             src: rm-version-switcher-aarch64
         supported_envs:
           - linux/arm64
-

--- a/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
+++ b/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: rmitchellscott
+    repo_name: rm-version-switcher
+    description: A beginner-friendly application for switching between installed reMarkable OS versions with an interactive interface

--- a/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
+++ b/pkgs/rmitchellscott/rm-version-switcher/registry.yaml
@@ -4,3 +4,13 @@ packages:
     repo_owner: rmitchellscott
     repo_name: rm-version-switcher
     description: A beginner-friendly application for switching between installed reMarkable OS versions with an interactive interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: rm-version-switcher-aarch64.tar.gz
+        files:
+          - name: rm-version-switcher
+            src: rm-version-switcher-aarch64
+        supported_envs:
+          - linux/arm64
+

--- a/registry.yaml
+++ b/registry.yaml
@@ -65191,6 +65191,16 @@ packages:
     repo_owner: rmitchellscott
     repo_name: rm-version-switcher
     description: A beginner-friendly application for switching between installed reMarkable OS versions with an interactive interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: rm-version-switcher-aarch64.tar.gz
+        files:
+          - name: rm-version-switcher
+            src: rm-version-switcher-aarch64
+        supported_envs:
+          - linux/arm64
+
   - type: github_release
     repo_owner: robinovitch61
     repo_name: kl

--- a/registry.yaml
+++ b/registry.yaml
@@ -65188,6 +65188,10 @@ packages:
       - goos: darwin
         format: zip
   - type: github_release
+    repo_owner: rmitchellscott
+    repo_name: rm-version-switcher
+    description: A beginner-friendly application for switching between installed reMarkable OS versions with an interactive interface
+  - type: github_release
     repo_owner: robinovitch61
     repo_name: kl
     description: An interactive Kubernetes log viewer for your terminal

--- a/registry.yaml
+++ b/registry.yaml
@@ -65200,7 +65200,6 @@ packages:
             src: rm-version-switcher-aarch64
         supported_envs:
           - linux/arm64
-
   - type: github_release
     repo_owner: robinovitch61
     repo_name: kl


### PR DESCRIPTION
[rmitchellscott/rm-version-switcher](https://github.com/rmitchellscott/rm-version-switcher) - A beginner-friendly application for switching between installed reMarkable OS versions with an interactive interface

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
