### PR TITLE
Added linux/windows/arm64 to supported_envs for dprint>=0.34.0

### DIFF
--- a/pkgs/dprint/dprint/registry.yaml
+++ b/pkgs/dprint/dprint/registry.yaml
@@ -32,18 +32,13 @@ packages:
           algorithm: sha256
       - version_constraint: "true"
         asset: dprint-{{.Arch}}-{{.OS}}.zip
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - linux
-          - windows
-          - darwin
-          - amd64
-          - arm64
         checksum:
           type: github_release
           asset: SHASUMS256.txt

--- a/pkgs/dprint/dprint/registry.yaml
+++ b/pkgs/dprint/dprint/registry.yaml
@@ -39,8 +39,11 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         supported_envs:
+          - linux
+          - windows
           - darwin
           - amd64
+          - arm64
         checksum:
           type: github_release
           asset: SHASUMS256.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -31011,8 +31011,11 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         supported_envs:
+          - linux
+          - windows
           - darwin
           - amd64
+          - arm64
         checksum:
           type: github_release
           asset: SHASUMS256.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -31004,18 +31004,13 @@ packages:
           algorithm: sha256
       - version_constraint: "true"
         asset: dprint-{{.Arch}}-{{.OS}}.zip
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - linux
-          - windows
-          - darwin
-          - amd64
-          - arm64
         checksum:
           type: github_release
           asset: SHASUMS256.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## Summary

- Add Linux, Windows, and arm64 to supported_envs for dprint versions >= 0.34.0 to align supported environments with the assets published in dprint releases.

## Context

[dprint releases (e.g., 0.34.0)](https://github.com/dprint/dprint/releases/tag/0.34.0) provide Linux aarch64/x86_64 and Windows x86_64 assets, but the registry limited supported envs to darwin/amd64. This change fixes that mismatch.