### PR TITLE
feat: add boostsecurityio/bagel

### DIFF
--- a/pkgs/boostsecurityio/bagel/pkg.yaml
+++ b/pkgs/boostsecurityio/bagel/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: boostsecurityio/bagel@v0.6.1
+  - name: boostsecurityio/bagel
+    version: v0.1.0

--- a/pkgs/boostsecurityio/bagel/registry.yaml
+++ b/pkgs/boostsecurityio/bagel/registry.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: boostsecurityio
+    repo_name: bagel
+    description: bagel, a CLI that inventories security-relevant metadata on developer workstations
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: bagel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: bagel_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/boostsecurityio/bagel/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: bagel_{{trimV .Version}}_checksums.txt.sigstore.json
+      - version_constraint: "true"
+        asset: bagel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: bagel_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/boostsecurityio/bagel/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: bagel_{{trimV .Version}}_checksums.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -19733,6 +19733,59 @@ packages:
       asset: kubectl-fzf_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: boostsecurityio
+    repo_name: bagel
+    description: bagel, a CLI that inventories security-relevant metadata on developer workstations
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: bagel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: bagel_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/boostsecurityio/bagel/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: bagel_{{trimV .Version}}_checksums.txt.sigstore.json
+      - version_constraint: "true"
+        asset: bagel_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: bagel_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/boostsecurityio/bagel/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: bagel_{{trimV .Version}}_checksums.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: bootandy
     repo_name: dust
     description: A more intuitive version of du in rust


### PR DESCRIPTION
[boostsecurityio/bagel](https://github.com/boostsecurityio/bagel): bagel, a CLI that inventories security-relevant metadata on developer workstations

```sh
aqua g -i boostsecurityio/bagel
```

Close #53139