### PR TITLE
feat: add takaishi/tftargets

### DIFF
--- a/pkgs/takaishi/tftargets/pkg.yaml
+++ b/pkgs/takaishi/tftargets/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: takaishi/tftargets@v0.0.6

--- a/pkgs/takaishi/tftargets/registry.yaml
+++ b/pkgs/takaishi/tftargets/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: takaishi
+    repo_name: tftargets
+    description: A tool that analyzes Terraform configurations and identifies directories that need to be executed based on Git changes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tftargets_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -75829,6 +75829,24 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: takaishi
+    repo_name: tftargets
+    description: A tool that analyzes Terraform configurations and identifies directories that need to be executed based on Git changes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tftargets_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: takumin
     repo_name: gjson
     description: Golang JSON Tool


### PR DESCRIPTION
[takaishi/tftargets](https://github.com/takaishi/tftargets): A tool that analyzes Terraform configurations and identifies directories that need to be executed based on Git changes

```console
$ aqua g -i takaishi/tftargets
```

Close #41999