### PR TITLE
fix(fwdcloudsec/granted): set type to GitHub release

### DIFF
--- a/pkgs/fwdcloudsec/granted/pkg.yaml
+++ b/pkgs/fwdcloudsec/granted/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: fwdcloudsec/granted@v0.38.0
+  - name: fwdcloudsec/granted@v0.39.0
+  - name: fwdcloudsec/granted
+    version: v0.35.0
   - name: fwdcloudsec/granted
     version: v0.17.0
   - name: fwdcloudsec/granted

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -49,6 +49,8 @@ packages:
       - version_constraint: "true"
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
         checksum:
           type: github_release
           asset: checksums.txt

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -14,6 +14,7 @@ packages:
     replacements:
       amd64: x86_64
     version_overrides:
+      # From version 0.35.0 forward, GitHub Release artifacts are also published.
       - version_constraint: semver("< 0.35.0")
         type: http
         url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
@@ -29,10 +30,15 @@ packages:
             - name: assumego
               src: granted
               link: assumego
+      # Version 0.39.0 did not publish prebuilt Darwin artifacts.
       - version_constraint: semver("= 0.39.0")
         type: github_release
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - windows
@@ -45,6 +51,10 @@ packages:
         repo_name: granted
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
         overrides:
         - goos: windows
           format: zip

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -1,26 +1,57 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: http
+  - type: github_release
     repo_owner: fwdcloudsec
     repo_name: granted
     aliases:
       - name: common-fate/granted
     description: The easiest way to access your cloud
-    url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
+    version_constraint: "false"
     files:
       - name: granted
       - name: assume
       - name: assumego
     replacements:
       amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: darwin
-        files:
-          - name: granted
-          - name: assume
-          - name: assumego
-            src: granted
-            link: assumego
+    version_overrides:
+      - version_constraint: semver("< 0.35.0")
+        type: http
+        url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+        - goos: windows
+          format: zip
+        - goos: darwin
+          files:
+            - name: granted
+            - name: assume
+            - name: assumego
+              src: granted
+              link: assumego
+      - version_constraint: semver("= 0.39.0")
+        type: github_release
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - windows
+        overrides:
+        - goos: windows
+          format: zip
+      - version_constraint: "true"
+        type: github_release
+        repo_owner: fwdcloudsec
+        repo_name: granted
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+        - goos: windows
+          format: zip
+        - goos: darwin
+          files:
+            - name: granted
+            - name: assume
+            - name: assumego
+              src: granted
+              link: assumego

--- a/pkgs/fwdcloudsec/granted/registry.yaml
+++ b/pkgs/fwdcloudsec/granted/registry.yaml
@@ -47,8 +47,6 @@ packages:
           format: zip
       - version_constraint: "true"
         type: github_release
-        repo_owner: fwdcloudsec
-        repo_name: granted
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -37778,6 +37778,10 @@ packages:
         type: github_release
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - windows
@@ -37790,6 +37794,10 @@ packages:
         repo_name: granted
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
         overrides:
         - goos: windows
           format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -37745,30 +37745,61 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-  - type: http
+  - type: github_release
     repo_owner: fwdcloudsec
     repo_name: granted
     aliases:
       - name: common-fate/granted
     description: The easiest way to access your cloud
-    url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
+    version_constraint: "false"
     files:
       - name: granted
       - name: assume
       - name: assumego
     replacements:
       amd64: x86_64
-    overrides:
-      - goos: windows
-        format: zip
-      - goos: darwin
-        files:
-          - name: granted
-          - name: assume
-          - name: assumego
-            src: granted
-            link: assumego
+    version_overrides:
+      - version_constraint: semver("< 0.35.0")
+        type: http
+        url: https://releases.commonfate.io/granted/{{.Version}}/granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+        - goos: windows
+          format: zip
+        - goos: darwin
+          files:
+            - name: granted
+            - name: assume
+            - name: assumego
+              src: granted
+              link: assumego
+      - version_constraint: semver("= 0.39.0")
+        type: github_release
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        supported_envs:
+          - linux
+          - windows
+        overrides:
+        - goos: windows
+          format: zip
+      - version_constraint: "true"
+        type: github_release
+        repo_owner: fwdcloudsec
+        repo_name: granted
+        asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+        - goos: windows
+          format: zip
+        - goos: darwin
+          files:
+            - name: granted
+            - name: assume
+            - name: assumego
+              src: granted
+              link: assumego
   - type: github_release
     repo_owner: g-plane
     repo_name: pnpm-shell-completion

--- a/registry.yaml
+++ b/registry.yaml
@@ -37860,6 +37860,8 @@ packages:
       - version_constraint: "true"
         asset: granted_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

This PR sets the type to `github_release` and adds checksum verification from version 0.35.0 onward. Since [0.35.0](https://github.com/fwdcloudsec/granted/releases/tag/v0.35.0) prebuilt binaries are also distributed through GitHub releases which I think is the preferred platform.

There is an issue with version 0.39.0 specifically that did not publish prebuilt Darwin binaries, not even on `releases.granted.dev`. See https://github.com/fwdcloudsec/granted/issues/936 for some more information.

References:
- Should supersede: https://github.com/aquaproj/aqua-registry/pull/51207
- Fixes: https://github.com/aquaproj/aqua-registry/pull/51171
- Fixes: #51918


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated granted package support: advanced to v0.39.0 and added a pinned v0.35.0 entry.
  * Per-version distribution strategy: older releases use HTTP downloads, newer releases use GitHub Releases with versioned assets.
  * Added checksum verification for GitHub release artifacts.
  * v0.39.0 now targets linux and windows packaging specifics; platform packaging rules vary by version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->