### PR TITLE
fix(pre-commit/pre-commit): remove checksums from v4.5.0

### DIFF
--- a/pkgs/pre-commit/pre-commit/pkg.yaml
+++ b/pkgs/pre-commit/pre-commit/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: pre-commit/pre-commit@v4.4.0
+  - name: pre-commit/pre-commit@v4.5.0
+  - name: pre-commit/pre-commit
+    version: v4.4.0

--- a/pkgs/pre-commit/pre-commit/registry.yaml
+++ b/pkgs/pre-commit/pre-commit/registry.yaml
@@ -16,7 +16,7 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
-      - version_constraint: semver("<= 4.4.0")
+      - version_constraint: "true"
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false

--- a/pkgs/pre-commit/pre-commit/registry.yaml
+++ b/pkgs/pre-commit/pre-commit/registry.yaml
@@ -6,11 +6,10 @@ packages:
     description: A framework for managing and maintaining multi-language pre-commit hooks
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 2.7.0")
+        no_asset: true
       - version_constraint: "true"
-        asset: pre-commit-{{trimV .Version}}.pyz
-        format: raw
-        complete_windows_ext: false
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256sum"
+          asset: pre-commit-{{trimV .Version}}.pyz.sha256sum
           algorithm: sha256

--- a/pkgs/pre-commit/pre-commit/registry.yaml
+++ b/pkgs/pre-commit/pre-commit/registry.yaml
@@ -8,8 +8,15 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 2.7.0")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 4.4.0")
+        asset: pre-commit-{{trimV .Version}}.pyz
+        format: raw
+        complete_windows_ext: false
         checksum:
           type: github_release
-          asset: pre-commit-{{trimV .Version}}.pyz.sha256sum
+          asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
+      - version_constraint: semver("<= 4.4.0")
+        asset: pre-commit-{{trimV .Version}}.pyz
+        format: raw
+        complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -64695,13 +64695,12 @@ packages:
     description: A framework for managing and maintaining multi-language pre-commit hooks
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 2.7.0")
+        no_asset: true
       - version_constraint: "true"
-        asset: pre-commit-{{trimV .Version}}.pyz
-        format: raw
-        complete_windows_ext: false
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256sum"
+          asset: pre-commit-{{trimV .Version}}.pyz.sha256sum
           algorithm: sha256
   - type: github_release
     repo_owner: pressly

--- a/registry.yaml
+++ b/registry.yaml
@@ -64705,7 +64705,7 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
-      - version_constraint: semver("<= 4.4.0")
+      - version_constraint: "true"
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -64697,11 +64697,18 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 2.7.0")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 4.4.0")
+        asset: pre-commit-{{trimV .Version}}.pyz
+        format: raw
+        complete_windows_ext: false
         checksum:
           type: github_release
-          asset: pre-commit-{{trimV .Version}}.pyz.sha256sum
+          asset: "{{.Asset}}.sha256sum"
           algorithm: sha256
+      - version_constraint: semver("<= 4.4.0")
+        asset: pre-commit-{{trimV .Version}}.pyz
+        format: raw
+        complete_windows_ext: false
   - type: github_release
     repo_owner: pressly
     repo_name: goose


### PR DESCRIPTION
Removes checksum from [pre-commit/pre-commit](https://github.com/pre-commit/pre-commit).
Fixes https://github.com/aquaproj/aqua-registry/pull/44615.

In https://github.com/pre-commit/pre-commit/pull/3586, they intentionally removed a checksum from release assets. https://github.com/pre-commit/pre-commit/issues/3587

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well