### PR TITLE
fix(cocogitto/cocogitto): add native arm64 macOS support for v6.4.0+

### DIFF
--- a/pkgs/cocogitto/cocogitto/pkg.yaml
+++ b/pkgs/cocogitto/cocogitto/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: cocogitto/cocogitto@7.0.0
   - name: cocogitto/cocogitto
+    version: 6.3.0
+  - name: cocogitto/cocogitto
     version: 6.0.0
   - name: cocogitto/cocogitto
     version: 5.6.0

--- a/pkgs/cocogitto/cocogitto/registry.yaml
+++ b/pkgs/cocogitto/cocogitto/registry.yaml
@@ -35,12 +35,15 @@ packages:
       - version_constraint: Version == "6.0.0"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
             src: "{{.Arch}}-{{.OS}}/cog/cog"
         overrides:
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:
@@ -61,7 +64,6 @@ packages:
       - version_constraint: "true"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
@@ -71,6 +73,10 @@ packages:
           darwin: apple-darwin
           windows: pc-windows-msvc
         overrides:
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:

--- a/pkgs/cocogitto/cocogitto/registry.yaml
+++ b/pkgs/cocogitto/cocogitto/registry.yaml
@@ -35,15 +35,12 @@ packages:
       - version_constraint: Version == "6.0.0"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
             src: "{{.Arch}}-{{.OS}}/cog/cog"
         overrides:
-          - goos: darwin
-            goarch: arm64
-            replacements:
-              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:
@@ -61,6 +58,32 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
+      - version_constraint: semver("<= 6.3.0")
+        asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cog
+            src: "{{.Arch}}-{{.OS}}/cog"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            files:
+              - name: cog
+                src: "{{.Arch}}-{{.OS}}/cog.exe"
       - version_constraint: "true"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -25207,12 +25207,15 @@ packages:
       - version_constraint: Version == "6.0.0"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
             src: "{{.Arch}}-{{.OS}}/cog/cog"
         overrides:
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:
@@ -25233,7 +25236,6 @@ packages:
       - version_constraint: "true"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
@@ -25243,6 +25245,10 @@ packages:
           darwin: apple-darwin
           windows: pc-windows-msvc
         overrides:
+          - goos: darwin
+            goarch: arm64
+            replacements:
+              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -25207,15 +25207,12 @@ packages:
       - version_constraint: Version == "6.0.0"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        rosetta2: true
         windows_arm_emulation: true
         files:
           - name: cog
             src: "{{.Arch}}-{{.OS}}/cog/cog"
         overrides:
-          - goos: darwin
-            goarch: arm64
-            replacements:
-              arm64: aarch64
           - goos: linux
             goarch: amd64
             replacements:
@@ -25233,6 +25230,32 @@ packages:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
+      - version_constraint: semver("<= 6.3.0")
+        asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: cog
+            src: "{{.Arch}}-{{.OS}}/cog"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            files:
+              - name: cog
+                src: "{{.Arch}}-{{.OS}}/cog.exe"
       - version_constraint: "true"
         asset: cocogitto-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
 ## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

From v6.0.0 cocogitto publishes aarch64-apple-darwin builds. Removed rosetta2: true and added darwin/arm64 override so ARM64 macOS gets the native binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added availability of cocogitto v6.3.0 in the registry.

* **Chores**
  * Updated platform architecture configuration to improve ARM64 compatibility.
  * Added explicit ARM64 mappings for macOS and Linux so packages are translated and named correctly.
  * Replaced a legacy translation flag with targeted overrides for clearer, version-specific handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->