### PR TITLE
feat(dprint/dprint): GitHub immutable release config

### DIFF
--- a/pkgs/dprint/dprint/pkg.yaml
+++ b/pkgs/dprint/dprint/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: dprint/dprint@0.52.0
   - name: dprint/dprint
+    version: 0.51.1
+  - name: dprint/dprint
     version: 0.33.0
   - name: dprint/dprint
     version: 0.13.1

--- a/pkgs/dprint/dprint/registry.yaml
+++ b/pkgs/dprint/dprint/registry.yaml
@@ -30,6 +30,19 @@ packages:
           type: github_release
           asset: SHASUMS256.txt
           algorithm: sha256
+      - version_constraint: semver("< 0.52.0")
+        asset: dprint-{{.Arch}}-{{.OS}}.zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: dprint-{{.Arch}}-{{.OS}}.zip
         windows_arm_emulation: true
@@ -43,3 +56,4 @@ packages:
           type: github_release
           asset: SHASUMS256.txt
           algorithm: sha256
+        github_immutable_release: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -32465,6 +32465,19 @@ packages:
           type: github_release
           asset: SHASUMS256.txt
           algorithm: sha256
+      - version_constraint: semver("< 0.52.0")
+        asset: dprint-{{.Arch}}-{{.OS}}.zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: dprint-{{.Arch}}-{{.OS}}.zip
         windows_arm_emulation: true
@@ -32478,6 +32491,7 @@ packages:
           type: github_release
           asset: SHASUMS256.txt
           algorithm: sha256
+        github_immutable_release: true
   - type: github_release
     repo_owner: drager
     repo_name: wasm-pack


### PR DESCRIPTION
https://github.com/dprint/dprint/releases

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Downgraded dprint to version 0.51.1 from 0.52.0
  * Added support for older dprint versions (< 0.52.0) with platform-specific configurations
  * Enhanced release stability with immutable release tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->