### PR TITLE
Add anthropics/claude-code

### DIFF
--- a/pkgs/anthropics/claude-code/pkg.yaml
+++ b/pkgs/anthropics/claude-code/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: anthropics/claude-code@v2.1.15

--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: anthropics
     repo_name: claude-code
     description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
+    files:
+      - name: claude
     version_source: github_tag
     version_constraint: "false"
     version_overrides:

--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: anthropics
+    repo_name: claude-code
+    description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
+    version_source: github_tag
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        format: raw
+        url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude
+        files:
+          - name: claude
+        replacements:
+          amd64: x64
+        supported_envs:
+          - darwin
+          - linux
+        overrides:
+          - goos: linux
+            url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude

--- a/registry.yaml
+++ b/registry.yaml
@@ -12054,6 +12054,8 @@ packages:
     repo_owner: anthropics
     repo_name: claude-code
     description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
+    files:
+      - name: claude
     version_source: github_tag
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -12051,6 +12051,14 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: anthropics
+    repo_name: claude-code
+    description: "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: antonmedv
     repo_name: fx
     description: Command-line tool and terminal JSON viewer

--- a/registry.yaml
+++ b/registry.yaml
@@ -12050,14 +12050,26 @@ packages:
           - darwin
           - windows
           - amd64
-  - type: github_release
+  - type: http
     repo_owner: anthropics
     repo_name: claude-code
-    description: "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands"
+    description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
+    version_source: github_tag
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
-        no_asset: true
+        format: raw
+        url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude
+        files:
+          - name: claude
+        replacements:
+          amd64: x64
+        supported_envs:
+          - darwin
+          - linux
+        overrides:
+          - goos: linux
+            url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude
   - type: github_release
     repo_owner: antonmedv
     repo_name: fx


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
Claude Code now prefers distributing via binaries, this allows Aqua and, by extension, Mise to install using the same links used by the installer.
