### PR TITLE
feat(pkg): add goteammate/lgtm

### DIFF
--- a/pkgs/goteammate/lgtm/pkg.yaml
+++ b/pkgs/goteammate/lgtm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: goteammate/lgtm@v0.1.0

--- a/pkgs/goteammate/lgtm/registry.yaml
+++ b/pkgs/goteammate/lgtm/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: goteammate
+    repo_name: lgtm
+    description: CLI-native email client with AI integration via MCP
+    asset: lgtm_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256


### PR DESCRIPTION
## Summary

Add [goteammate/lgtm](https://github.com/goteammate/lgtm) to the aqua registry.

lgtm is a CLI-native email client with AI integration via MCP. It provides a TUI for managing email directly from the terminal, with features like the Jerry List for auto-handling emails from tagged senders.

- Type: `github_release`
- Platforms: darwin (amd64, arm64), linux (amd64, arm64)
- Checksum: SHA256 via `checksums.txt`
- Built with GoReleaser

## Release

https://github.com/goteammate/lgtm/releases/tag/v0.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered the goteammate/lgtm v0.1.0 package, a CLI-native email client available for macOS and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->