### PR TITLE
Add sudorandom/fauxrpc

### DIFF
--- a/pkgs/sudorandom/fauxrpc/pkg.yaml
+++ b/pkgs/sudorandom/fauxrpc/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: sudorandom/fauxrpc@v0.19.5
+  - name: sudorandom/fauxrpc
+    version: v0.19.4
+  - name: sudorandom/fauxrpc
+    version: v0.16.1
+  - name: sudorandom/fauxrpc
+    version: v0.0.17
+  - name: sudorandom/fauxrpc
+    version: v0.0.17-4
+  - name: sudorandom/fauxrpc
+    version: v0.0.16

--- a/pkgs/sudorandom/fauxrpc/registry.yaml
+++ b/pkgs/sudorandom/fauxrpc/registry.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sudorandom
+    repo_name: fauxrpc
+    description: Easily start a fake gRPC/gRPC-Web/Connect/REST server from protobufs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.17-4"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.17"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: fauxrpc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.16")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: fauxrpc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.16.1")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.19.4")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -81371,6 +81371,59 @@ packages:
           - darwin
   - type: github_release
     repo_owner: sudorandom
+    repo_name: fauxrpc
+    description: Easily start a fake gRPC/gRPC-Web/Connect/REST server from protobufs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.17-4"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.0.17"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: fauxrpc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.0.16")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: fauxrpc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.16.1")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.19.4")
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+      - version_constraint: "true"
+        asset: fauxrpc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: sudorandom
     repo_name: protoc-gen-connect-openapi
     description: Plugin for generating OpenAPIv3 from protobufs matching the Connect RPC interface
     version_constraint: "false"


### PR DESCRIPTION
[sudorandom/fauxrpc](https://github.com/sudorandom/fauxrpc) - Easily start a fake gRPC/gRPC-Web/Connect/REST server from protobufs

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Add package for [`sudorandom/fauxrpc`](https://github.com/sudorandom/fauxrpc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the sudorandom/fauxrpc package with multiple version availability and automated GitHub release asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->