### PR TITLE
feat: add openbao/openbao/bao

### DIFF
--- a/pkgs/openbao/openbao/bao/pkg.yaml
+++ b/pkgs/openbao/openbao/bao/pkg.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: openbao/openbao/bao@v2.5.0
+  - name: openbao/openbao/bao
+    version: v2.5.0-beta20251125
+  - name: openbao/openbao/bao
+    version: v2.4.4
+  - name: openbao/openbao/bao
+    version: v2.3.0-beta20250528
+  - name: openbao/openbao/bao
+    version: v2.1.1
+  - name: openbao/openbao/bao
+    version: v2.0.0-beta20240618
+  - name: openbao/openbao/bao
+    version: v2.0.0-alpha20240329

--- a/pkgs/openbao/openbao/bao/registry.yaml
+++ b/pkgs/openbao/openbao/bao/registry.yaml
@@ -1,0 +1,132 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: openbao/openbao/bao
+    type: github_release
+    repo_owner: openbao
+    repo_name: openbao
+    description: OpenBao exists to provide a software solution to manage, store, and distribute sensitive data including secrets, certificates, and keys
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v2.0.0-alpha20240329"
+        asset: openbao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+      - version_constraint: Version == "v2.0.0-beta20240618"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.5.0-beta20251125"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt.gpgsig
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.1.1")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt.gpgsig
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.3.0-beta20250528")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-illumos.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.4.4")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums-darwin.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/openbao/openbao/bao/registry.yaml
+++ b/pkgs/openbao/openbao/bao/registry.yaml
@@ -36,7 +36,7 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: checksums-{{.OS}}.txt.gpgsig
+          asset: checksums-{{.OS}}.txt
           algorithm: sha256
         overrides:
           - goos: windows
@@ -51,33 +51,8 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: checksums-{{.OS}}.txt.gpgsig
+          asset: checksums-{{.OS}}.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 2.3.0-beta20250528")
-        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums-illumos.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-              - --signature
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -96,13 +71,13 @@ packages:
           cosign:
             opts:
               - --certificate
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.pem
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/tags/.*$'
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.sig
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -121,12 +96,12 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/tags/.*$'
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
-              asset: checksums-darwin.txt.sigstore.json
+              asset: checksums-{{.OS}}.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/openbao/openbao/bao/registry.yaml
+++ b/pkgs/openbao/openbao/bao/registry.yaml
@@ -26,21 +26,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v2.5.0-beta20251125"
-        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums-{{.OS}}.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 2.1.1")
         asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -78,6 +63,21 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.5.0-beta20251125"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -64210,6 +64210,136 @@ packages:
         overrides:
           - goos: windows
             asset: codex-{{.Arch}}-{{.OS}}.exe.{{.Format}}
+  - name: openbao/openbao/bao
+    type: github_release
+    repo_owner: openbao
+    repo_name: openbao
+    description: OpenBao exists to provide a software solution to manage, store, and distribute sensitive data including secrets, certificates, and keys
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v2.0.0-alpha20240329"
+        asset: openbao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+      - version_constraint: Version == "v2.0.0-beta20240618"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.5.0-beta20251125"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt.gpgsig
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.1.1")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt.gpgsig
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.3.0-beta20250528")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-illumos.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 2.4.4")
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums-darwin.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: openclarity
     repo_name: kubeclarity

--- a/registry.yaml
+++ b/registry.yaml
@@ -64236,21 +64236,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: Version == "v2.5.0-beta20251125"
-        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums-{{.OS}}.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 2.1.1")
         asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -64288,6 +64273,21 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v2.5.0-beta20251125"
+        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums-{{.OS}}.txt
+          algorithm: sha256
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -64246,7 +64246,7 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: checksums-{{.OS}}.txt.gpgsig
+          asset: checksums-{{.OS}}.txt
           algorithm: sha256
         overrides:
           - goos: windows
@@ -64261,33 +64261,8 @@ packages:
           windows: Windows
         checksum:
           type: github_release
-          asset: checksums-{{.OS}}.txt.gpgsig
+          asset: checksums-{{.OS}}.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 2.3.0-beta20250528")
-        asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums-illumos.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.pem
-              - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-              - --signature
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-illumos.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -64306,13 +64281,13 @@ packages:
           cosign:
             opts:
               - --certificate
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.pem
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.pem
               - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/tags/.*$'
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
               - --signature
-              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-darwin.txt.sig
+              - https://github.com/openbao/openbao/releases/download/{{.Version}}/checksums-{{.OS}}.txt.sig
         overrides:
           - goos: windows
             format: zip
@@ -64331,12 +64306,12 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/openbao/openbao/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/tags/.*$'
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
-              asset: checksums-darwin.txt.sigstore.json
+              asset: checksums-{{.OS}}.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
[openbao/openbao/bao](https://github.com/openbao/openbao) - OpenBao exists to provide a software solution to manage, store, and distribute sensitive data including secrets, certificates, and keys

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

## Description

This PR adds the [OpenBao](https://github.com/openbao/openbao) (bao) to the aqua standard registry. OpenBao is a fork of HashiCorp Vault which is already included in the standard registry: https://github.com/aquaproj/aqua-registry/tree/main/pkgs/hashicorp/vault.

### Details

[GitHub Releases for OpenBao](https://github.com/openbao/openbao/releases) seem to contain multiple asset types depending on the version:

- bao (general-purpose binary)
- bao-hsm (binary with HSM support)
- openbao (distribution package)

This PR registers only the bao binary, which is considered the most common and general-purpose executable. To clearly distinguish it from potential future support for bao-hsm, the package name is defined as `openbao/openbao/bao`. For details on bao-hsm, please refer to https://github.com/openbao/openbao/pull/889.

### Verification

- Checksum and cosign verification basically follow the official installation guidance: https://openbao.org/docs/install/
- Cosign verification is aligned with checksum assets and satisfies keyless identity requirements.