### PR TITLE
feat(yashikota/exiftool-go): yashikota/exiftool-go

### DIFF
--- a/pkgs/yashikota/exiftool-go/pkg.yaml
+++ b/pkgs/yashikota/exiftool-go/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yashikota/exiftool-go@v1.0.0

--- a/pkgs/yashikota/exiftool-go/registry.yaml
+++ b/pkgs/yashikota/exiftool-go/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: yashikota
+    repo_name: exiftool-go
+    description: Pure Go ExifTool wrapper powered by WebAssembly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: exiftool-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: exiftool-go_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -91650,6 +91650,19 @@ packages:
             src: "{{.AssetWithoutExt}}/bin/yarn"
   - type: github_release
     repo_owner: yashikota
+    repo_name: exiftool-go
+    description: Pure Go ExifTool wrapper powered by WebAssembly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: exiftool-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: exiftool-go_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: yashikota
     repo_name: genenv
     description: A simple CLI tool to generate .env files from template files, automatically filling in placeholders with cryptographically secure random values
     version_constraint: "false"


### PR DESCRIPTION
[yashikota/exiftool-go](https://github.com/yashikota/exiftool-go) - Pure Go ExifTool wrapper powered by WebAssembly

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added yashikota/exiftool-go package, a Pure Go ExifTool wrapper powered by WebAssembly, now available for installation through the registry with automatic version management and checksum verification support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->