### PR TITLE
Revert "fix kiro.dev/kiro-cli registry entry"

### DIFF
--- a/pkgs/kiro.dev/kiro-cli/registry.yaml
+++ b/pkgs/kiro.dev/kiro-cli/registry.yaml
@@ -14,5 +14,13 @@ packages:
     replacements:
       amd64: x86_64
       arm64: aarch64
+    overrides:
+      - goos: darwin
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
+        format: dmg
+        files:
+          - name: kiro-cli
+            src: Kiro CLI.app/Contents/MacOS/kiro-cli
     supported_envs:
       - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -53289,8 +53289,16 @@ packages:
     replacements:
       amd64: x86_64
       arm64: aarch64
+    overrides:
+      - goos: darwin
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
+        format: dmg
+        files:
+          - name: kiro-cli
+            src: Kiro CLI.app/Contents/MacOS/kiro-cli
     supported_envs:
       - linux
+      - darwin
   - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc


### PR DESCRIPTION
This reverts commit 762347a480bb5d7933e15d67f9b0ca7d45e807a7.

Revert 762347a480bb5d7933e15d67f9b0ca7d45e807a7 to support darwin.