### PR TITLE
feat: add Code-Hex/Neo-cowsay

### DIFF
--- a/pkgs/Code-Hex/Neo-cowsay/pkg.yaml
+++ b/pkgs/Code-Hex/Neo-cowsay/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: Code-Hex/Neo-cowsay@v2.0.4
+  - name: Code-Hex/Neo-cowsay
+    version: v1.0.4
+  - name: Code-Hex/Neo-cowsay
+    version: v1.0.1
+  - name: Code-Hex/Neo-cowsay
+    version: 0.0.5

--- a/pkgs/Code-Hex/Neo-cowsay/registry.yaml
+++ b/pkgs/Code-Hex/Neo-cowsay/registry.yaml
@@ -4,9 +4,6 @@ packages:
     repo_owner: Code-Hex
     repo_name: Neo-cowsay
     description: Cowsay reborn in Go
-    files:
-      - name: cowsay
-      - name: cowthink
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")
@@ -26,6 +23,9 @@ packages:
       - version_constraint: semver("<= 1.0.1")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -47,6 +47,9 @@ packages:
       - version_constraint: semver("<= 1.0.4")
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         replacements:
           amd64: x86_64
           darwin: macOS
@@ -64,6 +67,9 @@ packages:
       - version_constraint: "true"
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         replacements:
           amd64: x86_64
           darwin: macOS

--- a/pkgs/Code-Hex/Neo-cowsay/registry.yaml
+++ b/pkgs/Code-Hex/Neo-cowsay/registry.yaml
@@ -3,18 +3,26 @@ packages:
   - type: github_release
     repo_owner: Code-Hex
     repo_name: Neo-cowsay
-    description: cowsay is reborn. Neo Cowsay has written in Go
+    description: Cowsay reborn in Go
+    files:
+      - name: cowsay
+      - name: cowthink
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+            src: "{{.OS}}_{{.Arch}}/cowsay"
+          - name: cowthink
+            src: "{{.OS}}_{{.Arch}}/cowthink"
         rosetta2: true
         windows_arm_emulation: true
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
       - version_constraint: semver("<= 1.0.1")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -33,9 +41,9 @@ packages:
           - goos: windows
             format: zip
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
       - version_constraint: semver("<= 1.0.4")
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/Code-Hex/Neo-cowsay/registry.yaml
+++ b/pkgs/Code-Hex/Neo-cowsay/registry.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Code-Hex
+    repo_name: Neo-cowsay
+    description: cowsay is reborn. Neo Cowsay has written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.1")
+        asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.4")
+        asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm
+      - version_constraint: "true"
+        asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -2128,9 +2128,6 @@ packages:
     repo_owner: Code-Hex
     repo_name: Neo-cowsay
     description: Cowsay reborn in Go
-    files:
-      - name: cowsay
-      - name: cowthink
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")
@@ -2150,6 +2147,9 @@ packages:
       - version_constraint: semver("<= 1.0.1")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -2171,6 +2171,9 @@ packages:
       - version_constraint: semver("<= 1.0.4")
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         replacements:
           amd64: x86_64
           darwin: macOS
@@ -2188,6 +2191,9 @@ packages:
       - version_constraint: "true"
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+          - name: cowthink
         replacements:
           amd64: x86_64
           darwin: macOS

--- a/registry.yaml
+++ b/registry.yaml
@@ -2126,6 +2126,74 @@ packages:
           signer_workflow: ClementTsang/bottom/.github/workflows/build_releases.yml
   - type: github_release
     repo_owner: Code-Hex
+    repo_name: Neo-cowsay
+    description: cowsay is reborn. Neo Cowsay has written in Go
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.1")
+        asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.0.4")
+        asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements:
+              arm64: arm
+      - version_constraint: "true"
+        asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macOS
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: cowsay_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: Code-Hex
     repo_name: gqldoc
     description: The easiest way to make API documents for GraphQL
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -2127,18 +2127,26 @@ packages:
   - type: github_release
     repo_owner: Code-Hex
     repo_name: Neo-cowsay
-    description: cowsay is reborn. Neo Cowsay has written in Go
+    description: Cowsay reborn in Go
+    files:
+      - name: cowsay
+      - name: cowthink
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: cowsay
+            src: "{{.OS}}_{{.Arch}}/cowsay"
+          - name: cowthink
+            src: "{{.OS}}_{{.Arch}}/cowthink"
         rosetta2: true
         windows_arm_emulation: true
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
       - version_constraint: semver("<= 1.0.1")
         asset: cowsay_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -2157,9 +2165,9 @@ packages:
           - goos: windows
             format: zip
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
       - version_constraint: semver("<= 1.0.4")
         asset: cowsay_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add `Code-Hex/Neo-cowsay` to the standard registry.

This uses the upstream GitHub Release archives and exposes both published commands:

- `cowsay`
- `cowthink`

The scaffolded config needed a manual fix because the release archives contain `cowsay` and `cowthink`, not `Neo-cowsay`. The oldest tested release, `0.0.5`, also stores binaries under `{{.OS}}_{{.Arch}}/`, so that layout is handled with a version override.

Verification:

```console
$ aqua i -l
$ aqua exec -- conftest test --combine pkgs/Code-Hex/Neo-cowsay/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ aqua exec -- argd t Code-Hex/Neo-cowsay
# passed for linux/darwin/windows amd64/arm64

$ aqua --log-level error i
$ cowsay aqua
$ cowthink aqua
cowsay_ok=yes
cowthink_ok=yes
```
