### PR TITLE
fix: rename kunobi-ninja/kunobi-releases to kunobi-ninja/kunobi

### DIFF
--- a/pkgs/kunobi-ninja/kunobi-releases/pkg.yaml
+++ b/pkgs/kunobi-ninja/kunobi-releases/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: kunobi-ninja/kunobi-releases@0.1.0-beta.23

--- a/pkgs/kunobi-ninja/kunobi/pkg.yaml
+++ b/pkgs/kunobi-ninja/kunobi/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kunobi-ninja/kunobi@0.1.0-beta.23

--- a/pkgs/kunobi-ninja/kunobi/registry.yaml
+++ b/pkgs/kunobi-ninja/kunobi/registry.yaml
@@ -2,7 +2,9 @@
 packages:
   - type: http
     repo_owner: kunobi-ninja
-    repo_name: kunobi-releases
+    repo_name: kunobi
+    aliases:
+      - name: kunobi-ninja/kunobi-releases
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
     version_source: github_tag

--- a/registry.yaml
+++ b/registry.yaml
@@ -55842,7 +55842,9 @@ packages:
       algorithm: sha256
   - type: http
     repo_owner: kunobi-ninja
-    repo_name: kunobi-releases
+    repo_name: kunobi
+    aliases:
+      - name: kunobi-ninja/kunobi-releases
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
     version_source: github_tag


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [X] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [X] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [X] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [X] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

fix: rename kunobi-ninja/kunobi-releases to kunobi-ninja/kunobi

The GitHub repository `kunobi-ninja/kunobi-releases` has been renamed to `kunobi-ninja/kunobi`.  An alias has been added for `kunobi-ninja/kunobi-releases` to maintain backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manifest to consolidate kunobi-ninja/kunobi-releases into kunobi (version 0.1.0-beta.23).
  * Added alias support for backward compatibility with kunobi-ninja/kunobi-releases package references.
  * Updated registry configuration to reflect new package repository mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->