### PR TITLE
fix: fix scripts to run on Windows Git/MSYS2 bash

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -26,6 +26,7 @@ if [ "$(uname)" = Linux ] && docker version | grep -q Podman; then
 fi
 
 # shellcheck disable=SC2086
+export MSYS2_ARG_CONV_EXCL=/dev/null  # Disable Windows MSYS2 path mangling for specified args
 docker run $opts -d --name "$container_name" \
 	$envs aquaproj/aqua-registry \
 	tail -f /dev/null

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -27,6 +27,7 @@ if [ -z "$config" ] && [ -f "pkgs/$pkg/scaffold.yaml" ]; then
 	docker cp "pkgs/$pkg/scaffold.yaml" "aqua-registry:/workspace/scaffold.yaml"
 fi
 # shellcheck disable=SC2086
+export MSYS2_ARG_CONV_EXCL=/workspace  # Disable Windows MSYS2 path mangling for specified args
 docker exec -w /workspace aqua-registry bash -c "rm pkg.yaml 2>/dev/null || :"
 docker exec -w /workspace aqua-registry bash -c "echo '# yaml-language-server: \$schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json' > registry.yaml"
 docker exec -w /workspace aqua-registry bash -c "aqua gr $opts --out-testdata pkg.yaml \"$pkg\" >> registry.yaml"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->

Fixes bash scripts to run on Windows in MSYS2 bash installed with Git for Windows.

The only required fix is disabling [MSYS2 path mangling](https://www.msys2.org/wiki/Porting/#filesystem-namespaces) for specified docker exec args.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows compatibility issues in build scripts by correcting environment path handling for containerized execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->