### PR TITLE
feat: add alltuner/mise-completions-sync

### DIFF
--- a/pkgs/alltuner/mise-completions-sync/pkg.yaml
+++ b/pkgs/alltuner/mise-completions-sync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: alltuner/mise-completions-sync@v0.4.4

--- a/pkgs/alltuner/mise-completions-sync/registry.yaml
+++ b/pkgs/alltuner/mise-completions-sync/registry.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: alltuner
+    repo_name: mise-completions-sync
+    description: Automatically sync shell completions for tools managed by mise
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -11351,6 +11351,32 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: alltuner
+    repo_name: mise-completions-sync
+    description: Automatically sync shell completions for tools managed by mise
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: allyring
     repo_name: pvw
     description: A port viewer TUI made with BubbleTea in Go


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Install and execute the package and confirm if the package works well
- [x] [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

Add [alltuner/mise-completions-sync](https://github.com/alltuner/mise-completions-sync)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mise-completions-sync v0.4.4 package with multi-platform support
  * Supports multiple architectures across Linux, macOS, and Windows platforms
  * Configured for GitHub release-based distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->