### PR TITLE
fix(dimo414/bkt): split darwin arm64 support at 0.8.1

### DIFF
--- a/pkgs/dimo414/bkt/pkg.yaml
+++ b/pkgs/dimo414/bkt/pkg.yaml
@@ -1,4 +1,5 @@
 packages:
   - name: dimo414/bkt@0.8.1
+  - name: dimo414/bkt@0.8.0
   - name: dimo414/bkt
     version: 0.5.4

--- a/pkgs/dimo414/bkt/registry.yaml
+++ b/pkgs/dimo414/bkt/registry.yaml
@@ -20,7 +20,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.8.0")
         asset: bkt.v{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         rosetta2: true
@@ -38,4 +38,22 @@ packages:
             goarch: arm64
             replacements:
               arm64: aarch64
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: bkt.v{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
               linux: unknown-linux-gnu

--- a/registry.yaml
+++ b/registry.yaml
@@ -31061,7 +31061,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.8.0")
         asset: bkt.v{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         rosetta2: true
@@ -31079,6 +31079,24 @@ packages:
             goarch: arm64
             replacements:
               arm64: aarch64
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: bkt.v{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
               linux: unknown-linux-gnu
   - type: github_release
     repo_owner: dimonomid


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

This fixes `dimo414/bkt` on macOS ARM by splitting the current latest version range at `0.8.1`.

Versions `0.6.0` through `0.8.0` only ship `x86_64-apple-darwin`, so they still need `rosetta2: true`.
From `0.8.1` onward, upstream publishes native `aarch64-apple-darwin` assets, so the newest block now removes `rosetta2` and adds the top-level `arm64: aarch64` replacement there.

With this change, macOS ARM resolves `bkt.v{{.Version}}.aarch64-apple-darwin.zip` for `0.8.1+`, while older versions continue to use Rosetta-backed `x86_64-apple-darwin`. Linux ARM continues to resolve `aarch64-unknown-linux-gnu`.

I verified this locally on Apple Silicon by:

- bootstrapping a temporary `aqua` binary in `/tmp`
- running `argd gr` to regenerate the merged root `registry.yaml`
- executing `aqua exec -- bkt --version` with a fresh `AQUA_ROOT_DIR`

The debug logs showed aqua downloading `https://github.com/dimo414/bkt/releases/download/0.8.1/bkt.v0.8.1.aarch64-apple-darwin.zip`, and `bkt --version` completed successfully.

AI assistance was used to help investigate and prepare this change, and I reviewed the final patch before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened version matching for an existing Windows ARM emulation package to limit which releases use that asset.
  * Added a new Windows ARM emulation package entry (including an explicit versioned package) to broaden supported OS/architecture combinations.
  * Updated platform name remapping and Linux target overrides to improve cross-platform compatibility and clarify AMD64/ARM64 selection across OS targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->