### PR TITLE
feat(micahkepe/jsongrep): scaffold micahkepe/jsongrep

### DIFF
--- a/pkgs/micahkepe/jsongrep/pkg.yaml
+++ b/pkgs/micahkepe/jsongrep/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: micahkepe/jsongrep@v0.8.1
+  - name: micahkepe/jsongrep
+    version: v0.6.0
+  - name: micahkepe/jsongrep
+    version: v0.1.1

--- a/pkgs/micahkepe/jsongrep/registry.yaml
+++ b/pkgs/micahkepe/jsongrep/registry.yaml
@@ -44,6 +44,13 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              file_format: regexp
+              pattern:
+                checksum: (\b[A-Fa-f0-9]{64}\b)
         supported_envs:
           - darwin
           - windows
@@ -68,3 +75,10 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              file_format: regexp
+              pattern:
+                checksum: (\b[A-Fa-f0-9]{64}\b)

--- a/pkgs/micahkepe/jsongrep/registry.yaml
+++ b/pkgs/micahkepe/jsongrep/registry.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: micahkepe
+    repo_name: jsongrep
+    description: A path query language for JSON, YAML, TOML, and other serialization formats
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.6.0")
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/micahkepe/jsongrep/registry.yaml
+++ b/pkgs/micahkepe/jsongrep/registry.yaml
@@ -8,6 +8,9 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.1.1"
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         rosetta2: true
         replacements:
@@ -23,6 +26,9 @@ packages:
           - darwin
       - version_constraint: semver("<= 0.6.0")
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
@@ -44,6 +50,9 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -60283,6 +60283,65 @@ packages:
           - linux
           - windows/amd64
   - type: github_release
+    repo_owner: micahkepe
+    repo_name: jsongrep
+    description: A path query language for JSON, YAML, TOML, and other serialization formats
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.1"
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.6.0")
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: michidk
     repo_name: vscli
     description: A CLI tool to launch vscode projects, which supports devcontainers

--- a/registry.yaml
+++ b/registry.yaml
@@ -60290,6 +60290,9 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.1.1"
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         rosetta2: true
         replacements:
@@ -60305,6 +60308,9 @@ packages:
           - darwin
       - version_constraint: semver("<= 0.6.0")
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
@@ -60326,6 +60332,9 @@ packages:
           - amd64
       - version_constraint: "true"
         asset: jsongrep-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: jg
+            src: "{{.AssetWithoutExt}}/jg"
         format: tar.gz
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -60326,6 +60326,13 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              file_format: regexp
+              pattern:
+                checksum: (\b[A-Fa-f0-9]{64}\b)
         supported_envs:
           - darwin
           - windows
@@ -60350,6 +60357,13 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            checksum:
+              type: github_release
+              asset: "{{.Asset}}.sha256"
+              algorithm: sha256
+              file_format: regexp
+              pattern:
+                checksum: (\b[A-Fa-f0-9]{64}\b)
   - type: github_release
     repo_owner: michidk
     repo_name: vscli


### PR DESCRIPTION
#51455 [micahkepe/jsongrep](https://github.com/micahkepe/jsongrep) - A path query language for JSON, YAML, TOML, and other serialization formats @tmeijn

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing the jsongrep tool (v0.8.1, v0.6.0, v0.1.1) across Linux, macOS, and Windows with automatic selection of platform-specific binaries, archive handling, checksum verification, and runtime emulation for unsupported architectures where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->