### PR TITLE
add steipete/gogcli

### DIFF
--- a/pkgs/steipete/gogcli/pkg.yaml
+++ b/pkgs/steipete/gogcli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: steipete/gogcli@v0.11.0
+  - name: steipete/gogcli
+    version: v0.5.0

--- a/pkgs/steipete/gogcli/registry.yaml
+++ b/pkgs/steipete/gogcli/registry.yaml
@@ -10,6 +10,9 @@ packages:
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: gog
+            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -17,9 +20,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: gog
+                src: gog.exe
       - version_constraint: "true"
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gog
+            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -27,3 +36,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: gog
+                src: gog.exe

--- a/pkgs/steipete/gogcli/registry.yaml
+++ b/pkgs/steipete/gogcli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: steipete
     repo_name: gogcli
     description: "Google Suite CLI: Gmail, GCal, GDrive, GContacts"
+    files:
+      - name: gog
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.5.0")
@@ -12,7 +14,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: gog
-            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -20,15 +21,11 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: gog
-                src: gog.exe
       - version_constraint: "true"
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: gog
-            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -36,6 +33,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: gog
-                src: gog.exe

--- a/pkgs/steipete/gogcli/registry.yaml
+++ b/pkgs/steipete/gogcli/registry.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: steipete
+    repo_name: gogcli
+    description: "Google Suite CLI: Gmail, GCal, GDrive, GContacts"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0")
+        asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -79703,6 +79703,33 @@ packages:
           type: github_release
           asset: timoni_{{trimV .Version}}_provenance.intoto.jsonl
   - type: github_release
+    repo_owner: steipete
+    repo_name: gogcli
+    description: "Google Suite CLI: Gmail, GCal, GDrive, GContacts"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.0")
+        asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: stepchowfun
     repo_name: docuum
     description: Docuum performs least recently used (LRU) eviction of Docker images

--- a/registry.yaml
+++ b/registry.yaml
@@ -79706,6 +79706,8 @@ packages:
     repo_owner: steipete
     repo_name: gogcli
     description: "Google Suite CLI: Gmail, GCal, GDrive, GContacts"
+    files:
+      - name: gog
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.5.0")
@@ -79714,7 +79716,6 @@ packages:
         windows_arm_emulation: true
         files:
           - name: gog
-            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -79722,15 +79723,11 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: gog
-                src: gog.exe
       - version_constraint: "true"
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: gog
-            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -79738,9 +79735,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-            files:
-              - name: gog
-                src: gog.exe
   - type: github_release
     repo_owner: stepchowfun
     repo_name: docuum

--- a/registry.yaml
+++ b/registry.yaml
@@ -79712,6 +79712,9 @@ packages:
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: gog
+            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -79719,9 +79722,15 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: gog
+                src: gog.exe
       - version_constraint: "true"
         asset: gogcli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gog
+            src: gog
         checksum:
           type: github_release
           asset: checksums.txt
@@ -79729,6 +79738,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: gog
+                src: gog.exe
   - type: github_release
     repo_owner: stepchowfun
     repo_name: docuum


### PR DESCRIPTION
[steipete/gogcli](https://github.com/steipete/gogcli) - Google Suite CLI: Gmail, GCal, GDrive, GContacts

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

[steipete/gogcli](https://github.com/steipete/gogcli) is a cli tool that enables us to use Google services such as Gmail, Google Drive, and Google Calendar in our terminals.
