### PR TITLE
fix: fix support for apple/container v0.10.0

### DIFF
--- a/pkgs/apple/container/pkg.yaml
+++ b/pkgs/apple/container/pkg.yaml
@@ -1,4 +1,3 @@
 packages:
+  - name: apple/container@0.10.0
   - name: apple/container@0.9.0
-  - name: apple/container
-    version: 0.6.0

--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0")
+      - version_constraint: semver("<= 0.6.0") or semver(">= 0.10.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated apple/container to version 0.10.0 and adjusted version compatibility constraints to support both legacy and newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->