### PR TITLE
feat: add IohannRabeson/tmignore-rs

### DIFF
--- a/pkgs/IohannRabeson/tmignore-rs/pkg.yaml
+++ b/pkgs/IohannRabeson/tmignore-rs/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: IohannRabeson/tmignore-rs@0.3.0
+  - name: IohannRabeson/tmignore-rs@0.3.2
+  - name: IohannRabeson/tmignore-rs
+    version: 0.3.0

--- a/pkgs/IohannRabeson/tmignore-rs/pkg.yaml
+++ b/pkgs/IohannRabeson/tmignore-rs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: IohannRabeson/tmignore-rs@0.3.0

--- a/pkgs/IohannRabeson/tmignore-rs/registry.yaml
+++ b/pkgs/IohannRabeson/tmignore-rs/registry.yaml
@@ -8,6 +8,13 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.1.5")
         no_asset: true
-      - version_constraint: semver("<= 0.3.0")
-      - version_constraint: "true"
+      - version_constraint: semver("= 0.3.1")
         no_asset: true
+      - version_constraint: "true"
+        asset: tmignore-rs_{{trimV .Version}}_{{.Arch}}.zip
+        format: zip
+        replacements:
+          amd64: x86-64
+          arm64: aarch64
+        supported_envs:
+          - darwin

--- a/pkgs/IohannRabeson/tmignore-rs/registry.yaml
+++ b/pkgs/IohannRabeson/tmignore-rs/registry.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: IohannRabeson
+    repo_name: tmignore-rs
+    description: Makes Time Machine respect .gitignore files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        no_asset: true
+      - version_constraint: semver("<= 0.3.0")
+      - version_constraint: "true"
+        no_asset: true

--- a/pkgs/IohannRabeson/tmignore-rs/registry.yaml
+++ b/pkgs/IohannRabeson/tmignore-rs/registry.yaml
@@ -6,9 +6,7 @@ packages:
     description: Makes Time Machine respect .gitignore files
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.1.5")
-        no_asset: true
-      - version_constraint: semver("= 0.3.1")
+      - version_constraint: semver("<= 0.1.5") or Version == "0.3.1"
         no_asset: true
       - version_constraint: "true"
         asset: tmignore-rs_{{trimV .Version}}_{{.Arch}}.zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -3816,9 +3816,16 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.1.5")
         no_asset: true
-      - version_constraint: semver("<= 0.3.0")
-      - version_constraint: "true"
+      - version_constraint: semver("= 0.3.1")
         no_asset: true
+      - version_constraint: "true"
+        asset: tmignore-rs_{{trimV .Version}}_{{.Arch}}.zip
+        format: zip
+        replacements:
+          amd64: x86-64
+          arm64: aarch64
+        supported_envs:
+          - darwin
   - type: github_release
     repo_owner: IvanIsCoding
     repo_name: celq

--- a/registry.yaml
+++ b/registry.yaml
@@ -3809,6 +3809,17 @@ packages:
               - name: redli
                 src: redli_{{.Arch}}.exe
   - type: github_release
+    repo_owner: IohannRabeson
+    repo_name: tmignore-rs
+    description: Makes Time Machine respect .gitignore files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.5")
+        no_asset: true
+      - version_constraint: semver("<= 0.3.0")
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: IvanIsCoding
     repo_name: celq
     description: "celq - A Common Expression Language (CEL) CLI Tool"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3814,9 +3814,7 @@ packages:
     description: Makes Time Machine respect .gitignore files
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.1.5")
-        no_asset: true
-      - version_constraint: semver("= 0.3.1")
+      - version_constraint: semver("<= 0.1.5") or Version == "0.3.1"
         no_asset: true
       - version_constraint: "true"
         asset: tmignore-rs_{{trimV .Version}}_{{.Arch}}.zip


### PR DESCRIPTION
[IohannRabeson/tmignore-rs](https://github.com/IohannRabeson/tmignore-rs) - Makes Time Machine respect .gitignore files

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

## Description

Adds `IohannRabeson/tmignore-rs`.

The upstream release assets are macOS-only zip files named by architecture, so this config maps `amd64` to `x86-64`, maps `arm64` to `aarch64`, and limits supported environments to `darwin`.

The empty `0.3.1` release is marked `no_asset`, and `pkg.yaml` tests both the latest version and an older installable release.

## Verification

- `aqua exec -- conftest test --combine pkgs/IohannRabeson/tmignore-rs/*`
- `aqua exec -- argd t IohannRabeson/tmignore-rs`
- `AQUA_POLICY_CONFIG=/tmp/aqua-policy.yaml aqua -c /tmp/aqua-tmignore-rs.yaml exec -- tmignore-rs --version`
- `git diff --check`
