### PR TITLE
feat: add suzuki-shunsuke/ghir

### DIFF
--- a/pkgs/suzuki-shunsuke/ghir/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/ghir/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/ghir@v0.1.0-0
+  - name: suzuki-shunsuke/ghir@v0.0.1

--- a/pkgs/suzuki-shunsuke/ghir/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/ghir/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/ghir@v0.1.0-0

--- a/pkgs/suzuki-shunsuke/ghir/registry.yaml
+++ b/pkgs/suzuki-shunsuke/ghir/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: ghir
+    description: ghir is a CLI making GitHub Releases immutable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghir_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghir_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/ghir/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/suzuki-shunsuke/ghir/registry.yaml
+++ b/pkgs/suzuki-shunsuke/ghir/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: ghir
-    description: ghir is a CLI making GitHub Releases immutable
+    description: ghir is a CLI making past GitHub Releases immutable
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -18,7 +18,7 @@ packages:
               - --certificate
               - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/ghir/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -26,6 +26,8 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -74447,6 +74447,35 @@ packages:
             format: zip
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: ghir
+    description: ghir is a CLI making GitHub Releases immutable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghir_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghir_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/ghir/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.sig
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: ghomfc
     description: GitHub Organization Members' Followers Counter
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -74448,7 +74448,7 @@ packages:
   - type: github_release
     repo_owner: suzuki-shunsuke
     repo_name: ghir
-    description: ghir is a CLI making GitHub Releases immutable
+    description: ghir is a CLI making past GitHub Releases immutable
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -74463,7 +74463,7 @@ packages:
               - --certificate
               - https://github.com/suzuki-shunsuke/ghir/releases/download/{{.Version}}/ghir_checksums.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/ghir/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
@@ -74471,6 +74471,8 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
[suzuki-shunsuke/ghir](https://github.com/suzuki-shunsuke/ghir): ghir is a CLI making past GitHub Releases immutable

```console
$ aqua g -i suzuki-shunsuke/ghir
```