### PR TITLE
feat(jackchuka/mdschema): scaffold jackchuka/mdschema

### DIFF
--- a/pkgs/jackchuka/mdschema/pkg.yaml
+++ b/pkgs/jackchuka/mdschema/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jackchuka/mdschema@v0.4.0

--- a/pkgs/jackchuka/mdschema/registry.yaml
+++ b/pkgs/jackchuka/mdschema/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jackchuka
+    repo_name: mdschema
+    description: A declarative schema-based Markdown validator that helps maintain consistent documentation structure across projects
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mdschema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: mdschema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -45828,6 +45828,19 @@ packages:
           asset: confluence-md_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: jackchuka
+    repo_name: mdschema
+    description: A declarative schema-based Markdown validator that helps maintain consistent documentation structure across projects
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mdschema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: mdschema_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: jacobdeichert
     repo_name: mask
     description: A CLI task runner defined by a simple markdown file


### PR DESCRIPTION
#47186 [jackchuka/mdschema](https://github.com/jackchuka/mdschema) - A declarative schema-based Markdown validator that helps maintain consistent documentation structure across projects @jackchuka

```sh
❯ cmdx s jackchuka/mdschema
...

Successfully copied 2.05kB to /Users/jackchuka/ghq/github.com/jackchuka/aqua-registry/pkgs/jackchuka/mdschema/pkg.yaml
Successfully copied 2.56kB to /Users/jackchuka/ghq/github.com/jackchuka/aqua-registry/pkgs/jackchuka/mdschema/registry.yaml
+ aqua exec -- aqua-registry gr
[feat/jackchuka/mdschema 7a6f25d7d5] feat(jackchuka/mdschema): scaffold jackchuka/mdschema
 3 files changed, 30 insertions(+)
 create mode 100644 pkgs/jackchuka/mdschema/pkg.yaml
 create mode 100644 pkgs/jackchuka/mdschema/registry.yaml
Successfully copied 2.05kB to aqua-registry:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry:/workspace/registry.yaml
[INFO] Checking if the container aqua-registry-windows exists
[INFO] Checking if the container aqua-registry-windows is running
[INFO] Dockerfile isn't updated
Successfully copied 2.05kB to aqua-registry-windows:/workspace/pkg.yaml
Successfully copied 2.56kB to aqua-registry-windows:/workspace/registry.yaml
```

Installation confirmed
```sh
❯ aqua g -i jackchuka/mdschema
❯ aqua i
❯ which -a mdschema
/Users/jackchuka/.local/share/aquaproj-aqua/bin/mdschema
❯ mdschema -h
mdschema validates Markdown documentation structure and conventions
using declarative schemas to maintain consistent documentation across projects.
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
