### PR TITLE
feat(azu/dockerfile-pin): scaffold azu/dockerfile-pin

### DIFF
--- a/pkgs/azu/dockerfile-pin/pkg.yaml
+++ b/pkgs/azu/dockerfile-pin/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: azu/dockerfile-pin@v1.0.4

--- a/pkgs/azu/dockerfile-pin/registry.yaml
+++ b/pkgs/azu/dockerfile-pin/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: azu
+    repo_name: dockerfile-pin
+    description: A CLI tool that adds @sha256:<digest> to FROM lines in Dockerfiles and image fields in docker-compose.yml to prevent supply chain attacks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: dockerfile-pin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -16974,6 +16974,24 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: azu
+    repo_name: dockerfile-pin
+    description: A CLI tool that adds @sha256:<digest> to FROM lines in Dockerfiles and image fields in docker-compose.yml to prevent supply chain attacks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: dockerfile-pin_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_archive
     repo_owner: b3nj5m1n
     repo_name: xdg-ninja


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Add https://github.com/azu/dockerfile-pin to aqua registry.

azu/dockerfile-pin - A CLI tool that adds `@sha256:<digest>` to FROM lines inDockerfiles and image fields in docker-compose.yml to prevent supply chain attacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `dockerfile-pin` tool (v1.0.4) is now available for use, featuring support across multiple operating systems and processor architectures.
  * Implemented platform-specific download optimizations with compressed tar archives for Unix-based systems and zip archives for Windows.
  * Integrated SHA-256 checksum verification to validate package integrity and ensure secure installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->