### PR TITLE
feat: add Feel-ix-343/markdown-oxide

### DIFF
--- a/pkgs/Feel-ix-343/markdown-oxide/pkg.yaml
+++ b/pkgs/Feel-ix-343/markdown-oxide/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Feel-ix-343/markdown-oxide@v0.25.10
+  - name: Feel-ix-343/markdown-oxide
+    version: v0.0.11
+  - name: Feel-ix-343/markdown-oxide
+    version: v0.0.9

--- a/pkgs/Feel-ix-343/markdown-oxide/registry.yaml
+++ b/pkgs/Feel-ix-343/markdown-oxide/registry.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Feel-ix-343
+    repo_name: markdown-oxide
+    description: PKM Markdown Language Server
+    version_constraint: "false"
+    files:
+      - name: markdown-oxide
+        src: "{{.AssetWithoutExt}}/markdown-oxide"
+    version_overrides:
+      - version_constraint: Version == "v0.0.9"
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.0.11")
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -3193,6 +3193,53 @@ packages:
         format: raw
         windows_arm_emulation: true
   - type: github_release
+    repo_owner: Feel-ix-343
+    repo_name: markdown-oxide
+    description: PKM Markdown Language Server
+    version_constraint: "false"
+    files:
+      - name: markdown-oxide
+        src: "{{.AssetWithoutExt}}/markdown-oxide"
+    version_overrides:
+      - version_constraint: Version == "v0.0.9"
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.0.11")
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: markdown-oxide-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability


### PR DESCRIPTION
[Feel-ix-343/markdown-oxide](https://github.com/Feel-ix-343/markdown-oxide) - PKM Markdown Language Server

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->

Add `Feel-ix-343/markdown-oxide`.

Verification:

```console
$ aqua i -l
exit 0

$ aqua exec -- conftest test --combine pkgs/Feel-ix-343/markdown-oxide/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ aqua exec -- argd t Feel-ix-343/markdown-oxide
exit 0

$ docker exec aqua-registry /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/Feel-ix-343/markdown-oxide/v0.25.10/markdown-oxide-v0.25.10-aarch64-unknown-linux-gnu.tar.gz/markdown-oxide-v0.25.10-aarch64-unknown-linux-gnu/markdown-oxide --version
markdown-oxide v0.25.10

$ /private/tmp/codex-markdown-oxide-test/markdown-oxide --version
markdown-oxide v0.25.9
```

Note: The copied Darwin arm64 `v0.25.10` release asset executes successfully, but its embedded `--version` output is `v0.25.9`. This matches upstream report https://github.com/Feel-ix-343/markdown-oxide/issues/302#issuecomment-3478214226.

Implemented with Codex assistance; I reviewed the content and take responsibility for it.
