### PR TITLE
feat: add santosr2/TerraTidy

### DIFF
--- a/pkgs/santosr2/TerraTidy/pkg.yaml
+++ b/pkgs/santosr2/TerraTidy/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: santosr2/TerraTidy@v0.2.0-alpha.4
+  - name: santosr2/TerraTidy
+    version: v0.2.0-alpha.3

--- a/pkgs/santosr2/TerraTidy/registry.yaml
+++ b/pkgs/santosr2/TerraTidy/registry.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: santosr2
+    repo_name: TerraTidy
+    description: A comprehensive quality platform for Terraform and Terragrunt
+    files:
+      - name: terratidy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0-alpha.3")
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/santosr2/TerraTidy/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.bundle
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -76070,6 +76070,43 @@ packages:
         files:
           - name: jv
   - type: github_release
+    repo_owner: santosr2
+    repo_name: TerraTidy
+    description: A comprehensive quality platform for Terraform and Terragrunt
+    files:
+      - name: terratidy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0-alpha.3")
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: terratidy-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/santosr2/TerraTidy/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.bundle
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: sarub0b0
     repo_name: kubetui
     description: An intuitive Terminal User Interface (TUI) tool for real-time monitoring and exploration of Kubernetes resources


### PR DESCRIPTION
[santosr2/TerraTidy](https://github.com/santosr2/TerraTidy): A comprehensive quality platform for Terraform and Terragrunt

```sh
aqua g -i santosr2/TerraTidy
```

Close #51714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TerraTidy package is now available in the registry with support for versions v0.2.0-alpha.4 and v0.2.0-alpha.3.
  * Added automated security verification for TerraTidy packages including SHA256 checksums and cryptographic signature validation for enhanced artifact integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->