### PR TITLE
fix(kirodotdev): rename kiro-cli package

### DIFF
--- a/pkgs/kiro.dev/kiro-cli/pkg.yaml
+++ b/pkgs/kiro.dev/kiro-cli/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: kiro.dev/kiro-cli@2.0.0

--- a/pkgs/kirodotdev/kiro-cli/pkg.yaml
+++ b/pkgs/kirodotdev/kiro-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kirodotdev/kiro-cli@2.0.0

--- a/pkgs/kirodotdev/kiro-cli/registry.yaml
+++ b/pkgs/kirodotdev/kiro-cli/registry.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - type: http
-    name: kiro.dev/kiro-cli
+    name: kirodotdev/kiro-cli
+    aliases:
+      - name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
     url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -53367,7 +53367,9 @@ packages:
         supported_envs:
           - linux
   - type: http
-    name: kiro.dev/kiro-cli
+    name: kirodotdev/kiro-cli
+    aliases:
+      - name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
     url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip


### PR DESCRIPTION
This renames the canonical aqua package name from `kiro.dev/kiro-cli` to `kirodotdev/kiro-cli`.

To avoid breaking existing users, the old package name is kept as a compatibility alias.

## What changed

- Moved the package directory from [`pkgs/kiro.dev/kiro-cli`](../pkgs/kiro.dev/kiro-cli) to [`pkgs/kirodotdev/kiro-cli`](../pkgs/kirodotdev/kiro-cli)
- Changed the canonical package name in [`pkgs/kirodotdev/kiro-cli/registry.yaml`](../pkgs/kirodotdev/kiro-cli/registry.yaml) to `kirodotdev/kiro-cli`
- Added `kiro.dev/kiro-cli` as an alias for compatibility
- Updated [`pkgs/kirodotdev/kiro-cli/pkg.yaml`](../pkgs/kirodotdev/kiro-cli/pkg.yaml)
- Updated the merged [`registry.yaml`](../registry.yaml)

## Why this rename

The current official public GitHub org name for Kiro is [`kirodotdev`](https://github.com/kirodotdev), and there is not currently a separate public `kirodotdev/kiro-cli` repository.

If the Kiro CLI is open-sourced later under that org, using `kirodotdev/kiro-cli` now will align the aqua package name with the most likely future upstream naming.

That makes the package naming more consistent with aqua-registry conventions around canonical upstream ownership, while still preserving compatibility through an alias.

## Compatibility

The old package name is retained as an alias:

- `kirodotdev/kiro-cli` is the new canonical name
- `kiro.dev/kiro-cli` continues to resolve for existing users