### PR TITLE
feat: add racket-lang.org/racket-minimal

### DIFF
--- a/pkgs/racket-lang.org/racket-minimal/pkg.yaml
+++ b/pkgs/racket-lang.org/racket-minimal/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: racket-lang.org/racket-minimal@

--- a/pkgs/racket-lang.org/racket-minimal/pkg.yaml
+++ b/pkgs/racket-lang.org/racket-minimal/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: racket-lang.org/racket-minimal@
+  - name: racket-lang.org/racket-minimal@9.1

--- a/pkgs/racket-lang.org/racket-minimal/registry.yaml
+++ b/pkgs/racket-lang.org/racket-minimal/registry.yaml
@@ -1,5 +1,27 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
-    repo_owner: racket-lang.org
-    repo_name: racket-minimal
+  - type: http
+    name: racket-lang.org/racket-minimal
+    url: https://download.racket-lang.org/releases/{{.Version}}/installers/racket-minimal-{{.Version}}-{{.Arch}}-{{.OS}}-cs.tgz
+    format: tgz
+    description: Minimal Racket distribution
+    files:
+      - name: racket
+        src: racket/bin/racket
+      - name: raco
+        src: racket/bin/raco
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: macosx
+      linux: linux-buster
+      windows: win32
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
+        files:
+          - name: Racket
+            src: racket/Racket
+          - name: raco
+            src: racket/raco

--- a/pkgs/racket-lang.org/racket-minimal/registry.yaml
+++ b/pkgs/racket-lang.org/racket-minimal/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: racket-lang.org
+    repo_name: racket-minimal

--- a/pkgs/racket-lang.org/racket-minimal/registry.yaml
+++ b/pkgs/racket-lang.org/racket-minimal/registry.yaml
@@ -21,7 +21,7 @@ packages:
         replacements:
           arm64: arm64
         files:
-          - name: Racket
+          - name: racket
             src: racket/Racket
           - name: raco
             src: racket/raco

--- a/registry.yaml
+++ b/registry.yaml
@@ -73921,9 +73921,31 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-  - type: github_release
-    repo_owner: racket-lang.org
-    repo_name: racket-minimal
+  - type: http
+    name: racket-lang.org/racket-minimal
+    url: https://download.racket-lang.org/releases/{{.Version}}/installers/racket-minimal-{{.Version}}-{{.Arch}}-{{.OS}}-cs.tgz
+    format: tgz
+    description: Minimal Racket distribution
+    files:
+      - name: racket
+        src: racket/bin/racket
+      - name: raco
+        src: racket/bin/raco
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: macosx
+      linux: linux-buster
+      windows: win32
+    overrides:
+      - goos: windows
+        replacements:
+          arm64: arm64
+        files:
+          - name: Racket
+            src: racket/Racket
+          - name: raco
+            src: racket/raco
   - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot

--- a/registry.yaml
+++ b/registry.yaml
@@ -73942,7 +73942,7 @@ packages:
         replacements:
           arm64: arm64
         files:
-          - name: Racket
+          - name: racket
             src: racket/Racket
           - name: raco
             src: racket/raco

--- a/registry.yaml
+++ b/registry.yaml
@@ -73922,6 +73922,9 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: racket-lang.org
+    repo_name: racket-minimal
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases


