### PR TITLE
feat(spinel-coop/rv): GitHub artifact attestations config

### DIFF
--- a/pkgs/spinel-coop/rv/pkg.yaml
+++ b/pkgs/spinel-coop/rv/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: spinel-coop/rv@v0.5.3
   - name: spinel-coop/rv
+    version: v0.5.2
+  - name: spinel-coop/rv
     version: v0.1.1

--- a/pkgs/spinel-coop/rv/registry.yaml
+++ b/pkgs/spinel-coop/rv/registry.yaml
@@ -27,6 +27,21 @@ packages:
         supported_envs:
           - linux
           - darwin/arm64
+      - version_constraint: semver("<= 0.5.2")
+        asset: rv-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: rv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
@@ -42,3 +57,5 @@ packages:
         supported_envs:
           - linux
           - darwin
+        github_artifact_attestations:
+          signer_workflow: spinel-coop/rv/.github/workflows/release.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -79302,6 +79302,21 @@ packages:
         supported_envs:
           - linux
           - darwin/arm64
+      - version_constraint: semver("<= 0.5.2")
+        asset: rv-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: rv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
@@ -79317,6 +79332,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+        github_artifact_attestations:
+          signer_workflow: spinel-coop/rv/.github/workflows/release.yml
   - name: spinnaker/spin
     type: http
     format: raw


### PR DESCRIPTION
https://github.com/spinel-coop/rv/attestations

Registry is at 0.5.2 currently while attestations are available from 0.5.3 on, so no test coverage yet.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for v0.5.2 and earlier, including Linux and macOS tar.xz releases.
  * Registered an additional package entry for v0.5.2.

* **Security**
  * Enabled cryptographic verification for release artifacts via release attestations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->