### PR TITLE
feat: add hickford/git-credential-azure package

### DIFF
--- a/pkgs/hickford/git-credential-azure/pkg.yaml
+++ b/pkgs/hickford/git-credential-azure/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: hickford/git-credential-azure@v0.3.1
+  - name: hickford/git-credential-azure
+    version: v0.2.3

--- a/pkgs/hickford/git-credential-azure/registry.yaml
+++ b/pkgs/hickford/git-credential-azure/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: hickford
+    repo_name: git-credential-azure
+    description: A Git credential helper for Azure Repos
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        asset: git-credential-azure_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-azure_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: git-credential-azure_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-azure_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43950,6 +43950,29 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: hickford
+    repo_name: git-credential-azure
+    description: A Git credential helper for Azure Repos
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        asset: git-credential-azure_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-azure_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: git-credential-azure_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: git-credential-azure_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: hidetatz
     repo_name: kubecolor
     description: colorizes kubectl output


### PR DESCRIPTION
[hickford/git-credential-azure](https://github.com/hickford/git-credential-azure) - A Git credential helper for Azure Repos

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Adds [git-credential-azure](https://github.com/hickford/git-credential-azure) to the aqua registry. A Git credential helper that authenticates to Azure Repos (dev.azure.com) using Azure CLI or browser login.

Pre-built binaries are published as GitHub Releases for darwin (amd64, arm64), linux (amd64, arm64, 386), and windows (amd64, arm64, 386). Archives are tar.gz (zip on Windows) with SHA256 checksums.