### PR TITLE
feat: add opencontainers/umoci

### DIFF
--- a/pkgs/opencontainers/umoci/pkg.yaml
+++ b/pkgs/opencontainers/umoci/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: opencontainers/umoci@v0.6.0
+  - name: opencontainers/umoci
+    version: v0.4.7
+  - name: opencontainers/umoci
+    version: v0.2.1

--- a/pkgs/opencontainers/umoci/registry.yaml
+++ b/pkgs/opencontainers/umoci/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: opencontainers
+    repo_name: umoci
+    description: umoci modifies Open Container images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+      - version_constraint: semver("<= 0.4.7")
+        checksum:
+          type: github_release
+          asset: umoci.sha256sum
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: umoci.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: umoci.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux

--- a/pkgs/opencontainers/umoci/registry.yaml
+++ b/pkgs/opencontainers/umoci/registry.yaml
@@ -7,11 +7,19 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.1")
+        asset: umoci.amd64
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.4.7")
+        asset: umoci.amd64
+        format: raw
         checksum:
           type: github_release
           asset: umoci.sha256sum
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
       - version_constraint: "true"
         asset: umoci.{{.OS}}.{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -67894,11 +67894,19 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.2.1")
+        asset: umoci.amd64
+        format: raw
+        supported_envs:
+          - linux/amd64
       - version_constraint: semver("<= 0.4.7")
+        asset: umoci.amd64
+        format: raw
         checksum:
           type: github_release
           asset: umoci.sha256sum
           algorithm: sha256
+        supported_envs:
+          - linux/amd64
       - version_constraint: "true"
         asset: umoci.{{.OS}}.{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -67888,6 +67888,27 @@ packages:
           asset: runc.sha256sum
           algorithm: sha256
   - type: github_release
+    repo_owner: opencontainers
+    repo_name: umoci
+    description: umoci modifies Open Container images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+      - version_constraint: semver("<= 0.4.7")
+        checksum:
+          type: github_release
+          asset: umoci.sha256sum
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: umoci.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: umoci.sha256sum
+          algorithm: sha256
+        supported_envs:
+          - linux
+  - type: github_release
     repo_owner: openfaas
     repo_name: faas-cli
     format: raw


### PR DESCRIPTION
#53136 [opencontainers/umoci](https://github.com/opencontainers/umoci) - umoci modifies Open Container images @2xdevv

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [X] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## What

Add [opencontainers/umoci](https://github.com/opencontainers/umoci) to aqua-registry.

## Why

umoci is a tool for modifying Open Container images.

## Notes

Generated the registry config with:

```sh
aqua exec -- argd s opencontainers/umoci
```

Then manually updated `pkgs/opencontainers/umoci/registry.yaml` because older releases use different asset names from newer releases.

- Older releases: `umoci.amd64`
- Newer releases: `umoci.{{.OS}}.{{.Arch}}`

## Tests

```sh
aqua exec -- argd t opencontainers/umoci
```