### PR TITLE
feat(technicalpickles/envsense): add linux/arm64 support

### DIFF
--- a/pkgs/technicalpickles/envsense/pkg.yaml
+++ b/pkgs/technicalpickles/envsense/pkg.yaml
@@ -1,6 +1,9 @@
 packages:
   - name: technicalpickles/envsense@0.6.0
-  - name: technicalpickles/envsense@0.3.1
+  - name: technicalpickles/envsense
+    version: 0.3.4
+  - name: technicalpickles/envsense
+    version: 0.3.1
   - name: technicalpickles/envsense
     version: 0.2.2
   - name: technicalpickles/envsense

--- a/pkgs/technicalpickles/envsense/registry.yaml
+++ b/pkgs/technicalpickles/envsense/registry.yaml
@@ -68,7 +68,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.4")
         asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
         format: raw
         replacements:
@@ -93,4 +93,31 @@ packages:
             asset: envsense-{{.Version}}-universal-{{.OS}}
         supported_envs:
           - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity-regexp
+            - '^https://github\.com/technicalpickles/envsense/'
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -84374,7 +84374,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.3.4")
         asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
         format: raw
         replacements:
@@ -84399,6 +84399,33 @@ packages:
             asset: envsense-{{.Version}}-universal-{{.OS}}
         supported_envs:
           - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: envsense-{{.Version}}-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity-regexp
+            - '^https://github\.com/technicalpickles/envsense/'
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: darwin
+            asset: envsense-{{.Version}}-universal-{{.OS}}
+        supported_envs:
+          - linux
           - darwin
   - type: github_release
     repo_owner: tektoncd


### PR DESCRIPTION
## Summary

- Add `linux/arm64` to supported environments for envsense
- The `aarch64-unknown-linux-gnu` binary has shipped since v0.4.0 but the registry entry only declared `linux/amd64` and `darwin`
- Adds `arm64: aarch64` arch replacement and broadens `supported_envs` to `[linux, darwin]`

## Changes

- Changed the current catch-all `version_constraint: "true"` to `semver("<= 0.3.4")` (versions without arm64 binaries)
- Added new `version_constraint: "true"` block with `arm64: aarch64` replacement and `linux` (both arches) in `supported_envs`

## Validation

Tested in Docker containers using aqua with a local copy of this registry:

| Test | Platform | Result |
|------|----------|--------|
| Binary runs directly | linux/arm64 | Pass |
| Binary runs directly | linux/amd64 | Pass |
| aqua + local registry resolves & installs | linux/arm64 (aarch64) | Pass |
| aqua + local registry resolves & installs | linux/amd64 (x86_64) | Pass |

### Before (arm64)
```
mise ERROR Failed to install aqua:technicalpickles/envsense@latest: unsupported env: linux/arm64 (supported: ["linux/amd64", "darwin"])
```

### After (arm64)
```
aqua install -l  # resolves to envsense-0.6.0-aarch64-unknown-linux-gnu
envsense --version  # envsense 0.6.0
envsense info --json  # valid JSON output
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced security verification for package releases via cryptographic signing and provenance support.
  * Expanded support for additional platforms, architectures, and OS-specific assets.

* **Chores**
  * Tightened and refined package version constraints for more precise release selection.
  * Added explicit package version entries and improved platform-specific configuration handling for broader coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->