### PR TITLE
fix: change apache/spark URL to archive distribution directory

### DIFF
--- a/pkgs/apache/spark/registry.yaml
+++ b/pkgs/apache/spark/registry.yaml
@@ -17,5 +17,5 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        url: https://dlcdn.apache.org/spark/spark-{{trimV .Version}}/spark-{{trimV .Version}}-bin-hadoop3.tgz
+        url: https://archive.apache.org/dist/spark/spark-{{trimV .Version}}/spark-{{trimV .Version}}-bin-hadoop3.tgz
         format: tgz

--- a/registry.yaml
+++ b/registry.yaml
@@ -11808,7 +11808,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        url: https://dlcdn.apache.org/spark/spark-{{trimV .Version}}/spark-{{trimV .Version}}-bin-hadoop3.tgz
+        url: https://archive.apache.org/dist/spark/spark-{{trimV .Version}}/spark-{{trimV .Version}}-bin-hadoop3.tgz
         format: tgz
   - type: http
     repo_owner: apache


### PR DESCRIPTION
The main distribution directory includes only the few most recent versions (currently `3.5.7`, `4.0.1` and some preview versions of `4.1.0`).

This means installation of older versions (including that defined in the `pkg.yaml` for testing) fails.
i.e., `cmdx t apache/spark` fails without this change, and succeeds with it.

- [main distribution directory](https://dlcdn.apache.org/spark/)
- [archive distribution directory](https://archive.apache.org/dist/spark/)

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- ~~[Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)~~

<!-- Please write the description here -->
