### PR TITLE
feat(bootandy/dust): Fixed bootandy/dust to support new platforms added in v0.4.5.0 and later

### DIFF
--- a/pkgs/bootandy/dust/pkg.yaml
+++ b/pkgs/bootandy/dust/pkg.yaml
@@ -1,2 +1,14 @@
 packages:
   - name: bootandy/dust@v1.2.3
+  - name: bootandy/dust
+    version: v0.8.0
+  - name: bootandy/dust
+    version: v0.6.2
+  - name: bootandy/dust
+    version: v0.4.4
+  - name: bootandy/dust
+    version: v0.4.0.1
+  - name: bootandy/dust
+    version: v0.3.1
+  - name: bootandy/dust
+    version: v0.2.0

--- a/pkgs/bootandy/dust/registry.yaml
+++ b/pkgs/bootandy/dust/registry.yaml
@@ -87,6 +87,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: Version == "v0.7.0"
         no_asset: true
       - version_constraint: semver("<= 0.8.0")
@@ -111,6 +114,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -127,3 +133,6 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"

--- a/pkgs/bootandy/dust/registry.yaml
+++ b/pkgs/bootandy/dust/registry.yaml
@@ -4,22 +4,126 @@ packages:
     repo_owner: bootandy
     repo_name: dust
     description: A more intuitive version of du in rust
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-      386: i686
-    files:
-      - name: dust
-        src: dust-{{.Version}}-{{.Arch}}-{{.OS}}/dust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.2.0")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4.0"
+        no_asset: true
+      - version_constraint: Version == "v0.4.0.1"
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4.1.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.4.4")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.6.2")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
+            replacements:
+              arm64: arm
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v0.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.8.0")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
+            replacements:
+              arm64: arm
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip

--- a/pkgs/bootandy/dust/registry.yaml
+++ b/pkgs/bootandy/dust/registry.yaml
@@ -78,14 +78,12 @@ packages:
             goarch: amd64
             replacements:
               linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
-            replacements:
-              arm64: arm
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -103,14 +101,12 @@ packages:
             goarch: amd64
             replacements:
               linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
-            replacements:
-              arm64: arm
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/bootandy/dust/registry.yaml
+++ b/pkgs/bootandy/dust/registry.yaml
@@ -66,6 +66,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -83,14 +86,14 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -108,14 +111,14 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -127,6 +130,3 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"

--- a/pkgs/bootandy/dust/registry.yaml
+++ b/pkgs/bootandy/dust/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: A more intuitive version of du in rust
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.1.1"
+      - version_constraint: Version in ["v0.1.1", "v0.4.0", "v0.4.1.1", "v0.7.0"]
         no_asset: true
       - version_constraint: semver("<= 0.2.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -39,8 +39,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "v0.4.0"
-        no_asset: true
       - version_constraint: Version == "v0.4.0.1"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -52,8 +50,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "v0.4.1.1"
-        no_asset: true
       - version_constraint: semver("<= 0.4.4")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -90,8 +86,6 @@ packages:
         files:
           - name: dust
             src: "{{.AssetWithoutExt}}/dust"
-      - version_constraint: Version == "v0.7.0"
-        no_asset: true
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -18142,6 +18142,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: Version == "v0.7.0"
         no_asset: true
       - version_constraint: semver("<= 0.8.0")
@@ -18166,6 +18169,9 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -18182,6 +18188,9 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
   - type: github_release
     repo_owner: borgbackup
     repo_name: borg

--- a/registry.yaml
+++ b/registry.yaml
@@ -18061,7 +18061,7 @@ packages:
     description: A more intuitive version of du in rust
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.1.1"
+      - version_constraint: Version in ["v0.1.1", "v0.4.0", "v0.4.1.1", "v0.7.0"]
         no_asset: true
       - version_constraint: semver("<= 0.2.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -18094,8 +18094,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "v0.4.0"
-        no_asset: true
       - version_constraint: Version == "v0.4.0.1"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -18107,8 +18105,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "v0.4.1.1"
-        no_asset: true
       - version_constraint: semver("<= 0.4.4")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -18145,8 +18141,6 @@ packages:
         files:
           - name: dust
             src: "{{.AssetWithoutExt}}/dust"
-      - version_constraint: Version == "v0.7.0"
-        no_asset: true
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -18059,25 +18059,129 @@ packages:
     repo_owner: bootandy
     repo_name: dust
     description: A more intuitive version of du in rust
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-      386: i686
-    files:
-      - name: dust
-        src: dust-{{.Version}}-{{.Arch}}-{{.OS}}/dust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.2.0")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4.0"
+        no_asset: true
+      - version_constraint: Version == "v0.4.0.1"
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4.1.1"
+        no_asset: true
+      - version_constraint: semver("<= 0.4.4")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.6.2")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
+            replacements:
+              arm64: arm
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v0.7.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.8.0")
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
+            replacements:
+              arm64: arm
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: borgbackup
     repo_name: borg

--- a/registry.yaml
+++ b/registry.yaml
@@ -18133,14 +18133,12 @@ packages:
             goarch: amd64
             replacements:
               linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
-            replacements:
-              arm64: arm
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -18158,14 +18156,12 @@ packages:
             goarch: amd64
             replacements:
               linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}eabihf.{{.Format}}
-            replacements:
-              arm64: arm
-              linux: unknown-linux-gnu
           - goos: windows
             format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -18121,6 +18121,9 @@ packages:
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -18138,14 +18141,14 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: semver("<= 0.8.0")
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -18163,14 +18166,14 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"
       - version_constraint: "true"
         asset: dust-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: dust
+            src: "{{.AssetWithoutExt}}/dust"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -18182,9 +18185,6 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
-        files:
-          - name: dust
-            src: "{{.AssetWithoutExt}}/dust"
   - type: github_release
     repo_owner: borgbackup
     repo_name: borg


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Since `dust` now supports platforms other than Darwin and Linux/amd64, I updated the registry accordingly.
Also, as it appeared to be written in an older style, I regenerated it using `cmdx s`.
