### PR TITLE
Add spinframework/spin

### DIFF
--- a/pkgs/spinframework/spin/pkg.yaml
+++ b/pkgs/spinframework/spin/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: spinframework/spin@v4.0.0
+  - name: spinframework/spin
+    version: v0.6.0
+  - name: spinframework/spin
+    version: v0.1.0-rc.4
+  - name: spinframework/spin
+    version: v0.1.0-rc.1

--- a/pkgs/spinframework/spin/registry.yaml
+++ b/pkgs/spinframework/spin/registry.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: spinframework
+    repo_name: spin
+    description: Developer tool for building and running serverless WebAssembly applications
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-rc.1"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: Version == "v0.1.0-rc.4"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.0")
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}

--- a/registry.yaml
+++ b/registry.yaml
@@ -81861,6 +81861,69 @@ packages:
           - darwin
         github_artifact_attestations:
           signer_workflow: spinel-coop/rv/.github/workflows/release.yml
+  - type: github_release
+    repo_owner: spinframework
+    repo_name: spin
+    description: Developer tool for building and running serverless WebAssembly applications
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0-rc.1"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: Version == "v0.1.0-rc.4"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.6.0")
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: spin-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums-{{.Version}}.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
   - name: spinnaker/spin
     type: http
     format: raw


### PR DESCRIPTION
#53191 [spinframework/spin](https://github.com/spinframework/spin) - Developer tool for building and running serverless WebAssembly applications @2xdevv

## What

Add `spinframework/spin`.

## Verification

```sh
aqua exec -- argd t spinframework/spin
```

Result: passed for Linux, Darwin, and Windows test targets.

```sh
aqua exec -- conftest test pkgs/spinframework/spin/registry.yaml pkgs/spinframework/spin/pkg.yaml
```

Result:

```text
28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions
```

## Notes

This adds Fermyon Spin / Spin Framework. The existing `spinnaker/spin` package is unrelated.