### PR TITLE
fix(biomejs/biome): fix version_constraint order for 2.x releases

### DIFF
--- a/pkgs/biomejs/biome/registry.yaml
+++ b/pkgs/biomejs/biome/registry.yaml
@@ -11,7 +11,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "@biomejs/biome@2.0.1"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         version_prefix: cli/v
         asset: biome-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -17557,7 +17557,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "@biomejs/biome@2.0.1"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         version_prefix: cli/v
         asset: biome-{{.OS}}-{{.Arch}}
         format: raw


### PR DESCRIPTION
## Summary

The second `version_override` with `version_constraint: "true"` was matching all versions and incorrectly applying the `cli/v` prefix to biome 2.x releases. However, biome 2.x releases use `@biomejs/biome@` tags, not `cli/v` tags.

## Changes

Changed `version_constraint: "true"` to `semver("< 2.0.0")` so the `cli/v` prefix only applies to 1.x versions which actually use that tag format.

## Problem

Without this fix, installing `biome@latest` fails with a 404 error because it tries to fetch from tag `cli/vlatest` instead of the correct `@biomejs/biome@2.3.11` tag.

## Tag format reference

- **1.x versions**: `cli/v1.9.4`, `cli/v1.8.3`, etc.
- **2.x versions**: `@biomejs/biome@2.3.11`, `@biomejs/biome@2.0.0`, etc.