### PR TITLE
Add sandreas/tone

### DIFF
--- a/pkgs/sandreas/tone/pkg.yaml
+++ b/pkgs/sandreas/tone/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: sandreas/tone@v0.2.5
+  - name: sandreas/tone
+    version: v0.0.4

--- a/pkgs/sandreas/tone/registry.yaml
+++ b/pkgs/sandreas/tone/registry.yaml
@@ -5,6 +5,9 @@ packages:
     repo_name: tone
     description: tone is a cross platform audio tagger and metadata editor to dump and modify metadata for a wide variety of formats, including mp3, m4b, flac and more. It has no dependencies and can be downloaded as single binary for Windows, macOS, Linux and other common platforms
     version_constraint: "false"
+    files:
+      - name: tone
+        src: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}/tone
     version_overrides:
       - version_constraint: semver("<= 0.0.4")
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -17,6 +20,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: tone
+                src: tone.exe
       - version_constraint: "true"
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -29,5 +35,11 @@ packages:
           - goos: linux
             goarch: amd64
             asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+            files:
+              - name: tone
+                src: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}/tone
           - goos: windows
             format: zip
+            files:
+              - name: tone
+                src: tone.exe

--- a/pkgs/sandreas/tone/registry.yaml
+++ b/pkgs/sandreas/tone/registry.yaml
@@ -7,7 +7,7 @@ packages:
     version_constraint: "false"
     files:
       - name: tone
-        src: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}/tone
+        src: "{{.AssetWithoutExt}}/tone"
     version_overrides:
       - version_constraint: semver("<= 0.0.4")
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -22,7 +22,6 @@ packages:
             format: zip
             files:
               - name: tone
-                src: tone.exe
       - version_constraint: "true"
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -35,11 +34,7 @@ packages:
           - goos: linux
             goarch: amd64
             asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-            files:
-              - name: tone
-                src: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}/tone
           - goos: windows
             format: zip
             files:
               - name: tone
-                src: tone.exe

--- a/pkgs/sandreas/tone/registry.yaml
+++ b/pkgs/sandreas/tone/registry.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sandreas
+    repo_name: tone
+    description: tone is a cross platform audio tagger and metadata editor to dump and modify metadata for a wide variety of formats, including mp3, m4b, flac and more. It has no dependencies and can be downloaded as single binary for Windows, macOS, Linux and other common platforms
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -73180,6 +73180,37 @@ packages:
         src: statusok_{{.OS}}/statusok
     replacements:
       darwin: mac
+  - type: github_release
+    repo_owner: sandreas
+    repo_name: tone
+    description: tone is a cross platform audio tagger and metadata editor to dump and modify metadata for a wide variety of formats, including mp3, m4b, flac and more. It has no dependencies and can be downloaded as single binary for Windows, macOS, Linux and other common platforms
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+          windows: win
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
   - type: go_install
     repo_owner: sanposhiho
     repo_name: gomockhandler

--- a/registry.yaml
+++ b/registry.yaml
@@ -73185,6 +73185,9 @@ packages:
     repo_name: tone
     description: tone is a cross platform audio tagger and metadata editor to dump and modify metadata for a wide variety of formats, including mp3, m4b, flac and more. It has no dependencies and can be downloaded as single binary for Windows, macOS, Linux and other common platforms
     version_constraint: "false"
+    files:
+      - name: tone
+        src: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}/tone
     version_overrides:
       - version_constraint: semver("<= 0.0.4")
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -73197,6 +73200,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: tone
+                src: tone.exe
       - version_constraint: "true"
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -73209,8 +73215,14 @@ packages:
           - goos: linux
             goarch: amd64
             asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+            files:
+              - name: tone
+                src: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}/tone
           - goos: windows
             format: zip
+            files:
+              - name: tone
+                src: tone.exe
   - type: go_install
     repo_owner: sanposhiho
     repo_name: gomockhandler

--- a/registry.yaml
+++ b/registry.yaml
@@ -73187,7 +73187,7 @@ packages:
     version_constraint: "false"
     files:
       - name: tone
-        src: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}/tone
+        src: "{{.AssetWithoutExt}}/tone"
     version_overrides:
       - version_constraint: semver("<= 0.0.4")
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -73202,7 +73202,6 @@ packages:
             format: zip
             files:
               - name: tone
-                src: tone.exe
       - version_constraint: "true"
         asset: tone-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -73215,14 +73214,10 @@ packages:
           - goos: linux
             goarch: amd64
             asset: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-            files:
-              - name: tone
-                src: tone-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}/tone
           - goos: windows
             format: zip
             files:
               - name: tone
-                src: tone.exe
   - type: go_install
     repo_owner: sanposhiho
     repo_name: gomockhandler


### PR DESCRIPTION
[sandreas/tone](https://github.com/sandreas/tone) - tone is a cross platform audio tagger and metadata editor to dump and modify metadata for a wide variety of formats, including mp3, m4b, flac and more. It has no dependencies and can be downloaded as single binary for Windows, macOS, Linux and other common platforms

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
