### PR TITLE
Add kiali/kiali

### DIFF
--- a/pkgs/kiali/kiali/pkg.yaml
+++ b/pkgs/kiali/kiali/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kiali/kiali@v2.19.0

--- a/pkgs/kiali/kiali/registry.yaml
+++ b/pkgs/kiali/kiali/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kiali
+    repo_name: kiali
+    description: Kiali project, observability for the Istio service mesh
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.14.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: kiali-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -47966,6 +47966,19 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: kiali
+    repo_name: kiali
+    description: Kiali project, observability for the Istio service mesh
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.14.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: kiali-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
   - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc


### PR DESCRIPTION
[kiali/kiali](https://github.com/kiali/kiali) - Kiali project, observability for the Istio service mesh

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

This adds the CLI for [Kiali](https://kiali.io/), so you can run the dashboard locally.