### PR TITLE
fix: fix support for apple/container v0.10.0

### DIFF
--- a/pkgs/apple/container/pkg.yaml
+++ b/pkgs/apple/container/pkg.yaml
@@ -1,4 +1,3 @@
 packages:
+  - name: apple/container@0.10.0
   - name: apple/container@0.9.0
-  - name: apple/container
-    version: 0.6.0

--- a/pkgs/apple/container/pkg.yaml
+++ b/pkgs/apple/container/pkg.yaml
@@ -1,3 +1,4 @@
 packages:
   - name: apple/container@0.10.0
-  - name: apple/container@0.9.0
+  - name: apple/container
+    version: "0.9.0"

--- a/pkgs/apple/container/pkg.yaml
+++ b/pkgs/apple/container/pkg.yaml
@@ -2,3 +2,5 @@ packages:
   - name: apple/container@0.10.0
   - name: apple/container
     version: "0.9.0"
+  - name: apple/container
+    version: "0.6.0"

--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0") or semver(">= 0.10.0")
+      - version_constraint: semver("<= 0.6.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:
@@ -14,8 +14,16 @@ packages:
             src: Payload/bin/container
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.9.0")
         asset: container-installer-signed.{{.Format}}
+        format: pkg
+        files:
+          - name: container
+            src: Payload/bin/container
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:
           - name: container

--- a/pkgs/apple/container/registry.yaml
+++ b/pkgs/apple/container/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0")
+      - version_constraint: semver("<= 0.6.0") or semver(">= 0.10.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -12933,7 +12933,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0") or semver(">= 0.10.0")
+      - version_constraint: semver("<= 0.6.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:
@@ -12941,8 +12941,16 @@ packages:
             src: Payload/bin/container
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.9.0")
         asset: container-installer-signed.{{.Format}}
+        format: pkg
+        files:
+          - name: container
+            src: Payload/bin/container
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:
           - name: container

--- a/registry.yaml
+++ b/registry.yaml
@@ -12933,7 +12933,7 @@ packages:
     description: A tool for creating and running Linux containers using lightweight virtual machines on a Mac. It is written in Swift, and optimized for Apple silicon
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.0")
+      - version_constraint: semver("<= 0.6.0") or semver(">= 0.10.0")
         asset: container-{{.Version}}-installer-signed.{{.Format}}
         format: pkg
         files:


### PR DESCRIPTION
Close #49452

## Summary                                                                                  
                                                                                              
  - Add `apple/container v0.10.0` to the registry                                             
  - Update `version_overrides` condition in `registry.yaml` to correctly route v0.10.0 to the
  versioned asset naming convention                                                           
                  
  ## Background

  The `apple/container` tool uses two different asset naming conventions across its release
  history:

  | Versions | Asset filename |
  |---|---|
  | `<= 0.6.0` | `container-{{.Version}}-installer-signed.pkg` |
  | `>= 0.7.0` (previously) | `container-installer-signed.pkg` |

  ## Problem

  Starting with `v0.10.0`, Apple reverted to the **versioned** asset naming convention
  (`container-0.10.0-installer-signed.pkg`), abandoning the non-versioned pattern used
  between v0.7.0 and v0.9.0.

  Without updating the `version_constraint`, aqua would attempt to download
  `container-installer-signed.pkg` for v0.10.0 — a file that does not exist in the
  release, causing installation to fail.

  ## Fix

  Updated the `version_constraint` for the versioned asset override from:

  ```
  version_constraint: semver("<= 0.6.0")
```
  to:
```
version_constraint: semver("<= 0.6.0") or semver("<= 0.10.0")
```
  This ensures that v0.10.0 correctly resolves to the versioned asset filename.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated apple/container package to 0.10.0 and adjusted internal version entries.
  * Broadened installer selection to include builds up through v0.9.0.
  * Added a second macOS installer variant (an additional signed installer) that is now offered unconditionally, resulting in two stacked packaging rules for darwin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->