### PR TITLE
Add max-sixty/worktrunk

### DIFF
--- a/pkgs/max-sixty/worktrunk/pkg.yaml
+++ b/pkgs/max-sixty/worktrunk/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: max-sixty/worktrunk@v0.37.0
+  - name: max-sixty/worktrunk
+    version: v0.1.12

--- a/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/pkgs/max-sixty/worktrunk/registry.yaml
@@ -10,6 +10,9 @@ packages:
         asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -25,6 +28,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: wt
         supported_envs:
           - darwin
           - windows
@@ -33,6 +38,11 @@ packages:
         asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
+          - name: git-wt
+            src: "{{.AssetWithoutExt}}/git-wt"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -46,3 +56,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: wt
+              - name: git-wt

--- a/pkgs/max-sixty/worktrunk/registry.yaml
+++ b/pkgs/max-sixty/worktrunk/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: max-sixty
+    repo_name: worktrunk
+    description: Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.12")
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -60122,6 +60122,9 @@ packages:
         asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
         replacements:
           amd64: x86_64
           darwin: apple-darwin
@@ -60137,6 +60140,8 @@ packages:
               arm64: aarch64
           - goos: windows
             format: zip
+            files:
+              - name: wt
         supported_envs:
           - darwin
           - windows
@@ -60145,6 +60150,11 @@ packages:
         asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
+        files:
+          - name: wt
+            src: "{{.AssetWithoutExt}}/wt"
+          - name: git-wt
+            src: "{{.AssetWithoutExt}}/git-wt"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -60158,6 +60168,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: wt
+              - name: git-wt
   - type: github_release
     repo_owner: maxpert
     repo_name: marmot

--- a/registry.yaml
+++ b/registry.yaml
@@ -60113,6 +60113,52 @@ packages:
           - goos: linux
             format: tar.gz
   - type: github_release
+    repo_owner: max-sixty
+    repo_name: worktrunk
+    description: Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.12")
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: worktrunk-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: maxpert
     repo_name: marmot
     description: A distributed SQLite server with MySQL wire compatible interface


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

`argd s max-sixty/worktrunk` failed first so I generated the package files with `aqua gr` and then ran `argd gr` to update `registry.yaml`

I also ran ` argd t max-sixty/worktrunk` to test that the tool was installed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `max-sixty/worktrunk` package with support for versions v0.37.0 and v0.1.12.
  * Added GitHub release-based package distribution with automated asset selection, checksum verification across multiple platforms and architectures.
  * Version-specific configurations enable different binary packages for older (v0.1.12 and earlier) and newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->