### PR TITLE
fix(k1LoW/runn): support broader platforms

### DIFF
--- a/pkgs/k1LoW/runn/registry.yaml
+++ b/pkgs/k1LoW/runn/registry.yaml
@@ -9,9 +9,7 @@ packages:
     overrides:
       - goos: darwin
         format: zip
-    supported_envs:
-      - linux/amd64
-      - darwin
+    windows_arm_emulation: true
     checksum:
       type: github_release
       asset: checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Since major environments were supported except for Windows Arm, this PR removes `supported_envs` and set `windows_arm_emulation` to `true`. I checked win/amd64 only.

https://github.com/k1LoW/runn/releases/tag/v1.3.1

related: #49031