### PR TITLE
fix(google/go-jsonnet): support v0.22.0 asset naming change

### DIFF
--- a/pkgs/google/go-jsonnet/pkg.yaml
+++ b/pkgs/google/go-jsonnet/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: google/go-jsonnet@v0.21.0
+  - name: google/go-jsonnet@v0.22.0
+  - name: google/go-jsonnet
+    version: v0.21.0
   - name: google/go-jsonnet
     version: v0.20.0
   - name: google/go-jsonnet

--- a/pkgs/google/go-jsonnet/registry.yaml
+++ b/pkgs/google/go-jsonnet/registry.yaml
@@ -74,7 +74,7 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.21.0"
         asset: go-jsonnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -82,6 +82,13 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -42129,7 +42129,7 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.21.0"
         asset: go-jsonnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -42137,6 +42137,13 @@ packages:
           darwin: Darwin
           linux: Linux
           windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

google/go-jsonnet [v0.22.0](https://github.com/google/go-jsonnet/releases/tag/v0.22.0) removed GoReleaser archive naming overrides ([google/go-jsonnet#848](https://github.com/google/go-jsonnet/pull/848)), which changed the release asset naming convention.

**v0.21.0**: `go-jsonnet_Linux_x86_64.tar.gz` (capitalized OS, `x86_64`)
**v0.22.0**: `go-jsonnet_0.22.0_linux_amd64.tar.gz` (lowercase OS, standard Go arch, version in name)

This causes `no asset found` errors when installing v0.22.0 with the current registry definition.

### Changes

- Pin the existing catchall `version_constraint: "true"` to `Version == "v0.21.0"`
- Add a new `version_constraint: "true"` entry for v0.22.0+ with asset template `go-jsonnet_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}` (no `replacements` needed since v0.22.0 uses GoReleaser defaults matching aqua defaults)
- Update pkg.yaml test versions (add v0.22.0 as latest, add v0.21.0 as old version test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for go-jsonnet v0.22.0 while retaining earlier v0.x releases for compatibility.
  * Updated registry selection rules to pick the appropriate release asset per version for more reliable installs.
  * Added checksum validation for release artifacts to improve integrity and security of package installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->