### PR TITLE
Feat: add openshift/installer

### DIFF
--- a/pkgs/openshift/installer/pkg.yaml
+++ b/pkgs/openshift/installer/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: openshift/installer@

--- a/pkgs/openshift/installer/pkg.yaml
+++ b/pkgs/openshift/installer/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: openshift/installer@
+  - name: openshift/installer@4.20.12

--- a/pkgs/openshift/installer/registry.yaml
+++ b/pkgs/openshift/installer/registry.yaml
@@ -1,7 +1,22 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - type: http
     repo_owner: openshift
     repo_name: installer
+    url: https://mirror.openshift.com/pub/openshift-v4/{{.Arch}}/clients/ocp/{{trimV .Version}}/openshift-install-{{.OS}}.tar.gz
     description: Install an OpenShift 4.x cluster
-    no_asset: true
+    files:
+      - name: openshift-install
+    replacements:
+      darwin: mac
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: http
+      url: https://mirror.openshift.com/pub/openshift-v4/{{.Arch}}/clients/ocp/{{trimV .Version}}/sha256sum.txt
+      algorithm: sha256
+      file_format: regexp
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/openshift/installer/registry.yaml
+++ b/pkgs/openshift/installer/registry.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: openshift
+    repo_name: installer
+    description: Install an OpenShift 4.x cluster
+    no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -64436,6 +64436,11 @@ packages:
             asset: tkn-pac_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
   - type: github_release
     repo_owner: openshift
+    repo_name: installer
+    description: Install an OpenShift 4.x cluster
+    no_asset: true
+  - type: github_release
+    repo_owner: openshift
     repo_name: osdctl
     description: CLI for the OSD utilities
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -64434,11 +64434,26 @@ packages:
             asset: tkn-pac_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
           - goos: windows
             asset: tkn-pac_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-  - type: github_release
+  - type: http
     repo_owner: openshift
     repo_name: installer
+    url: https://mirror.openshift.com/pub/openshift-v4/{{.Arch}}/clients/ocp/{{trimV .Version}}/openshift-install-{{.OS}}.tar.gz
     description: Install an OpenShift 4.x cluster
-    no_asset: true
+    files:
+      - name: openshift-install
+    replacements:
+      darwin: mac
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: http
+      url: https://mirror.openshift.com/pub/openshift-v4/{{.Arch}}/clients/ocp/{{trimV .Version}}/sha256sum.txt
+      algorithm: sha256
+      file_format: regexp
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: openshift
     repo_name: osdctl


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## Description
This pull request adds support for managing the OpenShift Installer package via the package registry. The main changes involve introducing the necessary configuration to fetch, verify, and describe the `openshift-install` binary for both macOS and Linux environments.

**OpenShift Installer package integration:**

* Added `pkgs/openshift/installer/pkg.yaml` to define the use of the `openshift/installer@4.20.12` package.
* Added `pkgs/openshift/installer/registry.yaml` with metadata and download instructions for the `openshift-install` binary, including URL templates, supported environments, file replacements, and checksum validation.
* Updated the main `registry.yaml` to register the OpenShift Installer package, specifying its download, environment support, and checksum verification.