### PR TITLE
Add OpenAPITools/openapi-generator

### DIFF
--- a/pkgs/OpenAPITools/openapi-generator/pkg.yaml
+++ b/pkgs/OpenAPITools/openapi-generator/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/OpenAPITools/openapi-generator/pkg.yaml
+++ b/pkgs/OpenAPITools/openapi-generator/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: OpenAPITools/openapi-generator@v7.22.0

--- a/pkgs/OpenAPITools/openapi-generator/registry.yaml
+++ b/pkgs/OpenAPITools/openapi-generator/registry.yaml
@@ -6,5 +6,9 @@ packages:
     description: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 7.21.0")
         no_asset: true
+      - version_constraint: "true"
+        asset: openapi-generator-cli-{{trimV .Version}}.jar
+        format: raw
+        complete_windows_ext: false

--- a/pkgs/OpenAPITools/openapi-generator/registry.yaml
+++ b/pkgs/OpenAPITools/openapi-generator/registry.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: OpenAPITools
+    repo_name: openapi-generator
+    description: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -5671,6 +5671,14 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
   - type: github_release
+    repo_owner: OpenAPITools
+    repo_name: openapi-generator
+    description: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        no_asset: true
+  - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl
     description: Hurl, run and test HTTP requests with plain text

--- a/registry.yaml
+++ b/registry.yaml
@@ -5676,8 +5676,12 @@ packages:
     description: OpenAPI Generator allows generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 7.21.0")
         no_asset: true
+      - version_constraint: "true"
+        asset: openapi-generator-cli-{{trimV .Version}}.jar
+        format: raw
+        complete_windows_ext: false
   - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
Add support for `OpenAPITools/openapi-generator` (>= v7.21.0) via the `openapi-generator-cli-<version>.jar` GitHub Release asset.
Versions < v7.21.0 are marked `no_asset` as they do not publish a downloadable CLI artifact.

Background: https://github.com/OpenAPITools/openapi-generator/issues/23519