### PR TITLE
feat: add edoardottt/depsdev

### DIFF
--- a/pkgs/edoardottt/depsdev/pkg.yaml
+++ b/pkgs/edoardottt/depsdev/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: edoardottt/depsdev@v0.1.0

--- a/pkgs/edoardottt/depsdev/pkg.yaml
+++ b/pkgs/edoardottt/depsdev/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: edoardottt/depsdev@v0.1.0
+  - name: edoardottt/depsdev
+    version: v0.0.10

--- a/pkgs/edoardottt/depsdev/registry.yaml
+++ b/pkgs/edoardottt/depsdev/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: edoardottt
+    repo_name: depsdev
+    description: CLI client (and Golang module) for deps.dev API. Free access to dependencies, licenses, advisories, and other critical health and security signals for open source package versions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.10")
+        no_asset: true
+      - version_constraint: "true"
+        asset: depsdev_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: depsdev_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/pkgs/edoardottt/depsdev/registry.yaml
+++ b/pkgs/edoardottt/depsdev/registry.yaml
@@ -7,7 +7,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.10")
-        no_asset: true
+        type: go_install
       - version_constraint: "true"
         asset: depsdev_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -30063,7 +30063,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.10")
-        no_asset: true
+        type: go_install
       - version_constraint: "true"
         asset: depsdev_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -30057,6 +30057,24 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: edoardottt
+    repo_name: depsdev
+    description: CLI client (and Golang module) for deps.dev API. Free access to dependencies, licenses, advisories, and other critical health and security signals for open source package versions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.10")
+        no_asset: true
+      - version_constraint: "true"
+        asset: depsdev_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: depsdev_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: eficode
     repo_name: wait-for
     description: ./wait-for is a script to wait for another service to become available


### PR DESCRIPTION
[edoardottt/depsdev](https://github.com/edoardottt/depsdev): CLI client (and Golang module) for deps.dev API. Free access to dependencies, licenses, advisories, and other critical health and security signals for open source package versions

```console
$ aqua g -i edoardottt/depsdev
```

Close #41993