### PR TITLE
chore: update WebAssembly/wabt 1.0.37 to 1.0.40

### DIFF
--- a/pkgs/WebAssembly/wabt/pkg.yaml
+++ b/pkgs/WebAssembly/wabt/pkg.yaml
@@ -1,5 +1,9 @@
 packages:
-  - name: WebAssembly/wabt@1.0.37
+  - name: WebAssembly/wabt@1.0.40
+  - name: WebAssembly/wabt
+    version: 1.0.39
+  - name: WebAssembly/wabt
+    version: 1.0.36
   - name: WebAssembly/wabt
     version: 1.0.34
   - name: WebAssembly/wabt

--- a/pkgs/WebAssembly/wabt/registry.yaml
+++ b/pkgs/WebAssembly/wabt/registry.yaml
@@ -17,7 +17,7 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
-    files: &wabt_files_2
+    files:
       - name: spectest-interp
         src: wabt-{{.Version}}/bin/spectest-interp
       - name: wasm-decompile
@@ -60,7 +60,6 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-        files: *wabt_files_2
       - version_constraint: semver(">= 1.0.35")
         asset: wabt-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -81,7 +80,7 @@ packages:
           algorithm: sha256
       - version_constraint: Version == "1.0.34"
       - version_constraint: Version == "1.0.33"
-        files: &wabt_files_1
+        files:
           - name: spectest-interp
             src: wabt-{{.Version}}/bin/spectest-interp
           - name: wasm-interp
@@ -103,7 +102,27 @@ packages:
           - name: wat2wasm
             src: wabt-{{.Version}}/bin/wat2wasm
       - version_constraint: semver(">= 1.0.17")
-        files: *wabt_files_1
+        files:
+          - name: spectest-interp
+            src: wabt-{{.Version}}/bin/spectest-interp
+          - name: wasm-interp
+            src: wabt-{{.Version}}/bin/wasm-interp
+          - name: wasm-objdump
+            src: wabt-{{.Version}}/bin/wasm-objdump
+          - name: wasm-opcodecnt
+            src: wabt-{{.Version}}/bin/wasm-opcodecnt
+          - name: wasm-validate
+            src: wabt-{{.Version}}/bin/wasm-validate
+          - name: wasm2c
+            src: wabt-{{.Version}}/bin/wasm2c
+          - name: wasm2wat
+            src: wabt-{{.Version}}/bin/wasm2wat
+          - name: wast2json
+            src: wabt-{{.Version}}/bin/wast2json
+          - name: wat-desugar
+            src: wabt-{{.Version}}/bin/wat-desugar
+          - name: wat2wasm
+            src: wabt-{{.Version}}/bin/wat2wasm
         replacements:
           darwin: macos
           linux: ubuntu

--- a/pkgs/WebAssembly/wabt/registry.yaml
+++ b/pkgs/WebAssembly/wabt/registry.yaml
@@ -17,7 +17,7 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
-    files:
+    files: &wabt_files_2
       - name: spectest-interp
         src: wabt-{{.Version}}/bin/spectest-interp
       - name: wasm-decompile
@@ -44,6 +44,23 @@ packages:
         src: wabt-{{.Version}}/bin/wat2wasm
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 1.0.39")
+        asset: wabt-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: false
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files: *wabt_files_2
       - version_constraint: semver(">= 1.0.35")
         asset: wabt-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -8773,6 +8773,47 @@ packages:
         src: wabt-{{.Version}}/bin/wat2wasm
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 1.0.39")
+        asset: wabt-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: false
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        files:
+          - name: spectest-interp
+            src: wabt-{{.Version}}/bin/spectest-interp
+          - name: wasm-decompile
+            src: wabt-{{.Version}}/bin/wasm-decompile
+          - name: wasm-interp
+            src: wabt-{{.Version}}/bin/wasm-interp
+          - name: wasm-objdump
+            src: wabt-{{.Version}}/bin/wasm-objdump
+          - name: wasm-stats
+            src: wabt-{{.Version}}/bin/wasm-stats
+          - name: wasm-strip
+            src: wabt-{{.Version}}/bin/wasm-strip
+          - name: wasm-validate
+            src: wabt-{{.Version}}/bin/wasm-validate
+          - name: wasm2c
+            src: wabt-{{.Version}}/bin/wasm2c
+          - name: wasm2wat
+            src: wabt-{{.Version}}/bin/wasm2wat
+          - name: wast2json
+            src: wabt-{{.Version}}/bin/wast2json
+          - name: wat-desugar
+            src: wabt-{{.Version}}/bin/wat-desugar
+          - name: wat2wasm
+            src: wabt-{{.Version}}/bin/wat2wasm
       - version_constraint: semver(">= 1.0.35")
         asset: wabt-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -8746,7 +8746,7 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
