### PR TITLE
feat: add princjef/gomarkdoc

### DIFF
--- a/pkgs/princjef/gomarkdoc/pkg.yaml
+++ b/pkgs/princjef/gomarkdoc/pkg.yaml
@@ -2,5 +2,5 @@ packages:
   - name: princjef/gomarkdoc@v1.1.0
   - name: princjef/gomarkdoc
     version: v0.2.1
-  - name: princjef/gomarkdoc
-    version: v0.1.3
+  # - name: princjef/gomarkdoc
+  #   version: v0.1.3

--- a/pkgs/princjef/gomarkdoc/pkg.yaml
+++ b/pkgs/princjef/gomarkdoc/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: princjef/gomarkdoc@v1.1.0
+  - name: princjef/gomarkdoc
+    version: v0.2.1
+  - name: princjef/gomarkdoc
+    version: v0.1.3

--- a/pkgs/princjef/gomarkdoc/pkg.yaml
+++ b/pkgs/princjef/gomarkdoc/pkg.yaml
@@ -2,5 +2,3 @@ packages:
   - name: princjef/gomarkdoc@v1.1.0
   - name: princjef/gomarkdoc
     version: v0.2.1
-  # - name: princjef/gomarkdoc
-  #   version: v0.1.3

--- a/pkgs/princjef/gomarkdoc/registry.yaml
+++ b/pkgs/princjef/gomarkdoc/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: princjef
     repo_name: gomarkdoc
     description: Generate markdown documentation for Go (golang) code
+    files:
+      - name: gomarkdoc
+        src: "{{.AssetWithoutExt}}/gomarkdoc"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/pkgs/princjef/gomarkdoc/registry.yaml
+++ b/pkgs/princjef/gomarkdoc/registry.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: princjef
+    repo_name: gomarkdoc
+    description: Generate markdown documentation for Go (golang) code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.1.3")
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.2.1")
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -70071,6 +70071,47 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: princjef
+    repo_name: gomarkdoc
+    description: Generate markdown documentation for Go (golang) code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.1.3")
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.2.1")
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gomarkdoc_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gomarkdoc_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: printfn
     repo_name: fend
     description: Arbitrary-precision unit-aware calculator

--- a/registry.yaml
+++ b/registry.yaml
@@ -70074,6 +70074,9 @@ packages:
     repo_owner: princjef
     repo_name: gomarkdoc
     description: Generate markdown documentation for Go (golang) code
+    files:
+      - name: gomarkdoc
+        src: "{{.AssetWithoutExt}}/gomarkdoc"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"


### PR DESCRIPTION
[princjef/gomarkdoc](https://github.com/princjef/gomarkdoc): Generate markdown documentation for Go (golang) code

```console
$ aqua g -i princjef/gomarkdoc
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package registry configuration for gomarkdoc supporting multiple versions with platform-specific binary distributions and integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->