### PR TITLE
Add getdbt.com/dbt-fusion

### DIFF
--- a/pkgs/getdbt.com/dbt-fusion/pkg.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
-  - name: getdbt.com/dbt-fusion@
+  - name: getdbt.com/dbt-fusion@v2.0.0-preview.164
+  - name: getdbt.com/dbt-fusion
+    version: v2.0.0-preview.100
+  - name: getdbt.com/dbt-fusion
+    version: v2.0.0-beta.24
+  - name: getdbt.com/dbt-fusion
+    version: v2.0.0-beta.13

--- a/pkgs/getdbt.com/dbt-fusion/pkg.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: getdbt.com/dbt-fusion@

--- a/pkgs/getdbt.com/dbt-fusion/registry.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: getdbt.com
+    repo_name: dbt-fusion

--- a/pkgs/getdbt.com/dbt-fusion/registry.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/registry.yaml
@@ -1,5 +1,23 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
-    repo_owner: getdbt.com
-    repo_name: dbt-fusion
+  - type: http
+    repo_owner: ryan-pip
+    repo_name: dbt-fusion-versions
+    name: getdbt.com/dbt-fusion
+    description: The next-generation engine for dbt
+    link: https://docs.getdbt.com/docs/local/install-dbt
+    version_source: github_tag
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    format: tar.gz
+    replacements:
+      linux: unknown-linux-gnu
+      darwin: apple-darwin
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+    files:
+      - name: dbt

--- a/registry.yaml
+++ b/registry.yaml
@@ -38285,6 +38285,9 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: getdbt.com
+    repo_name: dbt-fusion
+  - type: github_release
     repo_owner: getgauge
     repo_name: gauge
     asset: gauge-{{trimV .Version}}-{{.OS}}.{{.Arch}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -38284,9 +38284,27 @@ packages:
             asset: ddosify_{{trimV .Version}}_{{.OS}}_all.{{.Format}}
           - goos: windows
             format: zip
-  - type: github_release
-    repo_owner: getdbt.com
-    repo_name: dbt-fusion
+  - type: http
+    repo_owner: ryan-pip
+    repo_name: dbt-fusion-versions
+    name: getdbt.com/dbt-fusion
+    description: The next-generation engine for dbt
+    link: https://docs.getdbt.com/docs/local/install-dbt
+    version_source: github_tag
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    format: tar.gz
+    replacements:
+      linux: unknown-linux-gnu
+      darwin: apple-darwin
+      amd64: x86_64
+      arm64: aarch64
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+    files:
+      - name: dbt
   - type: github_release
     repo_owner: getgauge
     repo_name: gauge


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

## What is this?

Adds [dbt Fusion](https://docs.getdbt.com/docs/local/install-dbt) (`getdbt.com/dbt-fusion`) — the next-generation Rust-based engine for dbt by dbt-labs. The binary installed is `dbt`.

## Why `http` type with a version tracking repo

`dbt-labs/dbt-fusion` has no GitHub Releases or tags. Binaries are distributed via dbt's public CDN:

```
https://public.cdn.getdbt.com/fs/cli/fs-v{VERSION}-{TARGET}.tar.gz
```

To give aqua a valid `version_source`, I created [`ryan-pip/dbt-fusion-versions`](https://github.com/ryan-pip/dbt-fusion-versions) — a tracking repo that runs on a schedule every 6 hours, parses the [`CHANGELOG.md`](https://github.com/dbt-labs/dbt-fusion/blob/main/CHANGELOG.md) from `dbt-labs/dbt-fusion`, and creates a git tag for each version found. This is the same pattern used for [`atlassian.com/acli`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/atlassian.com/acli/registry.yaml).

All 256 versions (`v2.0.0-beta.13` through `v2.0.0-preview.164`) have already been backfilled as tags.

## Platform support

Only Linux and macOS are supported (no Windows builds exist on the CDN):

| OS | Arch | CDN target |
|---|---|---|
| linux | amd64 | `x86_64-unknown-linux-gnu` |
| linux | arm64 | `aarch64-unknown-linux-gnu` |
| darwin | amd64 | `x86_64-apple-darwin` |
| darwin | arm64 | `aarch64-apple-darwin` |

Note: only `gnu` variants are published (no `musl`), so `unknown-linux-gnu` is used per the style guide ("use musl if both are supported").

## Note on current status

dbt Fusion is currently in preview (`v2.0.0-preview.164`). The `ryan-pip/dbt-fusion-versions` tracking repo will continue picking up new versions automatically every 6 hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new package has been registered and is now available in the package registry
  * Users can select from multiple version options based on their needs
  * The package is compatible with both Linux and macOS on multiple hardware platforms
  * Package downloads are delivered through a reliable centralized distribution network

<!-- end of auto-generated comment: release notes by coderabbit.ai -->