### PR TITLE
feat: add runkids/skillshare

### DIFF
--- a/pkgs/runkids/skillshare/pkg.yaml
+++ b/pkgs/runkids/skillshare/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: runkids/skillshare@v0.12.4

--- a/pkgs/runkids/skillshare/registry.yaml
+++ b/pkgs/runkids/skillshare/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: runkids
+    repo_name: skillshare
+    description: Sync skills across all AI CLI tools with one command and simplify team sharing. Supporting Claude Code, OpenClaw, OpenCode & more
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: skillshare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -72187,6 +72187,22 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: runkids
+    repo_name: skillshare
+    description: Sync skills across all AI CLI tools with one command and simplify team sharing. Supporting Claude Code, OpenClaw, OpenCode & more
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: skillshare_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: runmedev
     repo_name: runme
     description: DevOps Notebooks Built with Markdown


### PR DESCRIPTION
[runkids/skillshare](https://github.com/runkids/skillshare) - Sync skills across all AI CLI tools with one command and simplify team sharing. Supporting Claude Code, OpenClaw, OpenCode & more

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Add [runkids/skillshare](https://github.com/runkids/skillshare)
