### PR TITLE
feat: add tak848/ccgate

### DIFF
--- a/pkgs/tak848/ccgate/pkg.yaml
+++ b/pkgs/tak848/ccgate/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: tak848/ccgate@v0.5.3
+  - name: tak848/ccgate
+    version: v0.5.2

--- a/pkgs/tak848/ccgate/registry.yaml
+++ b/pkgs/tak848/ccgate/registry.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tak848
+    repo_name: ccgate
+    description: LLM-powered PermissionRequest hook for coding agents (e.g. Claude Code)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.2")
+        asset: ccgate-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: ccgate-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -85937,6 +85937,32 @@ packages:
           - goos: linux
             asset: tailwindcss-{{.OS}}-{{.Arch}}-musl
   - type: github_release
+    repo_owner: tak848
+    repo_name: ccgate
+    description: LLM-powered PermissionRequest hook for coding agents (e.g. Claude Code)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.2")
+        asset: ccgate-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: ccgate-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: takaishi
     repo_name: awscost
     description: Print AWS costs to text or graph image


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

Add `tak848/ccgate` — an LLM-powered PermissionRequest hook for coding agents (e.g. Claude Code).

- Upstream: https://github.com/tak848/ccgate
- License: MIT
- Language: Go (built with goreleaser)
- Asset pattern: `ccgate-{{.OS}}-{{.Arch}}.{{.Format}}` (`tar.gz` / `zip` for windows)
- Checksum: `checksums.txt` (sha256)
- Supported envs:
  - `v0.5.3` onwards: linux/darwin/windows × amd64/arm64
  - `v0.5.2` and earlier: linux/darwin only (windows assets added in v0.5.3)

### Verification

- `argd s tak848/ccgate` scaffolded cleanly; container tests passed on all 6 environments (linux/darwin/windows × amd64/arm64).
- Installed locally via `aqua i` against this registry and confirmed `ccgate --version` returns `v0.5.3` and `ccgate --help` works as expected.