### PR TITLE
fix: don't disable complete_windows_ext in kubernetes-sigs/kind

### DIFF
--- a/pkgs/kubernetes-sigs/kind/registry.yaml
+++ b/pkgs/kubernetes-sigs/kind/registry.yaml
@@ -18,7 +18,6 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        complete_windows_ext: false
         supported_envs:
           - darwin
           - windows
@@ -35,17 +34,14 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        complete_windows_ext: false
       - version_constraint: semver("<= 0.11.1")
         asset: kind-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
       - version_constraint: "true"
         asset: kind-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: kind-{{.OS}}-{{.Arch}}.sha256sum

--- a/registry.yaml
+++ b/registry.yaml
@@ -53019,7 +53019,6 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        complete_windows_ext: false
         supported_envs:
           - darwin
           - windows
@@ -53036,17 +53035,14 @@ packages:
         format: raw
         rosetta2: true
         windows_arm_emulation: true
-        complete_windows_ext: false
       - version_constraint: semver("<= 0.11.1")
         asset: kind-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
       - version_constraint: "true"
         asset: kind-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
-        complete_windows_ext: false
         checksum:
           type: github_release
           asset: kind-{{.OS}}-{{.Arch}}.sha256sum


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
The kubernetes-sigs/kind package has `complete_windows_ext` disabled incorrectly. [None of the releases on the kind GitHub Repo contain file names including the extension](https://github.com/kubernetes-sigs/kind/releases), so having this option disabled will result in downloading a binary that does not run on Windows.