### PR TITLE
fix(zyedidia/micro): Upgrade to 2.0.15

### DIFF
--- a/pkgs/zyedidia/micro/pkg.yaml
+++ b/pkgs/zyedidia/micro/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: zyedidia/micro@v2.0.14
+  - name: zyedidia/micro@v2.0.15
+  - name: zyedidia/micro
+    version: v2.0.14
   - name: zyedidia/micro
     version: v2.0.13
   - name: zyedidia/micro

--- a/pkgs/zyedidia/micro/registry.yaml
+++ b/pkgs/zyedidia/micro/registry.yaml
@@ -78,7 +78,7 @@ packages:
             asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 2.0.13")
+      - version_constraint: semver("<= 2.0.14")
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
         files:
@@ -106,7 +106,7 @@ packages:
             format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: tgz
+        format: tar.gz
         files:
           - name: micro
             src: micro-{{trimV .Version}}/micro

--- a/pkgs/zyedidia/micro/registry.yaml
+++ b/pkgs/zyedidia/micro/registry.yaml
@@ -78,32 +78,6 @@ packages:
             asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 2.0.14")
-        asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: micro
-            src: micro-{{trimV .Version}}/micro
-        replacements:
-          windows: win64
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
-          - goos: linux
-            goarch: arm64
-            asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: darwin
-            goarch: amd64
-            replacements:
-              darwin: osx
-          - goos: darwin
-            goarch: arm64
-            asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              darwin: macos
-          - goos: windows
-            format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -89509,32 +89509,32 @@ packages:
             asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 2.0.14")
-        asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: micro
-            src: micro-{{trimV .Version}}/micro
-        replacements:
-          windows: win64
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
-          - goos: linux
-            goarch: arm64
-            asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: darwin
-            goarch: amd64
-            replacements:
-              darwin: osx
-          - goos: darwin
-            goarch: arm64
-            asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              darwin: macos
-          - goos: windows
-            format: zip
+      # - version_constraint: semver("<= 2.0.14")
+      #   asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
+      #   format: tar.gz
+      #   files:
+      #     - name: micro
+      #       src: micro-{{trimV .Version}}/micro
+      #   replacements:
+      #     windows: win64
+      #   overrides:
+      #     - goos: linux
+      #       goarch: amd64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
+      #     - goos: linux
+      #       goarch: arm64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      #     - goos: darwin
+      #       goarch: amd64
+      #       replacements:
+      #         darwin: osx
+      #     - goos: darwin
+      #       goarch: arm64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      #       replacements:
+      #         darwin: macos
+      #     - goos: windows
+      #       format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -89509,32 +89509,6 @@ packages:
             asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-      # - version_constraint: semver("<= 2.0.14")
-      #   asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-      #   format: tar.gz
-      #   files:
-      #     - name: micro
-      #       src: micro-{{trimV .Version}}/micro
-      #   replacements:
-      #     windows: win64
-      #   overrides:
-      #     - goos: linux
-      #       goarch: amd64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
-      #     - goos: linux
-      #       goarch: arm64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      #     - goos: darwin
-      #       goarch: amd64
-      #       replacements:
-      #         darwin: osx
-      #     - goos: darwin
-      #       goarch: arm64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      #       replacements:
-      #         darwin: macos
-      #     - goos: windows
-      #       format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -89509,7 +89509,7 @@ packages:
             asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 2.0.13")
+      - version_constraint: semver("<= 2.0.14")
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
         files:
@@ -89535,9 +89535,35 @@ packages:
               darwin: macos
           - goos: windows
             format: zip
+      # - version_constraint: semver("<= 2.0.14")
+      #   asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
+      #   format: tgz
+      #   files:
+      #     - name: micro
+      #       src: micro-{{trimV .Version}}/micro
+      #   replacements:
+      #     windows: win64
+      #   overrides:
+      #     - goos: linux
+      #       goarch: amd64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
+      #     - goos: linux
+      #       goarch: arm64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      #     - goos: darwin
+      #       goarch: amd64
+      #       replacements:
+      #         darwin: osx
+      #     - goos: darwin
+      #       goarch: arm64
+      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+      #       replacements:
+      #         darwin: macos
+      #     - goos: windows
+      #       format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        format: tgz
+        format: tar.gz
         files:
           - name: micro
             src: micro-{{trimV .Version}}/micro

