### PR TITLE
feat(square/certigo): scaffold square/certigo

### DIFF
--- a/pkgs/square/certigo/pkg.yaml
+++ b/pkgs/square/certigo/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: square/certigo@v1.17.1
+  - name: square/certigo
+    version: v1.13.0
+  - name: square/certigo
+    version: v1.11.0

--- a/pkgs/square/certigo/registry.yaml
+++ b/pkgs/square/certigo/registry.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: square
+    repo_name: certigo
+    description: A utility to examine and validate certificates in a variety of formats
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.13.0"
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.6.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.11.0")
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.12.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -74501,6 +74501,44 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: square
+    repo_name: certigo
+    description: A utility to examine and validate certificates in a variety of formats
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.13.0"
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.6.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.11.0")
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.12.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: certigo-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: squat
     repo_name: kilo
     description: Kilo is a multi-cloud network overlay built on WireGuard and designed for Kubernetes (k8s + wg = kg)


### PR DESCRIPTION
[square/certigo](https://github.com/square/certigo) - A utility to examine and validate certificates in a variety of formats

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

[square/certigo](https://github.com/square/certigo) is a utility to examine and validate certificates to help with debugging SSL/TLS issues, is written in Go.

example usage:

```console
# cat aqua.yaml
...
packages:
...
  - name: square/certigo@v1.17.1

# aqua i -l
INFO[0000] create a symbolic link                        aqua_version=2.40.0 command=certigo env=darwin/arm64 package_name=square/certigo package_version=v1.17.1 program=aqua

# certigo
INFO[0000] download and unarchive the package            aqua_version=2.40.0 env=darwin/arm64 exe_name=certigo package_name=square/certigo package_version=v1.17.1 program=aqua registry=standard

# certigo connect example.com
** TLS Connection **
Version: TLS 1.3
Cipher Suite: AES_256_GCM_SHA384 cipher

** CERTIFICATE 1 **
Valid: 2025-01-15 00:00 UTC to 2026-01-15 23:59 UTC
Subject:
	C=US, ST=California, L=Los Angeles, O=Internet Corporation for Assigned
	Names and Numbers, CN=*.example.com
Issuer:
	C=US, O=DigiCert Inc, CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
DNS Names:
	*.example.com, example.com

** CERTIFICATE 2 **
Valid: 2021-04-14 00:00 UTC to 2031-04-13 23:59 UTC
Subject:
	C=US, O=DigiCert Inc, CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
Issuer:
	C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G3

Checked OCSP status for certificate (was stapled), got:
	Good (last update: 01 Dec 25 15:43 UTC)

Found 1 valid certificate chain(s):
[0] CN=*.example.com
	=> CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
	=> CN=DigiCert Global Root G3 [self-signed]
```