### PR TITLE
feat(bellicose100xp/jiq): scaffold bellicose100xp/jiq

### DIFF
--- a/pkgs/bellicose100xp/jiq/pkg.yaml
+++ b/pkgs/bellicose100xp/jiq/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: bellicose100xp/jiq@v3.21.0

--- a/pkgs/bellicose100xp/jiq/registry.yaml
+++ b/pkgs/bellicose100xp/jiq/registry.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: bellicose100xp
+    repo_name: jiq
+    description: Interactive JSON query tool with real-time output and AI assistance
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v2.0.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip

--- a/pkgs/bellicose100xp/jiq/registry.yaml
+++ b/pkgs/bellicose100xp/jiq/registry.yaml
@@ -10,6 +10,9 @@ packages:
         no_asset: true
       - version_constraint: "true"
         asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - src: "{{.AssetWithoutExt}}/jiq"
+            name: jiq
         format: tar.xz
         windows_arm_emulation: true
         replacements:
@@ -32,3 +35,5 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+            files:
+              - name: jiq

--- a/pkgs/bellicose100xp/jiq/registry.yaml
+++ b/pkgs/bellicose100xp/jiq/registry.yaml
@@ -11,8 +11,8 @@ packages:
       - version_constraint: "true"
         asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
         files:
-          - src: "{{.AssetWithoutExt}}/jiq"
-            name: jiq
+          - name: jiq
+            src: "{{.AssetWithoutExt}}/jiq"
         format: tar.xz
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -18129,8 +18129,8 @@ packages:
       - version_constraint: "true"
         asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
         files:
-          - src: "{{.AssetWithoutExt}}/jiq"
-            name: jiq
+          - name: jiq
+            src: "{{.AssetWithoutExt}}/jiq"
         format: tar.xz
         windows_arm_emulation: true
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -18128,6 +18128,9 @@ packages:
         no_asset: true
       - version_constraint: "true"
         asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - src: "{{.AssetWithoutExt}}/jiq"
+            name: jiq
         format: tar.xz
         windows_arm_emulation: true
         replacements:
@@ -18150,6 +18153,8 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+            files:
+              - name: jiq
   - type: github_release
     repo_owner: benbjohnson
     repo_name: litestream

--- a/registry.yaml
+++ b/registry.yaml
@@ -18119,6 +18119,38 @@ packages:
           asset: roumon_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: bellicose100xp
+    repo_name: jiq
+    description: Interactive JSON query tool with real-time output and AI assistance
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v2.0.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: jiq-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: benbjohnson
     repo_name: litestream
     description: Streaming replication for SQLite


### PR DESCRIPTION
#51457 [bellicose100xp/jiq](https://github.com/bellicose100xp/jiq) - Interactive JSON query tool with real-time output and AI assistance @tmeijn

- **feat(bellicose100xp/jiq): scaffold bellicose100xp/jiq**
- **fix path in archive and windows**

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added jiq v3.21.0 as a distributable package.
  * Multi-platform releases with OS/arch mappings, Windows ZIP support and Linux variants.
  * Automatic checksum verification and conditional handling for older v2.0.0 releases (no asset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->