### PR TITLE
fix(mozilla/sccache): fix aarch64 support for versions >= 0.7.0

### DIFF
--- a/pkgs/mozilla/sccache/pkg.yaml
+++ b/pkgs/mozilla/sccache/pkg.yaml
@@ -1,20 +1,20 @@
 packages:
   - name: mozilla/sccache@v0.14.0
   - name: mozilla/sccache
-    version: v0.5.2
+    version: v0.13.0
+  - name: mozilla/sccache
+    version: v0.8.1
   - name: mozilla/sccache
     version: v0.5.1
   - name: mozilla/sccache
-    version: v0.4.0-pre.2
+    version: v0.4.0-pre.1
   - name: mozilla/sccache
-    version: v0.3.3
-  - name: mozilla/sccache
-    version: 0.2.14
+    version: v0.3.1
   - name: mozilla/sccache
     version: 0.2.13
   - name: mozilla/sccache
-    version: 0.2.9
+    version: 0.2.12
   - name: mozilla/sccache
-    version: 0.2.6
+    version: 0.2.8
   - name: mozilla/sccache
-    version: 0.2.4
+    version: 0.2.5

--- a/pkgs/mozilla/sccache/pkg.yaml
+++ b/pkgs/mozilla/sccache/pkg.yaml
@@ -10,11 +10,3 @@ packages:
     version: v0.4.0-pre.1
   - name: mozilla/sccache
     version: v0.3.1
-  - name: mozilla/sccache
-    version: 0.2.13
-  - name: mozilla/sccache
-    version: 0.2.12
-  - name: mozilla/sccache
-    version: 0.2.8
-  - name: mozilla/sccache
-    version: 0.2.5

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -4,25 +4,13 @@ packages:
     repo_owner: mozilla
     repo_name: sccache
     description: Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible. Sccache has the capability to utilize caching in remote storage environments, including various cloud storage options, or alternatively, in local storage
+    files:
+      - name: sccache
+        src: "{{.AssetWithoutExt}}/sccache"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.3.2"
         no_asset: true
-      - version_constraint: Version == "0.2.13"
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: Version in ["v0.5.1", "v0.6.0"]
         asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -65,49 +53,8 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: semver("<= 0.2.5")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.2.8")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.2.12")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+      - version_constraint: semver("<= 0.2.13")
+        error_message: "This version is too old. Please use newer versions"
       - version_constraint: semver("<= 0.3.1")
         asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -3,88 +3,72 @@ packages:
   - type: github_release
     repo_owner: mozilla
     repo_name: sccache
-    description: sccache is ccache with cloud storage
-    asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: sccache
-        src: sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache
-    overrides:
-      - goos: windows
-        replacements:
-          arm64: arm64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - amd64
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
-    version_constraint: semver(">= 0.6.0")
-    # > aarch64-unknown-linux-musl was disabled 0.5.2 in https://github.com/mozilla/sccache/pull/1917
-    # and reenabled in 0.7.0 https://github.com/mozilla/sccache/pull/1926
+    description: Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible. Sccache has the capability to utilize caching in remote storage environments, including various cloud storage options, or alternatively, in local storage
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.7.0")
+      - version_constraint: Version == "v0.3.2"
+        no_asset: true
+      - version_constraint: Version == "0.2.13"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         supported_envs:
+          - linux/amd64
           - darwin
-          - linux
-      - version_constraint: semver(">= 0.5.2")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 0.5.1")
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
+      - version_constraint: Version in ["v0.5.1", "v0.6.0"]
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.4.0-pre.2")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 0.3.3")
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
           - goos: darwin
             replacements:
               arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.13.0"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.2.14")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
-          - goos: windows
+          - goos: darwin
             replacements:
