### PR TITLE
feat(owenlamont/ryl): GitHub artifact attestations config

### DIFF
--- a/pkgs/owenlamont/ryl/registry.yaml
+++ b/pkgs/owenlamont/ryl/registry.yaml
@@ -8,6 +8,18 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.2.0")
         no_asset: true
+      - version_constraint: semver("< 0.3.2")
+        asset: ryl-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: ryl-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -20,3 +32,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: owenlamont/ryl/.github/workflows/release.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -67625,6 +67625,18 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.2.0")
         no_asset: true
+      - version_constraint: semver("< 0.3.2")
+        asset: ryl-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: ryl-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -67637,6 +67649,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: owenlamont/ryl/.github/workflows/release.yml
   - type: github_release
     repo_owner: owenrumney
     repo_name: squealer


### PR DESCRIPTION
- https://github.com/owenlamont/ryl/attestations
- https://github.com/owenlamont/ryl/issues/101

The registry entry is currently stuck at 0.3.1 while 0.4.0 is already available, so there's no test coverage for the attestations yet.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package registry configuration with new version constraints and platform-specific distribution settings
  * Added GitHub artifact attestation support for enhanced package verification and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->