### PR TITLE
Add jackchuka/confluence-md

### DIFF
--- a/pkgs/jackchuka/confluence-md/pkg.yaml
+++ b/pkgs/jackchuka/confluence-md/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jackchuka/confluence-md@v0.2.0

--- a/pkgs/jackchuka/confluence-md/registry.yaml
+++ b/pkgs/jackchuka/confluence-md/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jackchuka
+    repo_name: confluence-md
+    description: From Confluence to clean Markdown, images and all — just one command
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: confluence-md_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: confluence-md_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -42978,6 +42978,19 @@ packages:
           - name: pik
             src: "{{.AssetWithoutExt}}/pik"
   - type: github_release
+    repo_owner: jackchuka
+    repo_name: confluence-md
+    description: From Confluence to clean Markdown, images and all — just one command
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: confluence-md_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: confluence-md_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: jacobdeichert
     repo_name: mask
     description: A CLI task runner defined by a simple markdown file


### PR DESCRIPTION
[jackchuka/confluence-md](https://github.com/jackchuka/confluence-md) - From Confluence to clean Markdown, images and all — just one command

[confluence-md](https://github.com/jackchuka/confluence-md) is a CLI tool to convert Confluence pages to Markdown format with a single command. Supports images, tables, lists, and various macros.

```sh
❯ aqua g -i jackchuka/confluence-md

❯ which -a confluence-md
/Users/jackchuka/.local/share/aquaproj-aqua/bin/confluence-md

❯ confluence-md -h
INFO[0000] download and unarchive the package            env=darwin/arm64 exe_name=confluence-md package_name=jackchuka/confluence-md package_version=v0.2.0 program=aqua program_version=2.55.0 registry=standard
INFO[0000] downloading a checksum file                   env=darwin/arm64 exe_name=confluence-md package_name=jackchuka/confluence-md package_version=v0.2.0 program=aqua program_version=2.55.0 registry=standard
Confluence to Markdown Converter

...
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
