### PR TITLE
fix(temporalio/temporal): refresh server bundle binaries

### DIFF
--- a/pkgs/temporalio/temporal/pkg.yaml
+++ b/pkgs/temporalio/temporal/pkg.yaml
@@ -1,3 +1,3 @@
 packages:
   - name: temporalio/temporal
-    version: v1.15.1
+    version: v1.30.3

--- a/pkgs/temporalio/temporal/pkg.yaml
+++ b/pkgs/temporalio/temporal/pkg.yaml
@@ -1,3 +1,6 @@
 packages:
+  - name: temporalio/temporal@v1.30.4
   - name: temporalio/temporal
-    version: v1.30.3
+    version: v1.30.1
+  - name: temporalio/temporal
+    version: v1.29.6

--- a/pkgs/temporalio/temporal/registry.yaml
+++ b/pkgs/temporalio/temporal/registry.yaml
@@ -3,14 +3,24 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal service and CLI
+    description: Temporal Server bundle (temporal-server, tdbg, and database tools)
     asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
       - goos: windows
         format: zip
     files:
-      - name: tctl
+      - name: temporal-server
+      - name: temporal-cassandra-tool
+      - name: temporal-sql-tool
+    version_overrides:
+      - version_constraint: "semver(\">= 1.30.1\")"
+        files:
+          - name: temporal-server
+          - name: temporal-cassandra-tool
+          - name: temporal-sql-tool
+          - name: temporal-elasticsearch-tool
+          - name: tdbg
     checksum:
       type: github_release
       asset: checksums.txt

--- a/pkgs/temporalio/temporal/registry.yaml
+++ b/pkgs/temporalio/temporal/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal Server bundle (temporal-server, tdbg, and database tools)
+    description: Temporal Server bundle (temporal-server + database tools)
     asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
@@ -14,7 +14,7 @@ packages:
       - name: temporal-cassandra-tool
       - name: temporal-sql-tool
     version_overrides:
-      - version_constraint: "semver(\">= 1.30.1\")"
+      - version_constraint: semver(">= 1.30.1")
         files:
           - name: temporal-server
           - name: temporal-cassandra-tool

--- a/pkgs/temporalio/temporal/registry.yaml
+++ b/pkgs/temporalio/temporal/registry.yaml
@@ -4,24 +4,35 @@ packages:
     repo_owner: temporalio
     repo_name: temporal
     description: Temporal Server bundle (temporal-server + database tools)
-    asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
     files:
       - name: temporal-server
       - name: temporal-cassandra-tool
       - name: temporal-sql-tool
+      - name: temporal-elasticsearch-tool
+      - name: tdbg
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.30.1")
+      - version_constraint: semver("<= 1.30.1")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         files:
           - name: temporal-server
           - name: temporal-cassandra-tool
           - name: temporal-sql-tool
-          - name: temporal-elasticsearch-tool
-          - name: tdbg
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -86488,27 +86488,38 @@ packages:
     repo_owner: temporalio
     repo_name: temporal
     description: Temporal Server bundle (temporal-server + database tools)
-    asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
     files:
       - name: temporal-server
       - name: temporal-cassandra-tool
       - name: temporal-sql-tool
+      - name: temporal-elasticsearch-tool
+      - name: tdbg
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.30.1")
+      - version_constraint: semver("<= 1.30.1")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         files:
           - name: temporal-server
           - name: temporal-cassandra-tool
           - name: temporal-sql-tool
-          - name: temporal-elasticsearch-tool
-          - name: tdbg
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: tenable
     repo_name: terrascan

--- a/registry.yaml
+++ b/registry.yaml
@@ -86487,14 +86487,24 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal service and CLI
+    description: Temporal Server bundle (temporal-server, tdbg, and database tools)
     asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
       - goos: windows
         format: zip
     files:
-      - name: tctl
+      - name: temporal-server
+      - name: temporal-cassandra-tool
+      - name: temporal-sql-tool
+    version_overrides:
+      - version_constraint: "semver(\">= 1.30.1\")"
+        files:
+          - name: temporal-server
+          - name: temporal-cassandra-tool
+          - name: temporal-sql-tool
+          - name: temporal-elasticsearch-tool
+          - name: tdbg
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -86487,7 +86487,7 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal Server bundle (temporal-server, tdbg, and database tools)
+    description: Temporal Server bundle (temporal-server + database tools)
     asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     overrides:
@@ -86498,7 +86498,7 @@ packages:
       - name: temporal-cassandra-tool
       - name: temporal-sql-tool
     version_overrides:
-      - version_constraint: "semver(\">= 1.30.1\")"
+      - version_constraint: semver(">= 1.30.1")
         files:
           - name: temporal-server
           - name: temporal-cassandra-tool


### PR DESCRIPTION
## Summary
- update package description and binary list to match the modern server bundle
- enforce new `tdbg` + `temporal-elasticsearch-tool` starting at v1.30.1 while keeping older releases installable
- bump validation matrix to v1.30.3 and regenerate aggregated registry

Disclosure: I'm a Temporal employee. This PR is a personal contribution, not an official Temporal packaging effort — please treat it like any other community submission.

AI assistance: Assisted by Claude Code and GPT-5-Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Temporal Server dependency from v1.15.1 to v1.30.3
  * Updated release bundle to ship temporal-server, temporal-cassandra-tool, and temporal-sql-tool (replacing the previous CLI-only artifact)
  * Added conditional artifacts for versions >= 1.30.1 to include temporal-elasticsearch-tool and tdbg
<!-- end of auto-generated comment: release notes by coderabbit.ai -->