### PR TITLE
feat: add raaymax/lazytail

### DIFF
--- a/pkgs/raaymax/lazytail/pkg.yaml
+++ b/pkgs/raaymax/lazytail/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: raaymax/lazytail@v0.8.2

--- a/pkgs/raaymax/lazytail/registry.yaml
+++ b/pkgs/raaymax/lazytail/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: raaymax
     repo_name: lazytail
     description: Log viewer for app development
+    search_words:
+      - log
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"

--- a/pkgs/raaymax/lazytail/registry.yaml
+++ b/pkgs/raaymax/lazytail/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: raaymax
+    repo_name: lazytail
+    description: Log viewer for app development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: lazytail-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -71799,6 +71799,27 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: raaymax
+    repo_name: lazytail
+    description: Log viewer for app development
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: lazytail-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases

--- a/registry.yaml
+++ b/registry.yaml
@@ -71802,6 +71802,8 @@ packages:
     repo_owner: raaymax
     repo_name: lazytail
     description: Log viewer for app development
+    search_words:
+      - log
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.0"


### PR DESCRIPTION
[raaymax/lazytail](https://github.com/raaymax/lazytail): Log viewer for app development

```console
$ aqua g -i raaymax/lazytail
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ cat aqua.log
Mar 10 21:13:44.043 INF download and unarchive the package program=aqua version=2.56.6 package_name=rhysd/actionlint package_version=v1.7.11 registry=standard
Mar 10 21:13:45.660 INF verify GitHub Artifact Attestations program=aqua version=2.56.6 package_name=rhysd/actionlint package_version=v1.7.11 registry=standard
Mar 10 21:13:52.123 INF downloading a checksum file program=aqua version=2.56.6 package_name=rhysd/actionlint package_version=v1.7.11 registry=standard
$  lazytail aqua.log
┌Sources───────────────────────┐┌aqua.log — aqua.log──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│▼ Files                       ││     1 |    package_name=rhysd/actionlint package_version=v1.7.11 program=aqua registry=standard version=2.56.6              │
│  1> aqua.log F 3 · 471B      ││     2 |    package_name=rhysd/actionlint package_version=v1.7.11 program=aqua registry=standard version=2.56.6              │
│                              ││     3 |    package_name=rhysd/actionlint package_version=v1.7.11 program=aqua registry=standard version=2.56.6              │
└──────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌Stats─────────────────────────┐┌Status───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Lines: 3                     ││ Line 3/3 | Total: 3 | Mode: Normal  | FOLLOW                                                                                │
│ Index: 200B                  ││ q - Quit | j/k - Navigate | g/G - Start/End | / - Filter | ? - Help                                                         │
└──────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

If files such as configuration file are needed, please share them.

None

Reference

- [lazytail - GitHub Release](https://github.com/raaymax/lazytail/releases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added raaymax/lazytail package to the registry, enabling installation from GitHub releases.
  * Configured platform support for Linux (amd64) and Darwin, with architecture and OS name mappings for compatibility.
  * Added version-specific overrides for proper asset handling across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->