### PR TITLE
Add IBM-Cloud/ibm-cloud-cli-release

### DIFF
--- a/pkgs/IBM-Cloud/ibm-cloud-cli-release/pkg.yaml
+++ b/pkgs/IBM-Cloud/ibm-cloud-cli-release/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: IBM-Cloud/ibm-cloud-cli-release@v2.42.0
+  - name: IBM-Cloud/ibm-cloud-cli-release
+    version: v2.38.0
+  - name: IBM-Cloud/ibm-cloud-cli-release
+    version: v2.37.0
+  - name: IBM-Cloud/ibm-cloud-cli-release
+    version: v2.5.0

--- a/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
+++ b/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
@@ -6,47 +6,39 @@ packages:
     description: Command line interface for IBM Cloud
     search_words:
       - ibmcloud
-      - ibm
       - bluemix
-    aliases:
-      - name: IBM-Cloud/ibmcloud
-    # binaries are hosted on IBM's CDN, not as GitHub Release assets
-    url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
-    format: tar.gz
     files:
       - name: ibmcloud
         src: IBM_Cloud_CLI/ibmcloud
-    supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - linux/arm64
-      - windows/amd64 # IBM does not publish Windows ARM64 binaries
-    replacements:
-      darwin: macos
-      linux: linux
-      windows: windows
-    version_constraint: semver(">= 2.38.0")
-    overrides:
-      # macOS x86_64 has no arch suffix in the filename
-      - goos: darwin
-        goarch: amd64
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
-      # windows has a .zip archive rather than .tgz
-      - goos: windows
-        format: zip
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+    version_constraint: "false"
     version_overrides:
+      # distribution wasn't properly multi-arch until v2.5.0 and newer
+      - version_constraint: semver("< 2.5.0")
+        error_message: Please use v2.5.0 or later
       # the download base path changed from ibm-cloud-cli to ibm-cloud-cli-dn at v2.38.0
-      - version_constraint: semver(">= 2.5.0, < 2.38.0")
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+      - version_constraint: semver("< 2.38.0")
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
         overrides:
           - goos: darwin
             goarch: amd64
             url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
           - goos: windows
             format: zip
-            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
-      # distribution wasn't properly multi-arch until v2.5.0 and newer
-      - version_constraint: semver("< 2.5.0")
-        error_message: Please use v2.5.0 or later
+      - version_constraint: "true"
+        # binaries are hosted on IBM's CDN, not as GitHub Release assets
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          # macOS x86_64 has no arch suffix in the filename
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip

--- a/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
+++ b/pkgs/IBM-Cloud/ibm-cloud-cli-release/registry.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    repo_owner: IBM-Cloud
+    repo_name: ibm-cloud-cli-release
+    description: Command line interface for IBM Cloud
+    search_words:
+      - ibmcloud
+      - ibm
+      - bluemix
+    aliases:
+      - name: IBM-Cloud/ibmcloud
+    # binaries are hosted on IBM's CDN, not as GitHub Release assets
+    url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+    format: tar.gz
+    files:
+      - name: ibmcloud
+        src: IBM_Cloud_CLI/ibmcloud
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64 # IBM does not publish Windows ARM64 binaries
+    replacements:
+      darwin: macos
+      linux: linux
+      windows: windows
+    version_constraint: semver(">= 2.38.0")
+    overrides:
+      # macOS x86_64 has no arch suffix in the filename
+      - goos: darwin
+        goarch: amd64
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
+      # windows has a .zip archive rather than .tgz
+      - goos: windows
+        format: zip
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+    version_overrides:
+      # the download base path changed from ibm-cloud-cli to ibm-cloud-cli-dn at v2.38.0
+      - version_constraint: semver(">= 2.5.0, < 2.38.0")
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
+          - goos: windows
+            format: zip
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+      # distribution wasn't properly multi-arch until v2.5.0 and newer
+      - version_constraint: semver("< 2.5.0")
+        error_message: Please use v2.5.0 or later

--- a/registry.yaml
+++ b/registry.yaml
@@ -3731,50 +3731,42 @@ packages:
     description: Command line interface for IBM Cloud
     search_words:
       - ibmcloud
-      - ibm
       - bluemix
-    aliases:
-      - name: IBM-Cloud/ibmcloud
-    # binaries are hosted on IBM's CDN, not as GitHub Release assets
-    url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
-    format: tar.gz
     files:
       - name: ibmcloud
         src: IBM_Cloud_CLI/ibmcloud
