### PR TITLE
Update `kiro.dev/kiro-cli` to use Kiro's current CLI download host and package layout

### DIFF
--- a/pkgs/kiro.dev/kiro-cli/pkg.yaml
+++ b/pkgs/kiro.dev/kiro-cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: kiro.dev/kiro-cli@2.0.0
+  - name: kiro.dev/kiro-cli@2.2.0

--- a/pkgs/kiro.dev/kiro-cli/registry.yaml
+++ b/pkgs/kiro.dev/kiro-cli/registry.yaml
@@ -4,7 +4,7 @@ packages:
     name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
-    url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
+    url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
     format: zip
     files:
       - name: kiro-cli
@@ -16,7 +16,7 @@ packages:
       arm64: aarch64
     overrides:
       - goos: linux
-        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux.zip
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux.zip
         variants:
           - key: libc
             value: gnu
@@ -25,7 +25,7 @@ packages:
           - key: libc
             value: musl
       - goos: darwin
-        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/Kiro%20CLI.dmg
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
         format: dmg
         files:
           - name: kiro-cli

--- a/pkgs/kiro.dev/kiro-cli/registry.yaml
+++ b/pkgs/kiro.dev/kiro-cli/registry.yaml
@@ -4,7 +4,7 @@ packages:
     name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
-    url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
+    url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
     format: zip
     files:
       - name: kiro-cli
@@ -15,8 +15,17 @@ packages:
       amd64: x86_64
       arm64: aarch64
     overrides:
+      - goos: linux
+        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux.zip
+        variants:
+          - key: libc
+            value: gnu
+      - goos: linux
+        variants:
+          - key: libc
+            value: musl
       - goos: darwin
-        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
+        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/Kiro%20CLI.dmg
         format: dmg
         files:
           - name: kiro-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -53683,7 +53683,7 @@ packages:
     name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
-    url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
+    url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
     format: zip
     files:
       - name: kiro-cli
@@ -53695,7 +53695,7 @@ packages:
       arm64: aarch64
     overrides:
       - goos: linux
-        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux.zip
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux.zip
         variants:
           - key: libc
             value: gnu
@@ -53704,7 +53704,7 @@ packages:
           - key: libc
             value: musl
       - goos: darwin
-        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/Kiro%20CLI.dmg
+        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
         format: dmg
         files:
           - name: kiro-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -53683,7 +53683,7 @@ packages:
     name: kiro.dev/kiro-cli
     description: Kiro CLI is an agentic coding tool that lives in your terminal
     link: https://kiro.dev/docs/cli/installation/
-    url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
+    url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux-musl.zip
     format: zip
     files:
       - name: kiro-cli
@@ -53694,8 +53694,17 @@ packages:
       amd64: x86_64
       arm64: aarch64
     overrides:
+      - goos: linux
+        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/kirocli-{{.Arch}}-linux.zip
+        variants:
+          - key: libc
+            value: gnu
+      - goos: linux
+        variants:
+          - key: libc
+            value: musl
       - goos: darwin
-        url: https://prod.download.cli.kiro.dev/stable/{{.Version}}/Kiro%20CLI.dmg
+        url: https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/Kiro%20CLI.dmg
         format: dmg
         files:
           - name: kiro-cli


### PR DESCRIPTION
The previous `prod.download.cli.kiro.dev/stable/{{.Version}}/...` URLs are no longer aligned with the documented installation paths and can return 403. Kiro's CLI installation docs now publish artifacts from `desktop-release.q.us-east-1.amazonaws.com`.

## Changes

- Switch Kiro CLI downloads to `https://desktop-release.q.us-east-1.amazonaws.com/{{.Version}}/...`
- Keep the Linux musl archive as the default asset, matching registry style when both gnu and musl builds exist
- Add a Linux `libc=gnu` variant for the standard glibc archive
- Update the package test version from `2.0.0` to `2.2.0`
- Regenerate root `registry.yaml`