### PR TITLE
feat(j178/prek): GitHub immutable release config

### DIFF
--- a/pkgs/j178/prek/pkg.yaml
+++ b/pkgs/j178/prek/pkg.yaml
@@ -3,6 +3,8 @@ packages:
   - name: j178/prek
     version: v0.3.0
   - name: j178/prek
+    version: v0.1.6
+  - name: j178/prek
     version: v0.0.28
   - name: j178/prek
     version: v0.0.22

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -92,6 +92,27 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.1.6")
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: prek
       - version_constraint: semver("<= 0.3.0")
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -113,6 +134,7 @@ packages:
             format: zip
             files:
               - name: prek
+        github_immutable_release: true
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -136,3 +158,4 @@ packages:
               - name: prek
         github_artifact_attestations:
           signer_workflow: j178/prek/.github/workflows/release.yml
+        github_immutable_release: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -47669,6 +47669,27 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: semver("<= 0.1.6")
+        asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: prek
+            src: "{{.AssetWithoutExt}}/prek"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: prek
       - version_constraint: semver("<= 0.3.0")
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -47690,6 +47711,7 @@ packages:
             format: zip
             files:
               - name: prek
+        github_immutable_release: true
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -47713,6 +47735,7 @@ packages:
               - name: prek
         github_artifact_attestations:
           signer_workflow: j178/prek/.github/workflows/release.yml
+        github_immutable_release: true
   - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik


### PR DESCRIPTION
https://github.com/j178/prek/releases?page=4 (currently 0.1.6 and above on page 4)

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package version v0.1.6 with updated release configurations supporting multiple platforms and architectures.
  * Configured immutable release flags for enhanced package distribution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->