### PR TITLE
docs: clarify argd scaffold package support

### DIFF
--- a/docs/add_package.md
+++ b/docs/add_package.md
@@ -14,7 +14,8 @@ e.g.
 argd s cli/cli
 ```
 
-For package types other than github_release, specify `-l 1`.
+Auto-generation currently supports only `github_release` and `cargo`.
+For package types other than `github_release` and `cargo`, specify `-l 1` to generate only a template and write the rest manually.
 
 ```sh
 argd s -l 1 "<package name>"
@@ -117,12 +118,13 @@ Especially, we don't accept pull requests not using `argd s`.
 Standard Registry must support not only the latest version but also almost all versions and [various platforms](#supported-os-and-cpu-architecture).
 Many tools have so many versions that people can't check all of them manually.
 So we can't trust the code not using `argd s`.
-`argd s` checks all GitHub Releases and generates code supporting all of them (Strictly speaking, if there are too many GitHub Releases we have to restrict the number of GitHub Releases, though `argd s` can still check over 200 versions).
+For `github_release` packages, `argd s` checks all GitHub Releases and generates code supporting all of them (Strictly speaking, if there are too many GitHub Releases we have to restrict the number of GitHub Releases, though `argd s` can still check over 200 versions).
 `argd s` generates much better code than us.
 
 `argd s` isn't perfect and sometimes `argd s` causes errors and generates invalid code.
 Then you have to fix the code according to the error message.
-`argd s` supports only `github_release` type packages, so for other package types you have to fix the code.
+Code auto-generation currently supports only `github_release` and `cargo`.
+For package types other than `github_release` and `cargo`, `argd s -l 1` generates a template, and you have to fix the code.
 Even if so, you must still use `argd s`.
 `argd s` guarantees the quality of code.
 

--- a/docs/tool.md
+++ b/docs/tool.md
@@ -123,8 +123,8 @@ Code written manually from scratch is not quality assured, so Pull Requests will
 However, code auto-generation is not perfect and often generates incomplete code.
 In that case, you need to manually fix the generated code.
 
-aqua supports various package types, but currently auto-generation mainly supports only `github_release` and `cargo`.
-When generating code for other packages like `http` package, specify `-l 1` to generate only a template and write the rest manually.
+aqua supports various package types, but auto-generation currently supports only `github_release` and `cargo`.
+When generating code for package types other than `github_release` and `cargo`, such as `http`, specify `-l 1` to generate only a template and write the rest manually.
 
 ```sh
 argd s -l 1 "<package name>"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well
  - Not applicable: this pull request only updates documentation.

<!-- Please write the description here -->

## Summary

- Clarify that `argd s` auto-generation currently supports only `github_release` and `cargo`.
- Align `docs/add_package.md` with `docs/tool.md`.
- Clarify that package types other than `github_release` and `cargo` should use `argd s -l 1` to generate a template before manual fix-up.

## Why

`docs/add_package.md` and `docs/tool.md` contradicted each other about `cargo` packages. `docs/add_package.md` implied all non-`github_release` packages should use `-l 1`, while `docs/tool.md` listed `cargo` as supported by auto-generation.

This change makes the supported package types explicit and keeps the fallback guidance for other package types.

## AI Disclosure

This pull request was prepared with assistance from Codex. I reviewed the change and take responsibility for the contents.
