### PR TITLE
feat(max-sixty/worktrunk): scaffold max-sixty/worktrunk

### DIFF
--- a/pkgs/max-sixty/worktrunk/pkg.yaml
+++ b/pkgs/max-sixty/worktrunk/pkg.yaml
@@ -1,2 +1,3 @@
 packages:
   - name: max-sixty/worktrunk
+    version: v0.33.0

--- a/pkgs/max-sixty/worktrunk/pkg.yaml
+++ b/pkgs/max-sixty/worktrunk/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: max-sixty/worktrunk

--- a/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/pkgs/max-sixty/worktrunk/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: max-sixty
     repo_name: worktrunk
-    description: A CLI for git worktree management, designed for running AI agents in parallel.
+    description: A CLI for git worktree management, designed for running AI agents in parallel
     asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.xz
     replacements:
@@ -16,6 +16,22 @@ packages:
       type: github_release
       asset: sha256.sum
       algorithm: sha256
+    files:
+      - name: wt
+        src: worktrunk-{{.Arch}}-{{.OS}}/wt
+      - name: git-wt
+        src: worktrunk-{{.Arch}}-{{.OS}}/git-wt
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
     overrides:
       - goos: windows
         format: zip
+        files:
+          - name: wt.exe
+            src: wt.exe
+          - name: git-wt.exe
+            src: git-wt.exe

--- a/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/pkgs/max-sixty/worktrunk/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: max-sixty
+    repo_name: worktrunk
+    description: A CLI for git worktree management, designed for running AI agents in parallel.
+    asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    checksum:
+      type: github_release
+      asset: sha256.sum
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip

--- a/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/pkgs/max-sixty/worktrunk/registry.yaml
@@ -31,7 +31,7 @@ packages:
       - goos: windows
         format: zip
         files:
-          - name: wt.exe
-            src: wt.exe
-          - name: git-wt.exe
-            src: git-wt.exe
+          - name: wt
+            src: wt
+          - name: git-wt
+            src: git-wt

--- a/registry.yaml
+++ b/registry.yaml
@@ -59621,6 +59621,41 @@ packages:
           - goos: linux
             format: tar.gz
   - type: github_release
+    repo_owner: max-sixty
+    repo_name: worktrunk
+    description: A CLI for git worktree management, designed for running AI agents in parallel
+    asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.xz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    checksum:
+      type: github_release
+      asset: sha256.sum
+      algorithm: sha256
+    files:
+      - name: wt
+        src: worktrunk-{{.Arch}}-{{.OS}}/wt
+      - name: git-wt
+        src: worktrunk-{{.Arch}}-{{.OS}}/git-wt
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64
+    overrides:
+      - goos: windows
+        format: zip
+        files:
+          - name: wt.exe
+            src: wt.exe
+          - name: git-wt.exe
+            src: git-wt.exe
+  - type: github_release
     repo_owner: maxpert
     repo_name: marmot
     description: A distributed SQLite server with MySQL wire compatible interface


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

This is to add `worktrunk` lib to the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The max-sixty/worktrunk CLI (v0.33.0) is now available in the package registry for installation.
  * Supported platforms: macOS (amd64, arm64), Linux (amd64, arm64), and Windows (amd64).
  * Installs include the wt and git-wt executables (Windows installs use .exe).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->