### PR TITLE
feat(amir20/dtop): scaffold amir20/dtop

### DIFF
--- a/pkgs/amir20/dtop/pkg.yaml
+++ b/pkgs/amir20/dtop/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: amir20/dtop@v0.0.43
+  - name: amir20/dtop
+    version: v0.0.4

--- a/pkgs/amir20/dtop/registry.yaml
+++ b/pkgs/amir20/dtop/registry.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: amir20
+    repo_name: dtop
+    description: Terminal dashboard for Docker monitoring across multiple hosts with Dozzle integration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: dtop_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: dtop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: dtop_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: dtop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -10375,6 +10375,39 @@ packages:
             checksum:
               enabled: false
   - type: github_release
+    repo_owner: amir20
+    repo_name: dtop
+    description: Terminal dashboard for Docker monitoring across multiple hosts with Dozzle integration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: dtop_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: dtop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: dtop_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: dtop_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: anchore
     repo_name: grype
     description: A vulnerability scanner for container images and filesystems


### PR DESCRIPTION
[amir20/dtop](https://github.com/amir20/dtop) - Terminal dashboard for Docker monitoring across multiple hosts with Dozzle integration.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
<details>
<summary>`cmd t output`</summary>

```txt
+ PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

bash scripts/start.sh
bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry exists
[INFO] Creating a container aqua-registry
[INFO] Get a GitHub Access token by gh auth token
no oauth token found for github.com
6c0554c21b4fe920a8b767dc55b874b61e35eeb189d3fcfee6095e305f6e68d5
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 3.07kB to aqua-registry:/workspace/registry.yaml
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0001] create a symbolic link                        env=linux/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0001] create a symbolic link                        command=dtop env=linux/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0
INFO[0001] download and unarchive the package            env=linux/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0001] download and unarchive the package            env=linux/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0005] downloading a checksum file                   env=linux/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0005] downloading a checksum file                   env=linux/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=linux/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0002] downloading a checksum file                   env=linux/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=darwin/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0002] downloading a checksum file                   env=darwin/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=darwin/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=darwin/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Creating a container aqua-registry-windows
[INFO] Get a GitHub Access token by gh auth token
no oauth token found for github.com
7bd14262c6db5a4c76c088f84a92b9379f8aa7debb14d21c80652658baef97c3
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 3.07kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] create a symbolic link                        env=windows/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] create a symbolic link                        command=dtop env=windows/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=windows/amd64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=windows/amd64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=windows/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.55.0 registry=
INFO[0000] download and unarchive the package            env=windows/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0000] download and unarchive the package            env=windows/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=windows/arm64 package_name=amir20/dtop package_version=v0.0.4 program=aqua program_version=2.55.0 registry=standard
INFO[0001] downloading a checksum file                   env=windows/arm64 package_name=amir20/dtop package_version=v0.0.43 program=aqua program_version=2.55.0 registry=standard
```

</details>