### PR TITLE
feat: add trzsz/trzsz-go

### DIFF
--- a/pkgs/trzsz/trzsz-go/pkg.yaml
+++ b/pkgs/trzsz/trzsz-go/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: trzsz/trzsz-go@v1.2.0
+  - name: trzsz/trzsz-go
+    version: v0.1.8
+  - name: trzsz/trzsz-go
+    version: v0.1.7

--- a/pkgs/trzsz/trzsz-go/registry.yaml
+++ b/pkgs/trzsz/trzsz-go/registry.yaml
@@ -4,6 +4,13 @@ packages:
     repo_owner: trzsz
     repo_name: trzsz-go
     description: trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )
+    files:
+      - name: trzsz
+        src: "{{.AssetWithoutExt}}/trzsz"
+      - name: trz
+        src: "{{.AssetWithoutExt}}/trzsz"
+      - name: tsz
+        src: "{{.AssetWithoutExt}}/trzsz"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.8"
@@ -18,6 +25,13 @@ packages:
             format: zip
       - version_constraint: semver("<= 0.1.7")
         asset: trzsz_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: trzsz
+            src: "bin/trzsz"
+          - name: trz
+            src: "bin/trz"
+          - name: tsz
+            src: "bin/tsz"
         format: zip
         rosetta2: true
         windows_arm_emulation: true

--- a/pkgs/trzsz/trzsz-go/registry.yaml
+++ b/pkgs/trzsz/trzsz-go/registry.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: trzsz
+    repo_name: trzsz-go
+    description: trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.8"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.7")
+        asset: trzsz_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: trzsz_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/trzsz/trzsz-go/registry.yaml
+++ b/pkgs/trzsz/trzsz-go/registry.yaml
@@ -8,9 +8,9 @@ packages:
       - name: trzsz
         src: "{{.AssetWithoutExt}}/trzsz"
       - name: trz
-        src: "{{.AssetWithoutExt}}/trzsz"
+        src: "{{.AssetWithoutExt}}/trz"
       - name: tsz
-        src: "{{.AssetWithoutExt}}/trzsz"
+        src: "{{.AssetWithoutExt}}/tsz"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.8"

--- a/registry.yaml
+++ b/registry.yaml
@@ -88933,6 +88933,47 @@ packages:
           - name: trunk
   - type: github_release
     repo_owner: trzsz
+    repo_name: trzsz-go
+    description: trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.8"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.7")
+        asset: trzsz_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: trzsz_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: trzsz_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: trzsz
     repo_name: trzsz-ssh
     description: trzsz-ssh ( tssh ) is an ssh client designed as a drop-in replacement for the openssh client. It aims to provide complete compatibility with openssh, mirroring all its features, while also offering additional useful features. Such as login prompt, batch login, remember password, automated interaction, trzsz, zmodem(rz/sz), udp mode like mosh, etc
     files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -88939,9 +88939,9 @@ packages:
       - name: trzsz
         src: "{{.AssetWithoutExt}}/trzsz"
       - name: trz
-        src: "{{.AssetWithoutExt}}/trzsz"
+        src: "{{.AssetWithoutExt}}/trz"
       - name: tsz
-        src: "{{.AssetWithoutExt}}/trzsz"
+        src: "{{.AssetWithoutExt}}/tsz"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.8"

--- a/registry.yaml
+++ b/registry.yaml
@@ -88935,6 +88935,13 @@ packages:
     repo_owner: trzsz
     repo_name: trzsz-go
     description: trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )
+    files:
+      - name: trzsz
+        src: "{{.AssetWithoutExt}}/trzsz"
+      - name: trz
+        src: "{{.AssetWithoutExt}}/trzsz"
+      - name: tsz
+        src: "{{.AssetWithoutExt}}/trzsz"
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.8"
@@ -88949,6 +88956,13 @@ packages:
             format: zip
       - version_constraint: semver("<= 0.1.7")
         asset: trzsz_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: trzsz
+            src: "bin/trzsz"
+          - name: trz
+            src: "bin/trz"
+          - name: tsz
+            src: "bin/tsz"
         format: zip
         rosetta2: true
         windows_arm_emulation: true


### PR DESCRIPTION
[trzsz/trzsz-go](https://github.com/trzsz/trzsz-go) - trzsz-go is the go version of trzsz, makes all terminals that support local shell to support trzsz ( trz / tsz )

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the `trzsz-go` package, making the `trzsz`, `trz`, and `tsz` command-line utilities available
  * Supports multiple versions with optimized handling for different operating systems including Windows, macOS, and Linux
  * Includes configuration for platform-specific binary formats and compatibility across different processor architectures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->