### PR TITLE
fix(iann0036/iamlive): update for asset format since v1.1.28

### DIFF
--- a/pkgs/iann0036/iamlive/pkg.yaml
+++ b/pkgs/iann0036/iamlive/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: iann0036/iamlive@v1.1.27
+  - name: iann0036/iamlive@v1.1.28
+  - name: iann0036/iamlive
+    version: v1.1.27

--- a/pkgs/iann0036/iamlive/registry.yaml
+++ b/pkgs/iann0036/iamlive/registry.yaml
@@ -3,13 +3,23 @@ packages:
   - type: github_release
     repo_owner: iann0036
     repo_name: iamlive
-    asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: zip
     description: Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy
-    overrides:
-      - goos: linux
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.27")
+        asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: "true"
+        asset: iamlive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+        supported_envs:
+          - darwin
+          - linux
+          - windows

--- a/pkgs/iann0036/iamlive/registry.yaml
+++ b/pkgs/iann0036/iamlive/registry.yaml
@@ -19,7 +19,3 @@ packages:
       - version_constraint: "true"
         asset: iamlive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        supported_envs:
-          - darwin
-          - linux
-          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -2325,50 +2325,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: github_release
-    repo_owner: DataDog
-    repo_name: pup
-    aliases:
-      - name: datadog-labs/pup
-    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.21.0")
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
-        supported_envs:
-          - linux
-          - darwin
   - name: DeNA/unity-meta-check/gh-action
     type: github_release
     repo_owner: DeNA
@@ -30029,6 +29985,50 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: DataDog
+    repo_name: pup
+    aliases:
+      - name: datadog-labs/pup
+    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.21.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: datanymizer
     repo_name: datanymizer
     asset: pg_datanymizer-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -47161,10 +47161,6 @@ packages:
       - version_constraint: "true"
         asset: iamlive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        supported_envs:
-          - darwin
-          - linux
-          - windows
   - type: github_release
     repo_owner: iawia002
     repo_name: lux

--- a/registry.yaml
+++ b/registry.yaml
@@ -2325,6 +2325,50 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: github_release
+    repo_owner: DataDog
+    repo_name: pup
+    aliases:
+      - name: datadog-labs/pup
+    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.21.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
   - name: DeNA/unity-meta-check/gh-action
     type: github_release
     repo_owner: DeNA
@@ -29984,50 +30028,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-  - type: github_release
-    repo_owner: DataDog
-    repo_name: pup
-    aliases:
-      - name: datadog-labs/pup
-    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.21.0")
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
-        supported_envs:
-          - linux
-          - darwin
   - type: github_release
     repo_owner: datanymizer
     repo_name: datanymizer

--- a/registry.yaml
+++ b/registry.yaml
@@ -47145,16 +47145,26 @@ packages:
   - type: github_release
     repo_owner: iann0036
     repo_name: iamlive
-    asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: zip
     description: Generate an IAM policy from AWS calls using client-side monitoring (CSM) or embedded proxy
-    overrides:
-      - goos: linux
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.1.27")
+        asset: iamlive-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+      - version_constraint: "true"
+        asset: iamlive_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+        supported_envs:
+          - darwin
+          - linux
+          - windows
   - type: github_release
     repo_owner: iawia002
     repo_name: lux


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

From iamlive 1.1.28, the asset files' format changed:

- from `iamlive-v1.1.27-darwin-arm64.zip`
- to `iamlive_1.1.28_darwin_arm64.tar.gz`

Ref: https://github.com/iann0036/iamlive/issues/105#issuecomment-4406063791

There is a related PR (https://github.com/aquaproj/aqua-registry/pull/52317) but the checks fail because of the format change.

Close #52317