### PR TITLE
fix(CycloneDX/cyclonedx-cli): stop using musl builds on Linux

### DIFF
--- a/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
+++ b/pkgs/CycloneDX/cyclonedx-cli/registry.yaml
@@ -16,10 +16,6 @@ packages:
           amd64: x64
           darwin: osx
           windows: win
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: cyclonedx-{{.OS}}-musl-{{.Arch}}
       - version_constraint: "true"
         asset: cyclonedx-{{.OS}}-{{.Arch}}
         format: raw
@@ -27,7 +23,3 @@ packages:
           amd64: x64
           darwin: osx
           windows: win
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: cyclonedx-{{.OS}}-musl-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -2060,10 +2060,6 @@ packages:
           amd64: x64
           darwin: osx
           windows: win
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: cyclonedx-{{.OS}}-musl-{{.Arch}}
       - version_constraint: "true"
         asset: cyclonedx-{{.OS}}-{{.Arch}}
         format: raw
@@ -2071,10 +2067,6 @@ packages:
           amd64: x64
           darwin: osx
           windows: win
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: cyclonedx-{{.OS}}-musl-{{.Arch}}
   - type: github_release
     repo_owner: Darth-Tech
     repo_name: samwise-cli


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Resolves https://github.com/aquaproj/aqua-registry/issues/41896