### PR TITLE
feat(tuist): add tuist/tuist

### DIFF
--- a/pkgs/tuist/tuist/pkg.yaml
+++ b/pkgs/tuist/tuist/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: tuist/tuist@4.115.1
+  - name: tuist/tuist
+    version: "4.100.0"

--- a/pkgs/tuist/tuist/registry.yaml
+++ b/pkgs/tuist/tuist/registry.yaml
@@ -6,8 +6,6 @@ packages:
     asset: tuist.zip
     format: zip
     version_filter: Version matches "^[0-9]"
-    files:
-      - name: tuist
     supported_envs:
       - darwin
     checksum:

--- a/pkgs/tuist/tuist/registry.yaml
+++ b/pkgs/tuist/tuist/registry.yaml
@@ -1,0 +1,16 @@
+packages:
+  - type: github_release
+    repo_owner: tuist
+    repo_name: tuist
+    description: A toolchain to generate Xcode projects from Swift packages
+    asset: tuist.zip
+    format: zip
+    version_filter: Version matches "^[0-9]"
+    files:
+      - name: tuist
+    supported_envs:
+      - darwin
+    checksum:
+      type: github_release
+      asset: SHASUMS256.txt
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -82428,8 +82428,6 @@ packages:
     asset: tuist.zip
     format: zip
     version_filter: Version matches "^[0-9]"
-    files:
-      - name: tuist
     supported_envs:
       - darwin
     checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -82422,6 +82422,21 @@ packages:
               - name: lnav
                 src: lnav-{{trimV .Version}}/bin/lnav.exe
   - type: github_release
+    repo_owner: tuist
+    repo_name: tuist
+    description: A toolchain to generate Xcode projects from Swift packages
+    asset: tuist.zip
+    format: zip
+    version_filter: Version matches "^[0-9]"
+    files:
+      - name: tuist
+    supported_envs:
+      - darwin
+    checksum:
+      type: github_release
+      asset: SHASUMS256.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: tummychow
     repo_name: git-absorb
     description: git commit --fixup, but automatic


### PR DESCRIPTION
[tuist/tuist](https://github.com/tuist/tuist) - A toolchain to generate Xcode projects from Swift packages

## Overview

Adds tuist - A toolchain to generate Xcode projects from Swift packages.

- Repository: https://github.com/tuist/tuist
- macOS only (darwin)
- Uses SHA256 checksum verification from SHASUMS256.txt

## Notes

- Version filter excludes non-release tags like `server@*` and `app@*`
- The release provides a single `tuist.zip` asset containing a universal binary for macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)