### PR TITLE
feat(terraprovider/statebridge): GitHub artifact attestations config

### DIFF
--- a/pkgs/terraprovider/statebridge/registry.yaml
+++ b/pkgs/terraprovider/statebridge/registry.yaml
@@ -27,6 +27,8 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: terraprovider/statebridge/\.github/workflows/release\.yml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -86400,6 +86400,8 @@ packages:
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: terraprovider/statebridge/\.github/workflows/release\.yml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
https://github.com/terraprovider/statebridge/attestations

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for GitHub artifact attestations to release configuration, including a configured signer workflow to attest released artifacts.
  * Enhances supply-chain security alongside existing SLSA provenance, checksum, and signing/cosign verifications for stronger artifact integrity assurance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->