### PR TITLE
registry: add anthropic/claude-code

### DIFF
--- a/pkgs/anthropic/claude-code/pkg.yaml
+++ b/pkgs/anthropic/claude-code/pkg.yaml
@@ -1,0 +1,3 @@
+packages:
+  - name: anthropic/claude-code@2.0.50
+  - name: anthropic/claude-code@2.0.53

--- a/pkgs/anthropic/claude-code/registry.yaml
+++ b/pkgs/anthropic/claude-code/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: anthropics
+    repo_name: claude-code
+    name: anthropic/claude-code
+    description: Terminal-based AI coding assistant
+    link: https://www.anthropic.com/claude-code
+    replacements:
+      darwin: darwin
+      linux: linux
+      windows: win32
+      amd64: x64
+      arm64: arm64
+    supported_envs:
+      - darwin
+      - linux
+      - windows
+      - amd64
+      - arm64
+    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{.Version}}/{{.OS}}-{{.Arch}}/claude{{.Format}}
+        format: ""
+        overrides:
+          - goos: windows
+            format: .exe
+        files:
+          - name: claude


### PR DESCRIPTION
## Package Information

**Name:** anthropic/claude-code  
**Description:** Terminal-based AI coding assistant  
**Homepage:** https://www.anthropic.com/claude-code  
**GitHub:** https://github.com/anthropics/claude-code

## Distribution Details

- **Type:** HTTP package
- **Source:** Google Cloud Storage (`storage.googleapis.com/claude-code-dist-...`)
- **Platforms:** darwin (x64, arm64), linux (x64, arm64), windows (x64)
- **Version Detection:** GitHub repository tags/releases

## Testing

Tested versions:
- 2.0.50
- 2.0.53

## Notes

Claude Code is distributed as pre-compiled binaries from Google Cloud Storage. The distribution follows the pattern used by Homebrew cask:
- Direct binary downloads (no archive extraction needed except on Windows)
- SHA256 checksums available in manifest.json
- Rosetta2 support enabled for macOS

This package enables users to install Claude Code via aqua without requiring Node.js/npm.