### PR TITLE
gruntwork-io/terragrunt: Support the verification using Cosign

### DIFF
--- a/pkgs/gruntwork-io/terragrunt/pkg.yaml
+++ b/pkgs/gruntwork-io/terragrunt/pkg.yaml
@@ -1,17 +1,5 @@
 packages:
-  - name: gruntwork-io/terragrunt@alpha-2026011301
-  - name: gruntwork-io/terragrunt
-    version: alpha2025121801
-  - name: gruntwork-io/terragrunt
-    version: alpha-2025111104
-  - name: gruntwork-io/terragrunt
-    version: beta-2025111005
-  - name: gruntwork-io/terragrunt
-    version: beta-2025111003
-  - name: gruntwork-io/terragrunt
-    version: alpha-2025110301
-  - name: gruntwork-io/terragrunt
-    version: v0.98.0
+  - name: gruntwork-io/terragrunt@v0.98.0
   - name: gruntwork-io/terragrunt
     version: v0.97.2
   - name: gruntwork-io/terragrunt

--- a/pkgs/gruntwork-io/terragrunt/pkg.yaml
+++ b/pkgs/gruntwork-io/terragrunt/pkg.yaml
@@ -1,2 +1,22 @@
 packages:
-  - name: gruntwork-io/terragrunt@v0.97.2
+  - name: gruntwork-io/terragrunt@alpha-2026011301
+  - name: gruntwork-io/terragrunt
+    version: alpha2025121801
+  - name: gruntwork-io/terragrunt
+    version: alpha-2025111104
+  - name: gruntwork-io/terragrunt
+    version: beta-2025111005
+  - name: gruntwork-io/terragrunt
+    version: beta-2025111003
+  - name: gruntwork-io/terragrunt
+    version: alpha-2025110301
+  - name: gruntwork-io/terragrunt
+    version: v0.98.0
+  - name: gruntwork-io/terragrunt
+    version: v0.97.2
+  - name: gruntwork-io/terragrunt
+    version: v0.93.5
+  - name: gruntwork-io/terragrunt
+    version: v0.28.11
+  - name: gruntwork-io/terragrunt
+    version: v0.18.0

--- a/pkgs/gruntwork-io/terragrunt/registry.yaml
+++ b/pkgs/gruntwork-io/terragrunt/registry.yaml
@@ -40,80 +40,9 @@ packages:
         asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 0.98.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-              - --signature
