### PR TITLE
feat: add libc variants for jdx tools

### DIFF
--- a/pkgs/jdx/fnox/pkg.yaml
+++ b/pkgs/jdx/fnox/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: jdx/fnox@v1.23.1

--- a/pkgs/jdx/fnox/registry.yaml
+++ b/pkgs/jdx/fnox/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jdx
+    repo_name: fnox
+    description: encrypted/remote secret manager
+    asset: fnox-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+      - goos: linux
+        variants:
+          - key: libc
+            value: glibc
+      - goos: linux
+        replacements:
+          linux: unknown-linux-musl
+        variants:
+          - key: libc
+            value: musl
+    supported_envs:
+      - linux
+      - darwin
+      - windows
+    github_immutable_release: true

--- a/pkgs/jdx/hk/registry.yaml
+++ b/pkgs/jdx/hk/registry.yaml
@@ -56,6 +56,16 @@ packages:
               amd64: amd64
           - goos: windows
             format: zip
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         supported_envs:
           - linux
           - darwin/arm64

--- a/pkgs/jdx/mise/registry.yaml
+++ b/pkgs/jdx/mise/registry.yaml
@@ -30,6 +30,9 @@ packages:
         overrides:
           - goos: linux
             asset: rtx-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
         replacements:
           amd64: x64
           darwin: macos
@@ -39,12 +42,21 @@ packages:
       - version_constraint: semver(">= 2025.7.13, <= 2025.7.15")
         no_asset: true
       - version_constraint: semver("<= 2025.8.21")
-        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: mise
             src: mise/bin/mise
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -54,12 +66,21 @@ packages:
           - linux
           - darwin
       - version_constraint: "true"
-        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: mise
             src: mise/bin/mise
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:

--- a/pkgs/jdx/usage/registry.yaml
+++ b/pkgs/jdx/usage/registry.yaml
@@ -13,13 +13,25 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         supported_envs:
           - linux
           - darwin
@@ -30,12 +42,23 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
         supported_envs:
@@ -46,12 +69,23 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
         supported_envs:
@@ -65,11 +99,21 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         overrides:
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
           - goos: windows
             format: zip
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         github_immutable_release: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -49509,6 +49509,36 @@ packages:
       algorithm: sha256
   - type: github_release
     repo_owner: jdx
+    repo_name: fnox
+    description: encrypted/remote secret manager
+    asset: fnox-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-gnu
+      windows: pc-windows-msvc
+    overrides:
+      - goos: windows
+        format: zip
+      - goos: linux
+        variants:
+          - key: libc
+            value: glibc
+      - goos: linux
+        replacements:
+          linux: unknown-linux-musl
+        variants:
+          - key: libc
+            value: musl
+    supported_envs:
+      - linux
+      - darwin
+      - windows
+    github_immutable_release: true
+  - type: github_release
+    repo_owner: jdx
     repo_name: hk
     description: git hook and pre-commit lint manager
     version_constraint: "false"
@@ -49563,6 +49593,16 @@ packages:
               amd64: amd64
           - goos: windows
             format: zip
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         supported_envs:
           - linux
           - darwin/arm64
@@ -49598,6 +49638,9 @@ packages:
         overrides:
           - goos: linux
             asset: rtx-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
         replacements:
           amd64: x64
           darwin: macos
@@ -49607,12 +49650,21 @@ packages:
       - version_constraint: semver(">= 2025.7.13, <= 2025.7.15")
         no_asset: true
       - version_constraint: semver("<= 2025.8.21")
-        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: mise
             src: mise/bin/mise
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -49622,12 +49674,21 @@ packages:
           - linux
           - darwin
       - version_constraint: "true"
-        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: mise
             src: mise/bin/mise
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: mise-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
@@ -49650,13 +49711,25 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         supported_envs:
           - linux
           - darwin
@@ -49667,12 +49740,23 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
         supported_envs:
@@ -49683,12 +49767,23 @@ packages:
         format: tar.gz
         replacements:
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
         supported_envs:
@@ -49702,13 +49797,23 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         overrides:
           - goos: darwin
             asset: usage-universal-{{.OS}}.{{.Format}}
           - goos: windows
             format: zip
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
         github_immutable_release: true
   - type: github_release
     repo_owner: jedisct1


### PR DESCRIPTION
## Summary
- Add libc variants for Linux assets in `jdx/mise`, `jdx/usage`, and `jdx/hk` so glibc hosts use glibc assets and musl hosts use musl assets.
- Add `jdx/fnox`, which publishes glibc/musl Linux assets plus macOS and Windows assets.
- Dropped `endevco/aube` from this PR per review: aube's musl binaries are static, so per the [registry style guide](https://aquaproj.github.io/docs/develop-registry/registry-style-guide/#1-when-the-musl-build-is-static) the static musl asset is preferred over a glibc/musl variant split.
- Did not update `endevco/pitchfork` because current releases do not publish musl Linux assets.

## Popularity
- `jdx/fnox`: 1,606 GitHub stars, 72 forks, latest release `v1.23.1` published 2026-05-02.
- Existing packages updated: `jdx/mise`, `jdx/usage`, `jdx/hk`.

## Tests
- `prettier -c pkgs/jdx/hk/registry.yaml pkgs/jdx/usage/registry.yaml pkgs/jdx/mise/registry.yaml pkgs/jdx/fnox/registry.yaml pkgs/jdx/fnox/pkg.yaml registry.yaml`
- `aqua exec -- conftest test pkgs/jdx/hk/*.yaml pkgs/jdx/usage/*.yaml pkgs/jdx/mise/*.yaml pkgs/jdx/fnox/*.yaml`
- `aqua exec -- argd t jdx/hk`
- `aqua exec -- argd t jdx/usage`
- `aqua exec -- argd t jdx/mise`
- `aqua exec -- argd t jdx/fnox`

*This PR was generated by an AI coding assistant.*