### PR TITLE
feat: add just-every/code

### DIFF
--- a/pkgs/just-every/code/pkg.yaml
+++ b/pkgs/just-every/code/pkg.yaml
@@ -1,9 +1,5 @@
 packages:
-  - name: just-every/code@preview-pr-121
-  - name: just-every/code
-    version: preview-windows-dup-input-6
-  - name: just-every/code
-    version: preview-windows-dup-input-4
+  - name: just-every/code@v0.2.169
   - name: just-every/code
     version: v0.2.34
   - name: just-every/code
@@ -14,5 +10,3 @@ packages:
     version: v0.1.5
   - name: just-every/code
     version: v0.1.3
-  - name: just-every/code
-    version: preview-agent-progress-ui

--- a/pkgs/just-every/code/pkg.yaml
+++ b/pkgs/just-every/code/pkg.yaml
@@ -1,0 +1,18 @@
+packages:
+  - name: just-every/code@preview-pr-121
+  - name: just-every/code
+    version: preview-windows-dup-input-6
+  - name: just-every/code
+    version: preview-windows-dup-input-4
+  - name: just-every/code
+    version: v0.2.34
+  - name: just-every/code
+    version: v0.1.13
+  - name: just-every/code
+    version: v0.1.8
+  - name: just-every/code
+    version: v0.1.5
+  - name: just-every/code
+    version: v0.1.3
+  - name: just-every/code
+    version: preview-agent-progress-ui

--- a/pkgs/just-every/code/registry.yaml
+++ b/pkgs/just-every/code/registry.yaml
@@ -67,7 +67,13 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        files:
+          - name: code
+            src: code-{{.Arch}}-{{.OS}}
         overrides:
           - goos: windows
             format: zip
             asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            files:
+              - name: code
+                src: code-{{.Arch}}-{{.OS}}.exe

--- a/pkgs/just-every/code/registry.yaml
+++ b/pkgs/just-every/code/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_owner: just-every
     repo_name: code
     description: Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider
+    version_filter: not (Version startsWith "preview")
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.3"
@@ -16,50 +17,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-      - version_constraint: Version == "preview-windows-dup-input-4"
-        asset: code-x86_6{{.SemVer}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-x86_6{{.SemVer}}-{{.OS}}.exe.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "preview-windows-dup-input-6"
-        asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.exe.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version in ["preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input"]
-        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
       - version_constraint: semver("<= 0.1.5")
         asset: coder-{{.Arch}}-{{.OS}}
         format: raw

--- a/pkgs/just-every/code/registry.yaml
+++ b/pkgs/just-every/code/registry.yaml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: just-every
+    repo_name: code
+    description: Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.3"
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: Version == "preview-windows-dup-input-4"
+        asset: code-x86_6{{.SemVer}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-x86_6{{.SemVer}}-{{.OS}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "preview-windows-dup-input-6"
+        asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input"]
+        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+      - version_constraint: semver("<= 0.1.5")
+        asset: coder-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.1.8")
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.1.13")
+        asset: coder-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.2.34")
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}

--- a/pkgs/just-every/code/scaffold.yaml
+++ b/pkgs/just-every/code/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: just-every/code
+version_filter: not (Version startsWith "preview")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -45197,6 +45197,7 @@ packages:
     repo_owner: just-every
     repo_name: code
     description: Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider
+    version_filter: not (Version startsWith "preview")
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.3"
@@ -45209,50 +45210,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-      - version_constraint: Version == "preview-windows-dup-input-4"
-        asset: code-x86_6{{.SemVer}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-x86_6{{.SemVer}}-{{.OS}}.exe.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "preview-windows-dup-input-6"
-        asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.exe.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version in ["preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input"]
-        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
       - version_constraint: semver("<= 0.1.5")
         asset: coder-{{.Arch}}-{{.OS}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -45194,6 +45194,120 @@ packages:
     checksum:
       enabled: false
   - type: github_release
+    repo_owner: just-every
+    repo_name: code
+    description: Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.3"
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: Version == "preview-windows-dup-input-4"
+        asset: code-x86_6{{.SemVer}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-x86_6{{.SemVer}}-{{.OS}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "preview-windows-dup-input-6"
+        asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-x8{{.SemVer}}_{{.SemVer}}4-{{.OS}}.exe.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input", "preview-windows-dup-input"]
+        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+      - version_constraint: semver("<= 0.1.5")
+        asset: coder-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.1.8")
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.1.13")
+        asset: coder-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.2.34")
+        asset: code-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+      - version_constraint: "true"
+        asset: code-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+  - type: github_release
     repo_owner: justjanne
     repo_name: powerline-go
     description: A beautiful and useful low-latency prompt for your shell, written in go

--- a/registry.yaml
+++ b/registry.yaml
@@ -45260,10 +45260,16 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
+        files:
+          - name: code
+            src: code-{{.Arch}}-{{.OS}}
         overrides:
           - goos: windows
             format: zip
             asset: code-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+            files:
+              - name: code
+                src: code-{{.Arch}}-{{.OS}}.exe
   - type: github_release
     repo_owner: justjanne
     repo_name: powerline-go


### PR DESCRIPTION
[just-every/code](https://github.com/just-every/code) - Fast, effective, mind-blowing, coding CLI. Browser integration, multi-agents, theming, and reasoning control. Orchestrate agents from OpenAI, Claude, Gemini or any provider

- **feat(just-every/code): scaffold just-every/code**
- **feat(just-every/code): scaffold just-every/code**
- **add just-every/code**

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
