### PR TITLE
feat: add astral-sh/ty

### DIFF
--- a/pkgs/astral-sh/ty/pkg.yaml
+++ b/pkgs/astral-sh/ty/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: astral-sh/ty@0.0.7

--- a/pkgs/astral-sh/ty/registry.yaml
+++ b/pkgs/astral-sh/ty/registry.yaml
@@ -4,14 +4,14 @@ packages:
     repo_owner: astral-sh
     repo_name: ty
     description: An extremely fast Python type checker and language server, written in Rust
-    files:
-      - name: ty
-        src: ty-{{.Arch}}-{{.OS}}/ty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: ty-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ty
+            src: ty-{{.Arch}}-{{.OS}}/ty
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -26,5 +26,4 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: ty.exe
-                src: ty.exe
+              - name: ty

--- a/pkgs/astral-sh/ty/registry.yaml
+++ b/pkgs/astral-sh/ty/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: astral-sh
+    repo_name: ty
+    description: An extremely fast Python type checker and language server, written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ty-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/astral-sh/ty/registry.yaml
+++ b/pkgs/astral-sh/ty/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: astral-sh
     repo_name: ty
     description: An extremely fast Python type checker and language server, written in Rust
+    files:
+      - name: ty
+        src: ty-{{.Arch}}-{{.OS}}/ty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -22,3 +25,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: ty.exe
+                src: ty.exe

--- a/registry.yaml
+++ b/registry.yaml
@@ -14442,6 +14442,28 @@ packages:
             asset: rye-{{.Arch}}-{{.OS}}
   - type: github_release
     repo_owner: astral-sh
+    repo_name: ty
+    description: An extremely fast Python type checker and language server, written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ty-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: astral-sh
     repo_name: uv
     description: An extremely fast Python package installer and resolver, written in Rust
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -14444,14 +14444,14 @@ packages:
     repo_owner: astral-sh
     repo_name: ty
     description: An extremely fast Python type checker and language server, written in Rust
-    files:
-      - name: ty
-        src: ty-{{.Arch}}-{{.OS}}/ty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: ty-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ty
+            src: ty-{{.Arch}}-{{.OS}}/ty
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -14466,8 +14466,7 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: ty.exe
-                src: ty.exe
+              - name: ty
   - type: github_release
     repo_owner: astral-sh
     repo_name: uv

--- a/registry.yaml
+++ b/registry.yaml
@@ -14444,6 +14444,9 @@ packages:
     repo_owner: astral-sh
     repo_name: ty
     description: An extremely fast Python type checker and language server, written in Rust
+    files:
+      - name: ty
+        src: ty-{{.Arch}}-{{.OS}}/ty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -14462,6 +14465,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: ty.exe
+                src: ty.exe
   - type: github_release
     repo_owner: astral-sh
     repo_name: uv


### PR DESCRIPTION
[astral-sh/ty](https://github.com/astral-sh/ty) - An extremely fast Python type checker and language server, written in Rust

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
This adds a new package for [`ty`](https://github.com/astral-sh/ty).