### PR TITLE
feat: add jorgelbg/pinentry-touchid

### DIFF
--- a/pkgs/jorgelbg/pinentry-touchid/pkg.yaml
+++ b/pkgs/jorgelbg/pinentry-touchid/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: jorgelbg/pinentry-touchid@v0.0.3
+  - name: jorgelbg/pinentry-touchid
+    version: v0.0.1

--- a/pkgs/jorgelbg/pinentry-touchid/registry.yaml
+++ b/pkgs/jorgelbg/pinentry-touchid/registry.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jorgelbg
+    repo_name: pinentry-touchid
+    description: Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the macOS keychain
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: pinentry-touchid_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: pinentry-touchid_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -49634,6 +49634,35 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: jorgelbg
+    repo_name: pinentry-touchid
+    description: Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the macOS keychain
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        asset: pinentry-touchid_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: pinentry-touchid_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: jorgerojas26
     repo_name: lazysql
     description: A cross-platform TUI database management tool written in Go


### PR DESCRIPTION
[jorgelbg/pinentry-touchid](https://github.com/jorgelbg/pinentry-touchid) - Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the macOS keychain

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Add [jorgelbg/pinentry-touchid](https://github.com/jorgelbg/pinentry-touchid)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinentry-touchid package to the registry with support for macOS (versions v0.0.1 and v0.0.3)
  * Configured package manifest and version management for pinentry-touchid releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->