-              arm64: arm64
-            checksum:
-              # https://github.com/aquaproj/aqua-registry/pull/13027
-              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
-              enabled: false # ERRO[0001] install the package                           actual_checksum=BA6BF184D2B0A78978629AAEF0D9FE3CA57923E228D949B1932EC1A91AB4CEAC aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��B\x00A\x006\x00B\x00F\x001\x008\x004\x00D\x002\x00B\x000\x00A\x007\x008\x009\x007\x008\x006\x002\x009\x00A\x00A\x00E\x00F\x000\x00D\x009\x00F\x00E\x003\x00C\x00A\x005\x007\x009\x002\x003\x00E\x002\x002\x008\x00D\x009\x004\x009\x00B\x001\x009\x003\x002\x00E\x00C\x001\x00A\x009\x001\x00A\x00B\x004\x00C\x00E\x00A\x00C\x00" package_name=mozilla/sccache package_version=0.2.14 program=aqua registry=standard
-      - version_constraint: semver(">= 0.2.13")
-        overrides: []
+              amd64: amd64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 0.2.5")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -92,45 +76,97 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 0.2.8")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-      - version_constraint: semver(">= 0.2.9")
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.2.12")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.0-pre.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
-          - goos: windows
-            checksum:
-              # https://github.com/aquaproj/aqua-registry/pull/13027
-              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
-              enabled: false # ERRO[0001] install the package                           actual_checksum=6DD85F65FCCB1CDB00E7C5804C3F3BA523C1ED20EA8F777D454826EEF17C636F aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��6\x00D\x00D\x008\x005\x00F\x006\x005\x00F\x00C\x00C\x00B\x001\x00C\x00D\x00B\x000\x000\x00E\x007\x00C\x005\x008\x000\x004\x00C\x003\x00F\x003\x00B\x00A\x005\x002\x003\x00C\x001\x00E\x00D\x002\x000\x00E\x00A\x008\x00F\x007\x007\x007\x00D\x004\x005\x004\x008\x002\x006\x00E\x00E\x00F\x001\x007\x00C\x006\x003\x006\x00F\x00" package_name=mozilla/sccache package_version=0.2.9 program=aqua registry=standard
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.2.6")
-        overrides: []
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
         checksum:
-          enabled: false
-      - version_constraint: semver("< 0.2.6")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-        checksum:
-          enabled: false
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/mozilla/sccache/registry.yaml
+++ b/pkgs/mozilla/sccache/registry.yaml
@@ -27,9 +27,13 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
     version_constraint: semver(">= 0.6.0")
-    # > aarch64-unknown-linux-musl was disabled
-    # https://github.com/mozilla/sccache/pull/1917
+    # > aarch64-unknown-linux-musl was disabled 0.5.2 in https://github.com/mozilla/sccache/pull/1917
+    # and reenabled in 0.7.0 https://github.com/mozilla/sccache/pull/1926
     version_overrides:
+      - version_constraint: semver(">= 0.7.0")
+        supported_envs:
+          - darwin
+          - linux
       - version_constraint: semver(">= 0.5.2")
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -61347,25 +61347,13 @@ packages:
     repo_owner: mozilla
     repo_name: sccache
     description: Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible. Sccache has the capability to utilize caching in remote storage environments, including various cloud storage options, or alternatively, in local storage
+    files:
+      - name: sccache
+        src: "{{.AssetWithoutExt}}/sccache"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.3.2"
         no_asset: true
-      - version_constraint: Version == "0.2.13"
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: Version in ["v0.5.1", "v0.6.0"]
         asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -61408,49 +61396,8 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: semver("<= 0.2.5")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.2.8")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.2.12")
-        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+      - version_constraint: semver("<= 0.2.13")
+        error_message: "This version is too old. Please use newer versions"
       - version_constraint: semver("<= 0.3.1")
         asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -61346,84 +61346,72 @@ packages:
   - type: github_release
     repo_owner: mozilla
     repo_name: sccache
