### PR TITLE
fix: update Granted release domain handling

### DIFF
--- a/pkgs/fwdcloudsec/granted/pkg.yaml
+++ b/pkgs/fwdcloudsec/granted/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: fwdcloudsec/granted@v0.38.0
+  - name: fwdcloudsec/granted@v0.39.0
+  - name: fwdcloudsec/granted
+    version: v0.37.0
   - name: fwdcloudsec/granted
     version: v0.17.0
   - name: fwdcloudsec/granted

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -6,21 +6,58 @@ packages:
     aliases:
       - name: common-fate/granted
     description: The easiest way to access your cloud
-    url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: granted
-      - name: assume
-      - name: assumego
-    replacements:
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: darwin
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 0.37.0")
+        url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         files:
           - name: granted
           - name: assume
           - name: assumego
-            src: granted
-            link: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego
+      - version_constraint: semver("< 0.39.0")
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego
+      - version_constraint: "true"
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - windows
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -46,7 +46,7 @@ packages:
               - name: assumego
                 src: granted
                 link: assumego
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.39.0"
         url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -61,3 +61,22 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego

--- a/registry.yaml
+++ b/registry.yaml
@@ -37706,7 +37706,7 @@ packages:
               - name: assumego
                 src: granted
                 link: assumego
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.39.0"
         url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -37721,6 +37721,25 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego
   - type: github_release
     repo_owner: g-plane
     repo_name: pnpm-shell-completion

--- a/registry.yaml
+++ b/registry.yaml
@@ -37666,24 +37666,61 @@ packages:
     aliases:
       - name: common-fate/granted
     description: The easiest way to access your cloud
-    url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: granted
-      - name: assume
-      - name: assumego
-    replacements:
-      amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: darwin
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("< 0.37.0")
+        url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         files:
           - name: granted
           - name: assume
           - name: assumego
-            src: granted
-            link: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego
+      - version_constraint: semver("< 0.39.0")
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            files:
+              - name: granted
+              - name: assume
+              - name: assumego
+                src: granted
+                link: assumego
+      - version_constraint: "true"
+        url: https://releases.granted.dev/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: granted
+          - name: assume
+          - name: assumego
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux
+          - windows
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: g-plane
     repo_name: pnpm-shell-completion


### PR DESCRIPTION
This updates `fwdcloudsec/granted` to handle the release hosting migration introduced by [`v0.39.0`](https://github.com/fwdcloudsec/granted/releases/tag/v0.39.0).

The registry previously downloaded every version from `releases.commonfate.io`, which breaks the latest release because `v0.39.0` is now published under the new `granted.dev` infrastructure.

## What changed

- Added `version_overrides` to [`pkgs/fwdcloudsec/granted/registry.yaml`](../pkgs/fwdcloudsec/granted/registry.yaml)
- Kept versions `< 0.37.0` on `https://releases.commonfate.io`
- Switched versions `>= 0.37.0` to `https://releases.granted.dev`
- Limited the latest override to `linux` and `windows` because `v0.39.0` does not currently ship prebuilt macOS binaries
- Updated [`pkgs/fwdcloudsec/granted/pkg.yaml`](../pkgs/fwdcloudsec/granted/pkg.yaml) to test `v0.39.0` and the migration boundary `v0.37.0`
- Regenerated the root [`registry.yaml`](../registry.yaml)

## Why this shape

### The migration is not a full backfill

I verified that the new domain is not a superset of the old one.

- `v0.39.0`, `v0.38.0`, and `v0.37.0` are available from `releases.granted.dev`
- `v0.36.3`, `v0.36.2`, `v0.36.1`, `v0.36.0`, `v0.35.0`, `v0.34.0`, `v0.30.0`, `v0.17.0`, `v0.16.0`, and `v0.1.3` return `404` from `releases.granted.dev`

That makes `v0.37.0` the oldest migrated version I found for the asset pattern this package uses.

### `v0.39.0` temporarily lacks prebuilt macOS binaries

The [`v0.39.0` release notes](https://github.com/fwdcloudsec/granted/releases/tag/v0.39.0) say:

> Homebrew (`brew install fwdcloudsec/granted/granted`) now builds from source via the `fwdcloudsec/homebrew-granted` tap. Prebuilt macOS binaries are not currently available.

This does not look like a permanent platform removal, so the change here is scoped to the latest override only:

- `< 0.39.0`: keep existing macOS asset handling
- `>= 0.39.0`: advertise only `linux` and `windows`

### Kept `type: http`

I considered switching this package to `github_release`, but older Granted releases still rely on the external release host.

For example, the GitHub API response for [`v0.17.0`](https://github.com/fwdcloudsec/granted/releases/tag/v0.17.0) has an empty `assets` array, while the binaries are still downloadable from `releases.commonfate.io`.

Because of that, a full `github_release` conversion would regress older versions. Keeping `type: http` is the lowest-risk fix for the current package.

## Validation

Manual checks performed:

- confirmed `releases.commonfate.io` returns `404` for `v0.39.0`
- confirmed `releases.granted.dev` returns `200` for `v0.39.0`, `v0.38.0`, and `v0.37.0`
- confirmed `releases.granted.dev` returns `404` for `v0.36.3` and older sampled versions
- confirmed `v0.39.0` still contains `granted`, `assume`, and `assumego` in the Linux archive
- confirmed `v0.39.0` Windows ZIP exists and matches the expected naming pattern
- regenerated the merged `registry.yaml`

I did not run `argd t fwdcloudsec/granted` in Docker in this environment because Docker socket access was not available in the sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated fwdcloudsec/granted package from v0.38.0 to v0.39.0 and added a v0.37.0 entry
  * Refactored registry entries to use version-specific overrides and constraints
  * Introduced OS-specific packaging rules per version and added supported_envs for v0.39.0 to improve platform handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->