### PR TITLE
feat(smithy-lang/smithy): add smithy CLI

### DIFF
--- a/pkgs/smithy-lang/smithy/pkg.yaml
+++ b/pkgs/smithy-lang/smithy/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: smithy-lang/smithy@1.65.0
+  - name: smithy-lang/smithy
+    version: 1.47.0

--- a/pkgs/smithy-lang/smithy/registry.yaml
+++ b/pkgs/smithy-lang/smithy/registry.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: smithy-lang
+    repo_name: smithy
+    description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.47.0")
+        asset: smithy-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: smithy
+            src: bin/smithy
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: smithy-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: smithy
+            src: smithy-cli-{{.OS}}-{{.Arch}}/bin/smithy
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x64

--- a/registry.yaml
+++ b/registry.yaml
@@ -75345,6 +75345,20 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: smartxworks
+    repo_name: knest
+    description: Kubernetes-in-Kubernetes Made Simple
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: knest
+        supported_envs:
+          - linux/amd64
+      - version_constraint: "true"
+        asset: knest-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+  - type: github_release
     repo_owner: smithy-lang
     repo_name: smithy
     description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
@@ -75386,20 +75400,6 @@ packages:
           - goos: windows
             replacements:
               amd64: x64
-  - type: github_release
-    repo_owner: smartxworks
-    repo_name: knest
-    description: Kubernetes-in-Kubernetes Made Simple
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v0.1.0"
-        asset: knest
-        supported_envs:
-          - linux/amd64
-      - version_constraint: "true"
-        asset: knest-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
   - type: github_release
     repo_owner: smtg-ai
     repo_name: claude-squad

--- a/registry.yaml
+++ b/registry.yaml
@@ -75345,6 +75345,48 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: smithy-lang
+    repo_name: smithy
+    description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.47.0")
+        asset: smithy-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: smithy
+            src: bin/smithy
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x64
+      - version_constraint: "true"
+        asset: smithy-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        files:
+          - name: smithy
+            src: smithy-cli-{{.OS}}-{{.Arch}}/bin/smithy
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            replacements:
+              amd64: x64
+  - type: github_release
     repo_owner: smartxworks
     repo_name: knest
     description: Kubernetes-in-Kubernetes Made Simple


### PR DESCRIPTION
## Description

Add [Smithy CLI](https://github.com/smithy-lang/smithy) - a language for defining services and SDKs.

## Version handling

Smithy releases changed archive format at version 1.48.0:
- **< 1.48.0**: `.tar.gz` format with flat directory structure (`bin/smithy`)
- **>= 1.48.0**: `.zip` format with nested directory structure (`smithy-cli-<os>-<arch>/bin/smithy`)

Both formats are supported via `version_overrides`.

## Supported platforms

- darwin/amd64
- darwin/arm64
- linux/amd64
- linux/arm64
- windows/amd64

## Test

Tested with mise:
- `smithy@1.65.0` (zip format) - OK
- `smithy@1.41.0` (tar.gz format) - OK