### PR TITLE
feat: add golangci/golines

### DIFF
--- a/aqua-all.yaml
+++ b/aqua-all.yaml
@@ -12,6 +12,7 @@ packages:
   # keep-sorted start
   - import: pkgs/ByteNess/aws-vault/pkg.yaml
   - import: pkgs/golang/go/pkg.yaml
+  - import: pkgs/golangci/golines/pkg.yaml
   - import: pkgs/sharkdp/bat/pkg.yaml
   - import: pkgs/suzuki-shunsuke/ghcp/pkg.yaml
   - import: pkgs/zigtools/zls/pkg.yaml

--- a/pkgs/golangci/golines/pkg.yaml
+++ b/pkgs/golangci/golines/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: golangci/golines@v0.14.0

--- a/pkgs/golangci/golines/registry.yaml
+++ b/pkgs/golangci/golines/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: golangci
+    repo_name: golines
+    description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines-{{trimV .Version}}-{{.OS}}-all.{{.Format}}
+          - goos: windows
+            format: zip

--- a/pkgs/golangci/golines/registry.yaml
+++ b/pkgs/golangci/golines/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: "true"
         asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: golines
+            src: "{{.AssetWithoutExt}}/golines"
         checksum:
           type: github_release
           asset: golines_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -38676,6 +38676,24 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: golangci
+    repo_name: golines
+    description: A golang formatter that fixes long lines
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: golines_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: golines-{{trimV .Version}}-{{.OS}}-all.{{.Format}}
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: golangci
     repo_name: misspell
     description: Correct commonly misspelled English words in source files
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -38683,6 +38683,9 @@ packages:
       - version_constraint: "true"
         asset: golines-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: golines
+            src: "{{.AssetWithoutExt}}/golines"
         checksum:
           type: github_release
           asset: golines_{{trimV .Version}}_checksums.txt


### PR DESCRIPTION
[golangci/golines](https://github.com/golangci/golines): A golang formatter that fixes long lines

```console
$ aqua g -i golangci/golines
```

Close #46084