### PR TITLE
feat(kunobi-ninja/kunobi): exclude pre-releases from default version

### DIFF
--- a/pkgs/kunobi-ninja/kunobi/registry.yaml
+++ b/pkgs/kunobi-ninja/kunobi/registry.yaml
@@ -8,6 +8,7 @@ packages:
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
     version_source: github_tag
+    version_filter: 'not (Version matches "-(rc|alpha|beta)")'
     url: https://r2.kunobi.ninja/v{{.Version}}/Kunobi_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     format: tar.gz
     replacements:


### PR DESCRIPTION
[kunobi-ninja/kunobi](https://github.com/kunobi-ninja/kunobi) - Kubernetes IDE for managing clusters, resources, and workloads

## Summary

Adds a `version_filter` to the existing `kunobi-ninja/kunobi` package so `aqua g` and `mise use aqua:kunobi-ninja/kunobi` resolve to the latest **stable** release, not the latest pre-release.

```yaml
version_filter: 'not (Version matches "-(rc|alpha|beta)")'
```

## Why

The kunobi-ninja/kunobi repository publishes both stable (e.g. `1.0.0`) and pre-release (`-rc`, `-beta`, `-alpha`) tags from the same release pipeline. Without a filter, the highest SemVer wins — and as soon as a pre-release exists between two stables (e.g. `1.0.0` is out, `1.0.1-beta.1` ships, `1.0.1` is not yet out), default users would land on the pre-release. That's the wrong behavior for an `aqua install` default; users who want pre-releases can still pin them explicitly with `kunobi-ninja/kunobi@<version>`.

The filter pattern is identical to the one [`apache/maven`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/apache/maven/registry.yaml) uses for the same `rc/alpha/beta` triad.

## Verification

Tested locally with this exact registry file:

| Scenario | Filter | Resolved version | Expected |
|---|---|---|---|
| `aqua g kunobi-local,kunobi-ninja/kunobi` | `not (Version matches "-(rc\|alpha\|beta)")` | `1.0.0` | stable ✅ |
| Same with filter inverted to `(Version matches "-(rc\|alpha\|beta)")` | inverted | `0.1.0-beta.34` | pre-release ✅ |
| `aqua install kunobi-ninja/kunobi@0.1.0-beta.34` | original | installs `0.1.0-beta.34` | pin bypasses filter ✅ |

The inverted-filter test is what proves the filter is actually being evaluated — otherwise both runs would resolve to `1.0.0` by SemVer ordering alone.

## Check List

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md) (GPG-signed, GitHub verified)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests) — will avoid force-pushes on this PR
- [x] Install and execute the package and confirm if the package works well — verified with `aqua g` and `aqua install` against the modified registry locally
- [x] No `cmdx s` / `argd s` needed — modifying an existing entry, not adding a new one

## AI disclosure

Drafted with assistance from Claude (claude-opus-4-7), per aqua-registry's [AI Guide](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). I've reviewed the change, ran local validation, and take responsibility for it.