### PR TITLE
fix(tstack/lnav): support v0.14.0 assets

### DIFF
--- a/pkgs/tstack/lnav/pkg.yaml
+++ b/pkgs/tstack/lnav/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: tstack/lnav@v0.13.2
+  - name: tstack/lnav@v0.14.0
   - name: tstack/lnav
     version: v0.12.4
   - name: tstack/lnav

--- a/pkgs/tstack/lnav/registry.yaml
+++ b/pkgs/tstack/lnav/registry.yaml
@@ -160,7 +160,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v0.14.0"
+      - version_constraint: semver(">= 0.14.0")
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true

--- a/pkgs/tstack/lnav/registry.yaml
+++ b/pkgs/tstack/lnav/registry.yaml
@@ -160,6 +160,30 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: Version == "v0.14.0"
+        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: lnav
+            src: lnav-{{trimV .Version}}/lnav
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: lnav
+                src: lnav-{{trimV .Version}}/bin/lnav
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
       - version_constraint: "true"
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
@@ -178,4 +202,4 @@ packages:
             asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
             files:
               - name: lnav
-                src: lnav-{{trimV .Version}}/bin/lnav.exe
+                src: lnav-{{trimV .Version}}/bin/lnav

--- a/pkgs/tstack/lnav/registry.yaml
+++ b/pkgs/tstack/lnav/registry.yaml
@@ -160,7 +160,26 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver(">= 0.14.0")
+      - version_constraint: semver("< 0.14.0")
+        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: lnav
+            src: lnav-{{trimV .Version}}/lnav
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: lnav
+                src: lnav-{{trimV .Version}}/bin/lnav
+      - version_constraint: "true"
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
@@ -184,22 +203,3 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: lnav
-            src: lnav-{{trimV .Version}}/lnav
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        overrides:
-          - goos: darwin
-            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: lnav
-                src: lnav-{{trimV .Version}}/bin/lnav

--- a/registry.yaml
+++ b/registry.yaml
@@ -90043,7 +90043,26 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver(">= 0.14.0")
+      - version_constraint: semver("< 0.14.0")
+        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        files:
+          - name: lnav
+            src: lnav-{{trimV .Version}}/lnav
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: windows
+            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: lnav
+                src: lnav-{{trimV .Version}}/bin/lnav
+      - version_constraint: "true"
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
@@ -90067,25 +90086,6 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
-        format: zip
-        rosetta2: true
-        windows_arm_emulation: true
-        files:
-          - name: lnav
-            src: lnav-{{trimV .Version}}/lnav
-        replacements:
-          amd64: x86_64
-          darwin: macos
-        overrides:
-          - goos: darwin
-            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: windows
-            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-            files:
-              - name: lnav
-                src: lnav-{{trimV .Version}}/bin/lnav
   - type: github_release
     repo_owner: tuist
     repo_name: tuist

--- a/registry.yaml
+++ b/registry.yaml
@@ -90043,6 +90043,30 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: Version == "v0.14.0"
+        asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: lnav
+            src: lnav-{{trimV .Version}}/lnav
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lnav-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+            files:
+              - name: lnav
+                src: lnav-{{trimV .Version}}/bin/lnav
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
       - version_constraint: "true"
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
@@ -90061,7 +90085,7 @@ packages:
             asset: lnav-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
             files:
               - name: lnav
-                src: lnav-{{trimV .Version}}/bin/lnav.exe
+                src: lnav-{{trimV .Version}}/bin/lnav
   - type: github_release
     repo_owner: tuist
     repo_name: tuist

--- a/registry.yaml
+++ b/registry.yaml
@@ -90043,7 +90043,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: Version == "v0.14.0"
+      - version_constraint: semver(">= 0.14.0")
         asset: lnav-{{trimV .Version}}-{{.OS}}-musl-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Follow-up/replacement for #51948.

lnav v0.14.0 changed release assets:

- macOS now publishes `lnav-0.14.0-aarch64-macos.zip`
- macOS no longer publishes `lnav-0.14.0-x86_64-macos.zip` or a universal macOS archive

This PR updates the latest test version to v0.14.0 and adds a v0.14.0-and-later registry override so `darwin/arm64` resolves to the aarch64 macOS archive instead of the old Rosetta x86_64 asset name. It also stops advertising `darwin/amd64` for these versions because no Intel macOS asset is published in the new layout.

Verification:

- `aqua exec -- conftest test --combine pkgs/tstack/lnav/*`
- `aqua exec -- argd t tstack/lnav`
- Linux direct binary execution from the argd container: `lnav 0.14.0`
- Copied macOS arm64 binary execution: `lnav 0.14.0`

Implemented with assistance from Codex. I reviewed the changes and am responsible for this PR.
