### PR TITLE
feat: add facebook/ktfmt

### DIFF
--- a/pkgs/facebook/ktfmt/pkg.yaml
+++ b/pkgs/facebook/ktfmt/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: facebook/ktfmt@
+  - name: facebook/ktfmt@v0.61

--- a/pkgs/facebook/ktfmt/pkg.yaml
+++ b/pkgs/facebook/ktfmt/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: facebook/ktfmt@

--- a/pkgs/facebook/ktfmt/registry.yaml
+++ b/pkgs/facebook/ktfmt/registry.yaml
@@ -4,3 +4,5 @@ packages:
     repo_owner: facebook
     repo_name: ktfmt
     description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
+    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
+    format: raw

--- a/pkgs/facebook/ktfmt/registry.yaml
+++ b/pkgs/facebook/ktfmt/registry.yaml
@@ -6,3 +6,4 @@ packages:
     description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
     asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
     format: raw
+    complete_windows_ext: false

--- a/pkgs/facebook/ktfmt/registry.yaml
+++ b/pkgs/facebook/ktfmt/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: facebook
+    repo_name: ktfmt
+    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions

--- a/registry.yaml
+++ b/registry.yaml
@@ -35081,6 +35081,7 @@ packages:
     description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
     asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
     format: raw
+    complete_windows_ext: false
   - type: github_release
     repo_owner: fastfetch-cli
     repo_name: fastfetch

--- a/registry.yaml
+++ b/registry.yaml
@@ -35079,6 +35079,8 @@ packages:
     repo_owner: facebook
     repo_name: ktfmt
     description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
+    asset: ktfmt-{{trimV .Version}}-with-dependencies.jar
+    format: raw
   - type: github_release
     repo_owner: fastfetch-cli
     repo_name: fastfetch

--- a/registry.yaml
+++ b/registry.yaml
@@ -35076,6 +35076,10 @@ packages:
           - goos: windows
             asset: buck2-{{.Arch}}-{{.OS}}.exe.{{.Format}}
   - type: github_release
+    repo_owner: facebook
+    repo_name: ktfmt
+    description: A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions
+  - type: github_release
     repo_owner: fastfetch-cli
     repo_name: fastfetch
     description: An actively maintained, feature-rich and performance oriented, neofetch like system information tool


### PR DESCRIPTION
[facebook/ktfmt](https://github.com/facebook/ktfmt): A program that reformats Kotlin source code to comply with the common community standard for Kotlin code conventions

```console
$ aqua g -i facebook/ktfmt
```

aqua >= v2.57.0 is required.

- https://github.com/aquaproj/aqua/pull/4625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added ktfmt v0.61 as an installable package, enabling use of the Kotlin code formatter.
  * Added registry configuration to fetch the prebuilt ktfmt release artifact, allowing straightforward installation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->