### PR TITLE
feat(suzuki-shunsuke/cmdx): GitHub immutable release config

### DIFF
--- a/pkgs/suzuki-shunsuke/cmdx/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/cmdx/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: suzuki-shunsuke/cmdx
+    version: v2.0.1
+  - name: suzuki-shunsuke/cmdx
     version: v2.0.0-0
   - name: suzuki-shunsuke/cmdx
     version: v1.7.0-2

--- a/pkgs/suzuki-shunsuke/cmdx/registry.yaml
+++ b/pkgs/suzuki-shunsuke/cmdx/registry.yaml
@@ -68,6 +68,29 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+      - version_constraint: semver("<= 2.0.1")
+        asset: cmdx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: cmdx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/suzuki-shunsuke/cmdx/releases/download/{{.Version}}/cmdx_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/suzuki-shunsuke/cmdx/releases/download/{{.Version}}/cmdx_{{trimV .Version}}_checksums.txt.pem
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: cmdx_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -88,6 +111,7 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_immutable_release: true
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -82549,6 +82549,29 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+      - version_constraint: semver("<= 2.0.1")
+        asset: cmdx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: cmdx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+              - --signature
+              - https://github.com/suzuki-shunsuke/cmdx/releases/download/{{.Version}}/cmdx_{{trimV .Version}}_checksums.txt.sig
+              - --certificate
+              - https://github.com/suzuki-shunsuke/cmdx/releases/download/{{.Version}}/cmdx_{{trimV .Version}}_checksums.txt.pem
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: cmdx_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -82569,6 +82592,7 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_immutable_release: true
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
All releases are marked immutable, but only >= 2.0.2-0 contain the required release attestations needed for verification.

This got me thinking, maybe the related registry property would be better renamed as `github_release_attestations` rather than `github_immutable_release`?

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for cmdx version 2.0.1 in package registry configurations.
  * Updated package manifests with new version constraints and asset specifications.
  * Enabled immutable release tracking for enhanced package management stability.
  * Implemented checksum verification and SLSA provenance tracking for improved package integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->