### PR TITLE
fix(kptdev/kpt): exclude package-examples/ tags

### DIFF
--- a/pkgs/kptdev/kpt/registry.yaml
+++ b/pkgs/kptdev/kpt/registry.yaml
@@ -7,7 +7,7 @@ packages:
       - name: GoogleContainerTools/kpt
     description: Automate Kubernetes Configuration Editing
     version_filter: |
-      not (Version startsWith "porch/")
+      not (Version startsWith "porch/" or Version startsWith "package-examples/")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.33.0")

--- a/pkgs/kptdev/kpt/scaffold.yaml
+++ b/pkgs/kptdev/kpt/scaffold.yaml
@@ -3,4 +3,4 @@
 # aqua - Declarative CLI Version Manager
 # https://aquaproj.github.io/
 name: kptdev/kpt
-version_filter: not (Version startsWith "porch/")
+version_filter: not (Version startsWith "porch/" or Version startsWith "package-examples/")

--- a/registry.yaml
+++ b/registry.yaml
@@ -50658,7 +50658,7 @@ packages:
       - name: GoogleContainerTools/kpt
     description: Automate Kubernetes Configuration Editing
     version_filter: |
-      not (Version startsWith "porch/")
+      not (Version startsWith "porch/" or Version startsWith "package-examples/")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.33.0")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

e.g.
- [package-examples/ingress-nginx/v0](https://github.com/kptdev/kpt/releases/tag/package-examples%2Fingress-nginx%2Fv0)
- [package-examples/ghost/v1](https://github.com/kptdev/kpt/releases/tag/package-examples%2Fghost%2Fv1)