### PR TITLE
feat: add versity/versitygw

### DIFF
--- a/pkgs/versity/versitygw/pkg.yaml
+++ b/pkgs/versity/versitygw/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: versity/versitygw@v1.4.1
+  - name: versity/versitygw
+    version: v1.3.0
+  - name: versity/versitygw
+    version: v0.14
+  - name: versity/versitygw
+    version: v0.13
+  - name: versity/versitygw
+    version: v0.5
+  - name: versity/versitygw
+    version: v0.4
+  - name: versity/versitygw
+    version: v0.3
+  - name: versity/versitygw
+    version: v0.1

--- a/pkgs/versity/versitygw/registry.yaml
+++ b/pkgs/versity/versitygw/registry.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: versity
+    repo_name: versitygw
+    description: A simple to deploy but feature rich S3 object storage server for your filesystem
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1"
+        asset: versitygw.{{.OS}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4"
+        asset: versitygw.{{.OS}}_{{.Arch}}.linux
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: darwin
+            asset: versitygw.{{.OS}}_{{.Arch}}.darwin
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.5"
+        asset: versitygw.{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.14"
+        asset: versitygw_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: versitygw.{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.13.0")
+        asset: versitygw_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.3.0")
+        asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/versity/versitygw/registry.yaml
+++ b/pkgs/versity/versitygw/registry.yaml
@@ -36,14 +36,15 @@ packages:
       - version_constraint: Version == "v0.14"
         asset: versitygw_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: cmd/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
+          enabled: false # checksums.txt has broken asset names for v0.14
         supported_envs:
           - linux
           - darwin
@@ -59,6 +60,9 @@ packages:
       - version_constraint: semver("<= 0.13.0")
         asset: versitygw_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: cmd/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -73,6 +77,9 @@ packages:
       - version_constraint: semver("<= 1.3.0")
         asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -87,6 +94,9 @@ packages:
       - version_constraint: "true"
         asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -99,3 +109,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: versitygw
+                src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw

--- a/registry.yaml
+++ b/registry.yaml
@@ -92021,6 +92021,105 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: versity
+    repo_name: versitygw
+    description: A simple to deploy but feature rich S3 object storage server for your filesystem
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1"
+        asset: versitygw.{{.OS}}
+        format: raw
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.4"
+        asset: versitygw.{{.OS}}_{{.Arch}}.linux
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: darwin
+            asset: versitygw.{{.OS}}_{{.Arch}}.darwin
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.5"
+        asset: versitygw.{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "v0.14"
+        asset: versitygw_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.0")
+        asset: versitygw.{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.13.0")
+        asset: versitygw_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.3.0")
+        asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: vi
     repo_name: websocat
     description: "Command-line client for WebSockets, like netcat (or curl) for ws:// with advanced socat-like functions"

--- a/registry.yaml
+++ b/registry.yaml
@@ -92056,14 +92056,15 @@ packages:
       - version_constraint: Version == "v0.14"
         asset: versitygw_.{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: cmd/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
+          enabled: false # checksums.txt has broken asset names for v0.14
         supported_envs:
           - linux
           - darwin
@@ -92079,6 +92080,9 @@ packages:
       - version_constraint: semver("<= 0.13.0")
         asset: versitygw_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: cmd/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -92093,6 +92097,9 @@ packages:
       - version_constraint: semver("<= 1.3.0")
         asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -92107,6 +92114,9 @@ packages:
       - version_constraint: "true"
         asset: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: versitygw
+            src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw
         replacements:
           amd64: x86_64
           darwin: Darwin
@@ -92119,6 +92129,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: versitygw
+                src: versitygw_{{.Version}}_{{.OS}}_{{.Arch}}/versitygw
   - type: github_release
     repo_owner: vi
     repo_name: websocat


### PR DESCRIPTION
[versity/versitygw](https://github.com/versity/versitygw) - A simple to deploy but feature rich S3 object storage server for your filesystem

https://github.com/versity/versitygw/wiki/Quickstart


## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Add `versity/versitygw`, an S3 object storage server for filesystems.

Notes:
- `argd s versity/versitygw` generated the scaffold.
- Manual follow-up sets `files[].src` for nested archive layouts.
- `v0.14` disables checksum verification because that release's `checksums.txt` contains asset names that do not match the uploaded assets.

Validation:
- `conftest test --combine pkgs/versity/versitygw/*`
- `argd t versity/versitygw`
- Executed Linux and Darwin `v1.4.1` binaries directly; both reported `Version  : 1.4.1`.

This PR was prepared with assistance from Codex; I reviewed and take responsibility for the content.