### PR TITLE
feat(pgplex/pgschema): scaffold pgplex/pgschema

### DIFF
--- a/pkgs/pgplex/pgschema/pkg.yaml
+++ b/pkgs/pgplex/pgschema/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: pgplex/pgschema@v1.9.0
+  - name: pgplex/pgschema
+    version: v1.5.0
+  - name: pgplex/pgschema
+    version: v1.4.1
+  - name: pgplex/pgschema
+    version: v1.2.1

--- a/pkgs/pgplex/pgschema/registry.yaml
+++ b/pkgs/pgplex/pgschema/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: pgplex
+    repo_name: pgschema
+    description: Terraform-style, declarative schema migration CLI for Postgres. Agent friendly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 1.4.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: semver("<= 1.5.0")
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -69666,6 +69666,36 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: pgplex
+    repo_name: pgschema
+    description: Terraform-style, declarative schema migration CLI for Postgres. Agent friendly
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.2.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 1.4.1")
+        asset: pgschema-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: semver("<= 1.5.0")
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: pgschema-{{trimV .Version}}-{{.OS}}-{{.Arch}}
+        format: raw
+        supported_envs:
+          - linux
+          - darwin
   - name: pgrok/pgrok/pgrok
     type: github_release
     repo_owner: pgrok


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well
```
$ argd con
Apr  9 13:54:44.668 INF + /usr/local/bin/docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=arm64 aqua-registry aqua i -l program=argd version=0.5.1
Apr  9 13:54:45.070 INF + /usr/local/bin/docker exec -i -t -w /workspace -e AQUA_GOARCH=arm64 -e AQUA_GOOS=linux aqua-registry bash program=argd version=0.5.1
root@c02ef98741fe:/workspace# pgschema
Declarative schema migration for Postgres

Version: 1.9.0@e5673daf linux/arm64 2026-04-08 03:55:40

Commands:
  dump    Dump PostgreSQL schema
  plan    Generate migration plan
  apply   Apply schema migrations

Use "pgschema [command] --help" for more information about a command.

Usage:
  pgschema [command]

Available Commands:
  apply       Apply migration plan to update a database schema
  dump        Dump database schema for a specific schema
  help        Help about any command
  plan        Generate migration plan for a specific schema

Flags:
      --debug   Enable debug logging
  -h, --help    help for pgschema

Use "pgschema [command] --help" for more information about a command.
```

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new package entry for pgschema (declarative Postgres schema migration CLI) to the registry and package manifest.
  * Provides curated support for multiple released versions (v1.2.1 through v1.9.0) with platform-specific binary distributions for Linux and macOS across several architectures and version-specific asset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->