### PR TITLE
fix(mvdan/gofumpt): support gofumpt v0.9.2 or later. sha256sums.txt was removed

### DIFF
--- a/pkgs/mvdan/gofumpt/pkg.yaml
+++ b/pkgs/mvdan/gofumpt/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: mvdan/gofumpt@v0.9.1
+  - name: mvdan/gofumpt@v0.9.2
+  - name: mvdan/gofumpt
+    version: v0.9.1
   - name: mvdan/gofumpt
     version: v0.4.0
   - name: mvdan/gofumpt

--- a/pkgs/mvdan/gofumpt/registry.yaml
+++ b/pkgs/mvdan/gofumpt/registry.yaml
@@ -15,7 +15,7 @@ packages:
         asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.9.1")
         asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -23,3 +23,7 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -57049,7 +57049,7 @@ packages:
         asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.9.1")
         asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -57057,6 +57057,10 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        asset: gofumpt_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: mvdan
     repo_name: sh


### PR DESCRIPTION
- https://github.com/mvdan/gofumpt/issues/340

Close #43080