### PR TITLE
feat: add Adembc/lazyssh

### DIFF
--- a/pkgs/Adembc/lazyssh/pkg.yaml
+++ b/pkgs/Adembc/lazyssh/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Adembc/lazyssh@v0.2.1

--- a/pkgs/Adembc/lazyssh/registry.yaml
+++ b/pkgs/Adembc/lazyssh/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Adembc
+    repo_name: lazyssh
+    description: "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lazyssh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -295,6 +295,27 @@ packages:
           - linux/amd64
           - windows
   - type: github_release
+    repo_owner: Adembc
+    repo_name: lazyssh
+    description: "A terminal-based SSH manager inspired by lazydocker and k9s - Written in go"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lazyssh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: AlexNabokikh
     repo_name: tfsort
     description: A CLI utility to sort Terraform variables and outputs


### PR DESCRIPTION
[Adembc/lazyssh](https://github.com/Adembc/lazyssh): A terminal-based SSH manager inspired by lazydocker and k9s - Written in go

```console
$ aqua g -i Adembc/lazyssh
```

Close #41829