### PR TITLE
feat: add remoteoss/dexter

### DIFF
--- a/pkgs/remoteoss/dexter/pkg.yaml
+++ b/pkgs/remoteoss/dexter/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: remoteoss/dexter@v0.6.0

--- a/pkgs/remoteoss/dexter/registry.yaml
+++ b/pkgs/remoteoss/dexter/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: "true"
         asset: dexter_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: dexter
+            src: "{{.AssetWithoutExt}}/dexter"
         replacements:
           darwin: Darwin
           linux: Linux

--- a/pkgs/remoteoss/dexter/registry.yaml
+++ b/pkgs/remoteoss/dexter/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: remoteoss
+    repo_name: dexter
+    description: A fast, full-featured Elixir LSP optimized for large codebases
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dexter_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/pkgs/remoteoss/dexter/registry.yaml
+++ b/pkgs/remoteoss/dexter/registry.yaml
@@ -13,16 +13,13 @@ packages:
           - name: dexter
             src: "{{.AssetWithoutExt}}/dexter"
         replacements:
+          amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -74843,6 +74843,29 @@ packages:
               amd64: x86_64
               arm64: aarch64
   - type: github_release
+    repo_owner: remoteoss
+    repo_name: dexter
+    description: A fast, full-featured Elixir LSP optimized for large codebases
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: dexter_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
     repo_owner: replicatedhq
     repo_name: kots
     description: KOTS provides the framework, tools and integrations that enable the delivery and management of 3rd-party Kubernetes applications, a.k.a. Kubernetes Off-The-Shelf (KOTS) Software

--- a/registry.yaml
+++ b/registry.yaml
@@ -74855,16 +74855,13 @@ packages:
           - name: dexter
             src: "{{.AssetWithoutExt}}/dexter"
         replacements:
+          amd64: x86_64
           darwin: Darwin
           linux: Linux
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -74851,6 +74851,9 @@ packages:
       - version_constraint: "true"
         asset: dexter_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: dexter
+            src: "{{.AssetWithoutExt}}/dexter"
         replacements:
           darwin: Darwin
           linux: Linux


### PR DESCRIPTION
#53056 [remoteoss/dexter](https://github.com/remoteoss/dexter) - A fast, full-featured Elixir LSP optimized for large codebases @AlternateRT

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

[Dexter](https://github.com/remoteoss/dexter) is another language server for elixir built in go. It's main appeal is is that it is fast at indexing.