### PR TITLE
fix(ariga/atlas/community): add files directive to name binary atlas

### DIFF
--- a/pkgs/ariga/atlas/community/registry.yaml
+++ b/pkgs/ariga/atlas/community/registry.yaml
@@ -11,6 +11,8 @@ packages:
     supported_envs:
       - darwin
       - linux
+    files:
+      - name: atlas
     checksum:
       type: http
       url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -13989,6 +13989,8 @@ packages:
     supported_envs:
       - darwin
       - linux
+    files:
+      - name: atlas
     checksum:
       type: http
       url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256


### PR DESCRIPTION
## Summary
- Add `files` directive to `ariga/atlas/community` so the binary is named `atlas` instead of `community`

## Test plan
- [x] Verified with `cmdx t ariga/atlas/community`

🤖 Generated with [Claude Code](https://claude.ai/code)