### PR TITLE
feat: add k1LoW/mo

### DIFF
--- a/pkgs/k1LoW/mo/pkg.yaml
+++ b/pkgs/k1LoW/mo/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: k1LoW/mo@v0.13.0

--- a/pkgs/k1LoW/mo/registry.yaml
+++ b/pkgs/k1LoW/mo/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: k1LoW
+    repo_name: mo
+    description: mo is a Markdown viewer that opens .md files in a browser
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -50731,6 +50731,23 @@ packages:
             format: zip
   - type: github_release
     repo_owner: k1LoW
+    repo_name: mo
+    description: mo is a Markdown viewer that opens .md files in a browser
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mo_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: zip
+  - type: github_release
+    repo_owner: k1LoW
     repo_name: ndiag
     description: ndiag is a high-level architecture diagramming/documentation tool
     version_constraint: "false"


### PR DESCRIPTION
[k1LoW/mo](https://github.com/k1LoW/mo): mo is a Markdown viewer that opens .md files in a browser

```console
$ aqua g -i k1LoW/mo
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added k1LoW/mo v0.13.0, a Markdown viewer that opens .md files directly in your browser. Now available across multiple platforms with optimized builds for Windows, macOS, and ARM-based systems for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->