### PR TITLE
feat(kawaz/authsock-filter): add new package

### DIFF
--- a/pkgs/kawaz/authsock-filter/pkg.yaml
+++ b/pkgs/kawaz/authsock-filter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kawaz/authsock-filter@v0.1.35

--- a/pkgs/kawaz/authsock-filter/registry.yaml
+++ b/pkgs/kawaz/authsock-filter/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kawaz
+    repo_name: authsock-filter
+    description: SSH agent proxy with filtering and logging
+    asset: authsock-filter-{{.Arch}}-{{.OS}}.tar.gz
+    format: tar.gz
+    files:
+      - name: authsock-filter
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    supported_envs:
+      - darwin
+      - linux/amd64
+    rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -49240,6 +49240,23 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: kawaz
+    repo_name: authsock-filter
+    description: SSH agent proxy with filtering and logging
+    asset: authsock-filter-{{.Arch}}-{{.OS}}.tar.gz
+    format: tar.gz
+    files:
+      - name: authsock-filter
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+    supported_envs:
+      - darwin
+      - linux/amd64
+    rosetta2: true
+  - type: github_release
     repo_owner: kayac
     repo_name: ecspresso
     asset: ecspresso_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[kawaz/authsock-filter](https://github.com/kawaz/authsock-filter) - SSH agent proxy with filtering and logging

## Package

- name: `kawaz/authsock-filter`
- repo: https://github.com/kawaz/authsock-filter

## Description

SSH agent proxy with filtering and logging. Create multiple filtered sockets from a single upstream SSH agent.

## Features

- Multiple filtered sockets from a single upstream SSH agent
- Filter keys by fingerprint, comment, key type, GitHub user keys, or keyfile
- Pattern matching with glob and regex support
- JSONL logging for auditing
- OS service integration (launchd/systemd)

## Supported Environments

- macOS (arm64, amd64)
- Linux (amd64)

## Checklist

- [x] The commit is signed
- [x] `pkg.yaml` and `registry.yaml` are created
- [x] Package name follows `owner/repo` format