### PR TITLE
Azure/azure-dev: Modify asset formats and versioning in registry.yaml

### DIFF
--- a/pkgs/Azure/azure-dev/pkg.yaml
+++ b/pkgs/Azure/azure-dev/pkg.yaml
@@ -1,2 +1,10 @@
 packages:
   - name: Azure/azure-dev@azure-dev-cli_1.23.13
+  - name: Azure/azure-dev
+    version: azure-dev-cli_1.9.3
+  - name: Azure/azure-dev
+    version: azure-dev-cli_1.3.1
+  - name: Azure/azure-dev
+    version: azure-dev-cli_0.9.0-beta.1
+  - name: Azure/azure-dev
+    version: azure-dev-cli_0.8.0-beta.2

--- a/pkgs/Azure/azure-dev/registry.yaml
+++ b/pkgs/Azure/azure-dev/registry.yaml
@@ -6,11 +6,17 @@ packages:
     description: "A developer CLI for working with Azure resources to build and deploy AI applications. Commands map to key workflow stages: code, build, deploy, and monitor"
     version_prefix: azure-dev-cli_
     version_constraint: "false"
+    files:
+      - name: azd
+        src: "{{.AssetWithoutExt}}"
     version_overrides:
       - version_constraint: Version == "azure-dev-cli_0.9.0-beta.1"
         asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: azd
+            src: azd-{{.OS}}-{{.Arch}}
         overrides:
           - goos: linux
             format: tar.gz

--- a/pkgs/Azure/azure-dev/registry.yaml
+++ b/pkgs/Azure/azure-dev/registry.yaml
@@ -3,16 +3,10 @@ packages:
   - type: github_release
     repo_owner: Azure
     repo_name: azure-dev
-    asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: zip
     description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications
+    version_prefix: azure-dev-cli_
     overrides:
       - goos: linux
-        format: tar.gz
-    files:
-      - name: azd
-        src: azd-{{.OS}}-{{.Arch}}
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
+        asset: "azd-{{.OS}}-{{.Arch}}.tar.gz"
+      - goos: [windows, darwin]
+        asset: "azd-{{.OS}}-{{.Arch}}.zip"

--- a/pkgs/Azure/azure-dev/registry.yaml
+++ b/pkgs/Azure/azure-dev/registry.yaml
@@ -3,10 +3,64 @@ packages:
   - type: github_release
     repo_owner: Azure
     repo_name: azure-dev
-    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications
+    description: "A developer CLI for working with Azure resources to build and deploy AI applications. Commands map to key workflow stages: code, build, deploy, and monitor"
     version_prefix: azure-dev-cli_
-    overrides:
-      - goos: linux
-        asset: "azd-{{.OS}}-{{.Arch}}.tar.gz"
-      - goos: [windows, darwin]
-        asset: "azd-{{.OS}}-{{.Arch}}.zip"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "azure-dev-cli_0.9.0-beta.1"
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.0-beta.2")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.3.1")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: tar.gz
+          - goos: linux
+            goarch: arm64
+            format: tar.gz
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+      - version_constraint: semver("<= 1.9.3")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: "true"
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-alpha.{{.Format}}

--- a/pkgs/Azure/azure-dev/scaffold.yaml
+++ b/pkgs/Azure/azure-dev/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: Azure/azure-dev
+# version_filter: not (Version matches "-rc$")
+version_prefix: azure-dev-cli_
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -687,19 +687,67 @@ packages:
   - type: github_release
     repo_owner: Azure
     repo_name: azure-dev
-    asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: zip
-    description: The Azure Developer CLI is a developer-centric command-line interface tool for creating Azure applications
-    overrides:
-      - goos: linux
-        format: tar.gz
-    files:
-      - name: azd
-        src: azd-{{.OS}}-{{.Arch}}
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
+    description: "A developer CLI for working with Azure resources to build and deploy AI applications. Commands map to key workflow stages: code, build, deploy, and monitor"
+    version_prefix: azure-dev-cli_
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "azure-dev-cli_0.9.0-beta.1"
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: darwin
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.8.0-beta.2")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.3.1")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: tar.gz
+          - goos: linux
+            goarch: arm64
+            format: tar.gz
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-beta.{{.Format}}
+      - version_constraint: semver("<= 1.9.3")
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        overrides:
+          - goos: linux
+            format: tar.gz
+      - version_constraint: "true"
+        asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+          - goos: windows
+            goarch: arm64
+            asset: azd-{{.OS}}-{{.Arch}}-alpha.{{.Format}}
   - type: github_release
     repo_owner: Azure
     repo_name: bicep

--- a/registry.yaml
+++ b/registry.yaml
@@ -690,11 +690,17 @@ packages:
     description: "A developer CLI for working with Azure resources to build and deploy AI applications. Commands map to key workflow stages: code, build, deploy, and monitor"
     version_prefix: azure-dev-cli_
     version_constraint: "false"
+    files:
+      - name: azd
+        src: "{{.AssetWithoutExt}}"
     version_overrides:
       - version_constraint: Version == "azure-dev-cli_0.9.0-beta.1"
         asset: azd-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: azd
+            src: azd-{{.OS}}-{{.Arch}}
         overrides:
           - goos: linux
             format: tar.gz


### PR DESCRIPTION
https://github.com/Azure/azure-dev

Updated asset formats and version prefix for Azure Developer CLI.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Azure Dev CLI distribution to versioned, rule-based packaging to deliver specific builds per release.
  * Added multiple pinned versions so installers can obtain stable, beta, and alpha releases explicitly.
  * Improved platform coverage: explicit handling for Windows, macOS (including arm64/Rosetta considerations) and Linux variants.
* **Documentation**
  * Added scaffold/config guidance for registry/version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->