### PR TITLE
Enable arm64 for psf/black

### DIFF
--- a/pkgs/psf/black/pkg.yaml
+++ b/pkgs/psf/black/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: psf/black@25.12.0
   - name: psf/black
+    version: 25.9.0
+  - name: psf/black
     version: 22.8.0
   - name: psf/black
     version: 22.6.0

--- a/pkgs/psf/black/registry.yaml
+++ b/pkgs/psf/black/registry.yaml
@@ -24,7 +24,7 @@ packages:
         format: raw
         supported_envs:
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 25.9.0")
         asset: black_{{.OS}}
         format: raw
         replacements:
@@ -33,3 +33,16 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: black_{{.OS}}
+        format: raw
+        replacements:
+          arm64: arm
+          darwin: macos
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: black_{{.OS}}-{{.Arch}}
+          - goos: windows
+            goarch: arm64
+            asset: black_{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -66893,7 +66893,7 @@ packages:
         format: raw
         supported_envs:
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 25.9.0")
         asset: black_{{.OS}}
         format: raw
         replacements:
@@ -66902,6 +66902,19 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: black_{{.OS}}
+        format: raw
+        replacements:
+          arm64: arm
+          darwin: macos
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: black_{{.OS}}-{{.Arch}}
+          - goos: windows
+            goarch: arm64
+            asset: black_{{.OS}}-{{.Arch}}
   - type: github_release
     repo_owner: pulumi
     repo_name: esc


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

psf/black recently added support for arm64 both on linux & windows. The config change was generated by aqua, tested with `cmdx t` and I've confirmed the linux arm64 bin is functional. The windows arm64 bin at least has a correct looking signature:
> /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/psf/black/25.12.0/black_windows-arm.exe/black_windows-arm.exe: PE32+ executable (console) Aarch64, for MS Windows, 7 sections