### PR TITLE
feat(txn2/kubefwd): cosign config

### DIFF
--- a/pkgs/txn2/kubefwd/pkg.yaml
+++ b/pkgs/txn2/kubefwd/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: txn2/kubefwd@v1.24.1
   - name: txn2/kubefwd
+    version: v1.24.0
+  - name: txn2/kubefwd
     version: 1.18.1
   - name: txn2/kubefwd
     version: 1.14.7

--- a/pkgs/txn2/kubefwd/registry.yaml
+++ b/pkgs/txn2/kubefwd/registry.yaml
@@ -131,6 +131,22 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 1.24.1")
+        asset: kubefwd_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kubefwd_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: kubefwd_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -144,6 +160,15 @@ packages:
           type: github_release
           asset: kubefwd_checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: kubefwd_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/txn2/kubefwd/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -83759,6 +83759,22 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 1.24.1")
+        asset: kubefwd_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: kubefwd_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: kubefwd_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -83772,6 +83788,15 @@ packages:
           type: github_release
           asset: kubefwd_checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: kubefwd_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/txn2/kubefwd/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
This was initially added upstream for 1.24.0 but with detached .sig and .pem form, without providing the .pem.

- https://github.com/txn2/kubefwd/issues/325
- https://github.com/txn2/kubefwd/releases/tag/v1.24.0
- https://github.com/txn2/kubefwd/releases/tag/v1.24.1

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
