### PR TITLE
feat: add CyberAgent/reminder-lint

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,3 +13,4 @@ packages:
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: jqlang/jq@jq-1.8.1
   - name: cli/cli@v2.79.0
+  - name: CyberAgent/reminder-lint@0.2.0

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,4 +13,3 @@ packages:
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: jqlang/jq@jq-1.8.1
   - name: cli/cli@v2.79.0
-  - name: CyberAgent/reminder-lint@0.2.0

--- a/pkgs/CyberAgent/reminder-lint/pkg.yaml
+++ b/pkgs/CyberAgent/reminder-lint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: CyberAgent/reminder-lint@0.2.0

--- a/pkgs/CyberAgent/reminder-lint/registry.yaml
+++ b/pkgs/CyberAgent/reminder-lint/registry.yaml
@@ -13,7 +13,7 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         files:
           - name: reminder-lint

--- a/pkgs/CyberAgent/reminder-lint/registry.yaml
+++ b/pkgs/CyberAgent/reminder-lint/registry.yaml
@@ -13,8 +13,11 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: reminder-lint
+            src: "{{.AssetWithoutExt}}/reminder-lint"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -25,6 +28,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: reminder-lint
         supported_envs:
           - darwin
           - windows

--- a/pkgs/CyberAgent/reminder-lint/registry.yaml
+++ b/pkgs/CyberAgent/reminder-lint/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: CyberAgent
+    repo_name: reminder-lint
+    description: Code remind tool for any languages and any config files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: reminder-lint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -2011,6 +2011,35 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: CyberAgent
+    repo_name: reminder-lint
+    description: Code remind tool for any languages and any config files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: reminder-lint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     description: CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions

--- a/registry.yaml
+++ b/registry.yaml
@@ -2023,8 +2023,11 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        files:
+          - name: reminder-lint
+            src: "{{.AssetWithoutExt}}/reminder-lint"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -2035,6 +2038,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: reminder-lint
         supported_envs:
           - darwin
           - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -2023,7 +2023,7 @@ packages:
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         files:
           - name: reminder-lint


### PR DESCRIPTION
[CyberAgent/reminder-lint](https://github.com/CyberAgent/reminder-lint): Code remind tool for any languages and any config files

```console
$ aqua g -i CyberAgent/reminder-lint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ reminder-lint
Usage: reminder-lint <command> [<args>]

Args

Options:
  --help            display usage information

Commands:
  run               run reminder-lint with a path
  init              initialize a config of reminder-lint
  list              list reminder-lint comments
  validate          validate reminder-lint comments
```

If files such as configuration file are needed, please share them.

Reference

- Blog (JP)
	- https://developers.cyberagent.co.jp/blog/archives/47402/
- README (JP)
	- https://github.com/CyberAgent/reminder-lint
