### PR TITLE
feat: add grafana/flint

### DIFF
--- a/pkgs/grafana/flint/pkg.yaml
+++ b/pkgs/grafana/flint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grafana/flint@v0.21.0

--- a/pkgs/grafana/flint/registry.yaml
+++ b/pkgs/grafana/flint/registry.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: flint
+    description: Flint is a fast linter runner that keeps local and CI checks consistent with one binary, one config, and only the tools your repo declares
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: flint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43887,6 +43887,31 @@ packages:
             asset: alloy-{{.OS}}-{{.Arch}}.exe.{{.Format}}
   - type: github_release
     repo_owner: grafana
+    repo_name: flint
+    description: Flint is a fast linter runner that keeps local and CI checks consistent with one binary, one config, and only the tools your repo declares
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.2")
+        no_asset: true
+      - version_constraint: "true"
+        asset: flint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: grafana
     repo_name: gcx
     description: A CLI for managing Grafana Cloud resources. Optimized for agentic usage
     version_constraint: "false"


### PR DESCRIPTION
[grafana/flint](https://github.com/grafana/flint) - Flint is a fast linter runner that keeps local and CI checks consistent with one binary, one config, and only the tools your repo declares @zeitlinger

## Summary

Flint is a fast linter runner that keeps local and CI checks consistent with one binary, one config, and only the tools your repo declares.

- add `grafana/flint` to Aqua Registry
- scaffold the package via `argd scaffold --local grafana/flint`
- use the current GitHub release assets with sha256 sidecar checksums and Windows zip handling

