### PR TITLE
feat(crates.io/wasmi_cli): add crates.io/wasmi_cli

### DIFF
--- a/pkgs/crates.io/wasmi_cli/pkg.yaml
+++ b/pkgs/crates.io/wasmi_cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/wasmi_cli@2.0.0-beta.2

--- a/pkgs/crates.io/wasmi_cli/registry.yaml
+++ b/pkgs/crates.io/wasmi_cli/registry.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: crates.io/wasmi_cli
+    type: cargo
+    repo_owner: wasmi-labs
+    repo_name: wasmi
+    description: WebAssembly interpreter
+    crate: wasmi_cli

--- a/pkgs/crates.io/wasmi_cli/registry.yaml
+++ b/pkgs/crates.io/wasmi_cli/registry.yaml
@@ -6,3 +6,5 @@ packages:
     repo_name: wasmi
     description: WebAssembly interpreter
     crate: wasmi_cli
+    files:
+      - name: wasmi

--- a/pkgs/crates.io/wasmi_cli/registry.yaml
+++ b/pkgs/crates.io/wasmi_cli/registry.yaml
@@ -6,5 +6,3 @@ packages:
     repo_name: wasmi
     description: WebAssembly interpreter
     crate: wasmi_cli
-    files:
-      - name: wasmi

--- a/registry.yaml
+++ b/registry.yaml
@@ -28354,6 +28354,8 @@ packages:
     repo_name: wasmi
     description: WebAssembly interpreter
     crate: wasmi_cli
+    files:
+      - name: wasmi
   - name: crates.io/zizmor
     type: cargo
     repo_owner: zizmorcore

--- a/registry.yaml
+++ b/registry.yaml
@@ -28348,6 +28348,12 @@ packages:
     repo_name: tfocus
     description: Terminal UI for Terraform workspace management
     crate: tfocus
+  - name: crates.io/wasmi_cli
+    type: cargo
+    repo_owner: wasmi-labs
+    repo_name: wasmi
+    description: WebAssembly interpreter
+    crate: wasmi_cli
   - name: crates.io/zizmor
     type: cargo
     repo_owner: zizmorcore

--- a/registry.yaml
+++ b/registry.yaml
@@ -28354,8 +28354,6 @@ packages:
     repo_name: wasmi
     description: WebAssembly interpreter
     crate: wasmi_cli
-    files:
-      - name: wasmi
   - name: crates.io/zizmor
     type: cargo
     repo_owner: zizmorcore


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds the `wasmi` CLI tool to the registry.

The `wasmi-labs/wasmi` repository does not provide pre-compiled binaries in its GitHub releases, so this has been configured as a  `cargo` package using its published crate name, `wasmi_cli`. The executable name is mapped to `wasmi`.

Ran `argd t crates.io/wasmi_cli` to build and test the package successfully across container environments.