### PR TITLE
fix(rust-cross/cargo-zigbuild): v0.21.4 to v0.21.5

### DIFF
--- a/pkgs/rust-cross/cargo-zigbuild/pkg.yaml
+++ b/pkgs/rust-cross/cargo-zigbuild/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: rust-cross/cargo-zigbuild@v0.21.4
+  - name: rust-cross/cargo-zigbuild@v0.21.5
+  - name: rust-cross/cargo-zigbuild
+    version: v0.21.4
   - name: rust-cross/cargo-zigbuild
     version: v0.10.0
   - name: rust-cross/cargo-zigbuild

--- a/pkgs/rust-cross/cargo-zigbuild/registry.yaml
+++ b/pkgs/rust-cross/cargo-zigbuild/registry.yaml
@@ -61,7 +61,7 @@ packages:
           - linux/arm64
           - darwin
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.21.4")
         asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -83,3 +83,24 @@ packages:
             asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
               amd64: x64
+      - version_constraint: "true"
+        asset: cargo-zigbuild-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files:
+          - name: cargo-zigbuild
+            src: "{{.AssetWithoutExt}}/{{.FileName}}"
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: cargo-zigbuild.exe

--- a/pkgs/rust-cross/cargo-zigbuild/registry.yaml
+++ b/pkgs/rust-cross/cargo-zigbuild/registry.yaml
@@ -103,4 +103,4 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: cargo-zigbuild.exe
+              - name: cargo-zigbuild

--- a/registry.yaml
+++ b/registry.yaml
@@ -71829,7 +71829,7 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: cargo-zigbuild.exe
+              - name: cargo-zigbuild
   - type: github_release
     repo_owner: rust-lang
     repo_name: mdBook

--- a/registry.yaml
+++ b/registry.yaml
@@ -71787,7 +71787,7 @@ packages:
           - linux/arm64
           - darwin
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.21.4")
         asset: cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -71809,6 +71809,27 @@ packages:
             asset: cargo-zigbuild-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
             replacements:
               amd64: x64
+      - version_constraint: "true"
+        asset: cargo-zigbuild-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files:
+          - name: cargo-zigbuild
+            src: "{{.AssetWithoutExt}}/{{.FileName}}"
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: cargo-zigbuild.exe
   - type: github_release
     repo_owner: rust-lang
     repo_name: mdBook


### PR DESCRIPTION
close #47804

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## Summary

Update registry configuration for v0.21.5 due to release asset format changes.

## Changes in v0.21.5

### Asset naming
- Before: `cargo-zigbuild-{{.Version}}.{{.Arch}}-{{.OS}}.tar.gz`
- After: `cargo-zigbuild-{{.Arch}}-{{.OS}}.tar.xz`

### Compression format
- Linux/macOS: `tar.gz` → `tar.xz`
- Windows: `zip` (unchanged)

## What this PR does

1. Add new asset configuration for v0.21.5+
2. Add `version_constraint: semver("<= 0.21.4")` for backward compatibility with older versions
3. Update default package version to v0.21.5

## References

- [v0.21.5 Release](https://github.com/rust-cross/cargo-zigbuild/releases/tag/v0.21.5)
- [Compare v0.21.4...v0.21.5](https://github.com/rust-cross/cargo-zigbuild/compare/v0.21.4...v0.21.5)