### PR TITLE
feat(sigstore/cosign): support 2.6.3

### DIFF
--- a/pkgs/sigstore/cosign/pkg.yaml
+++ b/pkgs/sigstore/cosign/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: sigstore/cosign@v3.0.6
   - name: sigstore/cosign
-    version: v2.6.2
+    version: v2.6.3
   - name: sigstore/cosign
     version: v1.4.1
   - name: sigstore/cosign

--- a/pkgs/sigstore/cosign/registry.yaml
+++ b/pkgs/sigstore/cosign/registry.yaml
@@ -91,7 +91,7 @@ packages:
           type: github_release
           asset: cosign_checksums.txt
           algorithm: sha256
-      - version_constraint: semver("<= 2.6.2")
+      - version_constraint: semver("<= 2.6.3")
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/pkgs/sigstore/cosign/registry.yaml
+++ b/pkgs/sigstore/cosign/registry.yaml
@@ -91,7 +91,7 @@ packages:
           type: github_release
           asset: cosign_checksums.txt
           algorithm: sha256
-      - version_constraint: semver("<= 2.6.3")
+      - version_constraint: semver("< 3.0.0")
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -78724,7 +78724,7 @@ packages:
           type: github_release
           asset: cosign_checksums.txt
           algorithm: sha256
-      - version_constraint: semver("<= 2.6.2")
+      - version_constraint: semver("<= 2.6.3")
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -78724,7 +78724,7 @@ packages:
           type: github_release
           asset: cosign_checksums.txt
           algorithm: sha256
-      - version_constraint: semver("<= 2.6.3")
+      - version_constraint: semver("< 3.0.0")
         asset: cosign-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated sigstore/cosign to v2.6.3.
  * Adjusted package registry version constraints to allow v2.6.3, ensuring the release artifact selection aligns with the new patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->