### PR TITLE
chore(DataDog/managed-kubernetes-auditing-toolkit): rename pkgs/datadog/ to canonical pkgs/DataDog/

### DIFF
--- a/pkgs/DataDog/managed-kubernetes-auditing-toolkit/pkg.yaml
+++ b/pkgs/DataDog/managed-kubernetes-auditing-toolkit/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: DataDog/managed-kubernetes-auditing-toolkit@v0.3.1
+  - name: DataDog/managed-kubernetes-auditing-toolkit
+    version: v0.1.1

--- a/pkgs/DataDog/managed-kubernetes-auditing-toolkit/registry.yaml
+++ b/pkgs/DataDog/managed-kubernetes-auditing-toolkit/registry.yaml
@@ -1,8 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - type: github_release
-    repo_owner: datadog
+    repo_owner: DataDog
     repo_name: managed-kubernetes-auditing-toolkit
+    aliases:
+      - name: datadog/managed-kubernetes-auditing-toolkit
     description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
     version_constraint: "false"
     version_overrides:

--- a/pkgs/datadog/managed-kubernetes-auditing-toolkit/pkg.yaml
+++ b/pkgs/datadog/managed-kubernetes-auditing-toolkit/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: datadog/managed-kubernetes-auditing-toolkit@v0.3.1
-  - name: datadog/managed-kubernetes-auditing-toolkit
-    version: v0.1.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -2325,50 +2325,6 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: github_release
-    repo_owner: DataDog
-    repo_name: pup
-    aliases:
-      - name: datadog-labs/pup
-    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.21.0")
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
-        supported_envs:
-          - linux
-          - darwin
   - name: DeNA/unity-meta-check/gh-action
     type: github_release
     repo_owner: DeNA
@@ -30006,8 +29962,10 @@ packages:
           - darwin
           - amd64
   - type: github_release
-    repo_owner: datadog
+    repo_owner: DataDog
     repo_name: managed-kubernetes-auditing-toolkit
+    aliases:
+      - name: datadog/managed-kubernetes-auditing-toolkit
     description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
     version_constraint: "false"
     version_overrides:
@@ -30039,6 +29997,50 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+  - type: github_release
+    repo_owner: DataDog
+    repo_name: pup
+    aliases:
+      - name: datadog-labs/pup
+    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.21.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: datanymizer
     repo_name: datanymizer

--- a/registry.yaml
+++ b/registry.yaml
@@ -2325,6 +2325,86 @@ packages:
         supported_envs:
           - linux
           - darwin
+  - type: github_release
+    repo_owner: DataDog
+    repo_name: managed-kubernetes-auditing-toolkit
+    aliases:
+      - name: datadog/managed-kubernetes-auditing-toolkit
+    description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.1")
+        asset: managed-kubernetes-auditing-toolkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: mkat
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: managed-kubernetes-auditing-toolkit_{{.OS}}_{{.Arch}}.{{.Format}}
+        files:
+          - name: mkat
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
+    repo_owner: DataDog
+    repo_name: pup
+    aliases:
+      - name: datadog-labs/pup
+    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.21.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
   - name: DeNA/unity-meta-check/gh-action
     type: github_release
     repo_owner: DeNA
@@ -29961,86 +30041,6 @@ packages:
         supported_envs:
           - darwin
           - amd64
-  - type: github_release
-    repo_owner: DataDog
-    repo_name: managed-kubernetes-auditing-toolkit
-    aliases:
-      - name: datadog/managed-kubernetes-auditing-toolkit
-    description: All-in-one auditing toolkit for identifying common security issues in managed Kubernetes environments. Currently supports Amazon EKS
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.1.1")
-        asset: managed-kubernetes-auditing-toolkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        files:
-          - name: mkat
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: managed-kubernetes-auditing-toolkit_{{.OS}}_{{.Arch}}.{{.Format}}
-        files:
-          - name: mkat
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-  - type: github_release
-    repo_owner: DataDog
-    repo_name: pup
-    aliases:
-      - name: datadog-labs/pup
-    description: Give your AI agent a Pup — a CLI companion with 200+ commands across 33+ Datadog products
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.21.0")
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-          windows: Windows
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-      - version_constraint: "true"
-        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          darwin: Darwin
-          linux: Linux
-        checksum:
-          type: github_release
-          asset: pup_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
-        supported_envs:
-          - linux
-          - darwin
   - type: github_release
     repo_owner: datanymizer
     repo_name: datanymizer


### PR DESCRIPTION
Closes #53456

## Summary

- Rename `pkgs/datadog/managed-kubernetes-auditing-toolkit/` to `pkgs/DataDog/managed-kubernetes-auditing-toolkit/`, and align `repo_owner` to `DataDog`. This matches the canonical casing on GitHub.
- Add `aliases: [{name: datadog/managed-kubernetes-auditing-toolkit}]` to preserve backward compatibility (https://aquaproj.github.io/docs/reference/registry-config/aliases/). Existing `aqua.yaml` configurations that reference the old name continue to work.

## Why

`pkgs/DataDog/pup/` (uppercase) and `pkgs/datadog/managed-kubernetes-auditing-toolkit/` (lowercase) coexisted at the same level, so on a case-insensitive filesystem (macOS APFS) they collapse to the same on-disk directory. `argd gr` (the sort in `registry-tool`'s `pkg/generate-registry/generate_registry.go`) is a byte-wise string compare on paths, so the entry appears as lowercase `datadog` locally on macOS but as uppercase `DataDog` on Linux CI, producing different sort orders.

As a result, autofix.ci on unrelated PRs kept generating commits that only moved the `DataDog/pup` entry inside `registry.yaml` (e.g. aquaproj/aqua-registry#53454). Consolidating `pkgs/datadog/` into `pkgs/DataDog/` resolves the collision on macOS and eliminates the local/CI sort-order divergence.

See #53456 for the full rationale.

## Test plan

- [ ] All CI green
- [ ] autofix.ci regenerates `registry.yaml` and produces a single commit (expected: it will move the entry under uppercase `pkgs/DataDog/managed-kubernetes-auditing-toolkit/` to its sorted position — this is the correct behavior)
- [ ] After that autofix.ci commit, `registry.yaml` reflects both `repo_owner: DataDog` and `aliases: [{name: datadog/managed-kubernetes-auditing-toolkit}]`

## AI usage

Planned and implemented with Claude Code (Opus 4.7). Diff was reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)