### PR TITLE
docs: deprecate cmdx lsa in favor of argd lsa

### DIFF
--- a/cmdx.yaml
+++ b/cmdx.yaml
@@ -223,25 +223,26 @@ tasks:
 
   - name: ls-assets
     short: lsa
-    description: List asset names
-    usage: List asset names
+    usage: "[DEPRECATED] Use argd lsa instead"
+    description: "[DEPRECATED] Use argd lsa instead"
+    quiet: true
     flags:
       - name: repo
         short: r
         type: string
         usage: Repo name
-        script_envs:
-          - REPO
     args:
       - name: version
         required: true
-        script_envs:
-          - VERSION
     script: |
-      REPO=${REPO#https://github.com/}
-      repo=$(bash scripts/get_test_pkg.sh "$REPO")
-
-      gh release view --json assets --jq ".assets[].name" -R "$repo" "$VERSION"
+      echo "DEPRECATED: Use argd lsa instead" >&2
+      echo "Please see docs/tool.md" >&2
+      if ! command -v argd >/dev/null 2>&1; then
+        if command -v aqua >/dev/null 2>&1; then
+          aqua i -l
+        fi
+      fi
+      exit 1
 
   - name: generate-copilot-instruction
     short: gci

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -20,15 +20,10 @@ You may or may not add `no_asset` and `error_message`.
 
 When an asset cannot be found, either the asset name is wrong or the asset hasn't been released.
 
-Running the `cmdx lsa [-r <repository name>] "<version>"` command outputs a list of assets, which is convenient.
+Running `argd lsa <owner/repo> <version>` outputs a list of assets, which is convenient.
 
 ```console
-$ cmdx lsa -repo suzuki-shunsuke/pinact v3.0.0
-+ REPO=${REPO#https://github.com/}
-repo=$(bash scripts/get_test_pkg.sh "$REPO")
-
-gh release view --json assets --jq ".assets[].name" -R "$repo" "$VERSION"
-
+$ argd lsa suzuki-shunsuke/pinact v3.0.0
 multiple.intoto.jsonl
 pinact_3.0.0_checksums.txt
 pinact_3.0.0_checksums.txt.pem

--- a/docs/tool.md
+++ b/docs/tool.md
@@ -51,6 +51,7 @@ argd rm # Remove containers
 argd rmp [<package>] # Remove installed packages from containers
 argd gr # Update registry.yaml by merging pkgs/**/registry.yaml
 argd con [<os>] [<arch>] # Connect a container by docker exec. This is useful for debugging.
+argd lsa <owner/repo> <version> # List release assets of a GitHub Release
 ```
 
 ## Format with prettier
@@ -107,6 +108,11 @@ When you edit `pkgs/**/registry.yaml`, please run `argd gr` to reflect the updat
 `argd scaffold` and `argd test` tests packages in containers.
 `argd con` is useful to look into the trouble in containers.
 By default, `<os>` is `linux` and `<arch>` is CPU architecture of your machine.
+
+## argd list-assets (lsa) - List release assets
+
+`argd list-assets (lsa) <owner/repo> <version>` lists the asset names of a GitHub Release.
+This is useful when debugging asset name mismatches during package configuration.
 
 ## Code Auto-generation
 


### PR DESCRIPTION
## Summary

- Deprecate `cmdx lsa` command with a stub that prints a deprecation notice and points users to `argd lsa`
- Update `docs/error_handling.md` to reference `argd lsa` instead of `cmdx lsa`
- Update `docs/tool.md` to document the `argd lsa` command

## Background

The `cmdx lsa` command shells out to `gh release view` which has limitations compared to the GitHub API.
The `argd lsa` command in registry-tool uses the GitHub API with proper pagination support.

This change updates the docs to point users to the new command.

## Related

- aquaproj/registry-tool#1633 — The corresponding code change that adds `argd lsa`

## Test plan

- [x] `cmdx lsa` prints deprecation message and exits with error
- [x] Docs reference the correct `argd lsa` syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `ls-assets` command is now deprecated. Users should migrate to using `argd lsa` instead.

* **Documentation**
  * Updated documentation to reflect the transition from the deprecated command to `argd lsa`.
  * Added documentation for the new `argd list-assets` (lsa) subcommand with usage examples and command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->