### PR TITLE
chore: update argd to v0.4.0

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,5 +8,5 @@ registries:
     type: local
     path: registry.yaml
 packages:
-  - name: aquaproj/registry-tool@v0.4.0-2
+  - name: aquaproj/registry-tool@v0.3.6
   - name: suzuki-shunsuke/cmdx@v2.0.2

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,5 +8,5 @@ registries:
     type: local
     path: registry.yaml
 packages:
-  - name: aquaproj/registry-tool@v0.3.6
+  - name: aquaproj/registry-tool@v0.4.0
   - name: suzuki-shunsuke/cmdx@v2.0.2

--- a/pkgs/aquaproj/registry-tool/pkg.yaml
+++ b/pkgs/aquaproj/registry-tool/pkg.yaml
@@ -1,10 +1,6 @@
 packages:
-  - name: aquaproj/registry-tool@v0.4.0-1
-  # - name: aquaproj/registry-tool
-  #   version: v0.4.0-0
-  # - name: aquaproj/registry-tool
-  #   version: v0.3.7-0
-  # - name: aquaproj/registry-tool
-  #   version: v0.3.6
-  # - name: aquaproj/registry-tool
-  #   version: v0.1.5
+  - name: aquaproj/registry-tool@v0.4.0
+  - name: aquaproj/registry-tool
+    version: v0.3.6
+  - name: aquaproj/registry-tool
+    version: v0.1.5

--- a/pkgs/aquaproj/registry-tool/registry.yaml
+++ b/pkgs/aquaproj/registry-tool/registry.yaml
@@ -29,27 +29,6 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
-      - version_constraint: Version == "v0.4.0-0"
-        asset: argd_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: aqua-registry
-        checksum:
-          type: github_release
-          asset: registry-tool_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: registry-tool_{{trimV .Version}}_checksums.txt.bundle
-        slsa_provenance:
-          type: github_release
-          asset: multiple.intoto.jsonl
       - version_constraint: semver("<= 0.1.5")
         asset: registry-tool_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -13170,27 +13170,6 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
-      - version_constraint: Version == "v0.4.0-0"
-        asset: argd_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: aqua-registry
-        checksum:
-          type: github_release
-          asset: registry-tool_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.*"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: registry-tool_{{trimV .Version}}_checksums.txt.bundle
-        slsa_provenance:
-          type: github_release
-          asset: multiple.intoto.jsonl
       - version_constraint: semver("<= 0.1.5")
         asset: registry-tool_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package entry to reference the newer v0.4.0 release.
  * Expanded registry to explicitly include multiple historical versions (v0.4.0, v0.3.6, v0.1.5).
  * Removed legacy version-specific override and artifact variant entries for an older v0.4.0 variant.
  * Consolidated registry/version declarations for clearer, more maintainable version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->