### PR TITLE
Add android-sms-gateway/cli

### DIFF
--- a/pkgs/android-sms-gateway/cli/pkg.yaml
+++ b/pkgs/android-sms-gateway/cli/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: android-sms-gateway/cli@v1.5.0
+  - name: android-sms-gateway/cli
+    version: v0.0.2
+  - name: android-sms-gateway/cli
+    version: v0.0.1

--- a/pkgs/android-sms-gateway/cli/registry.yaml
+++ b/pkgs/android-sms-gateway/cli/registry.yaml
@@ -4,16 +4,10 @@ packages:
     repo_owner: android-sms-gateway
     repo_name: cli
     description: A command-line interface for working with SMS Gateway for Android
-    version_constraint: "false"
     files:
       - name: smsgate
       - name: smsgate-ca
-    overrides:
-      - goos: windows
-        format: zip
-        files:
-          - name: smsgate
-          - name: smsgate-ca
+    version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -60,6 +54,9 @@ packages:
       - version_constraint: "true"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/pkgs/android-sms-gateway/cli/registry.yaml
+++ b/pkgs/android-sms-gateway/cli/registry.yaml
@@ -5,6 +5,15 @@ packages:
     repo_name: cli
     description: A command-line interface for working with SMS Gateway for Android
     version_constraint: "false"
+    files:
+      - name: smsgate
+      - name: smsgate-ca
+    overrides:
+      - goos: windows
+        format: zip
+        files:
+          - name: smsgate.exe
+          - name: smsgate-ca.exe
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -23,6 +32,12 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: smsgate.exe
+                src: cli.exe
+          - files:
+              - name: smsgate
+                src: cli
       - version_constraint: Version == "v0.0.2"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -38,6 +53,10 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: smsgate.exe
+          - files:
+              - name: smsgate
       - version_constraint: "true"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -50,6 +69,3 @@ packages:
           type: github_release
           asset: smsgate_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip

--- a/pkgs/android-sms-gateway/cli/registry.yaml
+++ b/pkgs/android-sms-gateway/cli/registry.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: android-sms-gateway
+    repo_name: cli
+    description: A command-line interface for working with SMS Gateway for Android
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.3"
+        no_asset: true
+      - version_constraint: Version == "v0.0.1"
+        asset: cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v0.0.2"
+        asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: smsgate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: smsgate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/android-sms-gateway/cli/registry.yaml
+++ b/pkgs/android-sms-gateway/cli/registry.yaml
@@ -12,8 +12,8 @@ packages:
       - goos: windows
         format: zip
         files:
-          - name: smsgate.exe
-          - name: smsgate-ca.exe
+          - name: smsgate
+          - name: smsgate-ca
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -33,8 +33,8 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: smsgate.exe
-                src: cli.exe
+              - name: smsgate
+                src: cli
           - files:
               - name: smsgate
                 src: cli
@@ -54,7 +54,7 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: smsgate.exe
+              - name: smsgate
           - files:
               - name: smsgate
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12287,16 +12287,10 @@ packages:
     repo_owner: android-sms-gateway
     repo_name: cli
     description: A command-line interface for working with SMS Gateway for Android
-    version_constraint: "false"
     files:
       - name: smsgate
       - name: smsgate-ca
-    overrides:
-      - goos: windows
-        format: zip
-        files:
-          - name: smsgate
-          - name: smsgate-ca
+    version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -12343,6 +12337,9 @@ packages:
       - version_constraint: "true"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         replacements:
           amd64: x86_64
           darwin: Darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -12295,8 +12295,8 @@ packages:
       - goos: windows
         format: zip
         files:
-          - name: smsgate.exe
-          - name: smsgate-ca.exe
+          - name: smsgate
+          - name: smsgate-ca
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -12316,8 +12316,8 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: smsgate.exe
-                src: cli.exe
+              - name: smsgate
+                src: cli
           - files:
               - name: smsgate
                 src: cli
@@ -12337,7 +12337,7 @@ packages:
           - goos: windows
             format: zip
             files:
-              - name: smsgate.exe
+              - name: smsgate
           - files:
               - name: smsgate
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -12284,6 +12284,59 @@ packages:
         supported_envs:
           - darwin
   - type: github_release
+    repo_owner: android-sms-gateway
+    repo_name: cli
+    description: A command-line interface for working with SMS Gateway for Android
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.3"
+        no_asset: true
+      - version_constraint: Version == "v0.0.1"
+        asset: cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v0.0.2"
+        asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: smsgate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: smsgate_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: ankitpokhrel
     repo_name: jira-cli
     description: Feature-rich interactive Jira command line

--- a/registry.yaml
+++ b/registry.yaml
@@ -12288,6 +12288,15 @@ packages:
     repo_name: cli
     description: A command-line interface for working with SMS Gateway for Android
     version_constraint: "false"
+    files:
+      - name: smsgate
+      - name: smsgate-ca
+    overrides:
+      - goos: windows
+        format: zip
+        files:
+          - name: smsgate.exe
+          - name: smsgate-ca.exe
     version_overrides:
       - version_constraint: Version == "v0.0.3"
         no_asset: true
@@ -12306,6 +12315,12 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: smsgate.exe
+                src: cli.exe
+          - files:
+              - name: smsgate
+                src: cli
       - version_constraint: Version == "v0.0.2"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -12321,6 +12336,10 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: smsgate.exe
+          - files:
+              - name: smsgate
       - version_constraint: "true"
         asset: smsgate_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -12333,9 +12352,6 @@ packages:
           type: github_release
           asset: smsgate_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
   - type: github_release
     repo_owner: ankitpokhrel
     repo_name: jira-cli


### PR DESCRIPTION
[android-sms-gateway/cli](https://github.com/android-sms-gateway/cli) - A command-line interface for working with SMS Gateway for Android

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
