### PR TITLE
feat: add runs-on/cli

### DIFF
--- a/pkgs/runs-on/cli/pkg.yaml
+++ b/pkgs/runs-on/cli/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: runs-on/cli@v3.0.5
+  - name: runs-on/cli
+    version: v3.0.1
+  - name: runs-on/cli
+    version: v2.12.6
+  - name: runs-on/cli
+    version: v0.1.5
+  - name: runs-on/cli
+    version: v0.1.3

--- a/pkgs/runs-on/cli/registry.yaml
+++ b/pkgs/runs-on/cli/registry.yaml
@@ -14,7 +14,8 @@ packages:
         asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
-          - name: cli
+          - name: roc
+            src: cli
         checksum:
           type: github_release
           asset: cli_{{trimV .Version}}_checksums.txt

--- a/pkgs/runs-on/cli/registry.yaml
+++ b/pkgs/runs-on/cli/registry.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: runs-on
+    repo_name: cli
+    description: CLI for RunsOn
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.4"
+        no_asset: true
+      - version_constraint: Version == "v0.1.5"
+        asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.1.3")
+        asset: roc-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.12.6")
+        asset: roc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.1")
+        asset: roc_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: roc_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/runs-on/cli/registry.yaml
+++ b/pkgs/runs-on/cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: runs-on
     repo_name: cli
     description: CLI for RunsOn
+    files:
+      - name: roc
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.4"
@@ -11,6 +13,8 @@ packages:
       - version_constraint: Version == "v0.1.5"
         asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cli
         checksum:
           type: github_release
           asset: cli_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -76026,6 +76026,8 @@ packages:
     repo_owner: runs-on
     repo_name: cli
     description: CLI for RunsOn
+    files:
+      - name: roc
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.4"
@@ -76033,6 +76035,8 @@ packages:
       - version_constraint: Version == "v0.1.5"
         asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cli
         checksum:
           type: github_release
           asset: cli_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -76174,7 +76174,8 @@ packages:
         asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
-          - name: cli
+          - name: roc
+            src: cli
         checksum:
           type: github_release
           asset: cli_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -76023,6 +76023,54 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: runs-on
+    repo_name: cli
+    description: CLI for RunsOn
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.4"
+        no_asset: true
+      - version_constraint: Version == "v0.1.5"
+        asset: cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.1.3")
+        asset: roc-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.md5"
+          algorithm: md5
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.12.6")
+        asset: roc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.1")
+        asset: roc_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 3.0.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: roc_{{.Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: rust-cross
     repo_name: cargo-zigbuild
     description: Compile Cargo project with zig as linker


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Adds support for the runs-on.com cli to the registry.
* https://runs-on.com/guides/cli/
* https://github.com/runs-on/cli

I ran `argd s runs-on/cli`, added `files` configuration to registry.yaml, then ran `argd test runs-on/cli`.
`argd con` then `aqua i runs-on/cli && roc --version` worked as expected.

Thanks for making this process so seamless!