### PR TITLE
fix(pnpm/pnpm): expose v11 aliases

### DIFF
--- a/pkgs/pnpm/pnpm/pkg.yaml
+++ b/pkgs/pnpm/pnpm/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: pnpm/pnpm@v11.0.9
   - name: pnpm/pnpm
+    version: v11.0.6
+  - name: pnpm/pnpm
     version: v11.0.4
   - name: pnpm/pnpm
     version: v10.33.4

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -89,6 +89,9 @@ packages:
         format: tar.gz
         files:
           - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
         replacements:
           amd64: x64
           windows: win32
@@ -97,11 +100,44 @@ packages:
             format: zip
         github_immutable_release: true
         github_release_attestations: true
+      - version_constraint: semver("<= 11.0.6")
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+        github_immutable_release: true
+        github_release_attestations: true
+        supported_envs:
+          - linux
+          - windows
+          - darwin/arm64
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
         replacements:
           amd64: x64
           windows: win32

--- a/registry.yaml
+++ b/registry.yaml
@@ -72051,6 +72051,9 @@ packages:
         format: tar.gz
         files:
           - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
         replacements:
           amd64: x64
           windows: win32
@@ -72059,11 +72062,44 @@ packages:
             format: zip
         github_immutable_release: true
         github_release_attestations: true
+      - version_constraint: semver("<= 11.0.6")
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+        github_immutable_release: true
+        github_release_attestations: true
+        supported_envs:
+          - linux
+          - windows
+          - darwin/arm64
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
           - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
         replacements:
           amd64: x64
           windows: win32


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## What

Expose pnpm v11 SEA aliases from the registry metadata:

- `v11.0.0` through `v11.0.6`: expose `pnpm` and `pn`.
- `v11.0.7+`: expose `pnpm`, `pn`, `pnpx`, and `pnx`.

`pnpx` and `pnx` use hard links so pnpm can detect the launched executable name via `process.execPath`. v10 remains unchanged because `@pnpm/exe@10.33.4` only publishes `pnpm`.

## Why this targets `@pnpm/exe`, not `npm install -g pnpm`

aqua installs the standalone GitHub release assets from `pnpm/pnpm`. Those assets correspond to pnpm's standalone executable distribution (`@pnpm/exe`), not the ordinary JavaScript `pnpm` npm package.

pnpm's own installation docs distinguish the two npm packages:

