### PR TITLE
feat: add containers/podlet package

### DIFF
--- a/pkgs/containers/podlet/pkg.yaml
+++ b/pkgs/containers/podlet/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: containers/podlet@v0.3.1
+  - name: containers/podlet
+    version: v0.3.0
+  - name: containers/podlet
+    version: v0.2.0
+  - name: containers/podlet
+    version: v0.1.1

--- a/pkgs/containers/podlet/registry.yaml
+++ b/pkgs/containers/podlet/registry.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: containers
+    repo_name: podlet
+    description: Generate Podman Quadlet files from a Podman command, compose file, or existing object
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.1")
+        asset: podlet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.0")
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/pkgs/containers/podlet/registry.yaml
+++ b/pkgs/containers/podlet/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: containers
     repo_name: podlet
     description: Generate Podman Quadlet files from a Podman command, compose file, or existing object
+    files:
+      - name: podlet
+        src: "{{.AssetWithoutExt}}/podlet"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"
@@ -21,6 +24,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -40,6 +45,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -63,6 +70,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -90,3 +99,5 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+            files:
+              - name: podlet

--- a/registry.yaml
+++ b/registry.yaml
@@ -26177,6 +26177,9 @@ packages:
     repo_owner: containers
     repo_name: podlet
     description: Generate Podman Quadlet files from a Podman command, compose file, or existing object
+    files:
+      - name: podlet
+        src: "{{.AssetWithoutExt}}/podlet"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"
@@ -26194,6 +26197,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -26213,6 +26218,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -26236,6 +26243,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: podlet
         supported_envs:
           - darwin
           - windows
@@ -26263,6 +26272,8 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+            files:
+              - name: podlet
   - type: github_release
     repo_owner: containrrr
     repo_name: shoutrrr

--- a/registry.yaml
+++ b/registry.yaml
@@ -26174,6 +26174,96 @@ packages:
         asset: kubernetes-mcp-server-{{.OS}}-{{.Arch}}
         format: raw
   - type: github_release
+    repo_owner: containers
+    repo_name: podlet
+    description: Generate Podman Quadlet files from a Podman command, compose file, or existing object
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.1.1")
+        asset: podlet-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.0")
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: podlet-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: containrrr
     repo_name: shoutrrr
     description: Notification library for gophers and their furry friends


### PR DESCRIPTION
[containers/podlet](https://github.com/containers/podlet) - Generate Podman Quadlet files from a Podman command, compose file, or existing object

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Adds [podlet](https://github.com/containers/podlet) to the aqua registry. Podlet generates Podman Quadlet files from a Podman command, compose file, or existing object.

Pre-built binaries are published as GitHub Releases for darwin (amd64, arm64), linux (amd64), and windows (amd64). Archives are tar.xz (zip on Windows) with SHA256 checksums. Version overrides handle historical asset naming changes across releases.