### PR TITLE
feat(kurama/dealve-tui): scaffold kurama/dealve-tui

### DIFF
--- a/pkgs/kurama/dealve-tui/pkg.yaml
+++ b/pkgs/kurama/dealve-tui/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kurama/dealve-tui@v1.0.2

--- a/pkgs/kurama/dealve-tui/registry.yaml
+++ b/pkgs/kurama/dealve-tui/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: kurama
     repo_name: dealve-tui
     description: Delve into game deals from your terminal
+    files:
+      - name: dealve
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/kurama/dealve-tui/registry.yaml
+++ b/pkgs/kurama/dealve-tui/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kurama
+    repo_name: dealve-tui
+    description: Delve into game deals from your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dealve-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            replacements: {}

--- a/registry.yaml
+++ b/registry.yaml
@@ -56732,6 +56732,23 @@ packages:
       - darwin/arm64
       - linux/amd64
   - type: github_release
+    repo_owner: kurama
+    repo_name: dealve-tui
+    description: Delve into game deals from your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dealve-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            replacements: {}
+  - type: github_release
     repo_owner: kurehajime
     repo_name: dajarep
     description: ダジャレを検索するコマンド

--- a/registry.yaml
+++ b/registry.yaml
@@ -56735,6 +56735,8 @@ packages:
     repo_owner: kurama
     repo_name: dealve-tui
     description: Delve into game deals from your terminal
+    files:
+      - name: dealve
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
#51454 [kurama/dealve-tui](https://github.com/kurama/dealve-tui) - Delve into game deals from your terminal @tmeijn

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

```
which dealve-tui
/home/tmeijn/.local/share/aquaproj-aqua/bin/dealve-tui
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added kurama/dealve-tui v1.0.2 to registries with a GitHub-release distribution, platform-specific asset naming, and re-enabled version-constraint handling via overrides.
  * Enabled cross-platform support including Windows ARM emulation and OS/architecture name mappings for consistent asset selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->