### PR TITLE
Re-scaffold apache/maven-mvnd

### DIFF
--- a/pkgs/apache/maven-mvnd/pkg.yaml
+++ b/pkgs/apache/maven-mvnd/pkg.yaml
@@ -1,21 +1,18 @@
 packages:
-  - name: apache/maven-mvnd@1.0.2
+  - name: apache/maven-mvnd@2.0.0-rc-3
   - name: apache/maven-mvnd
-    version: 1.0.1
+    version: 1.0.2
   - name: apache/maven-mvnd
     version: 1.0-m7
   - name: apache/maven-mvnd
     version: 1.0-m6
   - name: apache/maven-mvnd
-    version: 1.0.0-m4
-  # https://github.com/aquaproj/aqua-registry/pull/20468#issuecomment-1973173615
-  # - name: apache/maven-mvnd
-  #   version: 0.8.1
-  # - name: apache/maven-mvnd
-  #   version: 0.7.1
-  # - name: apache/maven-mvnd
-  #   version: 0.0.8
-  # - name: apache/maven-mvnd
-  #   version: 0.0.2
+    version: 0.8.1
+  - name: apache/maven-mvnd
+    version: 0.7.1
+  - name: apache/maven-mvnd
+    version: 0.0.8
+  - name: apache/maven-mvnd
+    version: 0.0.2
   - name: apache/maven-mvnd
     version: 0.0.1

--- a/pkgs/apache/maven-mvnd/registry.yaml
+++ b/pkgs/apache/maven-mvnd/registry.yaml
@@ -8,7 +8,7 @@ packages:
       - name: mvnd
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.0.1")
+      - version_constraint: Version == "0.0.1"
         asset: mvnd-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
@@ -22,13 +22,46 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: x86_64
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["1.0-m6", "1.0-m8"]
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m7"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0.2"
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         supported_envs:
           - darwin
           - windows
@@ -38,9 +71,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -50,9 +80,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -66,94 +93,16 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.0.0-m4")
-        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m6"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m7"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m8"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
         supported_envs:
           - darwin
           - windows
           - amd64
       - version_constraint: "true"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
         supported_envs:
           - darwin
           - windows

--- a/pkgs/apache/maven-mvnd/registry.yaml
+++ b/pkgs/apache/maven-mvnd/registry.yaml
@@ -22,8 +22,13 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
         supported_envs:
           - darwin
           - windows
@@ -32,6 +37,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:
@@ -39,9 +47,13 @@ packages:
           - windows
           - amd64
       - version_constraint: Version == "1.0-m7"
+        # Maven Daemon comes into two different flavours: m39 which embeds Maven 3.9.x, and m40 which embeds Maven 4.0.0-alpha-x.
         asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -56,6 +68,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -71,6 +86,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -80,6 +98,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -93,6 +114,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -101,6 +125,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -11358,8 +11358,13 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: x86_64
         supported_envs:
           - darwin
           - windows
@@ -11368,6 +11373,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:
@@ -11375,9 +11383,13 @@ packages:
           - windows
           - amd64
       - version_constraint: Version == "1.0-m7"
+        # Maven Daemon comes into two different flavours: m39 which embeds Maven 3.9.x, and m40 which embeds Maven 4.0.0-alpha-x.
         asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -11392,6 +11404,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         checksum:
@@ -11407,6 +11422,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -11416,6 +11434,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -11429,6 +11450,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -11437,6 +11461,9 @@ packages:
         asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mvnd
+            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -11344,7 +11344,7 @@ packages:
       - name: mvnd
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.0.1")
+      - version_constraint: Version == "0.0.1"
         asset: mvnd-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
@@ -11358,13 +11358,46 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: x86_64
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version in ["1.0-m6", "1.0-m8"]
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0-m7"
+        asset: maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "1.0.2"
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         supported_envs:
           - darwin
           - windows
@@ -11374,9 +11407,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         supported_envs:
           - darwin
           - windows
@@ -11386,9 +11416,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -11402,94 +11429,16 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.0.0-m4")
-        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m6"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m7"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: Version == "1.0-m8"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
-        replacements:
-          arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-m39-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
         supported_envs:
           - darwin
           - windows
           - amd64
       - version_constraint: "true"
-        type: http
-        url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        asset: maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        files:
-          - name: mvnd
-            src: "{{.AssetWithoutExt}}/bin/mvnd"
         replacements:
           arm64: aarch64
-        checksum:
-          type: http
-          url: https://downloads.apache.org/maven/mvnd/{{.Version}}/maven-mvnd-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}.sha256
-          algorithm: sha256
         supported_envs:
           - darwin
           - windows


### PR DESCRIPTION
Close #41693

The official way to download binaries to through `https://downloads.apache.org/maven/`.

https://github.com/apache/maven-mvnd/issues/1109#issuecomment-2308520463

> Still, the "official" way to download Apache Maven binaries is thru https://downloads.apache.org/maven/ (while some of them are available from Maven Central as well, but mvnd for example is not)

But unfortunately, old binaries are removed from `https://downloads.apache.org/maven/`.
And fortunately, binaries are released to GitHub Releases too.
So we decided to use GitHub Releases.