### PR TITLE
Re-scaffold dandavison/delta

### DIFF
--- a/pkgs/dandavison/delta/pkg.yaml
+++ b/pkgs/dandavison/delta/pkg.yaml
@@ -12,15 +12,3 @@ packages:
     version: 0.4.0
   - name: dandavison/delta
     version: 0.2.0
-  - name: dandavison/delta
-    version: 0.0.18
-  - name: dandavison/delta
-    version: 0.0.15
-  - name: dandavison/delta
-    version: 0.0.9
-  - name: dandavison/delta
-    version: 0.0.6
-  - name: dandavison/delta
-    version: 0.0.5
-  - name: dandavison/delta
-    version: 0.0.4

--- a/pkgs/dandavison/delta/pkg.yaml
+++ b/pkgs/dandavison/delta/pkg.yaml
@@ -1,26 +1,26 @@
 packages:
-  - name: dandavison/delta@0.18.2
+  - name: dandavison/delta@0.19.2
+  - name: dandavison/delta
+    version: 0.19.0
+  - name: dandavison/delta
+    version: 0.18.2
   - name: dandavison/delta
     version: 0.16.4
   - name: dandavison/delta
-    version: 0.15.0
+    version: 0.14.0
   - name: dandavison/delta
-    version: 0.4.1
+    version: 0.4.0
   - name: dandavison/delta
-    version: 0.3.0
+    version: 0.2.0
   - name: dandavison/delta
-    version: 0.1.0
+    version: 0.0.18
   - name: dandavison/delta
-    version: 0.0.16
+    version: 0.0.15
   - name: dandavison/delta
-    version: 0.0.10
-  - name: dandavison/delta
-    version: 0.0.8
-  - name: dandavison/delta
-    version: 0.0.7
+    version: 0.0.9
   - name: dandavison/delta
     version: 0.0.6
   - name: dandavison/delta
     version: 0.0.5
   - name: dandavison/delta
-    version: 0.0.1
+    version: 0.0.4

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -4,51 +4,15 @@ packages:
     repo_owner: dandavison
     repo_name: delta
     description: A syntax-highlighting pager for git, diff, grep, and blame output
+    files:
+      - name: delta
+        src: "{{.AssetWithoutExt}}/delta"
+    overrides:
+      - goos: windows
+        files:
+          - name: delta
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["0.0.5", "0.0.7"]
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "0.0.6"
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-            asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.16.4"
         asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -88,65 +52,6 @@ packages:
           - linux/amd64
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.0.4")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.0.9")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.0.15")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.0.18")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: semver("<= 0.2.0")
         asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/dandavison/delta/registry.yaml
+++ b/pkgs/dandavison/delta/registry.yaml
@@ -3,53 +3,18 @@ packages:
   - type: github_release
     repo_owner: dandavison
     repo_name: delta
-    description: A syntax-highlighting pager for git, diff, and grep output
-    asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: delta
-        src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
-    overrides:
-      - goos: linux
-        goarch: amd64
-        replacements:
-          linux: unknown-linux-musl
-      - goos: linux
-        goarch: arm64
-        replacements:
-          linux: unknown-linux-gnu
-      - goos: windows
-        format: zip
-        replacements:
-          arm64: arm64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.16.5")
+    description: A syntax-highlighting pager for git, diff, grep, and blame output
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.16.4")
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
+      - version_constraint: Version in ["0.0.5", "0.0.7"]
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.15.0")
-      - version_constraint: semver(">= 0.4.1")
         overrides:
           - goos: linux
             goarch: amd64
@@ -62,89 +27,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: Version == "0.0.6"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.3.0")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.1.0")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-gnu
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.16")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.10")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.8")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.7")
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.6")
         overrides:
           - goos: linux
             goarch: amd64
@@ -158,14 +49,147 @@ packages:
           - goos: windows
             format: zip
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-            files:
-              - name: delta
+      - version_constraint: Version == "0.16.4"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.19.0"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 0.0.4")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.0.9")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.0.15")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.18")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.14.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.5")
         overrides:
           - goos: linux
             goarch: amd64
