### PR TITLE
Feature: add solarwinds/swo-cli

### DIFF
--- a/pkgs/solarwinds/swo-cli/pkg.yaml
+++ b/pkgs/solarwinds/swo-cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: solarwinds/swo-cli@v1.3.7
+  - name: solarwinds/swo-cli
+    version: v1.3.0

--- a/pkgs/solarwinds/swo-cli/registry.yaml
+++ b/pkgs/solarwinds/swo-cli/registry.yaml
@@ -3,6 +3,7 @@ packages:
   - type: github_release
     repo_owner: solarwinds
     repo_name: swo-cli
+    description: SolarWinds Observability Command-Line Interface
     files:
       - name: swo
     version_constraint: "false"

--- a/pkgs/solarwinds/swo-cli/registry.yaml
+++ b/pkgs/solarwinds/swo-cli/registry.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: solarwinds
+    repo_name: swo-cli
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3.0")
+        asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: swo-cli_{{.OS}}_all.{{.Format}}
+      - version_constraint: "true"
+        asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: swo-cli_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: swo-cli_{{.OS}}_all.{{.Format}}

--- a/pkgs/solarwinds/swo-cli/registry.yaml
+++ b/pkgs/solarwinds/swo-cli/registry.yaml
@@ -9,6 +9,8 @@ packages:
         asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: swo
         checksum:
           type: github_release
           asset: checksums.txt
@@ -20,6 +22,8 @@ packages:
         asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: swo
         checksum:
           type: github_release
           asset: swo-cli_checksums.txt

--- a/pkgs/solarwinds/swo-cli/registry.yaml
+++ b/pkgs/solarwinds/swo-cli/registry.yaml
@@ -3,6 +3,8 @@ packages:
   - type: github_release
     repo_owner: solarwinds
     repo_name: swo-cli
+    files:
+      - name: swo
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.3.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -80902,6 +80902,8 @@ packages:
   - type: github_release
     repo_owner: solarwinds
     repo_name: swo-cli
+    files:
+      - name: swo
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.3.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -80908,6 +80908,8 @@ packages:
         asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: swo
         checksum:
           type: github_release
           asset: checksums.txt
@@ -80919,6 +80921,8 @@ packages:
         asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: swo
         checksum:
           type: github_release
           asset: swo-cli_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -80902,6 +80902,7 @@ packages:
   - type: github_release
     repo_owner: solarwinds
     repo_name: swo-cli
+    description: SolarWinds Observability Command-Line Interface
     files:
       - name: swo
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -80900,6 +80900,33 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: solarwinds
+    repo_name: swo-cli
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.3.0")
+        asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: swo-cli_{{.OS}}_all.{{.Format}}
+      - version_constraint: "true"
+        asset: swo-cli_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: swo-cli_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: swo-cli_{{.OS}}_all.{{.Format}}
+  - type: github_release
     repo_owner: solidiquis
     repo_name: erdtree
     description: A modern, cross-platform, multi-threaded, and general purpose filesystem and disk-usage utility that is aware of .gitignore and hidden file rules


### PR DESCRIPTION
[solarwinds/swo-cli](https://github.com/solarwinds/swo-cli) - Standalone command line tool to retrieve and search recent app server logs from SolarWinds Observability

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

This adds support for installing solarwinds observability CLI (https://github.com/solarwinds/swo-cli). The scaffold got most of it right and required a manual fix to commit the output file name.