### PR TITLE
feat(UpCloudLtd/upcloud-cli): attestation config updates

### DIFF
--- a/pkgs/UpCloudLtd/upcloud-cli/pkg.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: UpCloudLtd/upcloud-cli@v3.30.0
   - name: UpCloudLtd/upcloud-cli
+    version: v3.23.0
+  - name: UpCloudLtd/upcloud-cli
     version: v3.15.0
   - name: UpCloudLtd/upcloud-cli
     version: v1.3.0

--- a/pkgs/UpCloudLtd/upcloud-cli/pkg.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: UpCloudLtd/upcloud-cli@v3.30.0
+  - name: UpCloudLtd/upcloud-cli@v3.31.0
+  - name: UpCloudLtd/upcloud-cli
+    version: v3.30.0
   - name: UpCloudLtd/upcloud-cli
     version: v3.23.0
   - name: UpCloudLtd/upcloud-cli

--- a/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
@@ -46,6 +46,18 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 3.24.0")
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("< 3.31.0")
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -60,6 +72,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_immutable_release: true
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -74,3 +87,4 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_immutable_release: true

--- a/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
@@ -46,7 +46,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("< 3.31.0")
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -57,6 +57,20 @@ packages:
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: UpCloudLtd/upcloud-cli/.github/workflows/publish.yml
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: UpCloudLtd/workflows/.github/workflows/build-provenance.yaml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -7616,7 +7616,19 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("< 3.24.0")
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("< 3.31.0")
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -7630,6 +7642,22 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_immutable_release: true
+      - version_constraint: "true"
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: UpCloudLtd/workflows/.github/workflows/build-provenance.yaml
+        overrides:
+          - goos: windows
+            format: zip
+        github_immutable_release: true
   - type: github_release
     repo_owner: Versent
     repo_name: saml2aws


### PR DESCRIPTION
Refs
- https://github.com/UpCloudLtd/upcloud-cli/attestations (signer repo/workflow changed for >= 3.31.0)
- https://github.com/UpCloudLtd/upcloud-cli/releases (immutable since >= 3.24.0)

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Install and execute the package and confirm if the package works well
- [Execute `cmdx s` to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for UpCloudLtd/upcloud-cli v3.31.0 and reintroduced v3.30.0 and v3.23.0
  * Added OS-specific packaging handling (Windows ZIP)

* **New Security / Integrity**
  * Enhanced verification with checksums and provenance attestations
  * Enabled immutable-release flags for stronger release integrity

* **Chores**
  * Split generic release handling into explicit semver-based rules and updated package manifests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->