-    files: &wabt_files_2
+    files:
       - name: spectest-interp
         src: wabt-{{.Version}}/bin/spectest-interp
       - name: wasm-decompile
@@ -8789,7 +8789,6 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-        files: *wabt_files_2
       - version_constraint: semver(">= 1.0.35")
         asset: wabt-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -8810,7 +8809,7 @@ packages:
           algorithm: sha256
       - version_constraint: Version == "1.0.34"
       - version_constraint: Version == "1.0.33"
-        files: &wabt_files_1
+        files:
           - name: spectest-interp
             src: wabt-{{.Version}}/bin/spectest-interp
           - name: wasm-interp
@@ -8832,7 +8831,27 @@ packages:
           - name: wat2wasm
             src: wabt-{{.Version}}/bin/wat2wasm
       - version_constraint: semver(">= 1.0.17")
-        files: *wabt_files_1
+        files:
+          - name: spectest-interp
+            src: wabt-{{.Version}}/bin/spectest-interp
+          - name: wasm-interp
+            src: wabt-{{.Version}}/bin/wasm-interp
+          - name: wasm-objdump
+            src: wabt-{{.Version}}/bin/wasm-objdump
+          - name: wasm-opcodecnt
+            src: wabt-{{.Version}}/bin/wasm-opcodecnt
+          - name: wasm-validate
+            src: wabt-{{.Version}}/bin/wasm-validate
+          - name: wasm2c
+            src: wabt-{{.Version}}/bin/wasm2c
+          - name: wasm2wat
+            src: wabt-{{.Version}}/bin/wasm2wat
+          - name: wast2json
+            src: wabt-{{.Version}}/bin/wast2json
+          - name: wat-desugar
+            src: wabt-{{.Version}}/bin/wat-desugar
+          - name: wat2wasm
+            src: wabt-{{.Version}}/bin/wat2wasm
         replacements:
           darwin: macos
           linux: ubuntu

--- a/registry.yaml
+++ b/registry.yaml
@@ -8746,7 +8746,7 @@ packages:
       type: github_release
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
-    files:
+    files: &wabt_files_2
       - name: spectest-interp
         src: wabt-{{.Version}}/bin/spectest-interp
       - name: wasm-decompile
@@ -8789,31 +8789,7 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
-        files:
-          - name: spectest-interp
-            src: wabt-{{.Version}}/bin/spectest-interp
-          - name: wasm-decompile
-            src: wabt-{{.Version}}/bin/wasm-decompile
-          - name: wasm-interp
-            src: wabt-{{.Version}}/bin/wasm-interp
-          - name: wasm-objdump
-            src: wabt-{{.Version}}/bin/wasm-objdump
-          - name: wasm-stats
-            src: wabt-{{.Version}}/bin/wasm-stats
-          - name: wasm-strip
-            src: wabt-{{.Version}}/bin/wasm-strip
-          - name: wasm-validate
-            src: wabt-{{.Version}}/bin/wasm-validate
-          - name: wasm2c
-            src: wabt-{{.Version}}/bin/wasm2c
-          - name: wasm2wat
-            src: wabt-{{.Version}}/bin/wasm2wat
-          - name: wast2json
-            src: wabt-{{.Version}}/bin/wast2json
-          - name: wat-desugar
-            src: wabt-{{.Version}}/bin/wat-desugar
-          - name: wat2wasm
-            src: wabt-{{.Version}}/bin/wat2wasm
+        files: *wabt_files_2
       - version_constraint: semver(">= 1.0.35")
         asset: wabt-{{.Version}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Summary

wabt 1.0.39 changed asset naming (`ubuntu-20.04` → `linux-x64`/`linux-arm64`, `macos-14` → `macos-arm64`, `windows` → `windows-x64`; Intel macOS dropped). Adds a `>= 1.0.39` `version_overrides` block; existing `>= 1.0.35` block unchanged for 1.0.35–1.0.37.

1.0.38 left unsupported on Linux — upstream didn't ship a Linux artifact for that release.

Files list deduped via `&wabt_files_2` anchor (matching the `&wabt_files_1` pattern already in this manifest and `WebAssembly/binaryen`).

## Note on `rosetta2: false`

Base block has `rosetta2: true` (inherited via `*bool` semantics in `pkg/config/registry/package_info.go`). Without disabling here, `getArch` flips arm64 → amd64 on darwin/arm64 and templates `wabt-{ver}-macos-x64.tar.gz` (404). Native `macos-arm64` exists at 1.0.39+.

## Tested

`argd t` ✓ (linux/amd64, linux/arm64, darwin/arm64, windows/amd64). `conftest` ✓ 14/14.

## Supersedes

#50232, #43689, #43458 — auto-updater bumps `pkg.yaml` only; `registry.yaml` left stale, CI fails.

## AI disclosure

Prepared with Claude. Co-authored on both commits. Reviewed and owned by me.