@@ -178,12 +202,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.18.2")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver("< 0.0.5")
         overrides:
           - goos: linux
             goarch: amd64
@@ -192,12 +219,33 @@ packages:
           - goos: linux
             goarch: arm64
             replacements:
-              arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
         supported_envs:
           - linux
-          - darwin
-        rosetta2: true
+          - darwin/arm64
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -29025,51 +29025,15 @@ packages:
     repo_owner: dandavison
     repo_name: delta
     description: A syntax-highlighting pager for git, diff, grep, and blame output
+    files:
+      - name: delta
+        src: "{{.AssetWithoutExt}}/delta"
+    overrides:
+      - goos: windows
+        files:
+          - name: delta
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["0.0.5", "0.0.7"]
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "0.0.6"
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-            asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.16.4"
         asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -29109,65 +29073,6 @@ packages:
           - linux/amd64
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.0.4")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 0.0.9")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.0.15")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.0.18")
-        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: semver("<= 0.2.0")
         asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -29024,53 +29024,18 @@ packages:
   - type: github_release
     repo_owner: dandavison
     repo_name: delta
-    description: A syntax-highlighting pager for git, diff, and grep output
-    asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-    format: tar.gz
-    files:
-      - name: delta
-        src: delta-{{.Version}}-{{.Arch}}-{{.OS}}/delta
-    overrides:
-      - goos: linux
-        goarch: amd64
-        replacements:
-          linux: unknown-linux-musl
-      - goos: linux
-        goarch: arm64
-        replacements:
-          linux: unknown-linux-gnu
-      - goos: windows
-        format: zip
-        replacements:
-          arm64: arm64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    version_constraint: semver(">= 0.16.5")
+    description: A syntax-highlighting pager for git, diff, grep, and blame output
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.16.4")
-        overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
+      - version_constraint: Version in ["0.0.5", "0.0.7"]
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
           windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-      - version_constraint: semver(">= 0.15.0")
-      - version_constraint: semver(">= 0.4.1")
         overrides:
           - goos: linux
             goarch: amd64
@@ -29083,89 +29048,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: Version == "0.0.6"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.3.0")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.1.0")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-gnu
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.16")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.10")
-        overrides:
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        supported_envs:
-          - darwin
-          - amd64
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.8")
-        overrides: []
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-        supported_envs:
-          - linux/amd64
-          - darwin
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.7")
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              arm64: aarch64
-              linux: unknown-linux-gnu
-          - goos: windows
-            format: zip
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.6")
         overrides:
           - goos: linux
             goarch: amd64
@@ -29179,14 +29070,147 @@ packages:
           - goos: windows
             format: zip
             asset: bat-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-            files:
-              - name: delta
+      - version_constraint: Version == "0.16.4"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.19.0"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: semver("<= 0.0.4")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.0.9")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.0.15")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.0.18")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.2.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.14.0")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver(">= 0.0.5")
         overrides:
           - goos: linux
             goarch: amd64
@@ -29199,12 +29223,15 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.18.2")
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
-        rosetta2: true
-      - version_constraint: semver("< 0.0.5")
         overrides:
           - goos: linux
             goarch: amd64
@@ -29213,15 +29240,36 @@ packages:
           - goos: linux
             goarch: arm64
             replacements:
-              arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: delta-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
         supported_envs:
           - linux
-          - darwin
-        rosetta2: true
+          - darwin/arm64
+          - windows/amd64
   - type: github_release
     repo_owner: danielfoehrKn
     repo_name: kubeswitch


### PR DESCRIPTION
Close #50892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default delta tool version from 0.18.2 to 0.19.2.
  * Consolidated supported delta versions, retaining 0.19.0, 0.18.2, 0.16.4, 0.14.0, 0.4.0, and 0.2.0.
  * Enhanced delta package description to include blame functionality.
  * Streamlined binary distribution and platform support configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->