### PR TITLE
feat(go-delve/delve): use GitHub release binaries for >= 1.26.2

### DIFF
--- a/pkgs/go-delve/delve/pkg.yaml
+++ b/pkgs/go-delve/delve/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: go-delve/delve@v1.26.2
+  - name: go-delve/delve
+    version: v1.26.1

--- a/pkgs/go-delve/delve/registry.yaml
+++ b/pkgs/go-delve/delve/registry.yaml
@@ -1,12 +1,33 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: go_install
+  - type: github_release
     repo_owner: go-delve
     repo_name: delve
     description: Delve is a debugger for the Go programming language
+    files:
+      - name: dlv
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.26.1")
+        type: go_install
         path: github.com/go-delve/delve/cmd/dlv
-        files:
-          - name: dlv
+      - version_constraint: "true"
+        asset: dlv_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/go-delve/delve/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.cert
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -40474,16 +40474,37 @@ packages:
             format: zip
         github_artifact_attestations:
           signer_workflow: go-acme/lego/.github/workflows/release.yml
-  - type: go_install
+  - type: github_release
     repo_owner: go-delve
     repo_name: delve
     description: Delve is a debugger for the Go programming language
+    files:
+      - name: dlv
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.26.1")
+        type: go_install
         path: github.com/go-delve/delve/cmd/dlv
-        files:
-          - name: dlv
+      - version_constraint: "true"
+        asset: dlv_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - https://github.com/go-delve/delve/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate
+              - https://github.com/go-delve/delve/releases/download/{{.Version}}/checksums.txt.cert
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: go-gost
     repo_name: gost


### PR DESCRIPTION
https://github.com/go-delve/delve/releases

Note: windows/amd64 test fails for me for 1.26.1 on linux/amd64, but it fails in main the same way as well, so I suppose it's not an issue with this PR.

```
Apr 21 19:34:30.142 ERR check file_src is correct program=aqua version=2.57.1 env=windows/amd64 package_name=go-delve/delve package_version=v1.26.1 registry=standard file_name=dlv exe_path=/root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/go-delve/delve/cmd/dlv/v1.26.1/bin/dlv.exe error="check file_src is correct: exe_path isn't found: stat /root/.local/share/aquaproj-aqua/pkgs/go_install/github.com/go-delve/delve/cmd/dlv/v1.26.1/bin/dlv.exe: no such file or directory"
Apr 21 19:34:30.142 ERR executable files aren't found
Files in the unarchived package:
dlv
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
