### PR TITLE
fix: update apple/container asset name for versions 0.7.0 and later

### DIFF
--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0")
+      - version_constraint: semver("< 0.7.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:


### PR DESCRIPTION
[apple/container](https://github.com/apple/container) - A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [ ] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely) - Manually updated registry.yaml and tested with local registry

<!-- Please write the description here -->

## Summary
  Starting from version 0.7.0, the asset naming convention changed:
  - Before (≤0.6.0): `container-{version}-installer-signed.pkg`
  - After (≥0.7.0): `container-installer-signed.pkg`
  This change adds `version_overrides` to support both naming conventions.

- [x] Install and execute the package and confirm if the package works well
    - Tested with 0.6.0 (old format) 0.7.0 and 0.7.1 (new format)