-    supported_envs:
-      - darwin/amd64
-      - darwin/arm64
-      - linux/amd64
-      - linux/arm64
-      - windows/amd64 # IBM does not publish Windows ARM64 binaries
-    replacements:
-      darwin: macos
-      linux: linux
-      windows: windows
-    version_constraint: semver(">= 2.38.0")
-    overrides:
-      # macOS x86_64 has no arch suffix in the filename
-      - goos: darwin
-        goarch: amd64
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
-      # windows has a .zip archive rather than .tgz
-      - goos: windows
-        format: zip
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+    version_constraint: "false"
     version_overrides:
+      # distribution wasn't properly multi-arch until v2.5.0 and newer
+      - version_constraint: semver("< 2.5.0")
+        error_message: Please use v2.5.0 or later
       # the download base path changed from ibm-cloud-cli to ibm-cloud-cli-dn at v2.38.0
-      - version_constraint: semver(">= 2.5.0, < 2.38.0")
-        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+      - version_constraint: semver("< 2.38.0")
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
         overrides:
           - goos: darwin
             goarch: amd64
             url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
           - goos: windows
             format: zip
-            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
-      # distribution wasn't properly multi-arch until v2.5.0 and newer
-      - version_constraint: semver("< 2.5.0")
-        error_message: Please use v2.5.0 or later
+      - version_constraint: "true"
+        # binaries are hosted on IBM's CDN, not as GitHub Release assets
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tgz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          # macOS x86_64 has no arch suffix in the filename
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}.{{.Format}}
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: IBM-Cloud
     repo_name: redli

--- a/registry.yaml
+++ b/registry.yaml
@@ -3725,6 +3725,56 @@ packages:
       - darwin
       - linux
       - amd64
+  - type: http
+    repo_owner: IBM-Cloud
+    repo_name: ibm-cloud-cli-release
+    description: Command line interface for IBM Cloud
+    search_words:
+      - ibmcloud
+      - ibm
+      - bluemix
+    aliases:
+      - name: IBM-Cloud/ibmcloud
+    # binaries are hosted on IBM's CDN, not as GitHub Release assets
+    url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+    format: tar.gz
+    files:
+      - name: ibmcloud
+        src: IBM_Cloud_CLI/ibmcloud
+    supported_envs:
+      - darwin/amd64
+      - darwin/arm64
+      - linux/amd64
+      - linux/arm64
+      - windows/amd64 # IBM does not publish Windows ARM64 binaries
+    replacements:
+      darwin: macos
+      linux: linux
+      windows: windows
+    version_constraint: semver(">= 2.38.0")
+    overrides:
+      # macOS x86_64 has no arch suffix in the filename
+      - goos: darwin
+        goarch: amd64
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
+      # windows has a .zip archive rather than .tgz
+      - goos: windows
+        format: zip
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli-dn/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+    version_overrides:
+      # the download base path changed from ibm-cloud-cli to ibm-cloud-cli-dn at v2.38.0
+      - version_constraint: semver(">= 2.5.0, < 2.38.0")
+        url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tgz
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_macos.tgz
+          - goos: windows
+            format: zip
+            url: https://download.clis.cloud.ibm.com/ibm-cloud-cli/{{trimV .Version}}/binaries/IBM_Cloud_CLI_{{trimV .Version}}_windows_{{.Arch}}.zip
+      # distribution wasn't properly multi-arch until v2.5.0 and newer
+      - version_constraint: semver("< 2.5.0")
+        error_message: Please use v2.5.0 or later
   - type: github_release
     repo_owner: IBM-Cloud
     repo_name: redli


### PR DESCRIPTION
Add support for the ibmcloud tool, a command line interface for IBM Cloud

Note: binaries are hosted on IBM's CDN, not at GitHub Release assets, so this package is `type: http` and follows the same patterns as used in helm/helm and the various kubernetes packages.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IBM Cloud CLI package is now available for installation across supported versions.
  * Cross-platform support: macOS (arm64/amd64), Linux (arm64/amd64), Windows (amd64).
  * Multiple versions exposed (including v2.42.0, v2.38.0, v2.37.0, v2.5.0).
  * Alias added for easier discovery.
  * Version rules: releases older than v2.5.0 are blocked; download paths/formats vary for pre‑v2.38.0 and platform-specific builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->