- [`pnpm`](https://pnpm.io/installation#using-npm) is the ordinary CLI package and needs an existing Node.js runtime.
- [`@pnpm/exe`](https://pnpm.io/installation#using-npm) is packaged with Node.js into an executable and can run without Node.js installed.

That difference matters for aliases:

- [`pnpm@10.33.4`'s JS package](https://github.com/pnpm/pnpm/blob/v10.33.4/pnpm/package.json#L52-L55) publishes `pnpm` and `pnpx`.
- [`@pnpm/exe@10.33.4`](https://github.com/pnpm/pnpm/blob/v10.33.4/pnpm/artifacts/exe/package.json) publishes only `pnpm`.
- [`@pnpm/exe@11.0.9`](https://github.com/pnpm/pnpm/blob/v11.0.9/pnpm/artifacts/exe/package.json) publishes `pnpm`, `pn`, `pnpx`, and `pnx`.

So this PR follows the standalone executable behavior that aqua actually installs.

## Why not add `pnpx` for v10?

The v10 JavaScript package ships a separate `bin/pnpx.cjs`, but the v10 standalone executable does not have equivalent alias dispatch. If we expose the same v10 executable as `pnpx` in aqua, it still behaves like normal `pnpm`, not `pnpm dlx`.

Manual check with `@pnpm/exe@10.33.4`'s Linux standalone binary:

```console
$ pnpm --help | sed -n '1,3p'
Version 10.33.4 (compiled to binary; bundled Node.js v20.11.1)
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

$ pnpx-hard --help | sed -n '1,3p'
Version 10.33.4 (compiled to binary; bundled Node.js v20.11.1)
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

$ pnpx-sym --help | sed -n '1,3p'
Version 10.33.4 (compiled to binary; bundled Node.js v20.11.1)
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]
```

Adding a v10 `pnpx` alias in aqua would therefore create a misleading command: it would exist, but it would not run the documented [`pnx` / `pnpm dlx` behavior](https://pnpm.io/cli/pnx).

## Why v11.0.7 is the `pnpx` / `pnx` boundary

Although `@pnpm/exe` metadata advertised `pnpx` and `pnx` before v11.0.7, the standalone binary did not start routing those executable names to `dlx` until [`pnpm/pnpm#11501`](https://github.com/pnpm/pnpm/pull/11501), which fixed [`pnpm/pnpm#11486`](https://github.com/pnpm/pnpm/issues/11486).

- [`v11.0.6` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.6/pnpm/src/pnpm.ts) only passes `process.argv.slice(2)` to `main`.
- [`v11.0.7` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.7/pnpm/src/pnpm.ts) adds `buildArgv()` and checks `path.basename(process.execPath)` for `pnpx` / `pnx`.
- [`v11.0.9` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.9/pnpm/src/pnpm.ts) keeps that behavior and references `pnpm/pnpm#11486`.

`pn` is safe for earlier v11 because it is only a short name for normal `pnpm` behavior. It does not need the `pnpx` / `pnx` `dlx` dispatch.

## Why only `pnpx` / `pnx` use hard links

`pnpx` and `pnx` must preserve the launched executable name in `process.execPath`, because pnpm's standalone binary special-cases those basenames and prepends `dlx`. This is the same mechanism described in [`pnpm/pnpm#11501`](https://github.com/pnpm/pnpm/pull/11501) and it is why this PR uses `hard: true` for `pnpx` and `pnx`.

`pn` does not require that behavior. It should run normal `pnpm`, so a regular `link` is enough to expose the command. On Windows, aqua already implements `files[].link` using a hard link where symlinks are not used.

## Evidence

Package metadata:

```console
$ npm view pnpm@10.33.4 bin --json
{
  "pnpm": "bin/pnpm.cjs",
  "pnpx": "bin/pnpx.cjs"
}

$ npm view @pnpm/exe@10.33.4 bin --json
{
  "pnpm": "pnpm"
}

$ npm view pnpm@11.0.9 bin --json
{
  "pn": "bin/pnpm.mjs",
  "pnx": "bin/pnpx.mjs",
  "pnpm": "bin/pnpm.mjs",
  "pnpx": "bin/pnpx.mjs"
}

$ npm view @pnpm/exe@11.0.9 bin --json
{
  "pn": "pn",
  "pnx": "pnx",
  "pnpm": "pnpm",
  "pnpx": "pnpx"
}
```

pnpm source:

- [`v11.0.6` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.6/pnpm/src/pnpm.ts) only passes `process.argv.slice(2)` to `main`.
- [`v11.0.7` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.7/pnpm/src/pnpm.ts) added alias handling for `pnpx` and `pnx`.
- [`v11.0.9` `pnpm/src/pnpm.ts`](https://github.com/pnpm/pnpm/blob/v11.0.9/pnpm/src/pnpm.ts) keeps that handling and references [`pnpm/pnpm#11486`](https://github.com/pnpm/pnpm/issues/11486).

Related aqua context:

- [`files[].hard` docs](https://aquaproj.github.io/docs/reference/registry-config/files/)
- [`aquaproj/aqua#3775`](https://github.com/aquaproj/aqua/issues/3775)
- [`aquaproj/aqua-registry#34598`](https://github.com/aquaproj/aqua-registry/pull/34598)
- [`aquaproj/aqua-registry#52821`](https://github.com/aquaproj/aqua-registry/pull/52821)

Related issues checked:

- [`jdx/mise#9751`](https://github.com/jdx/mise/discussions/9751): missing `pnpx` command; this PR addresses the v11 standalone executable case.
- [`jdx/mise#9453`](https://github.com/jdx/mise/discussions/9453): original v11 asset naming break was fixed by [`aquaproj/aqua-registry#52821`](https://github.com/aquaproj/aqua-registry/pull/52821). The later [`comment about v10.33.4`](https://github.com/jdx/mise/discussions/9453#discussioncomment-16830792) is the v10 asset-boundary regression fixed by [`aquaproj/aqua-registry#53423`](https://github.com/aquaproj/aqua-registry/pull/53423), released in [`aqua-registry v4.510.0`](https://github.com/aquaproj/aqua-registry/releases/tag/v4.510.0).
- [`jdx/mise#9624`](https://github.com/jdx/mise/discussions/9624): same v10.33.3/v10.33.4 asset-boundary regression as above; already fixed by `#53423`.
- [`jdx/mise#9461`](https://github.com/jdx/mise/discussions/9461): same v11 asset naming issue as `#9453`; already fixed by `#52821`.
- [`jdx/mise#9554`](https://github.com/jdx/mise/discussions/9554): pnpm v11 standalone executable crash on Intel macOS; tracked upstream as [`pnpm/pnpm#11423`](https://github.com/pnpm/pnpm/issues/11423), not an alias exposure issue.
- [`aquaproj/aqua#3775`](https://github.com/aquaproj/aqua/issues/3775): original pnpm hard-link support context for aqua.

## Verification

```console
$ conftest test --combine pkgs/pnpm/pnpm/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ argd t pnpm/pnpm
# passed; output included v11.0.9 pnpx/pnx created as hard links
```

Manual aqua smoke with a local registry and policy:

```console
$ aqua -c /tmp/pnpm-aqua-smoke/current/aqua.yaml which pnpx
error="command is not found"

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1109/aqua.yaml which pnpm
/tmp/pnpm-aqua-smoke/patched-v1109/root/pkgs/github_release/github.com/pnpm/pnpm/v11.0.9/pnpm-linux-x64.tar.gz/pnpm

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1109/aqua.yaml which pn
/tmp/pnpm-aqua-smoke/patched-v1109/root/pkgs/github_release/github.com/pnpm/pnpm/v11.0.9/pnpm-linux-x64.tar.gz/pn

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1109/aqua.yaml which pnpx
/tmp/pnpm-aqua-smoke/patched-v1109/root/pkgs/github_release/github.com/pnpm/pnpm/v11.0.9/pnpm-linux-x64.tar.gz/pnpx

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1109/aqua.yaml which pnx
/tmp/pnpm-aqua-smoke/patched-v1109/root/pkgs/github_release/github.com/pnpm/pnpm/v11.0.9/pnpm-linux-x64.tar.gz/pnx

$ pnpx --help
Usage: pnpm dlx <command> [args...]

$ pnx --help
Usage: pnpm dlx <command> [args...]

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1106/aqua.yaml which pn
/tmp/pnpm-aqua-smoke/patched-v1106/root/pkgs/github_release/github.com/pnpm/pnpm/v11.0.6/pnpm-linux-x64.tar.gz/pn

$ aqua -c /tmp/pnpm-aqua-smoke/patched-v1106/aqua.yaml which pnpx
error="command is not found"

$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua -c /tmp/pnpm-aqua-smoke/patched-v10334-darwin/aqua.yaml install
# passed; v10.33.4 installed from pnpm-macos-arm64, confirming the v10 asset-boundary fix from #53423 is present on current main
```

Manual mise smoke against the patched local registry:

```console
$ MISE_AQUA_REGISTRY_URL=file:///tmp/patched-aqua-registry MISE_AQUA_BAKED_REGISTRY=false mise x pnpm@11.0.9 -- pnpm --version
11.0.9

$ MISE_AQUA_REGISTRY_URL=file:///tmp/patched-aqua-registry MISE_AQUA_BAKED_REGISTRY=false mise x pnpm@11.0.9 -- pn --version
11.0.9

$ MISE_AQUA_REGISTRY_URL=file:///tmp/patched-aqua-registry MISE_AQUA_BAKED_REGISTRY=false mise x pnpm@11.0.9 -- pnpx --help
Usage: pnpm dlx <command> [args...]

$ MISE_AQUA_REGISTRY_URL=file:///tmp/patched-aqua-registry MISE_AQUA_BAKED_REGISTRY=false mise x pnpm@11.0.9 -- pnx --help
Usage: pnpm dlx <command> [args...]
```

This PR was fully made by Codex GPT-5.5 xhigh; ~~I will review it before marking ready.~~

Sorry for the long explanation. I confirmed they're correct. This PR is ready to merge.
Thanks for your support!