### PR TITLE
fix(theryangeary/choose): remove complete_windows_ext

### DIFF
--- a/pkgs/theryangeary/choose/pkg.yaml
+++ b/pkgs/theryangeary/choose/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: theryangeary/choose@v1.3.7
   - name: theryangeary/choose
+    version: v1.3.6
+  - name: theryangeary/choose
     version: v1.3.5
   - name: theryangeary/choose
     version: v1.3.4

--- a/pkgs/theryangeary/choose/registry.yaml
+++ b/pkgs/theryangeary/choose/registry.yaml
@@ -8,6 +8,32 @@ packages:
     version_overrides:
       - version_constraint: Version == "v1.3.0"
         no_asset: true
+      - version_constraint: Version == "v1.3.6"
+        asset: choose-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
       - version_constraint: Version == "v1.3.5"
         asset: choose-{{.Arch}}-{{.OS}}
         format: raw
@@ -47,7 +73,6 @@ packages:
         asset: choose-{{.Arch}}-{{.OS}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/pkgs/theryangeary/choose/registry.yaml
+++ b/pkgs/theryangeary/choose/registry.yaml
@@ -42,7 +42,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          windows: win
+          windows: pc-window-gnu
         overrides:
           - goos: linux
             goarch: amd64
@@ -55,8 +55,6 @@ packages:
           - goos: darwin
             replacements:
               amd64: amd64
-          - goos: windows
-            asset: choose-{{.Arch}}-pc-{{.OS}}dow-gnu
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -82429,7 +82429,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          windows: win
+          windows: pc-window-gnu
         overrides:
           - goos: linux
             goarch: amd64
@@ -82442,8 +82442,6 @@ packages:
           - goos: darwin
             replacements:
               amd64: amd64
-          - goos: windows
-            asset: choose-{{.Arch}}-pc-{{.OS}}dow-gnu
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -82395,6 +82395,32 @@ packages:
     version_overrides:
       - version_constraint: Version == "v1.3.0"
         no_asset: true
+      - version_constraint: Version == "v1.3.6"
+        asset: choose-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
       - version_constraint: Version == "v1.3.5"
         asset: choose-{{.Arch}}-{{.OS}}
         format: raw
@@ -82434,7 +82460,6 @@ packages:
         asset: choose-{{.Arch}}-{{.OS}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
From version v1.3.7, theryangeary/choose releases a Windows executable file with the .exe extension.
See
- https://github.com/theryangeary/choose/releases/tag/v1.3.7
- https://github.com/theryangeary/choose/issues/72