### PR TITLE
ci: replace the deprecated macos-13 with macos-15-intel

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -14,7 +14,7 @@ jobs:
           - runs-on: ubuntu-24.04
             goos: ""
             goarch: ""
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             goos: ""
             goarch: ""
           - runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
- https://github.com/actions/runner-images/issues/13046