### PR TITLE
feat: add gittower/git-flow-next

### DIFF
--- a/pkgs/gittower/git-flow-next/pkg.yaml
+++ b/pkgs/gittower/git-flow-next/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: gittower/git-flow-next@v0.1.1
+  - name: gittower/git-flow-next
+    version: v0.1.0-alpha.1

--- a/pkgs/gittower/git-flow-next/pkg.yaml
+++ b/pkgs/gittower/git-flow-next/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: gittower/git-flow-next@v0.1.1
   - name: gittower/git-flow-next
-    version: v0.1.0-alpha.1
+    version: v0.1.0

--- a/pkgs/gittower/git-flow-next/registry.yaml
+++ b/pkgs/gittower/git-flow-next/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: gittower
+    repo_name: git-flow-next
+    description: A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh
+    files:
+      - name: git-flow
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-alpha.1"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/gittower/git-flow-next/registry.yaml
+++ b/pkgs/gittower/git-flow-next/registry.yaml
@@ -9,19 +9,14 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0-alpha.1"
-        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: git-flow-next-{{.Version}}-checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
+        no_asset: true
       - version_constraint: "true"
         asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: git-flow
+            src: git-flow-{{.Version}}-{{.OS}}-{{.Arch}}
         checksum:
           type: github_release
           asset: git-flow-next-{{.Version}}-checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -35634,19 +35634,14 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0-alpha.1"
-        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: git-flow-next-{{.Version}}-checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
+        no_asset: true
       - version_constraint: "true"
         asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: git-flow
+            src: git-flow-{{.Version}}-{{.OS}}-{{.Arch}}
         checksum:
           type: github_release
           asset: git-flow-next-{{.Version}}-checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -35626,6 +35626,35 @@ packages:
         checksum:
           enabled: false
   - type: github_release
+    repo_owner: gittower
+    repo_name: git-flow-next
+    description: A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh
+    files:
+      - name: git-flow
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-alpha.1"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: gittuf
     repo_name: gittuf
     description: A security layer for Git repositories


### PR DESCRIPTION
[gittower/git-flow-next](https://github.com/gittower/git-flow-next): A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh

```console
$ aqua g -i gittower/git-flow-next
```

Close #43208