### PR TITLE
feat: add miceliodev/hif package

### DIFF
--- a/pkgs/miceliodev/hif/pkg.yaml
+++ b/pkgs/miceliodev/hif/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: miceliodev/hif@0.1.0

--- a/pkgs/miceliodev/hif/registry.yaml
+++ b/pkgs/miceliodev/hif/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: http
+    name: miceliodev/hif
+    description: hif — the Micelio command-line client. A forge-first version-control system for the agent era.
+    link: https://micelio.dev
+    url: https://micelio-releases.t3.storage.dev/hif/{{.Version}}/hif-{{.OS}}-{{.Arch}}.{{.Format}}
+    files:
+      - name: hif
+    replacements:
+      amd64: x64
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: http
+      url: https://micelio-releases.t3.storage.dev/hif/{{.Version}}/SHA256SUMS
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -60588,6 +60588,23 @@ packages:
               file_format: regexp
               pattern:
                 checksum: (\b[A-Fa-f0-9]{64}\b)
+  - type: http
+    name: miceliodev/hif
+    description: hif — the Micelio command-line client. A forge-first version-control system for the agent era.
+    link: https://micelio.dev
+    url: https://micelio-releases.t3.storage.dev/hif/{{.Version}}/hif-{{.OS}}-{{.Arch}}.{{.Format}}
+    files:
+      - name: hif
+    replacements:
+      amd64: x64
+    format: tar.gz
+    supported_envs:
+      - darwin
+      - linux
+    checksum:
+      type: http
+      url: https://micelio-releases.t3.storage.dev/hif/{{.Version}}/SHA256SUMS
+      algorithm: sha256
   - type: github_release
     repo_owner: michidk
     repo_name: vscli


### PR DESCRIPTION
Adds the `miceliodev/hif` package — [hif](https://micelio.dev) is the Micelio command-line client, a forge-first version-control system for the agent era.

## Package details

- **Type**: `http` (binaries are hosted on Tigris storage at `micelio-releases.t3.storage.dev`, not on GitHub Releases)
- **Supported platforms**: darwin/amd64, darwin/arm64, linux/amd64, linux/arm64
- **Archive format**: `tar.gz`
- **Checksum**: SHA256SUMS file hosted alongside each version
- **First version**: `0.1.0`

## Verification

I've verified the artifacts and checksums are publicly accessible without auth:

```
$ curl -I https://micelio-releases.t3.storage.dev/hif/0.1.0/hif-darwin-arm64.tar.gz
HTTP/2 200

$ curl -sSL https://micelio-releases.t3.storage.dev/hif/0.1.0/hif-darwin-arm64.tar.gz | tar -xz && ./hif --version
hif 0.1.0
```

## Why draft

Opening as draft so the Aqua Registry maintainers can review the schema. I'll move it out of draft once any feedback is addressed. I modeled this after the [glossia.ai/cli package](https://github.com/aquaproj/aqua-registry/pull/48807) which uses the same HTTP-hosted pattern.