### PR TITLE
fix lychee release asset layouts

### DIFF
--- a/pkgs/lycheeverse/lychee/pkg.yaml
+++ b/pkgs/lycheeverse/lychee/pkg.yaml
@@ -1,10 +1,6 @@
 packages:
-  - name: lycheeverse/lychee@lychee-v0.23.0
+  - name: lycheeverse/lychee@lychee-v0.24.1
   - name: lycheeverse/lychee
-    version: v0.15.1
+    version: lychee-v0.24.0
   - name: lycheeverse/lychee
-    version: v0.8.0
-  - name: lycheeverse/lychee
-    version: v0.7.1
-  - name: lycheeverse/lychee
-    version: v0.5.1-alpha
+    version: lychee-v0.19.0

--- a/pkgs/lycheeverse/lychee/registry.yaml
+++ b/pkgs/lycheeverse/lychee/registry.yaml
@@ -71,7 +71,7 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
-      - version_constraint: "true"
+      - version_constraint: semverWithVersion(">= 0.16.0, < 0.19.0", trimPrefix(Version, "lychee-v"))
         version_prefix: lychee-
         asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -98,3 +98,70 @@ packages:
           - linux
           - windows/amd64
           - darwin/arm64
+      - version_constraint: semverWithVersion(">= 0.19.0, < 0.24.0", trimPrefix(Version, "lychee-v"))
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: raw
+            asset: lychee-{{.Arch}}-{{.OS}}
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin/arm64
+      - version_constraint: Version == "lychee-v0.24.0"
+        version_prefix: lychee-
+        asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: lychee
+            src: "{{.AssetWithoutExt}}/lychee"
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin
+      - version_constraint: "true"
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: lychee
+            src: "{{.AssetWithoutExt}}/lychee"
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -59552,7 +59552,7 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
-      - version_constraint: "true"
+      - version_constraint: semverWithVersion(">= 0.16.0, < 0.19.0", trimPrefix(Version, "lychee-v"))
         version_prefix: lychee-
         asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -59579,6 +59579,73 @@ packages:
           - linux
           - windows/amd64
           - darwin/arm64
+      - version_constraint: semverWithVersion(">= 0.19.0, < 0.24.0", trimPrefix(Version, "lychee-v"))
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: raw
+            asset: lychee-{{.Arch}}-{{.OS}}
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin/arm64
+      - version_constraint: Version == "lychee-v0.24.0"
+        version_prefix: lychee-
+        asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: lychee
+            src: "{{.AssetWithoutExt}}/lychee"
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin
+      - version_constraint: "true"
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: lychee
+            src: "{{.AssetWithoutExt}}/lychee"
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin
   - type: github_release
     repo_owner: m7medVision
     repo_name: lazycommit


### PR DESCRIPTION
## What

Fix `lycheeverse/lychee` registry settings for recent release asset layout changes.

## Why

`lychee-v0.24.0` and later changed the archive structure so the binary is no longer placed at the archive root. This caused aqua/mise installs to download the archive successfully but fail to resolve the executable path.

`lychee-v0.24.0` also used a temporary, different asset naming pattern, while `lychee-v0.24.1` restored the normal release asset names.

## Changes

- Add `files.src` for `lychee-v0.24.0` and newer archives.
- Add a dedicated override for the temporary `lychee-v0.24.0` asset names.
- Split the older release settings:
  - `0.16.0-0.18.x` keeps the existing macOS DMG handling.
  - `0.19.0-0.23.x` uses the pre-0.24 archive layout with macOS tar.gz support.
- Add `lychee-v0.19.0` to `pkg.yaml` to cover the old archive layout in tests.

## Verification

- `conftest test pkgs/lycheeverse/lychee/registry.yaml pkgs/lycheeverse/lychee/pkg.yaml`
- `argd gr`
- `argd test lycheeverse/lychee`
- `git diff --check origin/main..HEAD`
