### PR TITLE
Add Skarlso/crd-to-sample-yaml

### DIFF
--- a/pkgs/Skarlso/crd-to-sample-yaml/pkg.yaml
+++ b/pkgs/Skarlso/crd-to-sample-yaml/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Skarlso/crd-to-sample-yaml@v2.1.6
+  - name: Skarlso/crd-to-sample-yaml
+    version: v1.1.4
+  - name: Skarlso/crd-to-sample-yaml
+    version: v0.0.8

--- a/pkgs/Skarlso/crd-to-sample-yaml/registry.yaml
+++ b/pkgs/Skarlso/crd-to-sample-yaml/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: Skarlso
     repo_name: crd-to-sample-yaml
     description: Generate a sample YAML file from a CRD and view it rendered on a nice website
+    files:
+      - name: cty
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.8")

--- a/pkgs/Skarlso/crd-to-sample-yaml/registry.yaml
+++ b/pkgs/Skarlso/crd-to-sample-yaml/registry.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Skarlso
+    repo_name: crd-to-sample-yaml
+    description: Generate a sample YAML file from a CRD and view it rendered on a nice website
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.8")
+        asset: crd-to-yaml_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: crd-to-yaml
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: crd-to-yaml_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.4")
+        asset: cty_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: cty
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cty_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: cty_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: cty
+        checksum:
+          type: github_release
+          asset: cty_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -6658,6 +6658,8 @@ packages:
     repo_owner: Skarlso
     repo_name: crd-to-sample-yaml
     description: Generate a sample YAML file from a CRD and view it rendered on a nice website
+    files:
+      - name: cty
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.8")

--- a/registry.yaml
+++ b/registry.yaml
@@ -6654,6 +6654,51 @@ packages:
           - linux
           - darwin/arm64
           - windows
+  - type: github_release
+    repo_owner: Skarlso
+    repo_name: crd-to-sample-yaml
+    description: Generate a sample YAML file from a CRD and view it rendered on a nice website
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.8")
+        asset: crd-to-yaml_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: crd-to-yaml
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: crd-to-yaml_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.4")
+        asset: cty_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: cty
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: cty_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: cty_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: cty
+        checksum:
+          type: github_release
+          asset: cty_checksums.txt
+          algorithm: sha256
   - type: http
     repo_owner: SonarSource
     repo_name: sonar-scanner-cli


### PR DESCRIPTION
[Skarlso/crd-to-sample-yaml](https://github.com/Skarlso/crd-to-sample-yaml) - Generate a sample YAML file from a CRD and view it rendered on a nice website

## Summary

- Add [Skarlso/crd-to-sample-yaml](https://github.com/Skarlso/crd-to-sample-yaml) (`cty`) to the aqua registry
- Generate a sample YAML file from a CRD and view it rendered on a nice website
- Scaffolded with `cmdx s`, manually added `files` config since the binary name (`cty`) differs from the repo name

## Notes

- Binary name is `cty` (for v1.0.0+) and `crd-to-yaml` (for <= v0.0.8)
- Supports linux, darwin, windows on amd64/arm64 (latest versions also arm/v7)
- Checksum verification enabled
- Tested successfully with `cmdx t` in Linux and Windows containers