### PR TITLE
feat(LargeModGames/spotatui): scaffold LargeModGames/spotatui

### DIFF
--- a/pkgs/LargeModGames/spotatui/pkg.yaml
+++ b/pkgs/LargeModGames/spotatui/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: LargeModGames/spotatui@v0.38.0
+  - name: LargeModGames/spotatui
+    version: v0.31.0
+  - name: LargeModGames/spotatui
+    version: v0.26.0

--- a/pkgs/LargeModGames/spotatui/registry.yaml
+++ b/pkgs/LargeModGames/spotatui/registry.yaml
@@ -6,52 +6,6 @@ packages:
     description: A fully standalone Spotify client for the terminal. Native streaming included, no daemon required
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.26.0"
-        asset: spotatui-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.31.0")
-        asset: spotatui-{{.OS}}-alpine-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: "true"
         asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -59,14 +13,12 @@ packages:
         replacements:
           amd64: x86_64
           darwin: macos
+          arm64: aarch64
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
         supported_envs:

--- a/pkgs/LargeModGames/spotatui/registry.yaml
+++ b/pkgs/LargeModGames/spotatui/registry.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: LargeModGames
+    repo_name: spotatui
+    description: A fully standalone Spotify client for the terminal. Native streaming included, no daemon required
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.26.0"
+        asset: spotatui-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.31.0")
+        asset: spotatui-{{.OS}}-alpine-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4788,52 +4788,6 @@ packages:
     description: A fully standalone Spotify client for the terminal. Native streaming included, no daemon required
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.26.0"
-        asset: spotatui-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 0.31.0")
-        asset: spotatui-{{.OS}}-alpine-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: darwin
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-            replacements:
-              arm64: aarch64
-          - goos: windows
-            format: zip
-            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: "true"
         asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -4841,14 +4795,12 @@ packages:
         replacements:
           amd64: x86_64
           darwin: macos
+          arm64: aarch64
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
-          - goos: darwin
-            replacements:
-              arm64: aarch64
           - goos: windows
             format: zip
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -4783,6 +4783,79 @@ packages:
       - name: gorss
         src: dist/gorss_{{.OS}}
   - type: github_release
+    repo_owner: LargeModGames
+    repo_name: spotatui
+    description: A fully standalone Spotify client for the terminal. Native streaming included, no daemon required
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.26.0"
+        asset: spotatui-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.31.0")
+        asset: spotatui-{{.OS}}-alpine-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: spotatui-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: Lifailon
     repo_name: lazyjournal
     description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library


### PR DESCRIPTION
[LargeModGames/spotatui](https://github.com/LargeModGames/spotatui) - A fully standalone Spotify client for the terminal. Native streaming included, no daemon required

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
Spotatui is a TUI client for Spotify and is a fork of https://github.com/aquaproj/aqua-registry/tree/main/pkgs/Rigellute/spotify-tui
