### PR TITLE
fix(tuist/tuist): add Linux asset name to override

### DIFF
--- a/pkgs/tuist/tuist/registry.yaml
+++ b/pkgs/tuist/tuist/registry.yaml
@@ -28,6 +28,7 @@ packages:
           arm64: aarch64
         overrides:
           - goos: linux
+            asset: tuist-linux-{{.Arch}}.tar.gz
             format: tar.gz
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -85903,6 +85903,7 @@ packages:
           arm64: aarch64
         overrides:
           - goos: linux
+            asset: tuist-linux-{{.Arch}}.tar.gz
             format: tar.gz
         supported_envs:
           - darwin


### PR DESCRIPTION
## Summary

The refactoring in #48266 simplified the Linux override but removed the per-architecture `asset` names. Linux release assets are named `tuist-linux-{arch}.tar.gz`, not `tuist.zip`. Without specifying the asset in the Linux override, aqua downloads the macOS `tuist.zip` on Linux.

This adds the `asset` template back to the Linux override while keeping the simplified single-override structure.

## Reproduction with aqua

- aqua version: 2.56.6
- OS: linux/arm64
- aqua.yaml:

```yaml
---
registries:
  - type: standard
    ref: v4.467.0
packages:
  - name: tuist/tuist@4.142.0
```

- Command and output:

```
$ aqua install
$ aqua exec -- tuist version
ERR aqua failed program=aqua version=2.56.6 exe_name=tuist package_name=tuist/tuist package_version=4.142.0 registry=standard error="it failed to start the process"
```

```
$ file ~/.local/share/aquaproj-aqua/pkgs/github_release/github.com/tuist/tuist/4.142.0/tuist.zip/tuist
Mach-O universal binary with 2 architectures: [x86_64 arm64]
```

- Expected: aqua downloads `tuist-linux-aarch64.tar.gz` and installs a Linux ELF binary
- Actual: aqua downloads `tuist.zip` (macOS Mach-O binary) which cannot run on Linux