### PR TITLE
fix(UpCloudLtd/upcloud-cli): v3.32.0 is missing GH artifact attestations

### DIFF
--- a/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
@@ -73,6 +73,19 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+      - version_constraint: Version == "v3.32.0"
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_immutable_release: true
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -7792,6 +7792,19 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+      - version_constraint: Version == "v3.32.0"
+        asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        github_immutable_release: true
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
- https://github.com/UpCloudLtd/upcloud-cli/attestations
- https://github.com/UpCloudLtd/upcloud-cli/releases/tag/v3.32.1

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
