### PR TITLE
Add google/google-java-format

### DIFF
--- a/pkgs/google/google-java-format/pkg.yaml
+++ b/pkgs/google/google-java-format/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: google/google-java-format@v1.35.0
+  - name: google/google-java-format
+    version: v1.25.2
+  - name: google/google-java-format
+    version: v1.19.2

--- a/pkgs/google/google-java-format/pkg.yaml
+++ b/pkgs/google/google-java-format/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google/google-java-format@v1.35.0

--- a/pkgs/google/google-java-format/registry.yaml
+++ b/pkgs/google/google-java-format/registry.yaml
@@ -7,26 +7,26 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.19.2")
-      - version_constraint: semver("<= 1.25.2")
-        asset: google-java-format_{{.OS}}-x86-64
+        asset: google-java-format-{{trimV .Version}}-all-deps.jar
         format: raw
-        overrides:
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
+        complete_windows_ext: false
+      - version_constraint: semver("<= 1.25.2")
+        asset: google-java-format_{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86-64
         supported_envs:
           - linux/amd64
           - darwin/arm64
-          - windows/amd64
+          - windows
       - version_constraint: "true"
-        asset: google-java-format_{{.OS}}-x86-64
+        asset: google-java-format_{{.OS}}-{{.Arch}}
+        windows_arm_emulation: true
         format: raw
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: google-java-format_{{.OS}}-{{.Arch}}
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86-64
         supported_envs:
           - linux
           - darwin/arm64
-          - windows/amd64
+          - windows

--- a/pkgs/google/google-java-format/registry.yaml
+++ b/pkgs/google/google-java-format/registry.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: google
+    repo_name: google-java-format
+    description: Reformats Java source code to comply with Google Java Style
+    files:
+      - name: google-java-format
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.19.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.25.2")
+        asset: google-java-format_{{.OS}}-x86-64
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+        overrides:
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: google-java-format_{{.OS}}-x86-64
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: google-java-format_{{.OS}}-{{.Arch}}
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}

--- a/pkgs/google/google-java-format/registry.yaml
+++ b/pkgs/google/google-java-format/registry.yaml
@@ -4,32 +4,29 @@ packages:
     repo_owner: google
     repo_name: google-java-format
     description: Reformats Java source code to comply with Google Java Style
-    files:
-      - name: google-java-format
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.19.2")
-        no_asset: true
       - version_constraint: semver("<= 1.25.2")
         asset: google-java-format_{{.OS}}-x86-64
         format: raw
+        overrides:
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
           - darwin/arm64
           - windows/amd64
-        overrides:
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
       - version_constraint: "true"
         asset: google-java-format_{{.OS}}-x86-64
         format: raw
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
         overrides:
           - goos: linux
             goarch: arm64
             asset: google-java-format_{{.OS}}-{{.Arch}}
           - goos: darwin
             asset: google-java-format_{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -42781,29 +42781,29 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.19.2")
-      - version_constraint: semver("<= 1.25.2")
-        asset: google-java-format_{{.OS}}-x86-64
+        asset: google-java-format-{{trimV .Version}}-all-deps.jar
         format: raw
-        overrides:
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
+        complete_windows_ext: false
+      - version_constraint: semver("<= 1.25.2")
+        asset: google-java-format_{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86-64
         supported_envs:
           - linux/amd64
           - darwin/arm64
-          - windows/amd64
+          - windows
       - version_constraint: "true"
-        asset: google-java-format_{{.OS}}-x86-64
+        asset: google-java-format_{{.OS}}-{{.Arch}}
+        windows_arm_emulation: true
         format: raw
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: google-java-format_{{.OS}}-{{.Arch}}
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
+        replacements:
+          amd64: x86-64
         supported_envs:
           - linux
           - darwin/arm64
-          - windows/amd64
+          - windows
   - type: github_release
     repo_owner: google
     repo_name: jsonnet

--- a/registry.yaml
+++ b/registry.yaml
@@ -42776,6 +42776,39 @@ packages:
       - version_constraint: "true"
   - type: github_release
     repo_owner: google
+    repo_name: google-java-format
+    description: Reformats Java source code to comply with Google Java Style
+    files:
+      - name: google-java-format
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.19.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.25.2")
+        asset: google-java-format_{{.OS}}-x86-64
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+        overrides:
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}
+      - version_constraint: "true"
+        asset: google-java-format_{{.OS}}-x86-64
+        format: raw
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: google-java-format_{{.OS}}-{{.Arch}}
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}
+  - type: github_release
+    repo_owner: google
     repo_name: jsonnet
     asset: jsonnet-bin-{{.Version}}-linux.tar.gz
     supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -42778,35 +42778,32 @@ packages:
     repo_owner: google
     repo_name: google-java-format
     description: Reformats Java source code to comply with Google Java Style
-    files:
-      - name: google-java-format
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.19.2")
-        no_asset: true
       - version_constraint: semver("<= 1.25.2")
         asset: google-java-format_{{.OS}}-x86-64
         format: raw
+        overrides:
+          - goos: darwin
+            asset: google-java-format_{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
           - darwin/arm64
           - windows/amd64
-        overrides:
-          - goos: darwin
-            asset: google-java-format_{{.OS}}-{{.Arch}}
       - version_constraint: "true"
         asset: google-java-format_{{.OS}}-x86-64
         format: raw
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
         overrides:
           - goos: linux
             goarch: arm64
             asset: google-java-format_{{.OS}}-{{.Arch}}
           - goos: darwin
             asset: google-java-format_{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
   - type: github_release
     repo_owner: google
     repo_name: jsonnet


### PR DESCRIPTION
## Summary
Add an aqua-registry package entry for `google/google-java-format`.

## Changes
- add `pkgs/google/google-java-format/registry.yaml`
- add `pkgs/google/google-java-format/pkg.yaml`
- regenerate top-level `registry.yaml`

## Notes
- modeled on the current GitHub release asset layout, including the newer native binaries
- older versions without release assets are marked `no_asset: true`
- package-level `conftest test --combine pkgs/google/google-java-format/*` passed locally
