### PR TITLE
feat(shinagawa-web/gomarklint): SLSA provenance config

### DIFF
--- a/pkgs/shinagawa-web/gomarklint/pkg.yaml
+++ b/pkgs/shinagawa-web/gomarklint/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: shinagawa-web/gomarklint@v3.3.0
+  - name: shinagawa-web/gomarklint
+    version: v3.0.4

--- a/pkgs/shinagawa-web/gomarklint/pkg.yaml
+++ b/pkgs/shinagawa-web/gomarklint/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: shinagawa-web/gomarklint@v3.0.5
+  - name: shinagawa-web/gomarklint
+    version: v3.0.4

--- a/pkgs/shinagawa-web/gomarklint/registry.yaml
+++ b/pkgs/shinagawa-web/gomarklint/registry.yaml
@@ -8,6 +8,21 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.4.1") || Version == "v2.1.0"
         no_asset: true
+      - version_constraint: semver("<= 3.0.4")
+        asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gomarklint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -23,3 +38,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -82389,6 +82389,21 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.4.1") || Version == "v2.1.0"
         no_asset: true
+      - version_constraint: semver("<= 3.0.4")
+        asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gomarklint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -82404,6 +82419,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
   - type: github_release
     repo_owner: shini4i
     repo_name: argo-compare

--- a/registry.yaml
+++ b/registry.yaml
@@ -79288,6 +79288,21 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.4.1") || Version == "v2.1.0"
         no_asset: true
+      - version_constraint: semver("<= 3.0.4")
+        asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gomarklint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: gomarklint_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -79303,6 +79318,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
   - type: github_release
     repo_owner: shini4i
     repo_name: argo-compare


### PR DESCRIPTION
https://github.com/shinagawa-web/gomarklint/releases/tag/v3.0.5

Draft: this actually fails to verify at the moment:
```
Verifying artifact /tmp/955051957: FAILED: invalid ref: "f7dd8c54c2067bafc12ca7a55595d5ee9b75204a": unexpected ref type: ""
```
Likely related/breadcrumb: https://github.com/slsa-framework/slsa-github-generator/issues/4503

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