-              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025110301.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-      - version_constraint: semver("<= 2025111001.0.0")
-        no_asset: true
-      - version_constraint: semver("<= 2025111003.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-      - version_constraint: semver("<= 2025111005.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025111104.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025111107.0.0")
-        no_asset: true
-      - version_constraint: semver("<= 2025121801.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
+        files:
+          - name: terragrunt
+            src: "{{.AssetWithoutExt}}"
         checksum:
           type: github_release
           asset: SHA256SUMS
@@ -125,6 +54,9 @@ packages:
         asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: terragrunt
+            src: "{{.AssetWithoutExt}}"
         checksum:
           type: github_release
           asset: SHA256SUMS

--- a/pkgs/gruntwork-io/terragrunt/registry.yaml
+++ b/pkgs/gruntwork-io/terragrunt/registry.yaml
@@ -3,13 +3,142 @@ packages:
   - type: github_release
     repo_owner: gruntwork-io
     repo_name: terragrunt
-    description: Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules
-    asset: terragrunt_{{.OS}}_{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    checksum:
-      type: github_release
-      asset: SHA256SUMS
-      algorithm: sha256
+    description: Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.18.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.28.11")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.93.5")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.97.2")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 0.98.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025110301.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 2025111001.0.0")
+        no_asset: true
+      - version_constraint: semver("<= 2025111003.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 2025111005.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025111104.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025111107.0.0")
+        no_asset: true
+      - version_constraint: semver("<= 2025121801.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: "true"
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}

--- a/pkgs/gruntwork-io/terragrunt/scaffold.yaml
+++ b/pkgs/gruntwork-io/terragrunt/scaffold.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: gruntwork-io/terragrunt
+version_filter: |
+  let words = ["^alpha", "^beta"];
+  not any(words, {Asset matches #})
+
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -41630,80 +41630,9 @@ packages:
         asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 0.98.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-              - --signature
-              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025110301.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-      - version_constraint: semver("<= 2025111001.0.0")
-        no_asset: true
-      - version_constraint: semver("<= 2025111003.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-      - version_constraint: semver("<= 2025111005.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025111104.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
-      - version_constraint: semver("<= 2025111107.0.0")
-        no_asset: true
-      - version_constraint: semver("<= 2025121801.0.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
+        files:
+          - name: terragrunt
+            src: "{{.AssetWithoutExt}}"
         checksum:
           type: github_release
           asset: SHA256SUMS
@@ -41715,6 +41644,9 @@ packages:
         asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: terragrunt
+            src: "{{.AssetWithoutExt}}"
         checksum:
           type: github_release
           asset: SHA256SUMS

--- a/registry.yaml
+++ b/registry.yaml
@@ -41593,56 +41593,145 @@ packages:
   - type: github_release
     repo_owner: gruntwork-io
     repo_name: terragrunt
-    description: Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.
-    asset: terragrunt_{{.OS}}_{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    format: raw
-    files:
-      - name: terragrunt
-        src: terragrunt_{{.OS}}_{{.Arch}}
-    overrides:
-      - goos: windows
-        asset: terragrunt_windows_{{.Arch}}.exe
-        files:
-          - name: terragrunt
-            src: terragrunt_windows_{{.Arch}}.exe
-    version_constraint: semver("< 0.98.0")
-    checksum:
-      type: github_release
-      asset: SHA256SUMS
-      algorithm: sha256
-      enabled: true
-      cosign:
-        enabled: false
+    description: Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.98.0")
-        asset: terragrunt_{{.OS}}_{{.Arch}}.tar.gz
+      - version_constraint: semver("<= 0.18.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.28.11")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.93.5")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.97.2")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        files:
-          - name: terragrunt
-            src: terragrunt_{{.OS}}_{{.Arch}}
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
         overrides:
           - goos: windows
-            asset: terragrunt_windows_{{.Arch}}.exe.zip
-            format: zip
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 0.98.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         checksum:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
           cosign:
-            enabled: true
             opts:
               - --certificate
               - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
-              - --signature
-              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+              - --certificate-identity-regexp
+              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025110301.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 2025111001.0.0")
+        no_asset: true
+      - version_constraint: semver("<= 2025111003.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 2025111005.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025111104.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: semver("<= 2025111107.0.0")
+        no_asset: true
+      - version_constraint: semver("<= 2025121801.0.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
+      - version_constraint: "true"
+        asset: terragrunt_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
               - --certificate-identity-regexp
-              - github.com/gruntwork-io/terragrunt
+              - "^https://github\\.com/gruntwork-io/terragrunt/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+        overrides:
+          - goos: windows
+            asset: terragrunt_{{.OS}}_{{.Arch}}.exe.{{.Format}}
   - type: github_release
     repo_owner: gsamokovarov
     repo_name: jump

--- a/registry.yaml
+++ b/registry.yaml
@@ -41593,16 +41593,56 @@ packages:
   - type: github_release
     repo_owner: gruntwork-io
     repo_name: terragrunt
-    description: Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules
+    description: Terragrunt is a flexible orchestration tool that allows Infrastructure as Code written in OpenTofu/Terraform to scale.
     asset: terragrunt_{{.OS}}_{{.Arch}}
     supported_envs:
       - darwin
       - linux
       - amd64
+    format: raw
+    files:
+      - name: terragrunt
+        src: terragrunt_{{.OS}}_{{.Arch}}
+    overrides:
+      - goos: windows
+        asset: terragrunt_windows_{{.Arch}}.exe
+        files:
+          - name: terragrunt
+            src: terragrunt_windows_{{.Arch}}.exe
+    version_constraint: semver("< 0.98.0")
     checksum:
       type: github_release
       asset: SHA256SUMS
       algorithm: sha256
+      enabled: true
+      cosign:
+        enabled: false
+    version_overrides:
+      - version_constraint: semver(">= 0.98.0")
+        asset: terragrunt_{{.OS}}_{{.Arch}}.tar.gz
+        format: tar.gz
+        files:
+          - name: terragrunt
+            src: terragrunt_{{.OS}}_{{.Arch}}
+        overrides:
+          - goos: windows
+            asset: terragrunt_windows_{{.Arch}}.exe.zip
+            format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+          cosign:
+            enabled: true
+            opts:
+              - --certificate
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.pem
+              - --signature
+              - https://github.com/gruntwork-io/terragrunt/releases/download/{{.Version}}/SHA256SUMS.sig
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --certificate-identity-regexp
+              - github.com/gruntwork-io/terragrunt
   - type: github_release
     repo_owner: gsamokovarov
     repo_name: jump


### PR DESCRIPTION


## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

As of version [`v0.98.0`](https://github.com/gruntwork-io/terragrunt/releases/tag/v0.98.0), Terragrunt supports cosign signed checksums in release assets.

This updates the registry entry to validate checksum signatures when installing a version of Terragrunt newer than `v0.98.0`.