### PR TITLE
feat: add k1LoW/git-wt

### DIFF
--- a/pkgs/k1LoW/git-wt/pkg.yaml
+++ b/pkgs/k1LoW/git-wt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/git-wt@v0.15.0

--- a/pkgs/k1LoW/git-wt/registry.yaml
+++ b/pkgs/k1LoW/git-wt/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: git-wt
+    description: A Git subcommand that makes `git worktree` simple
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-wt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -49058,6 +49058,23 @@ packages:
             format: zip
   - type: github_release
     repo_owner: k1LoW
+    repo_name: git-wt
+    description: A Git subcommand that makes `git worktree` simple
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-wt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: gostyle
     description: gostyle is a set of analyzers for coding styles
     version_constraint: "false"


### PR DESCRIPTION
[k1LoW/git-wt](https://github.com/k1LoW/git-wt): A Git subcommand that makes `git worktree` simple

```console
$ aqua g -i k1LoW/git-wt
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@2fc5802b4a06:/workspace# git-wt --help
git-wt is a Git subcommand that makes 'git worktree' simple.

Examples:
  git wt                                    List all worktrees
  git wt <branch|worktree>                  Switch to worktree (create worktree/branch if needed)
  git wt <branch|worktree> <start-point>    Create worktree from start-point (e.g., origin/main)
  git wt -d <branch|worktree>...            Delete worktree and branch (safe)
  git wt -D <branch|worktree>...            Force delete worktree and branch

Note: The default branch (e.g., main, master) is protected from accidental deletion.
      - With worktree: worktree is deleted, but branch is preserved.
      - Without worktree: deletion is blocked entirely.
      Use --allow-delete-default to override and delete the branch.

Shell Integration:
  Add the following to your shell config to enable worktree switching and completion:

  # bash (~/.bashrc)
  eval "$(git-wt --init bash)"

  # zsh (~/.zshrc)
  eval "$(git-wt --init zsh)"

  # fish (~/.config/fish/config.fish)
  git-wt --init fish | source

  # powershell ($PROFILE)
  Invoke-Expression (git-wt --init powershell | Out-String)

Configuration:
  Configuration is done via git config. All config options can be overridden
  with flags for a single invocation.

  wt.basedir (--basedir)
    Worktree base directory.
    Supported template variables: {gitroot} (repository root directory name)
    Default: ../{gitroot}-wt
    Example: git config wt.basedir "../{gitroot}-worktrees"

  wt.copyignored (--copyignored)
    Copy .gitignore'd files (e.g., .env) to new worktrees.
    Default: false

  wt.copyuntracked (--copyuntracked)
    Copy untracked files to new worktrees.
    Default: false

  wt.copymodified (--copymodified)
    Copy modified files to new worktrees.
    Default: false

  wt.nocopy (--nocopy)
    Patterns for files to exclude from copying (gitignore syntax).
    Can be specified multiple times.
    Example: git config --add wt.nocopy "*.log"
             git config --add wt.nocopy "vendor/"

  wt.copy (--copy)
    Patterns for files to always copy, even if gitignored (gitignore syntax).
    Can be specified multiple times. Useful for copying specific IDE files.
    Note: If the same file matches both wt.copy and wt.nocopy, wt.nocopy takes precedence.
    Example: git config --add wt.copy "*.code-workspace"
             git config --add wt.copy ".vscode/"

  wt.hook (--hook)
    Commands to run after creating a new worktree.
    Can be specified multiple times. Hooks run in the new worktree directory.
    Note: Hooks do NOT run when switching to an existing worktree.
    Example: git config --add wt.hook "npm install"
             git config --add wt.hook "go generate ./..."

  wt.nocd (--nocd)
    Do not change directory to the worktree. Only print the worktree path.
    Supported values:
      - true, all: Never cd to worktree (both new and existing)
      - create: Only prevent cd when creating new worktrees (allow cd to existing)
      - false (default): Always cd to worktree
    Note: --nocd flag always prevents cd regardless of config value.
    Using --nocd with --init disables git() wrapper (wt.nocd config does not).
    Example: git config wt.nocd create

Usage:
  git wt [branch|worktree] [start-point] [flags]

Flags:
      --allow-delete-default   Allow deletion of the default branch (main, master)
      --basedir string         Override wt.basedir config (worktree base directory)
      --copy stringArray       Always copy files matching pattern (can be specified multiple times)
      --copyignored            Override wt.copyignored config (copy .gitignore'd files)
      --copymodified           Override wt.copymodified config (copy modified files)
      --copyuntracked          Override wt.copyuntracked config (copy untracked files)
  -d, --delete                 Delete worktree and branch (safe delete, only if merged)
  -D, --force-delete           Force delete worktree and branch
  -h, --help                   help for git
      --hook stringArray       Run command after creating new worktree (can be specified multiple times)
      --init string            Output shell initialization script (bash, zsh, fish, powershell)
      --nocd                   Do not change directory to the worktree (also disables git() wrapper when used with --init)
      --nocopy stringArray     Exclude files matching pattern from copying (can be specified multiple times)
  -v, --version                version for git

```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/k1LoW/git-wt/blob/main/README.md
