### PR TITLE
namespacelabs/foundation/nsc: Add bazel-credential-nsc

### DIFF
--- a/pkgs/namespacelabs/foundation/nsc/pkg.yaml
+++ b/pkgs/namespacelabs/foundation/nsc/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: namespacelabs/foundation/nsc@v0.0.488
   - name: namespacelabs/foundation/nsc
+    version: v0.0.391
+  - name: namespacelabs/foundation/nsc
     version: v0.0.212
   - name: namespacelabs/foundation/nsc
     version: v0.0.195

--- a/pkgs/namespacelabs/foundation/nsc/registry.yaml
+++ b/pkgs/namespacelabs/foundation/nsc/registry.yaml
@@ -8,6 +8,7 @@ packages:
     files:
       - name: nsc
       - name: docker-credential-nsc
+      - name: bazel-credential-nsc
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.158")

--- a/pkgs/namespacelabs/foundation/nsc/registry.yaml
+++ b/pkgs/namespacelabs/foundation/nsc/registry.yaml
@@ -25,6 +25,19 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.0.391")
+        asset: nsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: nsc
+          - name: docker-credential-nsc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -61933,6 +61933,19 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.0.391")
+        asset: nsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: nsc
+          - name: docker-credential-nsc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nsc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -61916,6 +61916,7 @@ packages:
     files:
       - name: nsc
       - name: docker-credential-nsc
+      - name: bazel-credential-nsc
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.158")


### PR DESCRIPTION
https://github.com/namespacelabs/foundation

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Also package bazel-credential-nsc in nsc releases.
