### PR TITLE
Add apache/ant

### DIFF
--- a/pkgs/apache/ant/pkg.yaml
+++ b/pkgs/apache/ant/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: apache/ant@rel/1.10.15

--- a/pkgs/apache/ant/registry.yaml
+++ b/pkgs/apache/ant/registry.yaml
@@ -27,4 +27,4 @@ packages:
           - goos: windows
             files:
               - name: ant
-                src: apache-ant-{{.SemVer}}/bin/ant.cmd
+                src: apache-ant-{{.SemVer}}/bin/ant.bat

--- a/pkgs/apache/ant/registry.yaml
+++ b/pkgs/apache/ant/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: apache
+    repo_name: ant
+    description: Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other
+    version_source: github_tag
+    version_prefix: rel/
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.10.0")
+        error_message: Please use 1.10.1 or later
+      - version_constraint: "true"
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
+        format: tar.xz
+        checksum:
+          type: http
+          url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}.sha512
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{128}\b)
+        files:
+          - name: ant
+            src: apache-ant-{{.SemVer}}/bin/ant
+        overrides:
+          - goos: windows
+            files:
+              - name: ant
+                src: apache-ant-{{.SemVer}}/bin/ant.cmd

--- a/registry.yaml
+++ b/registry.yaml
@@ -12412,7 +12412,7 @@ packages:
   - type: http
     repo_owner: apache
     repo_name: ant
-    description: Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.
+    description: Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other
     version_source: github_tag
     version_prefix: rel/
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12436,7 +12436,7 @@ packages:
           - goos: windows
             files:
               - name: ant
-                src: apache-ant-{{.SemVer}}/bin/ant.cmd
+                src: apache-ant-{{.SemVer}}/bin/ant.bat
   - type: github_release
     repo_owner: apache
     repo_name: camel-k

--- a/registry.yaml
+++ b/registry.yaml
@@ -12409,6 +12409,34 @@ packages:
       - version_constraint: "true"
         asset: walk_{{.OS}}_{{.Arch}}
         format: raw
+  - type: http
+    repo_owner: apache
+    repo_name: ant
+    description: Apache Ant is a Java library and command-line tool whose mission is to drive processes described in build files as targets and extension points dependent upon each other.
+    version_source: github_tag
+    version_prefix: rel/
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.10.0")
+        error_message: Please use 1.10.1 or later
+      - version_constraint: "true"
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
+        format: tar.xz
+        checksum:
+          type: http
+          url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}.sha512
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{128}\b)
+        files:
+          - name: ant
+            src: apache-ant-{{.SemVer}}/bin/ant
+        overrides:
+          - goos: windows
+            files:
+              - name: ant
+                src: apache-ant-{{.SemVer}}/bin/ant.cmd
   - type: github_release
     repo_owner: apache
     repo_name: camel-k


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Adds Apache Ant, largely following the [pattern of Apache Maven](https://github.com/aquaproj/aqua-registry/tree/main/pkgs/apache/maven).
- For simplicity, ignores versions `1.10.0` and earlier ([before smaller `.xz` archives were being published](https://archive.apache.org/dist/ant/binaries/)). Ant is very old, and 1.10.x series is [from 2017](https://ant.apache.org/antnews.html) so nearly 9 years old. There's little value in supporting older versions IMHO, but someone can add support later if they like.
- I set release prefix to `rel/` because that's what [the GitHub tags have](https://github.com/apache/ant/tags), but not sure if this is the right approach, as I am mainly use the Aqua Registry via Mise and such prefixes typically aren't displayed or used there.
- There are other scripts included in the binaries such as `antenv` or `antRun` but don't think these are commonly used, so didn't configure them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apache Ant is now available as a managed package with automated discovery from releases.
  * Enforced version constraints with clear error messages for unsupported releases.
  * Fallback binary distribution for older releases with SHA-512 integrity verification.
  * Cross-platform support including Windows executable mapping and architecture-specific artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->