### PR TITLE
feat: add elixir-lsp/elixir-ls

### DIFF
--- a/pkgs/elixir-lsp/elixir-ls/pkg.yaml
+++ b/pkgs/elixir-lsp/elixir-ls/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/elixir-lsp/elixir-ls/pkg.yaml
+++ b/pkgs/elixir-lsp/elixir-ls/pkg.yaml
@@ -1,1 +1,10 @@
-packages: []
+packages:
+  - name: elixir-lsp/elixir-ls@v0.30.0
+  - name: elixir-lsp/elixir-ls
+    version: v0.29.0
+  - name: elixir-lsp/elixir-ls
+    version: v0.28.0
+  - name: elixir-lsp/elixir-ls
+    version: v0.17.10
+  - name: elixir-lsp/elixir-ls
+    version: v0.14.6

--- a/pkgs/elixir-lsp/elixir-ls/registry.yaml
+++ b/pkgs/elixir-lsp/elixir-ls/registry.yaml
@@ -4,3 +4,80 @@ packages:
     repo_owner: elixir-lsp
     repo_name: elixir-ls
     description: A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.14.6")
+        asset: elixir-ls.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debugger.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debugger.bat
+      - version_constraint: semver("<= 0.17.10")
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debugger.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debugger.bat
+      - version_constraint: semver("<= 0.28.0")
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat
+      - version_constraint: Version == "v0.29.0"
+        asset: elixir-ls.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat
+      - version_constraint: "true"
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat

--- a/pkgs/elixir-lsp/elixir-ls/registry.yaml
+++ b/pkgs/elixir-lsp/elixir-ls/registry.yaml
@@ -36,21 +36,6 @@ packages:
                 src: language_server.bat
               - name: elixir-debug-adapter
                 src: debugger.bat
-      - version_constraint: semver("<= 0.28.0")
-        asset: elixir-ls-{{.Version}}.{{.Format}}
-        format: zip
-        files:
-          - name: elixir-ls
-            src: language_server.sh
-          - name: elixir-debug-adapter
-            src: debug_adapter.sh
-        overrides:
-          - goos: windows
-            files:
-              - name: elixir-ls
-                src: language_server.bat
-              - name: elixir-debug-adapter
-                src: debug_adapter.bat
       - version_constraint: Version == "v0.29.0"
         asset: elixir-ls.{{.Format}}
         format: zip

--- a/pkgs/elixir-lsp/elixir-ls/registry.yaml
+++ b/pkgs/elixir-lsp/elixir-ls/registry.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: elixir-lsp
+    repo_name: elixir-ls
+    description: A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol"

--- a/registry.yaml
+++ b/registry.yaml
@@ -34286,6 +34286,10 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: elixir-lsp
+    repo_name: elixir-ls
+    description: A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol"
+  - type: github_release
     repo_owner: elkowar
     repo_name: pipr
     description: A tool to interactively write shell pipelines

--- a/registry.yaml
+++ b/registry.yaml
@@ -34321,21 +34321,6 @@ packages:
                 src: language_server.bat
               - name: elixir-debug-adapter
                 src: debugger.bat
-      - version_constraint: semver("<= 0.28.0")
-        asset: elixir-ls-{{.Version}}.{{.Format}}
-        format: zip
-        files:
-          - name: elixir-ls
-            src: language_server.sh
-          - name: elixir-debug-adapter
-            src: debug_adapter.sh
-        overrides:
-          - goos: windows
-            files:
-              - name: elixir-ls
-                src: language_server.bat
-              - name: elixir-debug-adapter
-                src: debug_adapter.bat
       - version_constraint: Version == "v0.29.0"
         asset: elixir-ls.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -34289,6 +34289,83 @@ packages:
     repo_owner: elixir-lsp
     repo_name: elixir-ls
     description: A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.14.6")
+        asset: elixir-ls.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debugger.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debugger.bat
+      - version_constraint: semver("<= 0.17.10")
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debugger.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debugger.bat
+      - version_constraint: semver("<= 0.28.0")
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat
+      - version_constraint: Version == "v0.29.0"
+        asset: elixir-ls.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat
+      - version_constraint: "true"
+        asset: elixir-ls-{{.Version}}.{{.Format}}
+        format: zip
+        files:
+          - name: elixir-ls
+            src: language_server.sh
+          - name: elixir-debug-adapter
+            src: debug_adapter.sh
+        overrides:
+          - goos: windows
+            files:
+              - name: elixir-ls
+                src: language_server.bat
+              - name: elixir-debug-adapter
+                src: debug_adapter.bat
   - type: github_release
     repo_owner: elkowar
     repo_name: pipr


### PR DESCRIPTION
#53067 [elixir-lsp/elixir-ls](https://github.com/elixir-lsp/elixir-ls) - A frontend-independent IDE "smartness" server for Elixir. Implements the "Language Server Protocol" standard and provides debugger support via the "Debug Adapter Protocol" @AlternateRT

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds [ElixirLS](https://github.com/elixir-lsp/elixir-ls), the very first language server for Elixir.

---

**Note:** Although I ran `argd s`, the command failed to actually detect any versions, so the generated scaffold was practically empty.