### PR DESCRIPTION
[racket-lang.org/racket-minimal](https://github.com/racket-lang.org/racket-minimal): Minimal Racket distribution

```sh
aqua g -i racket-lang.org/racket-minimal
```

Close #1140

```console
$ racket --help
May  5 18:14:55.701 INF download and unarchive the package program=aqua version=2.57.2 env=darwin/arm64 exe_name=racket package_name=racket-lang.org/racket-minimal package_version=9.1 registry=standard
Downloading racket-lang.org/racket-minimal 9.1 100% |██████████████████████████████████████████████████████████████████████| (45/45 MB, 3.8 MB/s)
usage: racket [<option> ...] <argument> ...

File and expression options:

  -e <exprs>, --eval <exprs>
     Evaluate <exprs>, print results
  -f <file>, --load <file>
     Like -e '(load "<file>")' without printing, or
     evaluates all from input when <file> is "-"
  -t <file>, --require <file>
     Like -e '(require (file "<file>"))' [*]
  -l <path>, --lib <path>
     Like -e '(require (lib "<path>"))' [*]
  -p <package>
     Like -e '(require (planet "<package>"))' [*]
  -r <file>, --script <file>
     Same as -f <file> -N <file> --
  -u <file>, --require-script <file>
     Same as -t <file> -N <file> --
  -k <n> <m> <p>
     Load executable-embedded code from offset <n> to <p>
  -Y <file> <n> <m> <p>
     Like -k <n> <m> <p>, but from <file>
  -m, --main
     Call `main` with command-line arguments, print results

 [*] Also `require`s a `main` submodule, if any

Interaction options:

  -i, --repl
     Run interactive read-eval-print loop; implies -v
  -n, --no-lib
     Skip `(require (lib "<init-lib>"))` for -i/-e/-f/-r
  -v, --version
     Show version
  -V, --no-yield
     Skip `((executable-yield-handler) <status>)` on exit; implies -v

Configuration options:

  -y, --make
     Yes, enable automatic update of compiled files
  -c, --no-compiled
     Disable loading of compiled files
  -q, --no-init-file
     Skip load of racketrc.rktl for -i
  -I <path>
     Set <init-lib> to <path> (sets language)
  -X <dir>, --collects <dir>
     Main collects at <dir> (or "" disables all)
  -S <dir>, --search <dir>
     More collects at <dir> (after main collects)
  -G <dir>, --config <dir>
     Main configuration directory at <dir>
  -A <dir>, --addon <dir>
     Addon directory at <dir>
  -U, --no-user-path
     Ignore user-specific collects, etc.
  -R <paths>, --compiled <paths>
     Set compiled-file search roots to <paths>
  -C, --cross
     Cross-build mode; save current collects and config
     as host
  -N <file>, --name <file>
     Sets `(find-system-path 'run-file)` to <file>
  -E <file>, --exec <file>
     Sets `(find-system-path 'exec-file)` to <file>
  -j, --no-jit
     No effect, since there is no just-in-time compiler
  -M, --compile-any
     Compile to machine-independent form
  -d, --no-delay
     Disable on-demand loading of syntax and code
  -b, --binary
     No effect, since stdin and stdout/stderr are
     always binary
  -W <levels>, --warn <levels>
     Set stderr logging to <levels>
  -O <levels>, --stdout <levels>
     Set stdout logging to <levels>
  -L <levels>, --syslog <levels>
     Set syslog logging to <levels>
  --compile-machine <machine>
     Compile for <machine>
  --cross-compiler <machine> <plugin-dir>
     Use compiler plugin for <machine>
  --cross-server <mach> <comp> <lib>
     Drive cross-compiler (as only option)

Meta options:

  --
     No argument following this switch is used as a switch
  -Z
     Ignore the argument following this switch
  -h, --help
     Show this information and exits, ignoring other options

Default options:

  * If only configuration options are provided, -i is added
  * If only configuration options are before the first
    argument, -u is added
  * If -t/-l/-p/-u appears before the first -i/-e/-f/-r,
    -n is added
  * <init-lib> defaults to racket/init

Switch syntax:

  Multiple single-letter switches can be collapsed, with
  arguments placed after the collapsed switches; the first
  collapsed switch cannot be --

  For example,

      -ifve file expr

  is the same as

      -i -f file -v -e expr

Start-up sequence:

  1. Set `current-library-collection-paths`
  2. Require `(lib "<init-lib>")` [when -i/-e/-f/-r, unless -n]
  3. Evaluate/load expressions/files in order, until first error
  4. Load "racketrc.rktl" [when -i]
  5. Run read-eval-print loop [when -i]
```