### PR TITLE
chore: add Conftest Policy for pkgs/**/pkg.yaml and pkgs/**/registry.yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - [Support Policy](docs/support_policy.md)
 - [Repository Structure](docs/structure.md)
 - [Development Tools](docs/tool.md)
+- [Linting](docs/lint.md)
 - [Common Style Guide](docs/common_style.md)
 - [Registry Style Guide](docs/registry_yaml.md)
 - [pkg.yaml Guide](docs/pkg_yaml.md)

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -10,3 +10,4 @@ registries:
 packages:
   - name: aquaproj/registry-tool@v0.4.1
   - name: suzuki-shunsuke/cmdx@v2.0.2
+  - name: open-policy-agent/conftest@v0.67.0

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -1,0 +1,8 @@
+# Lint pkgs/**/pkg.yaml and pkgs/**/registry.yaml
+
+You can lint pkgs/**/pkg.yaml and pkgs/**/registry.yaml using [Conftest](https://www.conftest.dev/)
+For example, if you create or update a package `suzuki-shunsuke/pinact`, you can lint it using the following command:
+
+```sh
+conftest test --combine pkgs/suzuki-shunsuke/pinact/*
+```

--- a/docs/tool.md
+++ b/docs/tool.md
@@ -50,6 +50,10 @@ If the branch name is `feat/<package name>`, you can omit the argument `<package
 `argd test` copies files `pkgs/<package name>/{pkg.yaml,registry.yaml}` in containers and test them.
 If the test succeeds, `registry.yaml` is updated.
 
+## Linting
+
+Please see [Lint pkgs/**/pkg.yaml and pkgs/**/registry.yaml.](lint.md)
+
 ## aqua-regsitry remove (rm) - Remove containers
 
 `argd remove` removes containers.

--- a/policy/pkg/pkg.rego
+++ b/policy/pkg/pkg.rego
@@ -1,0 +1,26 @@
+package main
+
+import rego.v1
+
+# Rule 1: packages must not be empty
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/pkg.yaml")
+	count(entry.contents.packages) == 0
+	msg := sprintf("%s: packages is empty", [entry.path])
+}
+
+# Rule 2: package name must match directory-derived name
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/pkg.yaml")
+	# Extract expected package name from path: "pkgs/owner/repo/pkg.yaml" → "owner/repo"
+	trimmed := trim_prefix(entry.path, "pkgs/")
+	expected_name := trim_suffix(trimmed, "/pkg.yaml")
+	pkg := entry.contents.packages[_]
+	# pkg.name may include "@version", extract name part
+	name_parts := split(pkg.name, "@")
+	pkg_name := name_parts[0]
+	pkg_name != expected_name
+	msg := sprintf("%s: package name mismatch: expected %q but got %q", [entry.path, expected_name, pkg_name])
+}

--- a/policy/pkg/pkg_test.rego
+++ b/policy/pkg/pkg_test.rego
@@ -1,0 +1,46 @@
+package main
+
+import rego.v1
+
+test_deny_empty_packages if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": []},
+	}]
+	result == {"pkgs/owner/repo/pkg.yaml: packages is empty"}
+}
+
+test_allow_valid_packages if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": [{"name": "owner/repo"}]},
+	}]
+	count(result) == 0
+}
+
+test_deny_name_mismatch if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": [{"name": "wrong/name"}]},
+	}]
+	result == {"pkgs/owner/repo/pkg.yaml: package name mismatch: expected \"owner/repo\" but got \"wrong/name\""}
+}
+
+test_allow_name_with_version if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": [{"name": "owner/repo@v1.0.0"}]},
+	}]
+	count(result) == 0
+}
+
+test_deny_partial_mismatch if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": [
+			{"name": "owner/repo"},
+			{"name": "other/tool"},
+		]},
+	}]
+	result == {"pkgs/owner/repo/pkg.yaml: package name mismatch: expected \"owner/repo\" but got \"other/tool\""}
+}

--- a/policy/registry/registry.rego
+++ b/policy/registry/registry.rego
@@ -1,0 +1,168 @@
+package main
+
+import rego.v1
+
+# Helper: get_name replicates PackageInfo.GetName() logic
+get_name(pkg) := pkg.name if {
+	pkg.name != ""
+} else := concat("/", [pkg.repo_owner, pkg.repo_name]) if {
+	pkg.repo_owner != ""
+	pkg.repo_name != ""
+} else := pkg.path if {
+	pkg.type == "go_install"
+	pkg.path != ""
+} else := ""
+
+# Helper: collect all files from top-level, overrides, version_overrides, and version_overrides[].overrides
+all_files(pkg) := files if {
+	top := object.get(pkg, "files", [])
+	override_files := [f |
+		ov := pkg.overrides[_]
+		f := ov.files[_]
+	]
+	vo_files := [f |
+		vo := pkg.version_overrides[_]
+		f := vo.files[_]
+	]
+	vo_override_files := [f |
+		vo := pkg.version_overrides[_]
+		ov := vo.overrides[_]
+		f := ov.files[_]
+	]
+	files := array.concat(array.concat(array.concat(top, override_files), vo_files), vo_override_files)
+}
+
+# Rule 1: packages must not be empty
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 0
+	msg := sprintf("%s: packages is empty", [entry.path])
+}
+
+# Rule 2: packages must include only one package
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) > 1
+	msg := sprintf("%s: packages must include only one package", [entry.path])
+}
+
+# Rule 3: package name must match directory path
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	trimmed := trim_prefix(entry.path, "pkgs/")
+	expected_name := trim_suffix(trimmed, "/registry.yaml")
+	get_name(pkg) != expected_name
+	msg := sprintf("%s: package name mismatch: expected %q but got %q", [entry.path, expected_name, get_name(pkg)])
+}
+
+# Rule 4: top-level version_constraints must be empty or "false"
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	vc := pkg.version_constraint
+	vc != ""
+	vc != "false"
+	msg := sprintf("%s: the top level version_constraint must be either empty or \"false\"", [entry.path])
+}
+
+# Rule 5: files[].name must not end with .exe
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	file := all_files(pkg)[_]
+	endswith(file.name, ".exe")
+	msg := sprintf("%s: .files[].name must not end with .exe. Remove .exe from name", [entry.path])
+}
+
+# Rule 6: files[].src must not end with .exe
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	file := all_files(pkg)[_]
+	endswith(object.get(file, "src", ""), ".exe")
+	msg := sprintf("%s: .files[].src must not end with .exe. Remove .exe from src", [entry.path])
+}
+
+# Rule 7: omit files[].src if same as files[].name
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	file := all_files(pkg)[_]
+	file.name == file.src
+	msg := sprintf("%s: omit .files[].src if it's same with .files[].name", [entry.path])
+}
+
+# Rule 8: repo_owner/repo_name consistency
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	pkg.repo_owner != ""
+	object.get(pkg, "repo_name", "") == ""
+	msg := sprintf("%s: repo_name must be specified if repo_owner is specified", [entry.path])
+}
+
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	pkg.repo_name != ""
+	object.get(pkg, "repo_owner", "") == ""
+	msg := sprintf("%s: repo_owner must be specified if repo_name is specified", [entry.path])
+}
+
+# Rule 9: package name without period requires repo_owner/repo_name
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	trimmed := trim_prefix(entry.path, "pkgs/")
+	pkg_name := trim_suffix(trimmed, "/registry.yaml")
+	not contains(pkg_name, ".")
+	object.get(pkg, "repo_owner", "") == ""
+	msg := sprintf("%s: repo_owner and repo_name must be specified if package name doesn't include period", [entry.path])
+}
+
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	trimmed := trim_prefix(entry.path, "pkgs/")
+	pkg_name := trim_suffix(trimmed, "/registry.yaml")
+	not contains(pkg_name, ".")
+	pkg.repo_owner != ""
+	pkg.repo_name != ""
+	repo_full := concat("/", [pkg.repo_owner, pkg.repo_name])
+	pkg_name != repo_full
+	not startswith(pkg_name, concat("", [repo_full, "/"]))
+	msg := sprintf("%s: package name must start with repository full name if package name doesn't include period", [entry.path])
+}
+
+# Rule 10: omit name if same as repo_owner/repo_name
+deny contains msg if {
+	entry := input[_]
+	endswith(entry.path, "/registry.yaml")
+	count(entry.contents.packages) == 1
+	pkg := entry.contents.packages[0]
+	pkg.repo_owner != ""
+	pkg.repo_name != ""
+	pkg.name == concat("/", [pkg.repo_owner, pkg.repo_name])
+	msg := sprintf("%s: omit .name if it's same with repo_owner/repo_name", [entry.path])
+}

--- a/policy/registry/registry_test.rego
+++ b/policy/registry/registry_test.rego
@@ -1,0 +1,261 @@
+package main
+
+import rego.v1
+
+# Rule 1: packages must not be empty
+test_deny_empty_packages if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": []},
+	}]
+	result == {"pkgs/owner/repo/registry.yaml: packages is empty"}
+}
+
+# Rule 2: packages must include only one package
+test_deny_multiple_packages if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [
+			{"repo_owner": "owner", "repo_name": "repo"},
+			{"repo_owner": "owner", "repo_name": "other"},
+		]},
+	}]
+	"pkgs/owner/repo/registry.yaml: packages must include only one package" in result
+}
+
+# Rule 3: package name must match directory path
+test_deny_name_mismatch if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "wrong",
+			"repo_name": "name",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: package name mismatch: expected \"owner/repo\" but got \"wrong/name\"" in result
+}
+
+test_allow_matching_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+		}]},
+	}]
+	count(result) == 0
+}
+
+test_allow_explicit_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo",
+			"repo_owner": "owner",
+			"repo_name": "repo",
+		}]},
+	}]
+	# This triggers rule 10 (omit name) but not rule 3
+	not "pkgs/owner/repo/registry.yaml: package name mismatch: expected \"owner/repo\" but got \"owner/repo\"" in result
+}
+
+test_allow_go_install_path_name if {
+	result := deny with input as [{
+		"path": "pkgs/example.com/foo/bar/registry.yaml",
+		"contents": {"packages": [{
+			"type": "go_install",
+			"path": "example.com/foo/bar",
+		}]},
+	}]
+	count(result) == 0
+}
+
+# Rule 4: version_constraint must be empty or "false"
+test_deny_invalid_version_constraint if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"version_constraint": "true",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: the top level version_constraint must be either empty or \"false\"" in result
+}
+
+test_allow_false_version_constraint if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"version_constraint": "false",
+		}]},
+	}]
+	not "pkgs/owner/repo/registry.yaml: the top level version_constraint must be either empty or \"false\"" in result
+}
+
+# Rule 5: files[].name must not end with .exe
+test_deny_file_name_exe if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"files": [{"name": "tool.exe"}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: .files[].name must not end with .exe. Remove .exe from name" in result
+}
+
+test_deny_file_name_exe_in_version_overrides if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"version_overrides": [{"files": [{"name": "tool.exe"}]}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: .files[].name must not end with .exe. Remove .exe from name" in result
+}
+
+test_deny_file_name_exe_in_overrides if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"overrides": [{"files": [{"name": "tool.exe"}]}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: .files[].name must not end with .exe. Remove .exe from name" in result
+}
+
+test_deny_file_name_exe_in_vo_overrides if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"version_overrides": [{"overrides": [{"files": [{"name": "tool.exe"}]}]}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: .files[].name must not end with .exe. Remove .exe from name" in result
+}
+
+# Rule 6: files[].src must not end with .exe
+test_deny_file_src_exe if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"files": [{"name": "tool", "src": "tool.exe"}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: .files[].src must not end with .exe. Remove .exe from src" in result
+}
+
+# Rule 7: omit files[].src if same as files[].name
+test_deny_file_src_same_as_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+			"repo_name": "repo",
+			"files": [{"name": "tool", "src": "tool"}],
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: omit .files[].src if it's same with .files[].name" in result
+}
+
+# Rule 8: repo_owner/repo_name consistency
+test_deny_repo_owner_without_repo_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_owner": "owner",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: repo_name must be specified if repo_owner is specified" in result
+}
+
+test_deny_repo_name_without_repo_owner if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"repo_name": "repo",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: repo_owner must be specified if repo_name is specified" in result
+}
+
+# Rule 9: package name without period requires repo_owner/repo_name
+test_deny_no_period_without_repo if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: repo_owner and repo_name must be specified if package name doesn't include period" in result
+}
+
+test_deny_no_period_name_not_starting_with_repo if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/tool/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo/tool",
+			"repo_owner": "other",
+			"repo_name": "repo",
+		}]},
+	}]
+	"pkgs/owner/repo/tool/registry.yaml: package name must start with repository full name if package name doesn't include period" in result
+}
+
+test_allow_no_period_name_starting_with_repo if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/tool/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo/tool",
+			"repo_owner": "owner",
+			"repo_name": "repo",
+		}]},
+	}]
+	not "pkgs/owner/repo/tool/registry.yaml: package name must start with repository full name if package name doesn't include period" in result
+}
+
+# Rule 10: omit name if same as repo_owner/repo_name
+test_deny_redundant_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo",
+			"repo_owner": "owner",
+			"repo_name": "repo",
+		}]},
+	}]
+	"pkgs/owner/repo/registry.yaml: omit .name if it's same with repo_owner/repo_name" in result
+}
+
+test_allow_different_name if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/tool/registry.yaml",
+		"contents": {"packages": [{
+			"name": "owner/repo/tool",
+			"repo_owner": "owner",
+			"repo_name": "repo",
+		}]},
+	}]
+	not "pkgs/owner/repo/tool/registry.yaml: omit .name if it's same with repo_owner/repo_name" in result
+}
+
+# Test: non-registry.yaml files are ignored
+test_ignore_non_registry_yaml if {
+	result := deny with input as [{
+		"path": "pkgs/owner/repo/pkg.yaml",
+		"contents": {"packages": []},
+	}]
+	count(result) == 0
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added linting capabilities for package configuration files with validation rules ensuring non-empty package lists and correct naming conventions.
  * Introduced comprehensive validation rules for registry configuration files, enforcing package naming, repository linkage, file naming conventions, and version constraints.

* **Documentation**
  * Added documentation on linting configuration files using Conftest, including usage examples.
  * Updated development tools documentation with linting references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->