### PR TITLE
fix: exclude Windows from pre-commit/pre-commit supported_envs

### DIFF
--- a/pkgs/pre-commit/pre-commit/registry.yaml
+++ b/pkgs/pre-commit/pre-commit/registry.yaml
@@ -12,6 +12,9 @@ packages:
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - linux
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
@@ -20,3 +23,6 @@ packages:
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -69854,6 +69854,9 @@ packages:
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - linux
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
@@ -69862,6 +69865,9 @@ packages:
         asset: pre-commit-{{trimV .Version}}.pyz
         format: raw
         complete_windows_ext: false
+        supported_envs:
+          - darwin
+          - linux
   - type: github_release
     repo_owner: pressly
     repo_name: goose


### PR DESCRIPTION
## Summary

- Add `supported_envs: [darwin, linux]` to both active version_overrides
  for pre-commit/pre-commit

The .pyz asset requires a Python interpreter to run. On Unix this works
via shebang (`#!/usr/bin/env python3`), but on Windows aqua's exec path
uses `CreateProcess` which cannot execute non-PE binaries.

This is the same approach used when adding `pypa/pipx` (#39951), the
only other .pyz package in the registry.

Broader support for Python tools on Windows is tracked in
aquaproj/aqua#2128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package registry configuration to explicitly declare linux and darwin as supported environments across multiple package entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->