### PR TITLE
fix(mvdan/sh): add Windows .exe override for shfmt

### DIFF
--- a/pkgs/mvdan/sh/registry.yaml
+++ b/pkgs/mvdan/sh/registry.yaml
@@ -6,6 +6,9 @@ packages:
     description: A shell parser, formatter, and interpreter with bash and zsh support; includes shfmt
     files:
       - name: shfmt
+    overrides:
+      - goos: windows
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}.exe
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v3.6.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -63753,6 +63753,9 @@ packages:
     description: A shell parser, formatter, and interpreter with bash and zsh support; includes shfmt
     files:
       - name: shfmt
+    overrides:
+      - goos: windows
+        asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}.exe
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v3.6.0"


### PR DESCRIPTION
## Problem

`shfmt` Windows release assets have `.exe` extension (`shfmt_v3.13.1_windows_amd64.exe`) but the registry asset template `shfmt_{{.Version}}_{{.OS}}_{{.Arch}}` produces `shfmt_v3.13.1_windows_amd64` without the extension. Aqua fails to download the binary on Windows.

## Fix

Add a package-level Windows override that appends `.exe` to the asset name:

```yaml
overrides:
  - goos: windows
    asset: shfmt_{{.Version}}_{{.OS}}_{{.Arch}}.exe
```

This applies to all version_overrides since they all share the same asset naming pattern.

## Verification

Release assets confirm `.exe` is required on Windows:
- `shfmt_v3.13.1_windows_386.exe`
- `shfmt_v3.13.1_windows_amd64.exe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows support for shfmt downloads so the correct .exe binary is used, preventing failed installations and execution errors.
  * No other package metadata or version rules were changed.
  * Improves reliability of shfmt installs and updates on Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->