### PR TITLE
feat(ByteNess/aws-vault): scaffold ByteNess/aws-vault

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -14,6 +14,7 @@ packages:
   - import: pkgs/zizmorcore/zizmor/pkg.yaml
   - import: pkgs/zigtools/zls/pkg.yaml
   - import: pkgs/sharkdp/bat/pkg.yaml
+  - import: pkgs/ByteNess/aws-vault/pkg.yaml
   - import: pkgs/*/*/pkg.yaml
   - import: pkgs/*/*/*/pkg.yaml
   - import: pkgs/*/*/*/*/pkg.yaml

--- a/pkgs/ByteNess/aws-vault/pkg.yaml
+++ b/pkgs/ByteNess/aws-vault/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: ByteNess/aws-vault@v7.8.2
+  - name: ByteNess/aws-vault
+    version: v7.3.5
+  - name: ByteNess/aws-vault
+    version: v7.3.4

--- a/pkgs/ByteNess/aws-vault/registry.yaml
+++ b/pkgs/ByteNess/aws-vault/registry.yaml
@@ -40,10 +40,3 @@ packages:
           type: github_release
           asset: aws-vault_sha256_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: aws-vault-{{.OS}}-{{.Arch}}.exe
-        supported_envs:
-          - linux
-          - darwin
-          - windows

--- a/pkgs/ByteNess/aws-vault/registry.yaml
+++ b/pkgs/ByteNess/aws-vault/registry.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ByteNess
+    repo_name: aws-vault
+    description: A vault for securely storing and accessing AWS credentials in development environments
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v7.3.5"
+        asset: aws-vault-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: aws-vault_sha256_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 7.3.4")
+        asset: aws-vault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: aws-vault_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: aws-vault_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: aws-vault-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: aws-vault_sha256_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: aws-vault-{{.OS}}-{{.Arch}}.exe
+        supported_envs:
+          - linux
+          - darwin
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -1637,13 +1637,6 @@ packages:
           type: github_release
           asset: aws-vault_sha256_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: aws-vault-{{.OS}}-{{.Arch}}.exe
-        supported_envs:
-          - linux
-          - darwin
-          - windows
   - type: go_install
     repo_owner: CAFxX
     repo_name: mgo

--- a/registry.yaml
+++ b/registry.yaml
@@ -1597,6 +1597,53 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: ByteNess
+    repo_name: aws-vault
+    description: A vault for securely storing and accessing AWS credentials in development environments
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v7.3.5"
+        asset: aws-vault-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: aws-vault_sha256_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 7.3.4")
+        asset: aws-vault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: aws-vault_{{trimV .Version}}_sha256_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: aws-vault_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: aws-vault-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: aws-vault_sha256_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: aws-vault-{{.OS}}-{{.Arch}}.exe
+        supported_envs:
+          - linux
+          - darwin
+          - windows
   - type: go_install
     repo_owner: CAFxX
     repo_name: mgo


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well - Only tested it on macos. Don't have access to a windows machine
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

This adds support for a maintained fork of aws-vault. This is my first attempt at updating a registry. I used `cmdx s` to scaffold and had to manually fix the Windows override. I don't have a Windows machine to test, but `cmdx t` didn't throw any errors.

Please refer to this issue: https://github.com/99designs/aws-vault/issues/1269

Homebrew has also switched to this fork already: https://github.com/Homebrew/homebrew-core/blob/main/Formula/a/aws-vault.rb

