### PR TITLE
chore: update golines home repo from segmentio to golangci owner

### DIFF
--- a/pkgs/golangci/golines/pkg.yaml
+++ b/pkgs/golangci/golines/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golangci/golines@v0.14.0

--- a/pkgs/golangci/golines/registry.yaml
+++ b/pkgs/golangci/golines/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: golangci
+    repo_name: golines
+    description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines-{{trimV .Version}}-{{.OS}}-all.{{.Format}}
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -38330,6 +38330,24 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: golangci
+    repo_name: golines
+    description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines-{{trimV .Version}}-{{.OS}}-all.{{.Format}}
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: golangci
     repo_name: misspell
     description: Correct commonly misspelled English words in source files
     version_constraint: "false"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
