### PR TITLE
refactor(orf/gping): add version_prefix

### DIFF
--- a/pkgs/orf/gping/registry.yaml
+++ b/pkgs/orf/gping/registry.yaml
@@ -71,6 +71,7 @@ packages:
           - goos: windows
             format: zip
       - version_constraint: "true"
+        version_prefix: gping-
         asset: gping-{{.OS}}-gnu-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -62062,6 +62062,7 @@ packages:
           - goos: windows
             format: zip
       - version_constraint: "true"
+        version_prefix: gping-
         asset: gping-{{.OS}}-gnu-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true


### PR DESCRIPTION
[orf/gping](https://github.com/orf/gping): Ping, but with a graph

```console
$ aqua g -i orf/gping
```

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Sorry, afaik this doesn't change Aqua's behaviour. However, this consistency is helpful for mise.
Please feel free to close this.