### PR TITLE
fix(bazelbuild/buildtools): update asset pattern for v8.5.1+

### DIFF
--- a/pkgs/bazelbuild/buildtools/buildifier/registry.yaml
+++ b/pkgs/bazelbuild/buildtools/buildifier/registry.yaml
@@ -54,7 +54,11 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 8.2.1")
         asset: buildifier-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        asset: buildifier-{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/pkgs/bazelbuild/buildtools/buildozer/registry.yaml
+++ b/pkgs/bazelbuild/buildtools/buildozer/registry.yaml
@@ -54,7 +54,11 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 8.2.1")
         asset: buildozer-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        asset: buildozer-{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -17081,8 +17081,12 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 8.2.1")
         asset: buildifier-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        asset: buildifier-{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
   - name: bazelbuild/buildtools/buildozer
@@ -17139,8 +17143,12 @@ packages:
         supported_envs:
           - darwin
           - windows/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 8.2.1")
         asset: buildozer-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+      - version_constraint: "true"
+        asset: buildozer-{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
   - type: github_release


### PR DESCRIPTION
## Summary
- `bazelbuild/buildtools` v8.5.1 (released 2026-01-29) changed release asset naming from `{tool}-{os}-{arch}` (dash) to `{tool}-{os}_{arch}` (underscore between os and arch)
- Add a version override for `<= 8.2.1` with the old dash pattern
- Update the catch-all to use the new underscore pattern
- Affects both `buildifier` and `buildozer`

## Evidence
v8.2.1 assets use dashes: `buildifier-linux-amd64`
v8.5.1 assets use underscores: `buildifier-linux_amd64`