### PR TITLE
feat: add google/keep-sorted

### DIFF
--- a/pkgs/google/keep-sorted/pkg.yaml
+++ b/pkgs/google/keep-sorted/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/keep-sorted@v0.7.1

--- a/pkgs/google/keep-sorted/registry.yaml
+++ b/pkgs/google/keep-sorted/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: keep-sorted
+    description: keep-sorted is a language-agnostic formatter that sorts lines between two markers in a larger file
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: keep-sorted_{{.OS}}
+        format: raw
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -38690,6 +38690,21 @@ packages:
       - name: jsonnetfmt
   - type: github_release
     repo_owner: google
+    repo_name: keep-sorted
+    description: keep-sorted is a language-agnostic formatter that sorts lines between two markers in a larger file
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.0")
+        no_asset: true
+      - version_constraint: "true"
+        asset: keep-sorted_{{.OS}}
+        format: raw
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
+    repo_owner: google
     repo_name: mtail
     description: extract internal monitoring data from application logs for collection in a timeseries database
     version_constraint: "false"


### PR DESCRIPTION
[google/keep-sorted](https://github.com/google/keep-sorted): keep-sorted is a language-agnostic formatter that sorts lines between two markers in a larger file

```console
$ aqua g -i google/keep-sorted
```