### PR TITLE
feat: add anthropics/anthropic-cli

### DIFF
--- a/pkgs/anthropics/anthropic-cli/pkg.yaml
+++ b/pkgs/anthropics/anthropic-cli/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: anthropics/anthropic-cli@v1.6.0
+  - name: anthropics/anthropic-cli
+    version: v1.3.1
+  - name: anthropics/anthropic-cli
+    version: v1.2.1

--- a/pkgs/anthropics/anthropic-cli/pkg.yaml
+++ b/pkgs/anthropics/anthropic-cli/pkg.yaml
@@ -1,6 +1,2 @@
 packages:
   - name: anthropics/anthropic-cli@v1.6.0
-  - name: anthropics/anthropic-cli
-    version: v1.3.1
-  - name: anthropics/anthropic-cli
-    version: v1.2.1

--- a/pkgs/anthropics/anthropic-cli/pkg.yaml
+++ b/pkgs/anthropics/anthropic-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: anthropics/anthropic-cli@v1.6.0

--- a/pkgs/anthropics/anthropic-cli/registry.yaml
+++ b/pkgs/anthropics/anthropic-cli/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: anthropics
+    repo_name: anthropic-cli
+    description: The CLI for the Claude API
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.3.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: ant_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}

--- a/pkgs/anthropics/anthropic-cli/registry.yaml
+++ b/pkgs/anthropics/anthropic-cli/registry.yaml
@@ -4,13 +4,15 @@ packages:
     repo_owner: anthropics
     repo_name: anthropic-cli
     description: The CLI for the Claude API
+    files:
+      - name: ant
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.0"
         no_asset: true
       - version_constraint: "true"
         asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
+        format: tar.gz
         replacements:
           darwin: macos
         checksum:
@@ -18,6 +20,7 @@ packages:
           asset: ant_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            format: tar.zst
-            asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: darwin
+            format: zip
+          - goos: windows
+            format: zip

--- a/pkgs/anthropics/anthropic-cli/registry.yaml
+++ b/pkgs/anthropics/anthropic-cli/registry.yaml
@@ -12,7 +12,7 @@ packages:
         no_asset: true
       - version_constraint: "true"
         asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        format: zip
         replacements:
           darwin: macos
         checksum:
@@ -20,7 +20,5 @@ packages:
           asset: ant_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
-          - goos: darwin
-            format: zip
-          - goos: windows
-            format: zip
+          - goos: linux
+            format: tar.gz

--- a/pkgs/anthropics/anthropic-cli/scaffold.yaml
+++ b/pkgs/anthropics/anthropic-cli/scaffold.yaml
@@ -1,0 +1,4 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: anthropics/anthropic-cli
+all_assets_filter: not ((Asset matches ".apk$") or (Asset matches ".deb$") or (Asset matches ".rpm$") or (Asset matches ".pkg.tar.zst$"))

--- a/registry.yaml
+++ b/registry.yaml
@@ -12806,13 +12806,15 @@ packages:
     repo_owner: anthropics
     repo_name: anthropic-cli
     description: The CLI for the Claude API
+    files:
+      - name: ant
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.3.0"
         no_asset: true
       - version_constraint: "true"
         asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
+        format: tar.gz
         replacements:
           darwin: macos
         checksum:
@@ -12820,9 +12822,10 @@ packages:
           asset: ant_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
-          - goos: linux
-            format: tar.zst
-            asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
+          - goos: darwin
+            format: zip
+          - goos: windows
+            format: zip
   - type: http
     repo_owner: anthropics
     repo_name: claude-code

--- a/registry.yaml
+++ b/registry.yaml
@@ -12814,7 +12814,7 @@ packages:
         no_asset: true
       - version_constraint: "true"
         asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        format: zip
         replacements:
           darwin: macos
         checksum:
@@ -12822,10 +12822,8 @@ packages:
           asset: ant_{{trimV .Version}}_checksums.txt
           algorithm: sha256
         overrides:
-          - goos: darwin
-            format: zip
-          - goos: windows
-            format: zip
+          - goos: linux
+            format: tar.gz
   - type: http
     repo_owner: anthropics
     repo_name: claude-code

--- a/registry.yaml
+++ b/registry.yaml
@@ -12802,6 +12802,27 @@ packages:
           - darwin
           - windows
           - amd64
+  - type: github_release
+    repo_owner: anthropics
+    repo_name: anthropic-cli
+    description: The CLI for the Claude API
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.3.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: ant_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.pkg.{{.Format}}
   - type: http
     repo_owner: anthropics
     repo_name: claude-code


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

Add `anthropics/anthropic-cli` — the CLI for the Claude API. The repository ships a binary named `ant`.

- Upstream: https://github.com/anthropics/anthropic-cli
- Language: Go (built with goreleaser)
- Asset pattern: `ant_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}`
  - linux: `tar.gz`
  - darwin (`macos`) / windows: `zip`
- Checksum: `ant_{{trimV .Version}}_checksums.txt` (sha256)

### Notes / manual fixes after `argd s`

- `argd s` initially picked the Arch Linux `.pkg.tar.zst` for linux. Switched to `tar.gz` for portability across the matrix.
- The executable is named `ant`, not the repository name `anthropic-cli`. Set `files[].name: ant` accordingly.
- Asset names use `macos` rather than `darwin`. Handled with `replacements: {darwin: macos}`.
- `v1.3.0` was published without assets. Set `version_constraint: Version == "v1.3.0"` with `no_asset: true`.
- `pkg.yaml` includes the latest version plus the immediate neighbors of the v1.3.0 no_asset gap (`v1.2.1`, `v1.3.1`) so CI exercises the boundary on either side.

### Verification

- `argd t` passed on all 6 environments (linux/darwin/windows × amd64/arm64) for `v1.6.0` / `v1.3.1` / `v1.2.1`.
- Installed locally via `aqua i` against this registry and confirmed `ant --version` returns `ant version 1.6.0` and `ant --help` lists the expected subcommands.