### PR TITLE
fix(jkfran/killport): add files mapping for v2.0.0+

### DIFF
--- a/pkgs/jkfran/killport/pkg.yaml
+++ b/pkgs/jkfran/killport/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: jkfran/killport@v1.1.0
+  - name: jkfran/killport@v2.0.0
+  - name: jkfran/killport
+    version: v1.1.0
   - name: jkfran/killport
     version: v1.0.0
   - name: jkfran/killport

--- a/pkgs/jkfran/killport/registry.yaml
+++ b/pkgs/jkfran/killport/registry.yaml
@@ -37,9 +37,22 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 2.0.0")
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+          linux: linux-gnu
       - version_constraint: "true"
         asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: killport
+            src: "{{.AssetWithoutExt}}/killport"
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -49594,9 +49594,22 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 2.0.0")
+        asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-gnu
+          linux: linux-gnu
       - version_constraint: "true"
         asset: killport-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: killport
+            src: "{{.AssetWithoutExt}}/killport"
         windows_arm_emulation: true
         replacements:
           amd64: x86_64


### PR DESCRIPTION
## Summary

killport v2.0.0 changed the tarball structure. Previous versions had the binary at the archive root:

```
killport
```

v2.0.0 nests it in a subdirectory matching the asset name:

```
killport-x86_64-linux-gnu/
  killport
```

Without a `files` mapping, the binary is not found after extraction.

## Changes

- Add `semver("< 2.0.0")` version override to preserve existing behavior for v0.9.x–v1.x
- Add `files` with `src: "{{.AssetWithoutExt}}/killport"` to the `"true"` catch-all for v2.0.0+
- Update `pkg.yaml` to test v2.0.0 as the latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated killport package pinned version to v2.0.0 with explicit v1.1.0 compatibility support.
  * Enhanced cross-platform asset handling with improved architecture and OS mappings for multiple versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->