### PR TITLE
feat: enable windows support for latest Zellij

### DIFF
--- a/pkgs/zellij-org/zellij/pkg.yaml
+++ b/pkgs/zellij-org/zellij/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
   - name: zellij-org/zellij@v0.44.0
+  - name: zellij-org/zellij
+    version: v0.43.1
+  - name: zellij-org/zellij
+    version: v0.42.2
+  - name: zellij-org/zellij
+    version: v0.30.0
+  - name: zellij-org/zellij
+    version: v0.5.1
+  - name: zellij-org/zellij
+    version: v0.1.0-alpha

--- a/pkgs/zellij-org/zellij/pkg.yaml
+++ b/pkgs/zellij-org/zellij/pkg.yaml
@@ -3,8 +3,6 @@ packages:
   - name: zellij-org/zellij
     version: v0.43.1
   - name: zellij-org/zellij
-    version: v0.30.0
-  - name: zellij-org/zellij
     version: v0.5.1
   - name: zellij-org/zellij
     version: v0.1.0-alpha

--- a/pkgs/zellij-org/zellij/pkg.yaml
+++ b/pkgs/zellij-org/zellij/pkg.yaml
@@ -3,8 +3,6 @@ packages:
   - name: zellij-org/zellij
     version: v0.43.1
   - name: zellij-org/zellij
-    version: v0.42.2
-  - name: zellij-org/zellij
     version: v0.30.0
   - name: zellij-org/zellij
     version: v0.5.1

--- a/pkgs/zellij-org/zellij/registry.yaml
+++ b/pkgs/zellij-org/zellij/registry.yaml
@@ -27,17 +27,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 0.30.0")
-        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.43.1")
         asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/zellij-org/zellij/registry.yaml
+++ b/pkgs/zellij-org/zellij/registry.yaml
@@ -4,14 +4,84 @@ packages:
     repo_owner: zellij-org
     repo_name: zellij
     description: A terminal workspace with batteries included
-    supported_envs:
-      - darwin
-      - linux
-    asset: zellij-{{.Arch}}-{{.OS}}.tar.gz
-    replacements:
-      linux: unknown-linux-musl
-      darwin: apple-darwin
-      amd64: x86_64
-      arm64: aarch64
-    checksum:
-      enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-alpha"
+        asset: mosaic-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.5.1")
+        asset: zellij-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: zellij-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.30.0")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.42.2")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.43.1")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: zellij-no-web-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/zellij-org/zellij/registry.yaml
+++ b/pkgs/zellij-org/zellij/registry.yaml
@@ -38,21 +38,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.42.2")
-        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.43.1")
         asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -61,10 +46,6 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: zellij-no-web-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
         supported_envs:
           - linux
           - darwin
@@ -78,10 +59,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -94343,21 +94343,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 0.42.2")
-        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.43.1")
         asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -94366,10 +94351,6 @@ packages:
           arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
-        checksum:
-          type: github_release
-          asset: zellij-no-web-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
         supported_envs:
           - linux
           - darwin
@@ -94383,10 +94364,6 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc
-        checksum:
-          type: github_release
-          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
-          algorithm: sha256
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -94332,17 +94332,6 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 0.30.0")
-        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 0.43.1")
         asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -94309,17 +94309,87 @@ packages:
     repo_owner: zellij-org
     repo_name: zellij
     description: A terminal workspace with batteries included
-    supported_envs:
-      - darwin
-      - linux
-    asset: zellij-{{.Arch}}-{{.OS}}.tar.gz
-    replacements:
-      linux: unknown-linux-musl
-      darwin: apple-darwin
-      amd64: x86_64
-      arm64: aarch64
-    checksum:
-      enabled: false # https://github.com/aquaproj/aqua-registry/issues/6780#issuecomment-1267714776
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-alpha"
+        asset: mosaic-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.5.1")
+        asset: zellij-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: zellij-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.30.0")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.42.2")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.43.1")
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: zellij-no-web-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: zellij-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: zellij-{{.Arch}}-{{.OS}}.sha256sum
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: http
     repo_owner: ziglang
     repo_name: zig


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

## Description

### Summary

This PR is for enable to install Zellij into Windows on latest version (>=0.44.0).

### Why do I require this

Zellij v0.44.0 (latest update in this PR) has published Windows executables.
I want to use this on Windows too, current registry definition only supports macos and linux.

Therefore, I edit registry that it can install on Windows by these steps.

* Regenerate registry by `agrd s`
* Remove checksum properties because uploaded checksums are not for archive files.

### Refer to

- https://github.com/zellij-org/zellij/releases/tag/v0.44.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for multiple Zellij releases (v0.44.0, v0.43.1, v0.5.1, v0.1.0-alpha).
  * Introduced version-specific distribution handling (different archive formats and asset names per release).
  * Improved cross-platform support including macOS, Linux (glibc and musl), and Windows with emulation and ZIP handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->