### PR TITLE
feat(controlplaneio-fluxcd/flux-operator): scaffold controlplaneio-fluxcd/flux-operator

### DIFF
--- a/pkgs/controlplaneio-fluxcd/flux-operator/pkg.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: controlplaneio-fluxcd/flux-operator@v0.45.1
+  - name: controlplaneio-fluxcd/flux-operator
+    version: v0.19.0
+  - name: controlplaneio-fluxcd/flux-operator
+    version: v0.13.0

--- a/pkgs/controlplaneio-fluxcd/flux-operator/pkg.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/pkg.yaml
@@ -2,5 +2,3 @@ packages:
   - name: controlplaneio-fluxcd/flux-operator@v0.45.1
   - name: controlplaneio-fluxcd/flux-operator
     version: v0.19.0
-  - name: controlplaneio-fluxcd/flux-operator
-    version: v0.13.0

--- a/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
@@ -7,6 +7,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.13.0")
+        no_asset: true
       - version_constraint: semver("<= 0.19.0")
         asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
@@ -3,7 +3,9 @@ packages:
   - type: github_release
     repo_owner: controlplaneio-fluxcd
     repo_name: flux-operator
-    description: GitOps on Autopilot Mode
+    description: |
+      Flux Operator CLI allows you to manage the Flux Operator resources in your Kubernetes clusters.
+      It provides a convenient way to interact with the operator and perform various operations.
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.13.0")

--- a/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: controlplaneio-fluxcd
+    repo_name: flux-operator
+    description: GitOps on Autopilot Mode
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.13.0")
+      - version_constraint: semver("<= 0.19.0")
+        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: flux-operator_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: flux-operator_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
@@ -3,6 +3,7 @@ packages:
   - type: github_release
     repo_owner: controlplaneio-fluxcd
     repo_name: flux-operator
+    link: https://fluxoperator.dev/docs/guides/cli/
     description: |
       Flux Operator CLI allows you to manage the Flux Operator resources in your Kubernetes clusters.
       It provides a convenient way to interact with the operator and perform various operations.

--- a/registry.yaml
+++ b/registry.yaml
@@ -27313,6 +27313,34 @@ packages:
         supported_envs:
           - darwin/arm64
   - type: github_release
+    repo_owner: controlplaneio-fluxcd
+    repo_name: flux-operator
+    description: GitOps on Autopilot Mode
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.13.0")
+      - version_constraint: semver("<= 0.19.0")
+        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: flux-operator_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: flux-operator_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: controlplaneio
     repo_name: kubectl-kubesec
     description: Security risk analysis for Kubernetes resources

--- a/registry.yaml
+++ b/registry.yaml
@@ -27315,7 +27315,9 @@ packages:
   - type: github_release
     repo_owner: controlplaneio-fluxcd
     repo_name: flux-operator
-    description: GitOps on Autopilot Mode
+    description: |
+      Flux Operator CLI allows you to manage the Flux Operator resources in your Kubernetes clusters.
+      It provides a convenient way to interact with the operator and perform various operations.
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.13.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -27315,6 +27315,7 @@ packages:
   - type: github_release
     repo_owner: controlplaneio-fluxcd
     repo_name: flux-operator
+    link: https://fluxoperator.dev/docs/guides/cli/
     description: |
       Flux Operator CLI allows you to manage the Flux Operator resources in your Kubernetes clusters.
       It provides a convenient way to interact with the operator and perform various operations.

--- a/registry.yaml
+++ b/registry.yaml
@@ -27319,6 +27319,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.13.0")
+        no_asset: true
       - version_constraint: semver("<= 0.19.0")
         asset: flux-operator_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
[controlplaneio-fluxcd/flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator) - GitOps on Autopilot Mode

https://fluxoperator.dev/docs/guides/cli/

> The Flux Operator CLI is a command line tool that allows you to manage the Flux Operator resources in your Kubernetes clusters. It provides a convenient way to interact with the operator and perform various operations.
> The Flux Operator CLI is available as a binary executable for Linux, macOS, and Windows. The binaries can be downloaded from GitHub [releases page](https://github.com/controlplaneio-fluxcd/flux-operator/releases).

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

* scaffold controlplaneio-fluxcd/flux-operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added flux-operator package registration with support for multiple published versions (including v0.45.1, v0.19.0, v0.13.0).
  * Implemented platform-aware asset selection and checksum verification to ensure correct archive formats and improved Windows/ARM handling during installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->