### PR TITLE
chore: udpate aqua to v2.57.0

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: echo "AQUA_GLOBAL_CONFIG=${AQUA_GLOBAL_CONFIG:-}:${PWD}/aqua-all.yaml" >> "$GITHUB_ENV"
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           aqua_opts: -l -a
           policy_allow: "true"
 

--- a/.github/workflows/debug-with-action-tmate.yaml
+++ b/.github/workflows/debug-with-action-tmate.yaml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
           aqua_opts: -l -a
         env:

--- a/.github/workflows/wc-ci-info.yaml
+++ b/.github/workflows/wc-ci-info.yaml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-lintnet.yaml
+++ b/.github/workflows/wc-lintnet.yaml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -50,7 +50,7 @@ jobs:
       #     private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.56.7
+          aqua_version: v2.57.0
           policy_allow: "true"
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,6 @@ RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 RUN echo "acd21cbb06609dd9a701b0032ba4c21fa37b0e3b5cc4c9d721cc02f25ea33a28  aqua-installer" | sha256sum -c -
 RUN chmod +x aqua-installer
-RUN ./aqua-installer -v v2.56.7
+RUN ./aqua-installer -v v2.57.0
 COPY aqua-test.yaml aqua.yaml
 COPY aqua-policy.yaml aqua-policy.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Aqua installer version to v2.57.0 across all CI workflows and Docker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->