--- a/registry.yaml
+++ b/registry.yaml
@@ -89535,32 +89535,6 @@ packages:
               darwin: macos
           - goos: windows
             format: zip
-      # - version_constraint: semver("<= 2.0.14")
-      #   asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
-      #   format: tgz
-      #   files:
-      #     - name: micro
-      #       src: micro-{{trimV .Version}}/micro
-      #   replacements:
-      #     windows: win64
-      #   overrides:
-      #     - goos: linux
-      #       goarch: amd64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}64-static.{{.Format}}
-      #     - goos: linux
-      #       goarch: arm64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      #     - goos: darwin
-      #       goarch: amd64
-      #       replacements:
-      #         darwin: osx
-      #     - goos: darwin
-      #       goarch: arm64
-      #       asset: micro-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-      #       replacements:
-      #         darwin: macos
-      #     - goos: windows
-      #       format: zip
       - version_constraint: "true"
         asset: micro-{{trimV .Version}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

- Closes #46450

<details>
<summary>Output of `cmdx remove; cmdx gr; cmdx t zyedidia/micro`</summary>

```terminal
+ bash scripts/remove_container.sh
bash scripts/remove_container.sh aqua-registry-windows

[INFO] Checking if the container aqua-registry exists
aqua-registry
aqua-registry
[INFO] Checking if the container aqua-registry-windows exists
aqua-registry-windows
aqua-registry-windows
+ aqua exec -- aqua-registry gr
+ PACKAGE=${PACKAGE#https://github.com/}

pkg=$(bash scripts/get_test_pkg.sh "$PACKAGE")
if [ "$IS_RECREATE" = true ]; then
  cmdx rm
fi

bash scripts/start.sh
bash scripts/test.sh "$pkg"
bash scripts/start.sh aqua-registry-windows
bash scripts/test-windows.sh "$pkg"
aqua exec -- aqua-registry gr

[INFO] Checking if the container aqua-registry exists
[INFO] Creating a container aqua-registry
eeb10971a3f0b1ae79b23dd9ebd7bb1668189175b237743f1b46462d98e3dc49
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 6.14kB to aqua-registry:/workspace/registry.yaml
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] create a symbolic link                        env=linux/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] create a symbolic link                        command=micro env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.8 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.14 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.10 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.13 program=aqua program_version=2.56.1 registry=standard
INFO[0003] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v2.0.7 program=aqua program_version=2.56.1 registry=standard
INFO[0003] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=v1.4.1 program=aqua program_version=2.56.1 registry=standard
INFO[0003] download and unarchive the package            env=linux/amd64 package_name=zyedidia/micro package_version=1.0rc1 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.14 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.10 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.8 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.13 program=aqua program_version=2.56.1 registry=standard
INFO[0002] download and unarchive the package            env=linux/arm64 package_name=zyedidia/micro package_version=v2.0.7 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.8 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.13 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.14 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.10 program=aqua program_version=2.56.1 registry=standard
INFO[0002] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v2.0.7 program=aqua program_version=2.56.1 registry=standard
INFO[0002] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=v1.4.1 program=aqua program_version=2.56.1 registry=standard
INFO[0002] download and unarchive the package            env=darwin/amd64 package_name=zyedidia/micro package_version=1.0rc1 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=zyedidia/micro package_version=v2.0.13 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=zyedidia/micro package_version=v2.0.14 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=darwin/arm64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1 registry=standard
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Creating a container aqua-registry-windows
af6b300c11aef242a2796b03a809dc39b024641f7d324f7c430a2d37807f0246
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 6.14kB to aqua-registry-windows:/workspace/registry.yaml
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] create a symbolic link                        env=windows/amd64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
INFO[0000] create a symbolic link                        command=micro env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.8 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.15 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.14 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.13 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.10 program=aqua program_version=2.56.1 registry=standard
INFO[0002] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v2.0.7 program=aqua program_version=2.56.1 registry=standard
INFO[0003] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=v1.4.1 program=aqua program_version=2.56.1 registry=standard
INFO[0003] download and unarchive the package            env=windows/amd64 package_name=zyedidia/micro package_version=1.0rc1 program=aqua program_version=2.56.1 registry=standard
INFO[0000] download and unarchive the package            env=windows/arm64 package_name=aqua-proxy package_version=v1.2.12 program=aqua program_version=2.56.1 registry=
```

</details>
