### PR TITLE
feat: add bmf-san/ggc

### DIFF
--- a/pkgs/bmf-san/ggc/pkg.yaml
+++ b/pkgs/bmf-san/ggc/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bmf-san/ggc@v6.1.0

--- a/pkgs/bmf-san/ggc/registry.yaml
+++ b/pkgs/bmf-san/ggc/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: bmf-san
+    repo_name: ggc
+    description: A modern Git CLI tool with both traditional command-line and interactive incremental-search UI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: ggc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ggc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -16925,6 +16925,21 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: bmf-san
+    repo_name: ggc
+    description: A modern Git CLI tool with both traditional command-line and interactive incremental-search UI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 3.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: ggc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ggc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: bodaay
     repo_name: HuggingFaceModelDownloader
     description: Simple go utility to download HuggingFace Models and Datasets


### PR DESCRIPTION
[bmf-san/ggc](https://github.com/bmf-san/ggc): A modern Git CLI tool with both traditional command-line and interactive incremental-search UI

```console
$ aqua g -i bmf-san/ggc
```

Close #41828