### PR TITLE
feat: add codeberg.org/itiquette/gommitlint

### DIFF
--- a/pkgs/codeberg.org/itiquette/gommitlint/pkg.yaml
+++ b/pkgs/codeberg.org/itiquette/gommitlint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: codeberg.org/itiquette/gommitlint@

--- a/pkgs/codeberg.org/itiquette/gommitlint/pkg.yaml
+++ b/pkgs/codeberg.org/itiquette/gommitlint/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: codeberg.org/itiquette/gommitlint@
+  - name: codeberg.org/itiquette/gommitlint@v0.9.11

--- a/pkgs/codeberg.org/itiquette/gommitlint/registry.yaml
+++ b/pkgs/codeberg.org/itiquette/gommitlint/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: codeberg.org/itiquette/gommitlint
+    type: github_release
+    repo_owner: codeberg.org
+    repo_name: itiquette

--- a/pkgs/codeberg.org/itiquette/gommitlint/registry.yaml
+++ b/pkgs/codeberg.org/itiquette/gommitlint/registry.yaml
@@ -1,6 +1,24 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - name: codeberg.org/itiquette/gommitlint
-    type: github_release
-    repo_owner: codeberg.org
-    repo_name: itiquette
+  - type: http
+    name: codeberg.org/itiquette/gommitlint
+    description: Git commit message linter and validator with Conventional Commits support
+    link: https://codeberg.org/itiquette/gommitlint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://codeberg.org/itiquette/gommitlint/releases/download/{{.Version}}/gommitlint-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        files:
+          - name: gommitlint
+            src: gommitlint-{{trimV .Version}}-{{.OS}}-{{.Arch}}/gommitlint
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: http
+          url: https://codeberg.org/itiquette/gommitlint/releases/download/{{.Version}}/gommitlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -25811,6 +25811,10 @@ packages:
             files:
               - name: cog
                 src: "{{.Arch}}-{{.OS}}/cog.exe"
+  - name: codeberg.org/itiquette/gommitlint
+    type: github_release
+    repo_owner: codeberg.org
+    repo_name: itiquette
   - type: http
     name: codeberg.org/mergiraf/mergiraf
     description: A syntax-aware git merge driver for a growing collection of programming languages and file formats

--- a/registry.yaml
+++ b/registry.yaml
@@ -25811,10 +25811,28 @@ packages:
             files:
               - name: cog
                 src: "{{.Arch}}-{{.OS}}/cog.exe"
-  - name: codeberg.org/itiquette/gommitlint
-    type: github_release
-    repo_owner: codeberg.org
-    repo_name: itiquette
+  - type: http
+    name: codeberg.org/itiquette/gommitlint
+    description: Git commit message linter and validator with Conventional Commits support
+    link: https://codeberg.org/itiquette/gommitlint
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        url: https://codeberg.org/itiquette/gommitlint/releases/download/{{.Version}}/gommitlint-{{trimV .Version}}-{{.OS}}-{{.Arch}}.tar.gz
+        format: tar.gz
+        files:
+          - name: gommitlint
+            src: gommitlint-{{trimV .Version}}-{{.OS}}-{{.Arch}}/gommitlint
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: http
+          url: https://codeberg.org/itiquette/gommitlint/releases/download/{{.Version}}/gommitlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64
   - type: http
     name: codeberg.org/mergiraf/mergiraf
     description: A syntax-aware git merge driver for a growing collection of programming languages and file formats


### PR DESCRIPTION
[codeberg.org/itiquette/gommitlint](https://codeberg.org/itiquette/gommitlint) - Git commit message linter and validator with Conventional Commits support

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Adds [`codeberg.org/itiquette/gommitlint`](https://codeberg.org/itiquette/gommitlint) — a Git commit-message linter with Conventional Commits support.

Codeberg-hosted, so `type: http`. `supported_envs` covers the platforms upstream ships standalone tarballs for: `darwin/arm64`, `linux/amd64`, `linux/arm64`.

Verified locally with `argd s --local -l 1`, `argd t`, and `conftest test --combine`. `gommitlint validate` exercised inside the linux/amd64 test container against valid and invalid messages.