### PR TITLE
feat: add jamf/Notifier

### DIFF
--- a/pkgs/jamf/Notifier/pkg.yaml
+++ b/pkgs/jamf/Notifier/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: jamf/Notifier@3.1
+  - name: jamf/Notifier
+    version: "2.3"

--- a/pkgs/jamf/Notifier/registry.yaml
+++ b/pkgs/jamf/Notifier/registry.yaml
@@ -9,10 +9,16 @@ packages:
       - version_constraint: semver("<= 2.3.0")
         asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
         format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
         supported_envs:
           - darwin
       - version_constraint: "true"
         asset: Notifier-{{.Version}}.{{.Format}}
         format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
         supported_envs:
           - darwin

--- a/pkgs/jamf/Notifier/registry.yaml
+++ b/pkgs/jamf/Notifier/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jamf
+    repo_name: Notifier
+    description: Swift project which can post macOS alert or banner notifications on 10.15+ clients
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.3.0")
+        asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -44701,11 +44701,17 @@ packages:
       - version_constraint: semver("<= 2.3.0")
         asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
         format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
         supported_envs:
           - darwin
       - version_constraint: "true"
         asset: Notifier-{{.Version}}.{{.Format}}
         format: pkg
+        files:
+          - name: Notifier
+            src: Payload/Applications/Utilities/Notifier.app/Contents/MacOS/Notifier
         supported_envs:
           - darwin
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -44693,6 +44693,22 @@ packages:
     path: desk
     description: A lightweight workspace manager for the shell
   - type: github_release
+    repo_owner: jamf
+    repo_name: Notifier
+    description: Swift project which can post macOS alert or banner notifications on 10.15+ clients
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2.3.0")
+        asset: dataJAR-Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: Notifier-{{.Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: jamietsao
     repo_name: random-winner
     description: Wrote a silly program to select a random winner from my team


### PR DESCRIPTION
[jamf/Notifier](https://github.com/jamf/Notifier) - Swift project which can post macOS alert or banner notifications on 10.15+ clients

- **feat(jamf/Notifier): scaffold jamf/Notifier**
- **add jamf/Notifier**

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
