### PR TITLE
refactor(openai/codex): use zst assets

### DIFF
--- a/pkgs/openai/codex/registry.yaml
+++ b/pkgs/openai/codex/registry.yaml
@@ -9,7 +9,7 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.19.0")
         asset: codex-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zst
         files:
           - name: codex
             src: "{{.AssetWithoutExt}}"
@@ -23,7 +23,7 @@ packages:
           - darwin
       - version_constraint: "true"
         asset: codex-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zst
         windows_arm_emulation: true
         files:
           - name: codex

--- a/registry.yaml
+++ b/registry.yaml
@@ -61440,7 +61440,7 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.19.0")
         asset: codex-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zst
         files:
           - name: codex
             src: "{{.AssetWithoutExt}}"
@@ -61454,7 +61454,7 @@ packages:
           - darwin
       - version_constraint: "true"
         asset: codex-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zst
         windows_arm_emulation: true
         files:
           - name: codex


### PR DESCRIPTION
They're smaller than the tar.gz ones.

https://github.com/openai/codex

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
