### PR TITLE
feat: add kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin

### DIFF
--- a/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/pkg.yaml
+++ b/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin@

--- a/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/pkg.yaml
+++ b/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin@
+  - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin@v35.0.0

--- a/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/registry.yaml
+++ b/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/registry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin
+    type: github_release
+    repo_owner: kubernetes
+    repo_name: cloud-provider-gcp
+    description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud

--- a/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/registry.yaml
+++ b/pkgs/kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin/registry.yaml
@@ -1,7 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin
-    type: github_release
+    type: go_build
     repo_owner: kubernetes
     repo_name: cloud-provider-gcp
     description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud
+    files:
+      - name: gke-gcloud-auth-plugin
+        src: ./cmd/gke-gcloud-auth-plugin
+        dir: cloud-provider-gcp-{{trimV .Version}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -51923,6 +51923,11 @@ packages:
               - https://github.com/kubernetes-sigs/zeitgeist/releases/download/{{.Version}}/checksums.txt.sig
               - --certificate
               - https://github.com/kubernetes-sigs/zeitgeist/releases/download/{{.Version}}/checksums.txt.pem
+  - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin
+    type: github_release
+    repo_owner: kubernetes
+    repo_name: cloud-provider-gcp
+    description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud
   - type: github_release
     repo_owner: kubernetes
     repo_name: kompose

--- a/registry.yaml
+++ b/registry.yaml
@@ -51924,10 +51924,14 @@ packages:
               - --certificate
               - https://github.com/kubernetes-sigs/zeitgeist/releases/download/{{.Version}}/checksums.txt.pem
   - name: kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin
-    type: github_release
+    type: go_build
     repo_owner: kubernetes
     repo_name: cloud-provider-gcp
     description: cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud
+    files:
+      - name: gke-gcloud-auth-plugin
+        src: ./cmd/gke-gcloud-auth-plugin
+        dir: cloud-provider-gcp-{{trimV .Version}}
   - type: github_release
     repo_owner: kubernetes
     repo_name: kompose


### PR DESCRIPTION
[kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin](https://github.com/kubernetes/cloud-provider-gcp): cloud-provider-gcp contains several projects used to run Kubernetes in Google Cloud

```console
$ aqua g -i kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin
```

Close #46975