### PR TITLE
feat: add suzuki-shunsuke/docfresh

### DIFF
--- a/pkgs/suzuki-shunsuke/docfresh/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/docfresh/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/docfresh@v0.0.1

--- a/pkgs/suzuki-shunsuke/docfresh/registry.yaml
+++ b/pkgs/suzuki-shunsuke/docfresh/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: docfresh
+    description: Make document maintainable, reusable, and testable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: docfresh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: docfresh_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/docfresh/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: docfresh_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/suzuki-shunsuke/docfresh/registry.yaml
+++ b/pkgs/suzuki-shunsuke/docfresh/registry.yaml
@@ -14,14 +14,16 @@ packages:
           asset: docfresh_checksums.txt
           algorithm: sha256
           cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/docfresh/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
               asset: docfresh_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -82262,14 +82262,16 @@ packages:
           asset: docfresh_checksums.txt
           algorithm: sha256
           cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/docfresh/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
               asset: docfresh_checksums.txt.bundle
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -82250,6 +82250,34 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: docfresh
+    description: Make document maintainable, reusable, and testable
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: docfresh_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: docfresh_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/docfresh/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: docfresh_checksums.txt.bundle
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: durl
     description: "[DEPRECATED] Use https://github.com/lycheeverse/lychee"
     version_constraint: "false"


### PR DESCRIPTION
[suzuki-shunsuke/docfresh](https://github.com/suzuki-shunsuke/docfresh): Make document maintainable, reusable, and testable

```console
$ aqua g -i suzuki-shunsuke/docfresh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added docfresh package to the registry, a tool for making documents maintainable, reusable, and testable. The package includes support for multiple operating systems and security verification mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->