### PR TITLE
fix pnpm v11 assets

### DIFF
--- a/pkgs/pnpm/pnpm/pkg.yaml
+++ b/pkgs/pnpm/pnpm/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: pnpm/pnpm@v11.0.0
   - name: pnpm/pnpm
+    version: v10.33.2
+  - name: pnpm/pnpm
     version: v10.26.1
   - name: pnpm/pnpm
     version: v7.0.0-alpha.0

--- a/pkgs/pnpm/pnpm/pkg.yaml
+++ b/pkgs/pnpm/pnpm/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: pnpm/pnpm@v10.33.2
+  - name: pnpm/pnpm@v11.0.0
   - name: pnpm/pnpm
     version: v10.26.1
   - name: pnpm/pnpm

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -70,7 +70,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: "true"
+      - version_constraint: semver("< 11.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -82,4 +82,17 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
+        github_immutable_release: true
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: pnpm
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
         github_immutable_release: true

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -70,7 +70,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: semver("< 11.0.0")
+      - version_constraint: semver("<= 10.33.2")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -86,7 +86,6 @@ packages:
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         files:
           - name: pnpm
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -71368,7 +71368,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: semver("< 11.0.0")
+      - version_constraint: semver("<= 10.33.2")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -71384,7 +71384,6 @@ packages:
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         files:
           - name: pnpm
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -71368,7 +71368,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: "true"
+      - version_constraint: semver("< 11.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -71380,6 +71380,19 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
+        github_immutable_release: true
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: pnpm
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
         github_immutable_release: true
   - type: github_release
     repo_owner: po3rin


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

Fixes #52815.
Close #52854

## Summary

- Fix pnpm v11+ asset names to match the archive assets published by pnpm.
- Keep pnpm `<= v10.33.2` on the old raw binary asset mapping.
- Remove Windows arm64 emulation for v11+ because pnpm publishes native `pnpm-win32-arm64.zip`.
- Add `v10.33.2` as a long-form `pkg.yaml` test case for the version override boundary.

## Verification

- `aqua exec -- conftest test --combine pkgs/pnpm/pnpm/*` -> 14 passed.
- `argd t pnpm/pnpm` -> passed.
- `argd t -r pnpm/pnpm` recreate log verified the v11 Windows arm64 native asset/digest path.
- Asset resolution verified:
  - `darwin/arm64` -> `pnpm-darwin-arm64.tar.gz`
  - `darwin/amd64` -> `pnpm-darwin-x64.tar.gz`
  - `windows/amd64` -> `pnpm-win32-x64.zip`
  - `windows/arm64` -> `pnpm-win32-arm64.zip`
  - `linux/amd64` -> `pnpm-linux-x64.tar.gz`
- `v10.33.2` remains on the old raw binary mapping such as `pnpm-macos-arm64`.
- Isolated host aqua run with this registry returned `pnpm --version` = `11.0.0`.

## v11 Archive Layout

pnpm v11 archives include `pnpm` / `pnpm.exe` beside a sibling `dist/` directory, and the executable loads `dist/pnpm.mjs` relative to itself.

The v11+ registry block intentionally keeps only:

```yaml
files:
  - name: pnpm
```

This leaves `pnpm` in the unarchived package directory next to `dist/`, while aqua exposes the normal `AQUA_ROOT_DIR/bin/pnpm -> aqua-proxy` shim.

Tested alternatives:

- `hard: true` breaks v11 because it installs only `pnpm`, leaving no sibling `dist/`.
- `link: pnpm` without `hard: true` creates a self-symlink loop and aqua fails with `too many levels of symbolic links`.

Current worktree path redacted as `/Users/<user-name>/GitHub/forks/aqua-registry`.

_Codex helped research and draft this PR; all changes were reviewed by me, aligned with the aqua-registry AI disclosure guidance._
