### PR TITLE
feat: add rtk-ai/rtk

### DIFF
--- a/pkgs/rtk-ai/rtk/pkg.yaml
+++ b/pkgs/rtk-ai/rtk/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: rtk-ai/rtk@v0.24.0
+  - name: rtk-ai/rtk
+    version: v0.22.2
+  - name: rtk-ai/rtk
+    version: v0.12.0
+  - name: rtk-ai/rtk
+    version: v0.9.4

--- a/pkgs/rtk-ai/rtk/registry.yaml
+++ b/pkgs/rtk-ai/rtk/registry.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: rtk-ai
+    repo_name: rtk
+    description: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.4.0", "v0.6.0", "v0.8.0", "v0.13.0"]
+        no_asset: true
+      - version_constraint: Version == "v0.12.0"
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.9.4")
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.11.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.22.2")
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -73268,6 +73268,91 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: rtk-ai
+    repo_name: rtk
+    description: CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.4.0", "v0.6.0", "v0.8.0", "v0.13.0"]
+        no_asset: true
+      - version_constraint: Version == "v0.12.0"
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.9.4")
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.11.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.22.2")
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: rtk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
   - type: go_install
     repo_owner: rubenv
     repo_name: sql-migrate


### PR DESCRIPTION
[rtk-ai/rtk](https://github.com/rtk-ai/rtk) - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Add [rtk-ai/rtk](https://github.com/rtk-ai/rtk)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded package registry with new tools and utilities across multiple domains including Kubernetes, cloud services, and system management.

* **Chores**
  * Added version-specific configurations and platform-specific optimizations for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->