### PR TITLE
feat(danielfoehrKn/kubeswitch): Support arm64 architecture on Linux

### DIFF
--- a/pkgs/danielfoehrKn/kubeswitch/pkg.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/pkg.yaml
@@ -1,2 +1,10 @@
 packages:
   - name: danielfoehrKn/kubeswitch@0.9.3
+  - name: danielfoehrKn/kubeswitch
+    version: 0.8.1
+  - name: danielfoehrKn/kubeswitch
+    version: 0.5.0
+  - name: danielfoehrKn/kubeswitch
+    version: 0.2.0
+  - name: danielfoehrKn/kubeswitch
+    version: 0.0.3

--- a/pkgs/danielfoehrKn/kubeswitch/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/registry.yaml
@@ -7,7 +7,7 @@ packages:
     format: raw
     description: The kubectx for operators
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
     files:
       - name: switcher

--- a/pkgs/danielfoehrKn/kubeswitch/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/registry.yaml
@@ -3,11 +3,33 @@ packages:
   - type: github_release
     repo_owner: danielfoehrKn
     repo_name: kubeswitch
-    asset: switcher_{{.OS}}_{{.Arch}}
-    format: raw
-    description: The kubectx for operators
-    supported_envs:
-      - linux
-      - darwin
+    description: The kubectx  for operators
     files:
       - name: switcher
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+      - version_constraint: semver("<= 0.2.0")
+        asset: switcher_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/pkgs/danielfoehrKn/kubeswitch/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/registry.yaml
@@ -9,10 +9,16 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.3")
+        asset: switcher.tar.gz
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.2.0")
         asset: switcher_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: switcher
+            src: "{{.AssetWithoutExt}}"
         supported_envs:
           - linux/amd64
           - darwin

--- a/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
+++ b/pkgs/danielfoehrKn/kubeswitch/switch-sh/registry.yaml
@@ -8,7 +8,7 @@ packages:
     format: raw
     description: The kubectx for operators
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
     files:
       - name: kubeswitch.sh

--- a/registry.yaml
+++ b/registry.yaml
@@ -26738,10 +26738,16 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.3")
+        asset: switcher.tar.gz
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.2.0")
         asset: switcher_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         rosetta2: true
+        files:
+          - name: switcher
+            src: "{{.AssetWithoutExt}}"
         supported_envs:
           - linux/amd64
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -26732,14 +26732,36 @@ packages:
   - type: github_release
     repo_owner: danielfoehrKn
     repo_name: kubeswitch
-    asset: switcher_{{.OS}}_{{.Arch}}
-    format: raw
-    description: The kubectx for operators
-    supported_envs:
-      - linux
-      - darwin
+    description: The kubectx  for operators
     files:
       - name: switcher
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.3")
+      - version_constraint: semver("<= 0.2.0")
+        asset: switcher_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.8.1")
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: switcher_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - name: danielfoehrKn/kubeswitch/switch-sh
     type: github_release
     repo_owner: danielfoehrKn

--- a/registry.yaml
+++ b/registry.yaml
@@ -26736,7 +26736,7 @@ packages:
     format: raw
     description: The kubectx for operators
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
     files:
       - name: switcher
@@ -26748,7 +26748,7 @@ packages:
     format: raw
     description: The kubectx for operators
     supported_envs:
-      - linux/amd64
+      - linux
       - darwin
     files:
       - name: kubeswitch.sh


### PR DESCRIPTION
https://github.com/danielfoehrKn/kubeswitch

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Kubeswitch has arm64 Linux binaries but it's not configured in the Aqua registry, let's add it so it can be installed on arm64 Linux hosts.
