### PR TITLE
fix: lychee 0.24.1 archive layout

### DIFF
--- a/pkgs/lycheeverse/lychee/pkg.yaml
+++ b/pkgs/lycheeverse/lychee/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: lycheeverse/lychee@lychee-v0.23.0
+  - name: lycheeverse/lychee@lychee-v0.24.1
+  - name: lycheeverse/lychee
+    version: lychee-v0.23.0
   - name: lycheeverse/lychee
     version: v0.15.1
   - name: lycheeverse/lychee

--- a/pkgs/lycheeverse/lychee/registry.yaml
+++ b/pkgs/lycheeverse/lychee/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: lycheeverse
     repo_name: lychee
     description: Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more
+    files:
+      - name: lychee
     version_filter: not (Version startsWith "lychee-lib-")
     version_constraint: "false"
     version_overrides:
@@ -71,7 +73,7 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
-      - version_constraint: "true"
+      - version_constraint: semverWithVersion("<= 0.23.999", trimPrefix(Version, "lychee-"))
         version_prefix: lychee-
         asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -81,7 +83,11 @@ packages:
           darwin: macos
         overrides:
           - goos: darwin
-            format: dmg
+            asset: lychee-arm64-macos.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee
           - goos: linux
             goarch: amd64
             replacements:
@@ -94,6 +100,76 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Arch}}-{{.OS}}
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin/arm64
+      - version_constraint: Version == "lychee-v0.24.0"
+        version_prefix: lychee-
+        asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: lychee
+            src: lychee-{{.Version}}-{{.Arch}}-{{.OS}}/lychee
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lychee-{{.Version}}-aarch64-apple-darwin.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee-{{.Version}}-aarch64-apple-darwin/lychee
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: lychee-{{.Version}}-{{.Arch}}-pc-windows-msvc.zip
+            files:
+              - name: lychee
+                src: lychee-{{.Version}}-{{.Arch}}-pc-windows-msvc/lychee
+      - version_constraint: "true"
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: lychee
+            src: lychee-{{.Arch}}-{{.OS}}/lychee
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lychee-aarch64-apple-darwin.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee-aarch64-apple-darwin/lychee
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: lychee-{{.Arch}}-pc-windows-msvc.zip
+            files:
+              - name: lychee
+                src: lychee-{{.Arch}}-pc-windows-msvc/lychee
         supported_envs:
           - linux
           - windows/amd64

--- a/pkgs/lycheeverse/lychee/registry.yaml
+++ b/pkgs/lycheeverse/lychee/registry.yaml
@@ -87,7 +87,6 @@ packages:
             format: tar.gz
             files:
               - name: lychee
-                src: lychee
           - goos: linux
             goarch: amd64
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -58985,7 +58985,6 @@ packages:
             format: tar.gz
             files:
               - name: lychee
-                src: lychee
           - goos: linux
             goarch: amd64
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -58902,6 +58902,8 @@ packages:
     repo_owner: lycheeverse
     repo_name: lychee
     description: Fast, async, stream-based link checker written in Rust. Finds broken URLs and mail addresses inside Markdown, HTML, reStructuredText, websites and more
+    files:
+      - name: lychee
     version_filter: not (Version startsWith "lychee-lib-")
     version_constraint: "false"
     version_overrides:
@@ -58969,7 +58971,7 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Version}}-{{.OS}}-{{.Arch}}
-      - version_constraint: "true"
+      - version_constraint: semverWithVersion("<= 0.23.999", trimPrefix(Version, "lychee-"))
         version_prefix: lychee-
         asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -58979,7 +58981,11 @@ packages:
           darwin: macos
         overrides:
           - goos: darwin
-            format: dmg
+            asset: lychee-arm64-macos.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee
           - goos: linux
             goarch: amd64
             replacements:
@@ -58992,6 +58998,76 @@ packages:
           - goos: windows
             format: raw
             asset: lychee-{{.Arch}}-{{.OS}}
+        supported_envs:
+          - linux
+          - windows/amd64
+          - darwin/arm64
+      - version_constraint: Version == "lychee-v0.24.0"
+        version_prefix: lychee-
+        asset: lychee-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: lychee
+            src: lychee-{{.Version}}-{{.Arch}}-{{.OS}}/lychee
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lychee-{{.Version}}-aarch64-apple-darwin.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee-{{.Version}}-aarch64-apple-darwin/lychee
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: lychee-{{.Version}}-{{.Arch}}-pc-windows-msvc.zip
+            files:
+              - name: lychee
+                src: lychee-{{.Version}}-{{.Arch}}-pc-windows-msvc/lychee
+      - version_constraint: "true"
+        version_prefix: lychee-
+        asset: lychee-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: lychee
+            src: lychee-{{.Arch}}-{{.OS}}/lychee
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            asset: lychee-aarch64-apple-darwin.tar.gz
+            format: tar.gz
+            files:
+              - name: lychee
+                src: lychee-aarch64-apple-darwin/lychee
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+            asset: lychee-{{.Arch}}-pc-windows-msvc.zip
+            files:
+              - name: lychee
+                src: lychee-{{.Arch}}-pc-windows-msvc/lychee
         supported_envs:
           - linux
           - windows/amd64


### PR DESCRIPTION
## What changed

This updates the `lycheeverse/lychee` registry entry to handle the recent archive layout transitions explicitly and refreshes the package test data.

The version handling is now split into three eras:

- `<= 0.23.0`: flat archive layout, binary at archive root
- `0.24.0`: nested layout under `lychee-{{.Version}}-{{.Arch}}-{{.OS}}/lychee`
- `>= 0.24.1`: nested layout under `lychee-{{.Arch}}-{{.OS}}/lychee`

That change is mirrored in the generated root `registry.yaml`, and `pkgs/lycheeverse/lychee/pkg.yaml` tests `lychee-v0.24.1` as the latest version while keeping `lychee-v0.23.0` as an older-version check.

## Why

`lychee` changed both asset naming and archive layout across these releases. Without explicit `files.src` handling for the nested layouts, Aqua resolves the executable path incorrectly and downstream consumers fail to spawn `lychee`.

In my case this surfaced through `mise` + `flint`, where `flint` tried to spawn `lychee` and got `No such file or directory`.

## Impact

This should restore installability for current `lychee` releases in Aqua-backed consumers while preserving compatibility with the older flat-layout releases.

## Validation

I inspected the archive contents directly for:

- `lychee-v0.23.0`
- `lychee-v0.24.0`
- `lychee-v0.24.1`

and used those layouts to set the version split above.

I was not able to run `argd test` in my environment because Docker was unavailable, so this PR has not been through the normal container-based registry test flow locally.
