### PR TITLE
fix: assets name format for firecow/gitlab-ci-local

### DIFF
--- a/pkgs/firecow/gitlab-ci-local/registry.yaml
+++ b/pkgs/firecow/gitlab-ci-local/registry.yaml
@@ -30,7 +30,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<=4.65.1")
         asset: "{{.OS}}.{{.Format}}"
         format: gz
         rosetta2: true
@@ -42,3 +42,10 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: gitlab-ci-local-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -35006,7 +35006,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<=4.65.1")
         asset: "{{.OS}}.{{.Format}}"
         format: gz
         rosetta2: true
@@ -35018,6 +35018,13 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: gitlab-ci-local-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: firecracker-microvm
     repo_name: firecracker


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


Thanks for maintenance this registry.

`firecow/gitlab-ci-local` has changed asset name format. 
therefor add `version_constraint` section.

FYI: https://github.com/firecow/gitlab-ci-local/pull/1763