### PR TITLE
feat: add kubernetes-sigs/kubectl-validate package

### DIFF
--- a/pkgs/kubernetes-sigs/kubectl-validate/pkg.yaml
+++ b/pkgs/kubernetes-sigs/kubectl-validate/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: kubernetes-sigs/kubectl-validate@v0.0.4
+  - name: kubernetes-sigs/kubectl-validate
+    version: v0.0.1

--- a/pkgs/kubernetes-sigs/kubectl-validate/registry.yaml
+++ b/pkgs/kubernetes-sigs/kubectl-validate/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kubernetes-sigs
+    repo_name: kubectl-validate
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: kubectl-validate_{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-validate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+          - windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -52642,6 +52642,28 @@ packages:
           - darwin
   - type: github_release
     repo_owner: kubernetes-sigs
+    repo_name: kubectl-validate
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: kubectl-validate_{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: kubectl-validate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - darwin
+          - windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: kubernetes-sigs
     repo_name: kustomize
     description: Customization of kubernetes YAML configurations
     asset: kustomize_{{.SemVer}}_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
#48245 [kubernetes-sigs/kubectl-validate](https://github.com/kubernetes-sigs/kubectl-validate): kubectl-validate is a SIG-CLI subproject to support the local validation of resources for native Kubernetes types and CRDs

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

## Summary

This PR adds the `kubernetes-sigs/kubectl-validate` package to the aqua registry. kubectl-validate is a SIG-CLI subproject that enables local validation of Kubernetes resources with near-parity to server-side validation.

## Package Details

- **Repository:** kubernetes-sigs/kubectl-validate
- **Latest Version:** v0.0.4 (released 2024-05-29)
- **Description:** kubectl-validate enables local validation of Kubernetes resources
- **Type:** CLI tool for Kubernetes manifest validation

## Platform Support

The package supports multiple platforms based on actual GitHub release assets:

**For v0.0.4 and later:**
- Linux: 386, amd64, arm64
- Darwin: amd64, arm64  
- Windows: 386, amd64, arm64

**For v0.0.1 (legacy):**
- Darwin only: amd64 (with Rosetta2 support)

## Implementation Details

### Files Added/Modified
- `pkgs/kubernetes-sigs/kubectl-validate/pkg.yaml` - Test configuration with v0.0.4 and v0.0.1
- `pkgs/kubernetes-sigs/kubectl-validate/registry.yaml` - Package metadata and asset configuration
- `registry.yaml` - Main registry updated with package entry

### Key Features
- ✅ **Asset Pattern Validation:** Matches actual GitHub release assets
- ✅ **Checksum Validation:** SHA256 checksums via `checksums.txt` 
- ✅ **Cross-platform Support:** All major platforms (Linux, Darwin, Windows)
- ✅ **Version Handling:** Special support for v0.0.1 (raw format, Darwin-only)
- ✅ **Automated Testing:** Passed on Linux and Windows containers

### Asset Configuration
- **v0.0.4+:** `kubectl-validate_{{.OS}}_{{.Arch}}.tar.gz` format
- **v0.0.1:** `kubectl-validate_{{.OS}}-{{.Arch}}` raw binary format (Darwin only)

## Verification

- ✅ Package scaffolded using `cmdx s kubernetes-sigs/kubectl-validate`
- ✅ Automated testing passed on Linux and Windows containers  
- ✅ Manual verification: package installs and executes correctly
- ✅ Asset patterns validated against actual GitHub releases
- ✅ Checksum validation working correctly

## Usage

After merge, users will be able to install kubectl-validate via:

```bash
# Add to aqua.yaml
aqua g -i kubernetes-sigs/kubectl-validate

# Install the package  
aqua i kubectl-validate

# Use kubectl-validate
kubectl-validate --help
kubectl-validate --version 1.30 manifest.yaml
```

## References

- [kubectl-validate GitHub Repository](https://github.com/kubernetes-sigs/kubectl-validate)
- [kubernetes-sigs organization](https://github.com/kubernetes-sigs)
- [Latest Release v0.0.4](https://github.com/kubernetes-sigs/kubectl-validate/releases/tag/v0.0.4)