### PR TITLE
starting v3.13.0, mvdan/sh no longer includes a sha256sums.txt asset.…

### DIFF
--- a/pkgs/mvdan/sh/pkg.yaml
+++ b/pkgs/mvdan/sh/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: mvdan/sh@v3.12.0
+  - name: mvdan/sh@v3.13.0
+  - name: mvdan/sh
+    version: v3.12.0
   - name: mvdan/sh
     version: v3.7.0

--- a/pkgs/mvdan/sh/registry.yaml
+++ b/pkgs/mvdan/sh/registry.yaml
@@ -17,7 +17,7 @@ packages:
           - amd64
         files:
           - name: shfmt
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.12.0")
         format: raw
         asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
         supported_envs:
@@ -30,3 +30,12 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        format: raw
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        files:
+          - name: shfmt

--- a/registry.yaml
+++ b/registry.yaml
@@ -62408,7 +62408,7 @@ packages:
           - amd64
         files:
           - name: shfmt
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.12.0")
         format: raw
         asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
         supported_envs:
@@ -62421,6 +62421,15 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+      - version_constraint: "true"
+        format: raw
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        files:
+          - name: shfmt
   - type: github_release
     repo_owner: mvisonneau
     repo_name: approuvez


### PR DESCRIPTION
… disabling checksum for new version

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->
As of version 3.13.0 mvdan/sh stopped publishing sha256sum.txt asset as github now provides digest natively. So, I am removing the checksum for new version.
See notes: https://github.com/mvdan/sh/releases/tag/v3.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated shfmt tool from version 3.12.0 to 3.13.0.
  * Modified version constraints for improved compatibility management across releases.
  * Expanded registry configuration for multi-platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->