### PR TITLE
refactor: add github_release_attestations to where github_immutable_r…

### DIFF
--- a/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
+++ b/pkgs/UpCloudLtd/upcloud-cli/registry.yaml
@@ -73,6 +73,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: Version == "v3.32.0"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -86,6 +87,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -101,3 +103,4 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/dprint/dprint/registry.yaml
+++ b/pkgs/dprint/dprint/registry.yaml
@@ -57,3 +57,4 @@ packages:
           asset: SHASUMS256.txt
           algorithm: sha256
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/j178/prek/registry.yaml
+++ b/pkgs/j178/prek/registry.yaml
@@ -135,6 +135,7 @@ packages:
             files:
               - name: prek
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -159,3 +160,4 @@ packages:
         github_artifact_attestations:
           signer_workflow: j178/prek/.github/workflows/release.yml
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/jdx/hk/registry.yaml
+++ b/pkgs/jdx/hk/registry.yaml
@@ -61,3 +61,4 @@ packages:
           - darwin/arm64
           - windows
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/jdx/mise/registry.yaml
+++ b/pkgs/jdx/mise/registry.yaml
@@ -69,3 +69,4 @@ packages:
           - linux
           - darwin
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/jdx/usage/registry.yaml
+++ b/pkgs/jdx/usage/registry.yaml
@@ -58,6 +58,7 @@ packages:
           - linux
           - darwin
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -73,3 +74,4 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -83,6 +83,7 @@ packages:
           darwin: macos
           windows: win
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: semver("<= 11.0.4")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -95,6 +96,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -109,6 +111,7 @@ packages:
         github_artifact_attestations:
           signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
         github_immutable_release: true
+        github_release_attestations: true
         supported_envs:
           - linux
           - windows

--- a/pkgs/suzuki-shunsuke/cmdx/registry.yaml
+++ b/pkgs/suzuki-shunsuke/cmdx/registry.yaml
@@ -112,6 +112,7 @@ packages:
           type: github_release
           asset: multiple.intoto.jsonl
         github_immutable_release: true
+        github_release_attestations: true
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/suzuki-shunsuke/ghir/registry.yaml
+++ b/pkgs/suzuki-shunsuke/ghir/registry.yaml
@@ -29,6 +29,7 @@ packages:
         github_artifact_attestations:
           signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         github_immutable_release: true
+        github_release_attestations: true
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/twpayne/chezmoi/registry.yaml
+++ b/pkgs/twpayne/chezmoi/registry.yaml
@@ -213,6 +213,7 @@ packages:
             format: zip
             asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: semver("<= 2.68.1")
         asset: chezmoi_{{trimV .Version}}_{{.OS}}-glibc_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -241,6 +242,7 @@ packages:
             format: zip
             asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -258,3 +260,4 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -7896,6 +7896,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: Version == "v3.32.0"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -7909,6 +7910,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: upcloud-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -7924,6 +7926,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: Versent
     repo_name: saml2aws
@@ -33406,6 +33409,7 @@ packages:
           asset: SHASUMS256.txt
           algorithm: sha256
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: drlau
     repo_name: akashi
@@ -49194,6 +49198,7 @@ packages:
             files:
               - name: prek
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: prek-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -49218,6 +49223,7 @@ packages:
         github_artifact_attestations:
           signer_workflow: j178/prek/.github/workflows/release.yml
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: jacek-kurlit
     repo_name: pik
@@ -49568,6 +49574,7 @@ packages:
           - darwin/arm64
           - windows
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: jdx
     repo_name: mise
@@ -49637,6 +49644,7 @@ packages:
           - linux
           - darwin
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: jdx
     repo_name: usage
@@ -49695,6 +49703,7 @@ packages:
           - linux
           - darwin
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: usage-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -49710,6 +49719,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: jedisct1
     repo_name: minisign
@@ -71941,6 +71951,7 @@ packages:
           darwin: macos
           windows: win
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: semver("<= 11.0.4")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -71953,6 +71964,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -71967,6 +71979,7 @@ packages:
         github_artifact_attestations:
           signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
         github_immutable_release: true
+        github_release_attestations: true
         supported_envs:
           - linux
           - windows
@@ -84983,6 +84996,7 @@ packages:
           type: github_release
           asset: multiple.intoto.jsonl
         github_immutable_release: true
+        github_release_attestations: true
         overrides:
           - goos: windows
             format: zip
@@ -85346,6 +85360,7 @@ packages:
         github_artifact_attestations:
           signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         github_immutable_release: true
+        github_release_attestations: true
         overrides:
           - goos: windows
             format: zip
@@ -91320,6 +91335,7 @@ packages:
             format: zip
             asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: semver("<= 2.68.1")
         asset: chezmoi_{{trimV .Version}}_{{.OS}}-glibc_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -91348,6 +91364,7 @@ packages:
             format: zip
             asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         github_immutable_release: true
+        github_release_attestations: true
       - version_constraint: "true"
         asset: chezmoi_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -91365,6 +91382,7 @@ packages:
           - goos: windows
             format: zip
         github_immutable_release: true
+        github_release_attestations: true
   - type: github_release
     repo_owner: txn2
     repo_name: kubefwd


### PR DESCRIPTION
…elease is

The latter is deprecated and being phased out, ref https://github.com/aquaproj/aqua/pull/4667

I suppose this is in order to not lose info on existing packages, but going forward we should probably only add github_release_attestations and not github_immutable_release entries.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
