### PR TITLE
feat: add CrociDB/bulletty

### DIFF
--- a/pkgs/CrociDB/bulletty/pkg.yaml
+++ b/pkgs/CrociDB/bulletty/pkg.yaml
@@ -3,6 +3,4 @@ packages:
   - name: CrociDB/bulletty
     version: v0.1.9
   - name: CrociDB/bulletty
-    version: v0.1.8
-  - name: CrociDB/bulletty
     version: v0.1.7

--- a/pkgs/CrociDB/bulletty/pkg.yaml
+++ b/pkgs/CrociDB/bulletty/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: CrociDB/bulletty@v0.2.0
+  - name: CrociDB/bulletty
+    version: v0.1.9
+  - name: CrociDB/bulletty
+    version: v0.1.8
+  - name: CrociDB/bulletty
+    version: v0.1.7

--- a/pkgs/CrociDB/bulletty/registry.yaml
+++ b/pkgs/CrociDB/bulletty/registry.yaml
@@ -12,17 +12,7 @@ packages:
         supported_envs:
           - linux/amd64
       - version_constraint: Version == "v0.1.8"
-        asset: bulletty-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        error_message: This version is unavailable because the asset format is invalid.
       - version_constraint: Version == "v0.1.9"
         asset: bulletty-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.gz

--- a/pkgs/CrociDB/bulletty/registry.yaml
+++ b/pkgs/CrociDB/bulletty/registry.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: CrociDB
+    repo_name: bulletty
+    description: bulletty is a pretty feed reader for the terminal that stores the articles as Markdown
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.7"
+        asset: bulletty-{{.Version}}-{{.OS}}_x86-64.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.1.8"
+        asset: bulletty-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.9"
+        asset: bulletty-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+      - version_constraint: "true"
+        asset: bulletty-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}

--- a/registry.yaml
+++ b/registry.yaml
@@ -1988,17 +1988,7 @@ packages:
         supported_envs:
           - linux/amd64
       - version_constraint: Version == "v0.1.8"
-        asset: bulletty-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        error_message: This version is unavailable because the asset format is invalid.
       - version_constraint: Version == "v0.1.9"
         asset: bulletty-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -1977,6 +1977,53 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: CrociDB
+    repo_name: bulletty
+    description: bulletty is a pretty feed reader for the terminal that stores the articles as Markdown
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.7"
+        asset: bulletty-{{.Version}}-{{.OS}}_x86-64.{{.Format}}
+        format: zip
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.1.8"
+        asset: bulletty-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.1.9"
+        asset: bulletty-{{.OS}}-{{.Arch}}-{{.Version}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+      - version_constraint: "true"
+        asset: bulletty-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+  - type: github_release
     repo_owner: Crocmagnon
     repo_name: fatcontext
     description: detects nested contexts in loops


### PR DESCRIPTION
[CrociDB/bulletty](https://github.com/CrociDB/bulletty): bulletty is a pretty feed reader for the terminal that stores the articles as Markdown

```console
$ aqua g -i CrociDB/bulletty
```

Close #43885
