### PR TITLE
Add ricoberger/grafana-kubernetes-plugin

### DIFF
--- a/pkgs/ricoberger/grafana-kubernetes-plugin/pkg.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: ricoberger/grafana-kubernetes-plugin@v0.5.1
+  - name: ricoberger/grafana-kubernetes-plugin
+    version: v0.4.0

--- a/pkgs/ricoberger/grafana-kubernetes-plugin/pkg.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
   - name: ricoberger/grafana-kubernetes-plugin@v0.5.1
   - name: ricoberger/grafana-kubernetes-plugin
-    version: v0.4.0
+    version: v0.3.0

--- a/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ricoberger
+    repo_name: grafana-kubernetes-plugin
+    description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+      - version_constraint: "true"
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1

--- a/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
@@ -6,16 +6,18 @@ packages:
     description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
       - version_constraint: semver("<= 0.4.0")
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-      - version_constraint: "true"
-        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.{{.Format}}
+        asset: kubectl-grafana.tar.gz
         format: tar.gz
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
+        files:
+          - name: kubectl-grafana
+            src: kubectl-grafana-{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: kubectl-grafana

--- a/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: ricoberger
     repo_name: grafana-kubernetes-plugin
     description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
+    files:
+      - name: kubectl-grafana
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.0")
@@ -19,5 +21,3 @@ packages:
         asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
         format: tar.gz
         windows_arm_emulation: true
-        files:
-          - name: kubectl-grafana

--- a/registry.yaml
+++ b/registry.yaml
@@ -74661,6 +74661,25 @@ packages:
     description: Go license and dependency checker
     path: github.com/ribice/glice/v2/cmd/glice
   - type: github_release
+    repo_owner: ricoberger
+    repo_name: grafana-kubernetes-plugin
+    description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.0")
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+      - version_constraint: "true"
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha1"
+          algorithm: sha1
+  - type: github_release
     repo_owner: rlmcpherson
     repo_name: s3gof3r
     description: Fast, concurrent, streaming access to Amazon S3, including gof3r, a CLI

--- a/registry.yaml
+++ b/registry.yaml
@@ -74664,6 +74664,8 @@ packages:
     repo_owner: ricoberger
     repo_name: grafana-kubernetes-plugin
     description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
+    files:
+      - name: kubectl-grafana
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.0")
@@ -74679,8 +74681,6 @@ packages:
         asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
         format: tar.gz
         windows_arm_emulation: true
-        files:
-          - name: kubectl-grafana
   - type: github_release
     repo_owner: rlmcpherson
     repo_name: s3gof3r

--- a/registry.yaml
+++ b/registry.yaml
@@ -74666,19 +74666,21 @@ packages:
     description: The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+        no_asset: true
       - version_constraint: semver("<= 0.4.0")
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
-      - version_constraint: "true"
-        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.{{.Format}}
+        asset: kubectl-grafana.tar.gz
         format: tar.gz
         windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha1"
-          algorithm: sha1
+        files:
+          - name: kubectl-grafana
+            src: kubectl-grafana-{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: kubectl-grafana-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: kubectl-grafana
   - type: github_release
     repo_owner: rlmcpherson
     repo_name: s3gof3r


### PR DESCRIPTION
[ricoberger/grafana-kubernetes-plugin](https://github.com/ricoberger/grafana-kubernetes-plugin) - The Grafana Kubernetes Plugin allows you to explore your Kubernetes resources and logs directly within Grafana

scaffold ricoberger/grafana-kubernetes-plugin

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
