### PR TITLE
chore: use mirror.gcr.io

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-bookworm
+FROM mirror.gcr.io/golang:1.26.1-bookworm
 WORKDIR /workspace
 ENV AQUA_LOG_COLOR=always
 ENV AQUA_POLICY_CONFIG=/workspace/aqua-policy.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image registry to mirror.gcr.io while maintaining the same version. No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->