### PR TITLE
refactor: use preferred signer_workflow spelling

### DIFF
--- a/pkgs/caarlos0/fork-cleaner/registry.yaml
+++ b/pkgs/caarlos0/fork-cleaner/registry.yaml
@@ -130,4 +130,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer-workflow: caarlos0/fork-cleaner/.github/workflows/build.yml
+          signer_workflow: caarlos0/fork-cleaner/.github/workflows/build.yml

--- a/pkgs/containerd/containerd/registry.yaml
+++ b/pkgs/containerd/containerd/registry.yaml
@@ -114,7 +114,7 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         github_artifact_attestations:
-          signer-workflow: containerd/containerd/.github/workflows/release.yml
+          signer_workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"

--- a/pkgs/containerd/containerd/static/registry.yaml
+++ b/pkgs/containerd/containerd/static/registry.yaml
@@ -32,7 +32,7 @@ packages:
         asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         github_artifact_attestations:
-          signer-workflow: containerd/containerd/.github/workflows/release.yml
+          signer_workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"

--- a/pkgs/tmknom/actdocs/registry.yaml
+++ b/pkgs/tmknom/actdocs/registry.yaml
@@ -34,7 +34,7 @@ packages:
         asset: actdocs_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         github_artifact_attestations:
-          signer-workflow: tmknom/release-workflows/.github/workflows/go.yml
+          signer_workflow: tmknom/release-workflows/.github/workflows/go.yml
         checksum:
           type: github_release
           asset: actdocs_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -20868,7 +20868,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer-workflow: caarlos0/fork-cleaner/.github/workflows/build.yml
+          signer_workflow: caarlos0/fork-cleaner/.github/workflows/build.yml
   - type: github_release
     repo_owner: caarlos0
     repo_name: mdtree
@@ -26347,7 +26347,7 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         github_artifact_attestations:
-          signer-workflow: containerd/containerd/.github/workflows/release.yml
+          signer_workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
@@ -26387,7 +26387,7 @@ packages:
         asset: containerd-static-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         github_artifact_attestations:
-          signer-workflow: containerd/containerd/.github/workflows/release.yml
+          signer_workflow: containerd/containerd/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256sum"
@@ -86813,7 +86813,7 @@ packages:
         asset: actdocs_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         github_artifact_attestations:
-          signer-workflow: tmknom/release-workflows/.github/workflows/go.yml
+          signer_workflow: tmknom/release-workflows/.github/workflows/go.yml
         checksum:
           type: github_release
           asset: actdocs_{{trimV .Version}}_checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact attestation configuration naming conventions across all registry files for standardization and consistency. The configuration key `signer-workflow` has been renamed to `signer_workflow` in all affected registry files. This change ensures consistent naming patterns across registry configurations and affects how GitHub artifact signers are referenced in registry files for both the main registry and multiple package-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->