### PR TITLE
Add jonwiggins/xmloxide

### DIFF
--- a/pkgs/jonwiggins/xmloxide/pkg.yaml
+++ b/pkgs/jonwiggins/xmloxide/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jonwiggins/xmloxide@v0.4.2

--- a/pkgs/jonwiggins/xmloxide/registry.yaml
+++ b/pkgs/jonwiggins/xmloxide/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jonwiggins
+    repo_name: xmloxide
+    description: A pure Rust reimplementation of libxml2
+    files:
+      - name: xmllint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: xmllint_{{.OS}}-x86-64
+        format: raw
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+          - windows/amd64
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: xmllint_{{.OS}}-aarch64
+          - goos: darwin
+            goarch: arm64
+            asset: xmllint_{{.OS}}-aarch64

--- a/pkgs/jonwiggins/xmloxide/registry.yaml
+++ b/pkgs/jonwiggins/xmloxide/registry.yaml
@@ -11,20 +11,13 @@ packages:
       - version_constraint: semver("<= 0.4.1")
         no_asset: true
       - version_constraint: "true"
-        asset: xmllint_{{.OS}}-x86-64
+        asset: xmllint_{{.OS}}-{{.Arch}}
         format: raw
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          amd64: x86-64
         checksum:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-          - windows/amd64
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: xmllint_{{.OS}}-aarch64
-          - goos: darwin
-            goarch: arm64
-            asset: xmllint_{{.OS}}-aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -50749,23 +50749,16 @@ packages:
       - version_constraint: semver("<= 0.4.1")
         no_asset: true
       - version_constraint: "true"
-        asset: xmllint_{{.OS}}-x86-64
+        asset: xmllint_{{.OS}}-{{.Arch}}
         format: raw
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          amd64: x86-64
         checksum:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-          - windows/amd64
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: xmllint_{{.OS}}-aarch64
-          - goos: darwin
-            goarch: arm64
-            asset: xmllint_{{.OS}}-aarch64
   - type: github_release
     repo_owner: jorgelbg
     repo_name: pinentry-touchid

--- a/registry.yaml
+++ b/registry.yaml
@@ -50739,6 +50739,34 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: jonwiggins
+    repo_name: xmloxide
+    description: A pure Rust reimplementation of libxml2
+    files:
+      - name: xmllint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.4.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: xmllint_{{.OS}}-x86-64
+        format: raw
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+          - windows/amd64
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: xmllint_{{.OS}}-aarch64
+          - goos: darwin
+            goarch: arm64
+            asset: xmllint_{{.OS}}-aarch64
+  - type: github_release
     repo_owner: jorgelbg
     repo_name: pinentry-touchid
     description: Custom GPG pinentry program for macOS that allows using Touch ID for fetching the password from the macOS keychain


### PR DESCRIPTION
[jonwiggins/xmloxide](https://github.com/jonwiggins/xmloxide) - A pure Rust reimplementation of libxml2

## Summary
Add an aqua-registry package entry for `jonwiggins/xmloxide`.

## Changes
- add `pkgs/jonwiggins/xmloxide/registry.yaml`
- add `pkgs/jonwiggins/xmloxide/pkg.yaml`
- regenerate top-level `registry.yaml`

## Notes
- installs the `xmllint` binary from the upstream GitHub release assets
- uses the published `SHA256SUMS` file for checksum verification
- package-level `conftest test --combine pkgs/jonwiggins/xmloxide/*` passed locally
