### PR TITLE
add: flutter channel

### DIFF
--- a/pkgs/flutter/flutter/pkg.yaml
+++ b/pkgs/flutter/flutter/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: flutter/flutter@3.35.7
+  - name: flutter/flutter
+    version: 3.38.0-0.2.pre
+    vars:
+      channel: beta

--- a/pkgs/flutter/flutter/registry.yaml
+++ b/pkgs/flutter/flutter/registry.yaml
@@ -14,7 +14,10 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+        url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}
+        vars:
+          - name: channel
+            default: stable
         format: zip
         replacements:
           darwin: macos
@@ -23,6 +26,6 @@ packages:
             format: tar.xz
           - goos: windows
             goarch: arm64
-            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+            url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}
           - goarch: arm64
-            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{.Arch}}_{{trimV .Version}}-stable.{{.Format}}
+            url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{.Arch}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -32997,7 +32997,10 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+        url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}
+        vars:
+          - name: channel
+            default: stable
         format: zip
         replacements:
           darwin: macos
@@ -33006,9 +33009,9 @@ packages:
             format: tar.xz
           - goos: windows
             goarch: arm64
-            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-stable.{{.Format}}
+            url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}
           - goarch: arm64
-            url: https://storage.googleapis.com/flutter_infra_release/releases/stable/{{.OS}}/flutter_{{.OS}}_{{.Arch}}_{{trimV .Version}}-stable.{{.Format}}
+            url: https://storage.googleapis.com/flutter_infra_release/releases/{{.Vars.channel}}/{{.OS}}/flutter_{{.OS}}_{{.Arch}}_{{trimV .Version}}-{{.Vars.channel}}.{{.Format}}
   - name: flux-iac/tofu-controller/tfctl
     type: github_release
     repo_owner: flux-iac


### PR DESCRIPTION
## Summary

I added flutter/flutter in this PR https://github.com/aquaproj/aqua-registry/pull/42431, but `channel` isn’t supported yet, so I’ll add it in this PR.
## Check List


<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
