### PR TITLE
chore(cmdx): stop using `-ti` option for claude

### DIFF
--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -27,9 +27,9 @@ if [ -z "$config" ] && [ -f "pkgs/$pkg/scaffold.yaml" ]; then
 	docker cp "pkgs/$pkg/scaffold.yaml" "aqua-registry:/workspace/scaffold.yaml"
 fi
 # shellcheck disable=SC2086
-docker exec -ti -w /workspace aqua-registry bash -c "rm pkg.yaml 2>/dev/null || :"
-docker exec -ti -w /workspace aqua-registry bash -c "echo '# yaml-language-server: \$schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json' > registry.yaml"
-docker exec -ti -w /workspace aqua-registry bash -c "aqua gr $opts --out-testdata pkg.yaml \"$pkg\" >> registry.yaml"
+docker exec -w /workspace aqua-registry bash -c "rm pkg.yaml 2>/dev/null || :"
+docker exec -w /workspace aqua-registry bash -c "echo '# yaml-language-server: \$schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json' > registry.yaml"
+docker exec -w /workspace aqua-registry bash -c "aqua gr $opts --out-testdata pkg.yaml \"$pkg\" >> registry.yaml"
 docker cp "aqua-registry:/workspace/pkg.yaml" "pkgs/$pkg/pkg.yaml"
 docker cp "aqua-registry:/workspace/registry.yaml" "pkgs/$pkg/registry.yaml"
 if [ -n "$config" ];then


### PR DESCRIPTION
Close #47082

```
Run `docker exec -ti -w /workspace aqua-registry whoami`

⏺ Bash(docker exec -ti -w /workspace aqua-registry whoami)
  ⎿  Error: Exit code 1
     the input device is not a TTY

⏺ The -t flag requires a TTY which isn't available in this context. Let me run it without the TTY flag.

⏺ Bash(docker exec -w /workspace aqua-registry whoami)
  ⎿  root

⏺ The user inside the aqua-registry container is root.
```