### PR TITLE
fix(anthropics/claude-code): use glibc binary for Linux instead of musl

### DIFF
--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -19,6 +19,3 @@ packages:
         supported_envs:
           - darwin
           - linux
-        overrides:
-          - goos: linux
-            url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude

--- a/registry.yaml
+++ b/registry.yaml
@@ -12069,9 +12069,6 @@ packages:
         supported_envs:
           - darwin
           - linux
-        overrides:
-          - goos: linux
-            url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}-musl/claude
   - type: github_release
     repo_owner: antonmedv
     repo_name: fx


### PR DESCRIPTION
## Summary
- Remove the `overrides` section that forced musl binaries for all Linux systems
- The glibc binary works on more systems and is the safer default

## Context
The current configuration forces musl binaries for all Linux systems, but this doesn't work on glibc-based systems (which are the majority, including Ubuntu, Debian, Fedora, etc.).

The official Claude install script at https://claude.ai/install.sh properly detects musl vs glibc before choosing the binary:

```bash
if ldd /bin/ls 2>&1 | grep -q musl; then
  PLATFORM="linux-${ARCH}-musl"
else
  PLATFORM="linux-${ARCH}"
fi
```

Since aqua doesn't have a way to detect musl at runtime, defaulting to glibc is the safer choice as it works on more systems.

## Test
Verified the glibc URL exists and returns 200:
```bash
curl -sI "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.19/linux-x64/claude" | head -1
# HTTP/2 200
```