### PR TITLE
feat(tuist/tuist): add Linux support (amd64, arm64)

### DIFF
--- a/pkgs/tuist/tuist/registry.yaml
+++ b/pkgs/tuist/tuist/registry.yaml
@@ -3,12 +3,35 @@ packages:
     repo_owner: tuist
     repo_name: tuist
     description: A toolchain to generate Xcode projects from Swift packages
-    asset: tuist.zip
-    format: zip
     version_filter: Version matches "^[0-9]"
-    supported_envs:
-      - darwin
-    checksum:
-      type: github_release
-      asset: SHASUMS256.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 4.140.0")
+        asset: tuist.zip
+        format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - linux/arm64
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: tuist-linux-x86_64.tar.gz
+            format: tar.gz
+          - goos: linux
+            goarch: arm64
+            asset: tuist-linux-aarch64.tar.gz
+            format: tar.gz
+      - version_constraint: "true"
+        asset: tuist.zip
+        format: zip
+        supported_envs:
+          - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -85816,15 +85816,38 @@ packages:
     repo_owner: tuist
     repo_name: tuist
     description: A toolchain to generate Xcode projects from Swift packages
-    asset: tuist.zip
-    format: zip
     version_filter: Version matches "^[0-9]"
-    supported_envs:
-      - darwin
-    checksum:
-      type: github_release
-      asset: SHASUMS256.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 4.140.0")
+        asset: tuist.zip
+        format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - linux/arm64
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: tuist-linux-x86_64.tar.gz
+            format: tar.gz
+          - goos: linux
+            goarch: arm64
+            asset: tuist-linux-aarch64.tar.gz
+            format: tar.gz
+      - version_constraint: "true"
+        asset: tuist.zip
+        format: zip
+        supported_envs:
+          - darwin
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: tummychow
     repo_name: git-absorb


### PR DESCRIPTION
## Summary
- Starting from [v4.140.0](https://github.com/tuist/tuist/releases/tag/4.140.0), Tuist publishes Linux binaries (`tuist-linux-x86_64.tar.gz` and `tuist-linux-aarch64.tar.gz`) alongside the existing macOS `tuist.zip`
- Adds `version_overrides` with platform-specific `overrides` to serve the correct asset per OS/arch
- Older versions (< 4.140.0) remain darwin-only via the catch-all `version_constraint: "true"`

## Test plan
- [x] Tested `aqua i` in Docker for all 4 platform combos (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
- [x] Verified checksum validation passes (SHASUMS256.txt covers all assets)
- [x] Verified the Linux binary executes correctly in a Swift 6.1 container (`tuist --help`, `tuist auth whoami`, `tuist auth logout`, `tuist cache --help`)
- [x] Verified the macOS binary executes correctly (`tuist --help`)
- [x] Verified older version (4.100.0) still installs correctly on darwin only

🤖 Generated with [Claude Code](https://claude.com/claude-code)