### PR TITLE
fix(astral-sh/uv): disable github attestation for 0.9.11

### DIFF
--- a/pkgs/astral-sh/uv/pkg.yaml
+++ b/pkgs/astral-sh/uv/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: astral-sh/uv@0.9.13
   - name: astral-sh/uv
+    version: 0.9.11
+  - name: astral-sh/uv
     version: 0.9.7
   - name: astral-sh/uv
     version: 0.2.21

--- a/pkgs/astral-sh/uv/registry.yaml
+++ b/pkgs/astral-sh/uv/registry.yaml
@@ -55,7 +55,7 @@ packages:
             format: zip
             files:
               - name: uv
-      - version_constraint: semver("<= 0.9.7")
+      - version_constraint: semver("<= 0.9.7") || Version == "0.9.11"
         asset: uv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -14100,7 +14100,7 @@ packages:
             format: zip
             files:
               - name: uv
-      - version_constraint: semver("<= 0.9.7")
+      - version_constraint: semver("<= 0.9.7") || Version == "0.9.11"
         asset: uv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true


### PR DESCRIPTION
[astral-sh/uv](https://github.com/astral-sh/uv): An extremely fast Python package and project manager, written in Rust.

```console
$ aqua g -i astral-sh/uv
```

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
