### PR TITLE
fix(shellcheck): resolve windows zip binary paths

### DIFF
--- a/pkgs/koalaman/shellcheck/registry.yaml
+++ b/pkgs/koalaman/shellcheck/registry.yaml
@@ -21,7 +21,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
-                src: shellcheck-{{.Version}}.exe
+                src: shellcheck-{{.Version}}
         replacements:
           amd64: x86_64
         supported_envs:
@@ -45,6 +45,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: ./shellcheck
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
@@ -60,3 +61,4 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: ./shellcheck

--- a/registry.yaml
+++ b/registry.yaml
@@ -53532,7 +53532,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
-                src: shellcheck-{{.Version}}.exe
+                src: shellcheck-{{.Version}}
         replacements:
           amd64: x86_64
         supported_envs:
@@ -53556,6 +53556,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: ./shellcheck
       - version_constraint: "true"
         asset: shellcheck-{{.Version}}.{{.OS}}.{{.Arch}}.{{.Format}}
         format: tar.xz
@@ -53571,6 +53572,7 @@ packages:
             format: zip
             files:
               - name: shellcheck
+                src: ./shellcheck
   - type: github_release
     repo_owner: koki-develop
     repo_name: clive


### PR DESCRIPTION
## Summary
- make shellcheck Windows zip mappings explicit for newer releases
- keep the older Windows mapping on the same non-`.exe` pattern
- regenerate `registry.yaml`

## Verification
- `conftest test --combine pkgs/koalaman/shellcheck/*`
- `AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua i --all`
- `AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua which shellcheck`

The Windows-targeted install probe resolved to `.../shellcheck-v0.11.0.zip/shellcheck.exe`.