### PR TITLE
fix(apache/jena): filter out non-jena git tags

### DIFF
--- a/pkgs/apache/jena/registry.yaml
+++ b/pkgs/apache/jena/registry.yaml
@@ -6,6 +6,7 @@ packages:
     description: A free and open source Java framework for building Semantic Web and Linked Data applications (CLI tools)
     version_source: github_tag
     version_prefix: jena-
+    version_filter: Version matches "^jena-\\d+"
     files:
       - name: arq
         src: apache-jena-{{.SemVer}}/bin/arq

--- a/registry.yaml
+++ b/registry.yaml
@@ -11492,6 +11492,7 @@ packages:
     description: A free and open source Java framework for building Semantic Web and Linked Data applications (CLI tools)
     version_source: github_tag
     version_prefix: jena-
+    version_filter: Version matches "^jena-\\d+"
     files:
       - name: arq
         src: apache-jena-{{.SemVer}}/bin/arq


### PR DESCRIPTION
[apache/jena](https://github.com/apache/jena): Apache Jena, A free and open source Java framework for building Semantic Web and Linked Data applications.

```console
$ aqua g -i apache/jena
```

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Filters out these Git tags:

```
jena-arq-2.9.0-incubating
jena-core-2.7.0-incubating
jena-csv-1.0.0
jena-csv-1.0.1
jena-fuseki-0.2.1-incubating
jena-iri-0.9.0-incubating
jena-larq-1.0.0-incubating
jena-sdb-1.3.4-RC-1
jena-sdb-1.3.5
jena-sdb-1.3.6
jena-tdb-0.9.0-incubating
jena-top-0-incubating
```