### PR TITLE
feat: add dependency-check/DependencyCheck

### DIFF
--- a/pkgs/dependency-check/DependencyCheck/pkg.yaml
+++ b/pkgs/dependency-check/DependencyCheck/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dependency-check/DependencyCheck@v12.2.1

--- a/pkgs/dependency-check/DependencyCheck/registry.yaml
+++ b/pkgs/dependency-check/DependencyCheck/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dependency-check
+    repo_name: DependencyCheck
+    description: OWASP dependency-check is a software composition analysis utility that detects publicly disclosed vulnerabilities in application dependencies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dependency-check-{{trimV .Version}}-release.zip
+        format: zip
+        files:
+          - name: dependency-check
+            src: dependency-check/bin/dependency-check.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: dependency-check
+                src: dependency-check/bin/dependency-check.bat

--- a/pkgs/dependency-check/DependencyCheck/registry.yaml
+++ b/pkgs/dependency-check/DependencyCheck/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: dependency-check
     repo_name: DependencyCheck
     description: OWASP dependency-check is a software composition analysis utility that detects publicly disclosed vulnerabilities in application dependencies
+    files:
+      - name: dependency-check
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -30348,6 +30348,23 @@ packages:
         files:
           - name: dependabot
   - type: github_release
+    repo_owner: dependency-check
+    repo_name: DependencyCheck
+    description: OWASP dependency-check is a software composition analysis utility that detects publicly disclosed vulnerabilities in application dependencies
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dependency-check-{{trimV .Version}}-release.zip
+        format: zip
+        files:
+          - name: dependency-check
+            src: dependency-check/bin/dependency-check.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: dependency-check
+                src: dependency-check/bin/dependency-check.bat
+  - type: github_release
     repo_owner: derailed
     repo_name: k9s
     description: Kubernetes CLI To Manage Your Clusters In Style

--- a/registry.yaml
+++ b/registry.yaml
@@ -30351,6 +30351,8 @@ packages:
     repo_owner: dependency-check
     repo_name: DependencyCheck
     description: OWASP dependency-check is a software composition analysis utility that detects publicly disclosed vulnerabilities in application dependencies
+    files:
+      - name: dependency-check
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
## Summary

Add [dependency-check/DependencyCheck](https://github.com/dependency-check/DependencyCheck) — OWASP Dependency-Check is a software composition analysis (SCA) utility that detects publicly disclosed vulnerabilities in application dependencies by checking them against the National Vulnerability Database (NVD).

## Background

 ### Asset Naming Convention

GitHub releases for this package follow a consistent naming pattern across all versions (v8.x through v12.x):
```
dependency-check-{version}-release.zip
```
Where `{version}` is the tag name without the `v` prefix. For example, tag `v12.2.0` produces asset `dependency-check-12.2.0-release.zip`. The zip archive always extracts into a top-level `dependency-check/` directory with the following structure relevant to aqua:
  ```
  dependency-check/
  └── bin/
      ├── dependency-check.sh   # Unix entry point (Linux, macOS)
      └── dependency-check.bat  # Windows entry point
  ```
  ### No Standard Checksum Files

  Releases provide only PGP signatures (`.asc` files) — no SHA256 or other hash files are published. Therefore `checksum.enabled` is set to `false`.

  ## Fix Applied                                                                                                                       
   
  - Added `dependency-check/DependencyCheck` to `registry.yaml` and `pkgs/dependency-check/DependencyCheck/registry.yaml` with:        
    - `asset` template using `trimV` to strip the `v` prefix from the version tag
    - `files[].src` pointing to `dependency-check/bin/dependency-check.sh` for Unix                                                    
    - Windows `overrides` pointing to `dependency-check/bin/dependency-check.bat`
    - `checksum.enabled: false` since only PGP signatures are available                                                                
  - Added `pkgs/dependency-check/DependencyCheck/pkg.yaml` with test entries for v12.2.0 (latest) and v8.1.1 (older version to cover `version_overrides`)

## Test Result                                                                                                                       

  `argd t dependency-check/DependencyCheck` passed for all platforms:
   
  | OS | Arch | Result |                                                                                                               
  |----|------|--------|                                    
  | linux | amd64 | ✅ |                                                                                                               
  | linux | arm64 | ✅ |                                                                                                               
  | darwin | amd64 | ✅ |                                                                                                              
  | darwin | arm64 | ✅ |                                                                                                              
  | windows | amd64 | ✅ |                                                                                                             
  | windows | arm64 | ✅ | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OWASP Dependency-Check as a distributable package in the registry.
  * Introduced version override rules to improve selection of appropriate release artifacts.
  * Added a Windows-specific artifact mapping to ensure cross-platform availability and consistent invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->