### PR TITLE
feat: add hickford/git-credential-oauth package

### DIFF
--- a/pkgs/hickford/git-credential-oauth/pkg.yaml
+++ b/pkgs/hickford/git-credential-oauth/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: hickford/git-credential-oauth@v0.17.2
+  - name: hickford/git-credential-oauth
+    version: v0.11.0
+  - name: hickford/git-credential-oauth
+    version: v0.1.5

--- a/pkgs/hickford/git-credential-oauth/registry.yaml
+++ b/pkgs/hickford/git-credential-oauth/registry.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: hickford
+    repo_name: git-credential-oauth
+    description: A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0")
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43950,6 +43950,41 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: hickford
+    repo_name: git-credential-oauth
+    description: A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0")
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: git-credential-oauth_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-oauth_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: hidetatz
     repo_name: kubecolor
     description: colorizes kubectl output


### PR DESCRIPTION
[hickford/git-credential-oauth](https://github.com/hickford/git-credential-oauth) - A Git credential helper that securely authenticates to GitHub, GitLab and BitBucket using OAuth

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Adds [git-credential-oauth](https://github.com/hickford/git-credential-oauth) to the aqua registry. A Git credential helper that securely authenticates to GitHub, GitLab, BitBucket and other forges using OAuth.

Pre-built binaries are published as GitHub Releases for darwin (amd64, arm64), linux (amd64, arm64, 386), and windows (amd64, arm64, 386). Archives are tar.gz (zip on Windows) with SHA256 checksums.