### PR TITLE
Add matthart1983/netwatch

### DIFF
--- a/pkgs/matthart1983/netwatch/pkg.yaml
+++ b/pkgs/matthart1983/netwatch/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: matthart1983/netwatch@v0.13.0
+  - name: matthart1983/netwatch
+    version: v0.11.0

--- a/pkgs/matthart1983/netwatch/registry.yaml
+++ b/pkgs/matthart1983/netwatch/registry.yaml
@@ -5,6 +5,9 @@ packages:
     repo_name: netwatch
     description: Real-time network diagnostics in your terminal. One command, zero config, instant visibility
     version_constraint: "false"
+    files:
+      - name: netwatch
+        src: "{{.AssetWithoutExt}}"
     version_overrides:
       - version_constraint: Version == "v0.8.0"
         no_asset: true

--- a/pkgs/matthart1983/netwatch/registry.yaml
+++ b/pkgs/matthart1983/netwatch/registry.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: matthart1983
+    repo_name: netwatch
+    description: Real-time network diagnostics in your terminal. One command, zero config, instant visibility
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.11.0")
+        asset: netwatch-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            asset: netwatch-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}
+      - version_constraint: "true"
+        asset: netwatch-{{.OS}}-{{.Arch}}-static.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: netwatch-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: netwatch-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}

--- a/registry.yaml
+++ b/registry.yaml
@@ -60456,6 +60456,42 @@ packages:
       asset: "{{.Asset}}.md5.txt"
       algorithm: md5
   - type: github_release
+    repo_owner: matthart1983
+    repo_name: netwatch
+    description: Real-time network diagnostics in your terminal. One command, zero config, instant visibility
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.11.0")
+        asset: netwatch-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            asset: netwatch-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}
+      - version_constraint: "true"
+        asset: netwatch-{{.OS}}-{{.Arch}}-static.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: netwatch-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: netwatch-{{.OS}}-{{.Arch}}.exe.{{.Format}}
+            replacements: {}
+  - type: github_release
     repo_owner: mattn
     repo_name: algia
     description: A cli application for nostr

--- a/registry.yaml
+++ b/registry.yaml
@@ -60460,6 +60460,9 @@ packages:
     repo_name: netwatch
     description: Real-time network diagnostics in your terminal. One command, zero config, instant visibility
     version_constraint: "false"
+    files:
+      - name: netwatch
+        src: "{{.AssetWithoutExt}}"
     version_overrides:
       - version_constraint: Version == "v0.8.0"
         no_asset: true


### PR DESCRIPTION
[matthart1983/netwatch](https://github.com/matthart1983/netwatch) - Real-time network diagnostics in your terminal. One command, zero config, instant visibility

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

Adds matthart1983/netwatch.

The scaffold needed a manual `files.src` mapping because the release archives contain platform-named binaries like `netwatch-linux-x86_64-static`, not `netwatch`.

Verification:

- `aqua exec -- conftest test --combine pkgs/matthart1983/netwatch/*`
- `aqua exec -- argd t matthart1983/netwatch`
- Docker container execution: `netwatch --version` -> `netwatch 0.13.0`