### PR TITLE
Enable github_artifact_attestations for foundry-rs/foundry

### DIFF
--- a/pkgs/foundry-rs/foundry/registry.yaml
+++ b/pkgs/foundry-rs/foundry/registry.yaml
@@ -20,6 +20,17 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml
+      - version_constraint: semver("< 1.3.0-rc1")
+        asset: foundry_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: foundry_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -29,3 +40,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -33653,6 +33653,17 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml
+      - version_constraint: semver("< 1.3.0-rc1")
+        asset: foundry_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: foundry_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -33662,6 +33673,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml
   - type: github_release
     repo_owner: freshautomations
     repo_name: stoml


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Enable github_artifact_attestations for `foundry-rs/foundry`