-    description: sccache is ccache with cloud storage
-    asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: sccache
-        src: sccache-{{.Version}}-{{.Arch}}-{{.OS}}/sccache
-    overrides:
-      - goos: windows
-        replacements:
-          arm64: arm64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - amd64
-    checksum:
-      type: github_release
-      asset: "{{.Asset}}.sha256"
-      algorithm: sha256
-    version_constraint: semver(">= 0.6.0")
-    # > aarch64-unknown-linux-musl was disabled
-    # https://github.com/mozilla/sccache/pull/1917
+    description: Sccache is a ccache-like tool. It is used as a compiler wrapper and avoids compilation when possible. Sccache has the capability to utilize caching in remote storage environments, including various cloud storage options, or alternatively, in local storage
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.5.2")
+      - version_constraint: Version == "v0.3.2"
+        no_asset: true
+      - version_constraint: Version == "0.2.13"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         supported_envs:
+          - linux/amd64
           - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 0.5.1")
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
+      - version_constraint: Version in ["v0.5.1", "v0.6.0"]
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.4.0-pre.2")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
-      - version_constraint: semver(">= 0.3.3")
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
           - goos: darwin
             replacements:
               arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.13.0"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.2.14")
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
-          - goos: windows
+          - goos: darwin
             replacements:
-              arm64: arm64
-            checksum:
-              # https://github.com/aquaproj/aqua-registry/pull/13027
-              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
-              enabled: false # ERRO[0001] install the package                           actual_checksum=BA6BF184D2B0A78978629AAEF0D9FE3CA57923E228D949B1932EC1A91AB4CEAC aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��B\x00A\x006\x00B\x00F\x001\x008\x004\x00D\x002\x00B\x000\x00A\x007\x008\x009\x007\x008\x006\x002\x009\x00A\x00A\x00E\x00F\x000\x00D\x009\x00F\x00E\x003\x00C\x00A\x005\x007\x009\x002\x003\x00E\x002\x002\x008\x00D\x009\x004\x009\x00B\x001\x009\x003\x002\x00E\x00C\x001\x00A\x009\x001\x00A\x00B\x004\x00C\x00E\x00A\x00C\x00" package_name=mozilla/sccache package_version=0.2.14 program=aqua registry=standard
-      - version_constraint: semver(">= 0.2.13")
-        overrides: []
+              amd64: amd64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 0.2.5")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -61431,48 +61419,100 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("<= 0.2.8")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-      - version_constraint: semver(">= 0.2.9")
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.2.12")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 0.4.0-pre.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
         overrides:
-          - goos: windows
-            checksum:
-              # https://github.com/aquaproj/aqua-registry/pull/13027
-              # https://github.com/aquaproj/aqua-registry/actions/runs/5262947082/jobs/9512626767
-              enabled: false # ERRO[0001] install the package                           actual_checksum=6DD85F65FCCB1CDB00E7C5804C3F3BA523C1ED20EA8F777D454826EEF17C636F aqua_version=2.8.0 env=windows/amd64 error="checksum is invalid" expected_checksum="��6\x00D\x00D\x008\x005\x00F\x006\x005\x00F\x00C\x00C\x00B\x001\x00C\x00D\x00B\x000\x000\x00E\x007\x00C\x005\x008\x000\x004\x00C\x003\x00F\x003\x00B\x00A\x005\x002\x003\x00C\x001\x00E\x00D\x002\x000\x00E\x00A\x008\x00F\x007\x007\x007\x00D\x004\x005\x004\x008\x002\x006\x00E\x00E\x00F\x001\x007\x00C\x006\x003\x006\x00F\x00" package_name=mozilla/sccache package_version=0.2.9 program=aqua registry=standard
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.1")
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.2.6")
-        overrides: []
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: sccache-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
         checksum:
-          enabled: false
-      - version_constraint: semver("< 0.2.6")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-        checksum:
-          enabled: false
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - type: github_release
     repo_owner: mpalmer
     repo_name: action-validator


### PR DESCRIPTION
This builds on top of #16749 .

The binary for arm64 was fixed in [0.7.0](https://github.com/mozilla/sccache/releases/tag/v0.7.0) so we can add back support

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sccache registry configuration with new version overrides for 0.7.0 and later to specify darwin and linux platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->