### PR TITLE
fix(yaml/yamlscript): fix supported_envs at 0.2.9

### DIFF
--- a/pkgs/yaml/yamlscript/pkg.yaml
+++ b/pkgs/yaml/yamlscript/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: yaml/yamlscript@0.2.8
+  - name: yaml/yamlscript@0.2.9
+  - name: yaml/yamlscript
+    version: 0.2.8
   - name: yaml/yamlscript
     version: 0.1.71
   - name: yaml/yamlscript

--- a/pkgs/yaml/yamlscript/registry.yaml
+++ b/pkgs/yaml/yamlscript/registry.yaml
@@ -30,7 +30,11 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin/arm64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.8")
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -89739,10 +89739,14 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin/arm64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.8")
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
   - type: github_release
     repo_owner: yannh
     repo_name: kubeconform


### PR DESCRIPTION
https://github.com/yaml/yamlscript/releases/tag/0.2.9

> The following architectures are currently supported:
>
> Linux + Intel
> macOS + ARM

Close #47839