### PR TITLE
feat: add suzuki-shunsuke/ghaperf

### DIFF
--- a/pkgs/suzuki-shunsuke/ghaperf/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/ghaperf/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/ghaperf@v0.0.1

--- a/pkgs/suzuki-shunsuke/ghaperf/registry.yaml
+++ b/pkgs/suzuki-shunsuke/ghaperf/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: ghaperf
+    description: ghaperf is a CLI to analyze the performance of GitHub Actions using GitHub API and raw job logs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghaperf_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghaperf_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/ghaperf/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: ghaperf_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/pkgs/suzuki-shunsuke/ghaperf/registry.yaml
+++ b/pkgs/suzuki-shunsuke/ghaperf/registry.yaml
@@ -16,9 +16,9 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/ghaperf/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
+              - "https://token.actions.githubusercontent.com"
             bundle:
               type: github_release
               asset: ghaperf_checksums.txt.bundle

--- a/registry.yaml
+++ b/registry.yaml
@@ -75140,6 +75140,34 @@ packages:
             format: zip
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: ghaperf
+    description: ghaperf is a CLI to analyze the performance of GitHub Actions using GitHub API and raw job logs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghaperf_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ghaperf_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/ghaperf/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: ghaperf_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: ghatm
     description: Set timeout-minutes to all GitHub Actions jobs
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -75154,9 +75154,9 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/ghaperf/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
               - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
+              - "https://token.actions.githubusercontent.com"
             bundle:
               type: github_release
               asset: ghaperf_checksums.txt.bundle


### PR DESCRIPTION
[suzuki-shunsuke/ghaperf](https://github.com/suzuki-shunsuke/ghaperf): ghaperf is a CLI to analyze the performance of GitHub Actions using GitHub API and raw job logs

```console
$ aqua g -i suzuki-shunsuke/ghaperf
```