### PR TITLE
feat(mongodb/mongod): scaffold mongodb/mongod

### DIFF
--- a/pkgs/mongodb/mongod/pkg.yaml
+++ b/pkgs/mongodb/mongod/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mongodb/mongo@r8.2.1

--- a/pkgs/mongodb/mongod/registry.yaml
+++ b/pkgs/mongodb/mongod/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - repo_owner: mongodb
+    repo_name: mongo
+    type: http
+    description: mongod is the primary daemon process for the MongoDB system.
+    url: https://fastdl.mongodb.org/{{.OS}}/mongodb-{{.OS}}-{{.Arch}}-{{trimPrefix "r" .Version}}.{{.Format}}
+    format: tgz
+    version_source: github_tag
+    version_filter: Version startsWith "r" and not (Version contains "-rc" or Version contains "-beta" or Version contains "-alpha")
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        url: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        files:
+          - name: mongod
+            src: mongodb-macos-x86_64--{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: darwin
+        goarch: arm64
+        url: https://fastdl.mongodb.org/osx/mongodb-macos-arm64-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        files:
+          - name: mongod
+            src: mongodb-macos-aarch64--{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: linux
+        url: https://fastdl.mongodb.org/linux/mongodb-linux-{{.Arch}}-ubuntu2404-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        replacements:
+          arm64: aarch64
+          amd64: x86_64
+        files:
+          - name: mongod
+            src: mongodb-linux-{{.Arch}}-ubuntu2404-{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: windows
+        url: https://fastdl.mongodb.org/windows/mongodb-windows-{{.Arch}}-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+        files:
+          - name: mongod
+            src: mongodb-win32-{{.Arch}}-windows-{{trimPrefix "r" .Version}}/bin/mongod.exe

--- a/registry.yaml
+++ b/registry.yaml
@@ -55197,6 +55197,52 @@ packages:
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+  - repo_owner: mongodb
+    repo_name: mongo
+    type: http
+    description: mongod is the primary daemon process for the MongoDB system.
+    url: https://fastdl.mongodb.org/{{.OS}}/mongodb-{{.OS}}-{{.Arch}}-{{trimPrefix "r" .Version}}.{{.Format}}
+    format: tgz
+    version_source: github_tag
+    version_filter: Version startsWith "r" and not (Version contains "-rc" or Version contains "-beta" or Version contains "-alpha")
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
+    overrides:
+      - goos: darwin
+        goarch: amd64
+        url: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        files:
+          - name: mongod
+            src: mongodb-macos-x86_64--{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: darwin
+        goarch: arm64
+        url: https://fastdl.mongodb.org/osx/mongodb-macos-arm64-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        files:
+          - name: mongod
+            src: mongodb-macos-aarch64--{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: linux
+        url: https://fastdl.mongodb.org/linux/mongodb-linux-{{.Arch}}-ubuntu2404-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: tgz
+        replacements:
+          arm64: aarch64
+          amd64: x86_64
+        files:
+          - name: mongod
+            src: mongodb-linux-{{.Arch}}-ubuntu2404-{{trimPrefix "r" .Version}}/bin/mongod
+      - goos: windows
+        url: https://fastdl.mongodb.org/windows/mongodb-windows-{{.Arch}}-{{trimPrefix "r" .Version}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+        files:
+          - name: mongod
+            src: mongodb-win32-{{.Arch}}-windows-{{trimPrefix "r" .Version}}/bin/mongod.exe
   - name: mongodb/mongodb-atlas-cli/atlascli
     type: github_release
     repo_owner: mongodb


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Adds mongodb/mongod package.

As mongod itself and all its _very custom_ download URLs and also download paths are **not** following one pattern, `cmdx s` does not work all the time for me. Therefore I started with `cmdx s` and then had to adjust manually that it fits everything needed and tested with `cmdx t`.
