### PR TITLE
fix(anthropics/claude-code): exclude v2.1.88

### DIFF
--- a/pkgs/anthropics/claude-code/pkg.yaml
+++ b/pkgs/anthropics/claude-code/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: anthropics/claude-code@v2.1.88
+  - name: anthropics/claude-code@v2.1.89

--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -9,6 +9,8 @@ packages:
     version_source: github_tag
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v2.1.88"
+        no_asset: true
       - version_constraint: "true"
         format: raw
         url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude

--- a/registry.yaml
+++ b/registry.yaml
@@ -12488,6 +12488,8 @@ packages:
     version_source: github_tag
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v2.1.88"
+        no_asset: true
       - version_constraint: "true"
         format: raw
         url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code package dependency to v2.1.89
  * Added configuration override for v2.1.88 asset handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->