### PR TITLE
Add new package: modem-dev/hunk

### DIFF
--- a/pkgs/modem-dev/hunk/pkg.yaml
+++ b/pkgs/modem-dev/hunk/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: modem-dev/hunk@v0.11.0
+  - name: modem-dev/hunk
+    version: v0.6.1

--- a/pkgs/modem-dev/hunk/pkg.yaml
+++ b/pkgs/modem-dev/hunk/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: modem-dev/hunk@v0.11.0
+  - name: modem-dev/hunk
+    version: v0.6.1

--- a/pkgs/modem-dev/hunk/pkg.yaml
+++ b/pkgs/modem-dev/hunk/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: modem-dev/hunk@v0.11.0
-  - name: modem-dev/hunk
-    version: v0.6.1

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: semver("<= 0.6.1")
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
         replacements:
           amd64: x64
         supported_envs:

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: modem-dev
+    repo_name: hunk
+    description: Review-first terminal diff viewer for agentic coders
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.1")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -6,6 +6,14 @@ packages:
     description: Review-first terminal diff viewer for agentic coders
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.6.1")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -6,17 +6,12 @@ packages:
     description: Review-first terminal diff viewer for agentic coders
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.1")
-        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
         replacements:
           amd64: x64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -63232,6 +63232,9 @@ packages:
       - version_constraint: semver("<= 0.6.1")
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
         replacements:
           amd64: x64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -63224,6 +63224,28 @@ packages:
               - name: buildkitd
                 src: bin/{{.FileName}}
   - type: github_release
+    repo_owner: modem-dev
+    repo_name: hunk
+    description: Review-first terminal diff viewer for agentic coders
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.6.1")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: momaek
     repo_name: authy
     description: TOTP Alfred Workflow, Authy Aflred Workflow, Authy command line tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -63229,17 +63229,12 @@ packages:
     description: Review-first terminal diff viewer for agentic coders
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.6.1")
-        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
         replacements:
           amd64: x64
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -63229,6 +63229,14 @@ packages:
     description: Review-first terminal diff viewer for agentic coders
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 0.6.1")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

This PR adds a new package [`hunk`](https://github.com/modem-dev/hunk) with the latest release [v0.11.0](https://github.com/modem-dev/hunk/releases/tag/v0.11.0). I’ve removed the definition for releases prior to 0.6.1 (which the scaffold generated) because it’s a relatively old release.

As indicated in the co-author, I used Claude to create this change, but have tested locally myself according to the docs.