### PR TITLE
Replace deprecated cmdx references

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-support-request-dev-tool.yml
+++ b/.github/ISSUE_TEMPLATE/02-support-request-dev-tool.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: |
         [Please read the contribution guide first.](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
-        If `cmdx s` generates code but you can't resolve the failure of the test, please create a pull request.
+        If `argd s` generates code but you can't resolve the failure of the test, please create a pull request.
         Then we can help you on the pull request.
   - type: textarea
     id: overview

--- a/.github/ISSUE_TEMPLATE/03-bug-report-dev-tool.yml
+++ b/.github/ISSUE_TEMPLATE/03-bug-report-dev-tool.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: |
         [Please read the contribution guide first.](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
-        If `cmdx s` generates code but you can't resolve the failure of the test, please create a pull request.
+        If `argd s` generates code but you can't resolve the failure of the test, please create a pull request.
         Then we can help you on the pull request.
   - type: textarea
     id: overview

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,7 +82,7 @@ You can install any versions not listed in `pkgs/**/pkg.yaml`.
 packages: []
 ```
 
-If `cmdx s` fails to fetch versions, packages may become empty.
+If `argd s` fails to fetch versions, packages may become empty.
 
 ## Test multiple versions
 

--- a/.github/workflows/wc-test-docker.yaml
+++ b/.github/workflows/wc-test-docker.yaml
@@ -23,6 +23,6 @@ jobs:
           AQUA_GITHUB_TOKEN: ${{github.token}}
       # # Stop testing cargo package as this step takes a long time
       # - name: test cargo package
-      #   run: cmdx t bensadeh/tailspin
+      #   run: argd t bensadeh/tailspin
       #   env:
       #     AQUA_GITHUB_TOKEN: ${{github.token}}

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -40,7 +40,6 @@ jobs:
             test-docker:
               - docker/*
               - scripts/**
-              - cmdx.yaml
               - .github/workflows/wc-test-docker.yaml
 
   renovate-config-validator:

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,5 +9,4 @@ registries:
     path: registry.yaml
 packages:
   - name: aquaproj/registry-tool@v0.5.1
-  - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: open-policy-agent/conftest@v0.68.2

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,4 +9,5 @@ registries:
     path: registry.yaml
 packages:
   - name: aquaproj/registry-tool@v0.5.1
+  - name: suzuki-shunsuke/cmdx@v2.0.2
   - name: open-policy-agent/conftest@v0.68.2

--- a/docs/pkg_yaml.md
+++ b/docs/pkg_yaml.md
@@ -16,7 +16,7 @@ You can install any versions not listed in `pkgs/**/pkg.yaml`.
 packages: []
 ```
 
-If `cmdx s` fails to fetch versions, packages may become empty.
+If `argd s` fails to fetch versions, packages may become empty.
 
 ## Test multiple versions
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -14,4 +14,4 @@ pkg.yaml is just test data. You can install versions not included in this file.
 
 There is also a registry.yaml at the repository root, which is a huge YAML file merging all registry.yaml files under `pkgs`.
 When specifying Standard Registry in aqua.yaml, this repository root registry.yaml is referenced.
-To modify the repository root registry.yaml, modify the registry.yaml under pkgs and run the `cmdx gr` command.
+To modify the repository root registry.yaml, modify the registry.yaml under pkgs and run the `argd gr` command.


### PR DESCRIPTION
## Summary

- Replace deprecated `cmdx` command references with their `argd` equivalents.
- Remove the `cmdx` dev-tool dependency from `aqua.yaml`; `argd` is already provided by `aquaproj/registry-tool`.
- Remove the obsolete `cmdx.yaml` trigger from the `test-docker` path filter.

## Check List

- [x] Confirmed the requested files no longer contain `cmdx` references.
- [x] Ran `git diff --check`.
- [x] Ran `aqua i`.
- [x] Ran `aqua exec -- argd --version`.