### PR TITLE
feat: add swanysimon/markdownlint-rs

### DIFF
--- a/pkgs/swanysimon/markdownlint-rs/pkg.yaml
+++ b/pkgs/swanysimon/markdownlint-rs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: swanysimon/markdownlint-rs@v0.2.8

--- a/pkgs/swanysimon/markdownlint-rs/registry.yaml
+++ b/pkgs/swanysimon/markdownlint-rs/registry.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: swanysimon
+    repo_name: markdownlint-rs
+    description: Attempting to port markdownlint (and the markdownlint-cli2 interface) to Rust using mostly vibes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mdlint-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: mdlint-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mdlint-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}

--- a/pkgs/swanysimon/markdownlint-rs/registry.yaml
+++ b/pkgs/swanysimon/markdownlint-rs/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: swanysimon
     repo_name: markdownlint-rs
     description: Attempting to port markdownlint (and the markdownlint-cli2 interface) to Rust using mostly vibes
+    files:
+      - name: mdlint
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/swanysimon/markdownlint-rs/registry.yaml
+++ b/pkgs/swanysimon/markdownlint-rs/registry.yaml
@@ -27,4 +27,3 @@ packages:
           - goos: windows
             format: zip
             asset: mdlint-{{.OS}}-{{.Arch}}.exe.{{.Format}}
-            replacements: {}

--- a/pkgs/swanysimon/markdownlint-rs/registry.yaml
+++ b/pkgs/swanysimon/markdownlint-rs/registry.yaml
@@ -10,6 +10,8 @@ packages:
         asset: mdlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mdlint
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -82671,7 +82671,6 @@ packages:
           - goos: windows
             format: zip
             asset: mdlint-{{.OS}}-{{.Arch}}.exe.{{.Format}}
-            replacements: {}
   - type: github_release
     repo_owner: sxyazi
     repo_name: yazi

--- a/registry.yaml
+++ b/registry.yaml
@@ -82645,6 +82645,32 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: swanysimon
+    repo_name: markdownlint-rs
+    description: Attempting to port markdownlint (and the markdownlint-cli2 interface) to Rust using mostly vibes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mdlint-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: mdlint-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: mdlint-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}
+  - type: github_release
     repo_owner: sxyazi
     repo_name: yazi
     description: Blazing fast terminal file manager written in Rust, based on async I/O

--- a/registry.yaml
+++ b/registry.yaml
@@ -82648,6 +82648,8 @@ packages:
     repo_owner: swanysimon
     repo_name: markdownlint-rs
     description: Attempting to port markdownlint (and the markdownlint-cli2 interface) to Rust using mostly vibes
+    files:
+      - name: mdlint
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -82654,6 +82654,8 @@ packages:
         asset: mdlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: mdlint
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
[swanysimon/markdownlint-rs](https://github.com/swanysimon/markdownlint-rs): Attempting to port markdownlint (and the markdownlint-cli2 interface) to Rust using mostly vibes

```console
$ aqua g -i swanysimon/markdownlint-rs
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cmdx con
+ bash scripts/connect.sh
[INFO] Connecting to the container aqua-registry (linux/amd64)
root@0c3b71b5b54c:/workspace# mdlint -h
A fast, flexible, configuration-based command-line interface for linting Markdown files

Usage: mdlint [OPTIONS] [PATTERNS]...

Arguments:
  [PATTERNS]...  Glob patterns for files to lint (defaults to current directory)

Options:
      --config <CONFIG>  Path to configuration file
      --fix              Apply fixes to files
      --no-globs         Ignore globs from configuration
      --format <FORMAT>  Output format: default or json [default: default]
      --no-color         Disable color output
  -h, --help             Print help
  -V, --version          Print version
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/DavidAnson/markdownlint
- https://github.com/DavidAnson/markdownlint-cli2
