### PR TITLE
feat(atlassian.com/acli): add atlassian.com/acli

### DIFF
--- a/pkgs/atlassian.com/acli/pkg.yaml
+++ b/pkgs/atlassian.com/acli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: atlassian.com/acli@

--- a/pkgs/atlassian.com/acli/pkg.yaml
+++ b/pkgs/atlassian.com/acli/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: atlassian.com/acli@
+  - name: atlassian.com/acli@1.3.14-stable
+  - name: atlassian.com/acli
+    version: 1.2.0-stable

--- a/pkgs/atlassian.com/acli/registry.yaml
+++ b/pkgs/atlassian.com/acli/registry.yaml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
-    repo_owner: atlassian.com
-    repo_name: acli
+  - type: http
+    repo_owner: ryan-pip
+    repo_name: acli-versions
+    name: atlassian.com/acli
+    description: Software to interact with Atlassian Cloud from the terminal
+    link: https://developer.atlassian.com/cloud/acli/
+    version_source: github_tag
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    format: tar.gz
+    files:
+      - name: acli
+        src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
+    supported_envs:
+      - linux
+      - darwin

--- a/pkgs/atlassian.com/acli/registry.yaml
+++ b/pkgs/atlassian.com/acli/registry.yaml
@@ -13,5 +13,7 @@ packages:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
     supported_envs:
-      - linux
-      - darwin
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64

--- a/pkgs/atlassian.com/acli/registry.yaml
+++ b/pkgs/atlassian.com/acli/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: atlassian.com
+    repo_name: acli

--- a/registry.yaml
+++ b/registry.yaml
@@ -15627,8 +15627,10 @@ packages:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
     supported_envs:
-      - linux
-      - darwin
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin

--- a/registry.yaml
+++ b/registry.yaml
@@ -15614,9 +15614,21 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
-  - type: github_release
-    repo_owner: atlassian.com
-    repo_name: acli
+  - type: http
+    repo_owner: ryan-pip
+    repo_name: acli-versions
+    name: atlassian.com/acli
+    description: Software to interact with Atlassian Cloud from the terminal
+    link: https://developer.atlassian.com/cloud/acli/
+    version_source: github_tag
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    format: tar.gz
+    files:
+      - name: acli
+        src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
+    supported_envs:
+      - linux
+      - darwin
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin

--- a/registry.yaml
+++ b/registry.yaml
@@ -15615,6 +15615,9 @@ packages:
           - linux/amd64
           - windows/amd64
   - type: github_release
+    repo_owner: atlassian.com
+    repo_name: acli
+  - type: github_release
     repo_owner: atuinsh
     repo_name: atuin
     description: Magical shell history


### PR DESCRIPTION
## Summary

Adds the [Atlassian CLI (acli)](https://developer.atlassian.com/cloud/acli/) as a new package.

### Package details

- **Type**: `http` (no GitHub Releases)
- **Download URL**: `https://acli.atlassian.com/{os}/{version}/acli_{version}_{os}_{arch}.tar.gz`
- **Version source**: [`ryan-pip/acli-versions`](https://github.com/ryan-pip/acli-versions) — a community tracking repo whose tags are auto-synced every 6 hours from `atlassian/homebrew-acli` commit history via GitHub Actions
- **Supported platforms**: `linux` and `darwin` (amd64, arm64)
- **Tested versions**: `1.3.14-stable` (latest), `1.2.0-stable`

### Notes

- Atlassian does not publish GitHub releases or tags for acli, so a version-tracking repo (`ryan-pip/acli-versions`) was created to provide the required version source
- No checksum file is published by Atlassian
- Windows is excluded as the download format differs and is unconfirmed

---

> This pull request was created with the assistance of Claude (AI). The code has been reviewed and tested manually.

🤖 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the Atlassian CLI (acli) to the package registry with two published entries (1.3.14-stable and 1.2.0-stable). Installers support automated HTTP download and tar.gz extraction for Linux and macOS on amd64 and arm64. Package includes repository metadata and an external documentation link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->