### PR TITLE
fix(pnpm/pnpm): support v11 asset naming change

### DIFF
--- a/pkgs/pnpm/pnpm/pkg.yaml
+++ b/pkgs/pnpm/pnpm/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: pnpm/pnpm@v10.33.2
+  - name: pnpm/pnpm@v11.0.0
+  - name: pnpm/pnpm
+    version: v10.33.2
   - name: pnpm/pnpm
     version: v10.26.1
   - name: pnpm/pnpm

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -70,7 +70,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: "true"
+      - version_constraint: semver("<= 10.33.2")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -82,4 +82,18 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
+        github_immutable_release: true
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: pnpm
+            link: pnpm
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
         github_immutable_release: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -71368,7 +71368,7 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
-      - version_constraint: "true"
+      - version_constraint: semver("<= 10.33.2")
         asset: pnpm-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -71380,6 +71380,20 @@ packages:
           amd64: x64
           darwin: macos
           windows: win
+        github_immutable_release: true
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: pnpm
+            link: pnpm
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
         github_immutable_release: true
   - type: github_release
     repo_owner: po3rin


### PR DESCRIPTION
## Summary

pnpm v11.0.0 changed release asset naming conventions:

- **OS naming**: macos -> darwin, win -> win32
- **Format**: raw -> tar.gz (linux/macOS), zip (windows)
- **Windows ARM64**: native support (no emulation needed)

## Changes

- Capped existing config at semver(<= 10.33.2)
- Added new version override for v11+ with updated asset template, format, and replacements
- Updated pkg.yaml to test v11.0.0 and v10.33.2

## Testing

Verified locally that both pnpm v11.0.0 and pnpm v10.33.2 install and run correctly on darwin/arm64.

Fixes: mise ERROR Failed to install aqua:pnpm/pnpm@11: no asset found: pnpm-macos-arm64