### PR TITLE
fix(biomejs/biome): add version_prefix to fallback constraint

### DIFF
--- a/pkgs/biomejs/biome/registry.yaml
+++ b/pkgs/biomejs/biome/registry.yaml
@@ -30,6 +30,7 @@ packages:
           - linux
           - darwin
       - version_constraint: "true"
+        version_prefix: "@biomejs/biome@"
         asset: biome-{{.OS}}-{{.Arch}}
         format: raw
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -17576,6 +17576,7 @@ packages:
           - linux
           - darwin
       - version_constraint: "true"
+        version_prefix: "@biomejs/biome@"
         asset: biome-{{.OS}}-{{.Arch}}
         format: raw
         replacements:


### PR DESCRIPTION
## Summary

The fallback `version_constraint: "true"` was missing the `version_prefix`, causing biome versions > 2.3.8 (like 2.3.9, 2.3.10, 2.3.11) to fail installation with 404 errors.

## Problem

Without `version_prefix`, versions > 2.3.8 tried to fetch from tags like `2.3.11` or `v2.3.11` instead of `@biomejs/biome@2.3.11`.

## Fix

Added `version_prefix: "@biomejs/biome@"` to the fallback constraint.

## Follow-up to

This is a follow-up to #46638.