### PR TITLE
feat(levibostian/decaf): scaffold levibostian/decaf

### DIFF
--- a/pkgs/levibostian/decaf/pkg.yaml
+++ b/pkgs/levibostian/decaf/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
-  - name: levibostian/decaf@1.0.0-alpha.15
-  - name: levibostian/decaf
-    version: 0.13.0
+  - name: levibostian/decaf@0.13.0

--- a/pkgs/levibostian/decaf/pkg.yaml
+++ b/pkgs/levibostian/decaf/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: levibostian/decaf@1.0.0-alpha.15
+  - name: levibostian/decaf
+    version: 0.13.0

--- a/pkgs/levibostian/decaf/pkg.yaml
+++ b/pkgs/levibostian/decaf/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: levibostian/decaf@1.0.0-alpha.15
+  - name: levibostian/decaf@0.13.0
   - name: levibostian/decaf
-    version: 0.13.0
+    version: 1.0.0-alpha.15

--- a/pkgs/levibostian/decaf/pkg.yaml
+++ b/pkgs/levibostian/decaf/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: levibostian/decaf@0.13.0
+  - name: levibostian/decaf@1.0.0-alpha.15
+  - name: levibostian/decaf
+    version: 0.13.0

--- a/pkgs/levibostian/decaf/registry.yaml
+++ b/pkgs/levibostian/decaf/registry.yaml
@@ -8,9 +8,20 @@ packages:
     version_overrides:
       - version_constraint: Version == "0.1.0"
         no_asset: true
-      - version_constraint: semver(">= 1.0.0-alpha.1, < 1.0.0")
-        error_message: The version is a pre-release version. Use a stable version instead.
       - version_constraint: semver("<= 0.13.0")
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.0-alpha.8")
+        no_asset: true
+      - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}
         format: raw
         replacements:

--- a/pkgs/levibostian/decaf/registry.yaml
+++ b/pkgs/levibostian/decaf/registry.yaml
@@ -6,20 +6,7 @@ packages:
     description: Calm & reliable automated deployments. No more coffee breaks to deploy your code
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "0.1.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.13.0")
-        asset: bin-{{.Arch}}-{{.OS}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: Darwin
-          linux: Linux
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 1.0.0-alpha.8")
+      - version_constraint: Version == "0.1.0" or semver(">= 1.0.0-alpha.1, <= 1.0.0-alpha.8")
         no_asset: true
       - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}

--- a/pkgs/levibostian/decaf/registry.yaml
+++ b/pkgs/levibostian/decaf/registry.yaml
@@ -8,20 +8,9 @@ packages:
     version_overrides:
       - version_constraint: Version == "0.1.0"
         no_asset: true
+      - version_constraint: semver(">= 1.0.0-alpha.1, < 1.0.0")
+        error_message: The version is a pre-release version. Use a stable version instead.
       - version_constraint: semver("<= 0.13.0")
-        asset: bin-{{.Arch}}-{{.OS}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: Darwin
-          linux: Linux
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 1.0.0-alpha.8")
-        no_asset: true
-      - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}
         format: raw
         replacements:

--- a/pkgs/levibostian/decaf/registry.yaml
+++ b/pkgs/levibostian/decaf/registry.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: levibostian
+    repo_name: decaf
+    description: Calm & reliable automated deployments. No more coffee breaks to deploy your code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.13.0")
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.0-alpha.8")
+        no_asset: true
+      - version_constraint: "true"
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -58459,6 +58459,38 @@ packages:
               - name: fvm
                 src: fvm/fvm.exe
   - type: github_release
+    repo_owner: levibostian
+    repo_name: decaf
+    description: Calm & reliable automated deployments. No more coffee breaks to deploy your code
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.13.0")
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.0-alpha.8")
+        no_asset: true
+      - version_constraint: "true"
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: lewispeckover
     repo_name: consulator
     description: Import and synchronize your Consul KV data from JSON and YAML

--- a/registry.yaml
+++ b/registry.yaml
@@ -58466,20 +58466,9 @@ packages:
     version_overrides:
       - version_constraint: Version == "0.1.0"
         no_asset: true
+      - version_constraint: semver(">= 1.0.0-alpha.1, < 1.0.0")
+        error_message: The version is a pre-release version. Use a stable version instead.
       - version_constraint: semver("<= 0.13.0")
-        asset: bin-{{.Arch}}-{{.OS}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: Darwin
-          linux: Linux
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 1.0.0-alpha.8")
-        no_asset: true
-      - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}
         format: raw
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -58464,20 +58464,7 @@ packages:
     description: Calm & reliable automated deployments. No more coffee breaks to deploy your code
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "0.1.0"
-        no_asset: true
-      - version_constraint: semver("<= 0.13.0")
-        asset: bin-{{.Arch}}-{{.OS}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: Darwin
-          linux: Linux
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 1.0.0-alpha.8")
+      - version_constraint: Version == "0.1.0" or semver(">= 1.0.0-alpha.1, <= 1.0.0-alpha.8")
         no_asset: true
       - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -58466,9 +58466,20 @@ packages:
     version_overrides:
       - version_constraint: Version == "0.1.0"
         no_asset: true
-      - version_constraint: semver(">= 1.0.0-alpha.1, < 1.0.0")
-        error_message: The version is a pre-release version. Use a stable version instead.
       - version_constraint: semver("<= 0.13.0")
+        asset: bin-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.0.0-alpha.8")
+        no_asset: true
+      - version_constraint: "true"
         asset: bin-{{.Arch}}-{{.OS}}
         format: raw
         replacements:


### PR DESCRIPTION
#53118 [levibostian/decaf](https://github.com/levibostian/decaf) - Calm & reliable automated deployments. No more coffee breaks to deploy your code @levibostian

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [X] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add https://github.com/levibostian/decaf to registry. 

I reviewed the code that scaffold generated and it looks good. 
Ran: `argd test levibostian/decaf` and it successfully passed. 
Ran: `argd con` and I was able to run `decaf` command and it successfully executed the decaf CLI. 

To note: scaffold noticed that there are 2 'latest' versions of the CLI. `1.0.0-alpha.X` and `0.X.X`. I switched a little while back how I create pre-1.0 semantic versions. While I do not suggest installing the `1.0.0-alpha.X` versions anymore, they are technically valid versions and can still be installed so I left them in the scaffold. It's preferred to use the `0.X.X` versions. 