### PR TITLE
feat: add entireio/git-sync

### DIFF
--- a/pkgs/entireio/git-sync/pkg.yaml
+++ b/pkgs/entireio/git-sync/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: entireio/git-sync@v0.4.2

--- a/pkgs/entireio/git-sync/registry.yaml
+++ b/pkgs/entireio/git-sync/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: entireio
+    repo_name: git-sync
+    description: Mirror git refs from a source remote to a target remote without a local checkout. Packfiles stream directly over Smart HTTP and an in-memory object store
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-sync_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -34551,6 +34551,22 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: entireio
+    repo_name: git-sync
+    description: Mirror git refs from a source remote to a target remote without a local checkout. Packfiles stream directly over Smart HTTP and an in-memory object store
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: git-sync_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: env0
     repo_name: terratag
     asset: terratag_{{trimV .Version}}_{{.OS}}_amd64.tar.gz


### PR DESCRIPTION
[entireio/git-sync](https://github.com/entireio/git-sync): Mirror git refs from a source remote to a target remote without a local checkout. Packfiles stream directly over Smart HTTP and an in-memory object store

```sh
aqua g -i entireio/git-sync
```