### PR TITLE
Update `microsoft/edit` for the v2.0.0 release asset layout and add the newly published macOS artifact

### DIFF
--- a/pkgs/microsoft/edit/pkg.yaml
+++ b/pkgs/microsoft/edit/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: microsoft/edit@v1.2.1
+  - name: microsoft/edit@v2.0.0
+  - name: microsoft/edit
+    version: v1.2.1
   - name: microsoft/edit
     version: v1.2.0
   - name: microsoft/edit

--- a/pkgs/microsoft/edit/registry.yaml
+++ b/pkgs/microsoft/edit/registry.yaml
@@ -42,7 +42,7 @@ packages:
         supported_envs:
           - linux
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         asset: edit-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.zst
         overrides:
@@ -56,5 +56,23 @@ packages:
           arm64: aarch64
           linux: linux-gnu
         supported_envs:
+          - linux
+          - windows
+      - version_constraint: "true"
+        asset: edit-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: edit
+                src: "{{.AssetWithoutExt}}/edit.exe"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: linux-gnu
+        supported_envs:
+          - darwin/arm64
           - linux
           - windows

--- a/pkgs/microsoft/edit/registry.yaml
+++ b/pkgs/microsoft/edit/registry.yaml
@@ -15,7 +15,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -38,7 +38,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         supported_envs:
           - linux
           - windows
@@ -50,7 +50,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -66,7 +66,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -61705,7 +61705,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -61728,7 +61728,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         supported_envs:
           - linux
           - windows
@@ -61740,7 +61740,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -61756,7 +61756,7 @@ packages:
             format: zip
             files:
               - name: edit
-                src: "{{.AssetWithoutExt}}/edit.exe"
+                src: "{{.AssetWithoutExt}}/edit"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -61732,7 +61732,7 @@ packages:
         supported_envs:
           - linux
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         asset: edit-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.zst
         overrides:
@@ -61746,6 +61746,24 @@ packages:
           arm64: aarch64
           linux: linux-gnu
         supported_envs:
+          - linux
+          - windows
+      - version_constraint: "true"
+        asset: edit-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: edit
+                src: "{{.AssetWithoutExt}}/edit.exe"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: linux-gnu
+        supported_envs:
+          - darwin/arm64
           - linux
           - windows
   - type: github_release


### PR DESCRIPTION
Microsoft Edit v2 changed Linux archives from `.tar.zst` to `.tar.gz` and now publishes a Darwin arm64 asset. The previous catch-all override still expected the v1 asset format, so v2 installation would resolve the wrong archive name.

## Changes

- Add `v2.0.0` to `pkg.yaml` so CI covers the new release layout
- Keep v1 releases on the existing `.tar.zst`/`.xz` rules via `semver("< 2.0.0")`
- Add the v2+ `.tar.gz` asset rule
- Add `darwin: apple-darwin` replacement and `darwin/arm64` support
- Keep Windows zip extraction at `{{.AssetWithoutExt}}/edit.exe`
- Regenerate root `registry.yaml`