### PR TITLE
feat: add vectordotdev/vector

### DIFF
--- a/pkgs/vectordotdev/vector/pkg.yaml
+++ b/pkgs/vectordotdev/vector/pkg.yaml
@@ -1,0 +1,16 @@
+packages:
+  - name: vectordotdev/vector@v0.55.0
+  - name: vectordotdev/vector
+    version: v0.50.0
+  - name: vectordotdev/vector
+    version: v0.43.1
+  - name: vectordotdev/vector
+    version: v0.42.0
+  - name: vectordotdev/vector
+    version: v0.33.0
+  - name: vectordotdev/vector
+    version: v0.10.0
+  - name: vectordotdev/vector
+    version: v0.5.0
+  - name: vectordotdev/vector
+    version: v0.3.0

--- a/pkgs/vectordotdev/vector/registry.yaml
+++ b/pkgs/vectordotdev/vector/registry.yaml
@@ -1,0 +1,198 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+    - type: github_release
+      repo_owner: vectordotdev
+      repo_name: vector
+      description: A high-performance observability data pipeline
+      # Periodically, a `vdev-` release is cut for internal(?) use.
+      version_filter: not (Version startsWith "vdev-")
+      version_constraint: "false"
+      # The wall-of-text below is a lot. Briefly:
+      #  - v0.3.0: assets used vector-0.3.0-... names, extracted into vector-0.3.0/bin/vector.
+      #  - <= v0.5.0: assets dropped the version from the asset name and used vector-<arch>-<os>/bin/vector.
+      #  - <= v0.10.0: similar layout, but Windows zip support appears.
+      #  - <= v0.33.0: assets start including the version again: vector-{{trimV .Version}}-....
+      #  - <= v0.42.0: checksum files appear, so checksum verification is configured.
+      #  - <= v0.43.1: macOS assets disappeared for that range, so supported_envs is limited to Linux and Windows.
+      #  - <= v0.50.0: macOS assets are back.
+      # Note: The last x86_64-apple-darwin release was 0.50.0, only arm64-apple-darwin releases were made after that.
+      ##
+      version_overrides:
+          - version_constraint: Version == "v0.3.0"
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            rosetta2: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-gnu
+            files:
+                - name: vector
+                  src: vector-{{trimV .Version}}/bin/vector
+            supported_envs:
+                - linux/amd64
+                - darwin
+          - version_constraint: semver("<= 0.5.0")
+            asset: vector-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            rosetta2: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            supported_envs:
+                - linux/amd64
+                - darwin
+          - version_constraint: semver("<= 0.10.0")
+            asset: vector-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            rosetta2: true
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            overrides:
+                - goos: linux
+                  replacements:
+                      arm64: aarch64
+                - goos: windows
+                  format: zip
+                  files:
+                      - name: vector
+                        src: bin/vector.exe
+          - version_constraint: semver("<= 0.33.0")
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            rosetta2: true
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            overrides:
+                - goos: linux
+                  replacements:
+                      arm64: aarch64
+                - goos: windows
+                  format: zip
+                  files:
+                      - name: vector
+                        src: bin/vector.exe
+          - version_constraint: semver("<= 0.42.0")
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            rosetta2: true
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            checksum:
+                type: github_release
+                asset: vector-{{trimV .Version}}-SHA256SUMS
+                algorithm: sha256
+            overrides:
+                - goos: linux
+                  replacements:
+                      arm64: aarch64
+                - goos: windows
+                  format: zip
+                  files:
+                      - name: vector
+                        src: bin/vector.exe
+          - version_constraint: semver("<= 0.43.1")
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: zip
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: bin/vector.exe
+            checksum:
+                type: github_release
+                asset: vector-{{trimV .Version}}-SHA256SUMS
+                algorithm: sha256
+            overrides:
+                - goos: linux
+                  format: tar.gz
+                  replacements:
+                      arm64: aarch64
+                  files:
+                      - name: vector
+                        src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            supported_envs:
+                - linux
+                - windows/amd64
+          - version_constraint: semver("<= 0.50.0")
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            checksum:
+                type: github_release
+                asset: vector-{{trimV .Version}}-SHA256SUMS
+                algorithm: sha256
+            overrides:
+                - goos: linux
+                  replacements:
+                      arm64: aarch64
+                - goos: windows
+                  format: zip
+                  files:
+                      - name: vector
+                        src: bin/vector.exe
+          - version_constraint: "true"
+            asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+            format: tar.gz
+            windows_arm_emulation: true
+            replacements:
+                amd64: x86_64
+                darwin: apple-darwin
+                linux: unknown-linux-musl
+                windows: pc-windows-msvc
+            files:
+                - name: vector
+                  src: vector-{{.Arch}}-{{.OS}}/bin/vector
+            checksum:
+                type: github_release
+                asset: vector-{{trimV .Version}}-SHA256SUMS
+                algorithm: sha256
+            overrides:
+                - goos: linux
+                  replacements:
+                      arm64: aarch64
+                - goos: windows
+                  format: zip
+                  files:
+                      - name: vector
+                        src: bin/vector.exe
+            supported_envs:
+                - linux
+                - darwin/arm64
+                - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -92977,6 +92977,191 @@ packages:
             checksum:
               enabled: false
   - type: github_release
+    repo_owner: vectordotdev
+    repo_name: vector
+    description: A high-performance observability data pipeline
+    version_filter: not (Version startsWith "vdev-")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.3.0"
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        files:
+          - name: vector
+            src: vector-{{trimV .Version}}/bin/vector
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: vector-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.10.0")
+        asset: vector-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: vector
+                src: bin/vector.exe
+      - version_constraint: semver("<= 0.33.0")
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: vector
+                src: bin/vector.exe
+      - version_constraint: semver("<= 0.42.0")
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        checksum:
+          type: github_release
+          asset: vector-{{trimV .Version}}-SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: vector
+                src: bin/vector.exe
+      - version_constraint: semver("<= 0.43.1")
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: bin/vector.exe
+        checksum:
+          type: github_release
+          asset: vector-{{trimV .Version}}-SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.gz
+            replacements:
+              arm64: aarch64
+            files:
+              - name: vector
+                src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        supported_envs:
+          - linux
+          - windows/amd64
+      - version_constraint: semver("<= 0.50.0")
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        checksum:
+          type: github_release
+          asset: vector-{{trimV .Version}}-SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: vector
+                src: bin/vector.exe
+      - version_constraint: "true"
+        asset: vector-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        files:
+          - name: vector
+            src: vector-{{.Arch}}-{{.OS}}/bin/vector
+        checksum:
+          type: github_release
+          asset: vector-{{trimV .Version}}-SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: vector
+                src: bin/vector.exe
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+  - type: github_release
     repo_owner: veeso
     repo_name: termscp
     asset: termscp-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}


### PR DESCRIPTION
## Summary

Add [`vectordotdev/vector`](https://github.com/vectordotdev/vector) to aqua-registry.

Vector publishes multiple release families from the same repository, so this package excludes `vdev-*` releases; they [appear](https://github.com/vectordotdev/vector/releases?q=vdev&expanded=true) to be maintenance/internal things.

I targeted the main `v0.x` Vector release line.
I gave Codex github API access and asked it to build a through line of versions to confirm the various `version_overrides` notes.
I can make the argument for _not_ including the older versions since:  a) they're old and b) it wasn't until release `v0.33.1` that sha256 checksums were published, so the older versions are less secure to use.

I included them for completeness and because they still work.
I can remove them if "newer, more secure" is preferred over "more complete, but older and less secure".

## Verification

Generated with:

```sh
aqua gr --init vectordotdev/vector
argd s -B --local -c aqua-generate-registry.yaml vectordotdev/vector
argd gr
```

Tested with:

```sh
❯ conftest test pkgs/vectordotdev/vector/*.yaml

28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions
```

```sh
❯ argd t vectordotdev/vector
May  9 15:10:14.979 INF checking if the container exists program=argd version=0.5.2 container_name=aqua-registry
May  9 15:10:14.989 INF checking if the container is running program=argd version=0.5.2 container_name=aqua-registry
May  9 15:10:15.018 INF Dockerfile isn't updated program=argd version=0.5.2
# <...>
Successfully copied 403B (transferred 2.05kB) to aqua-registry-windows:/workspace/pkg.yaml
May  9 15:10:15.450 INF + /usr/bin/docker cp pkgs/vectordotdev/vector/registry.yaml aqua-registry-windows:/workspace/registry.yaml program=argd version=0.5.2
Successfully copied 7.71kB (transferred 9.73kB) to aqua-registry-windows:/workspace/registry.yaml
May  9 15:10:15.463 INF testing program=argd version=0.5.2 os=windows arch=amd64
May  9 15:10:15.463 INF + /usr/bin/docker exec -w /workspace aqua-registry-windows bash -c rm aqua-checksums.json 2>/dev/null || : program=argd version=0.5.2
May  9 15:10:15.498 INF + /usr/bin/docker exec -w /workspace -e AQUA_GOOS=windows -e AQUA_GOARCH=amd64 -e AQUA_GITHUB_TOKEN= aqua-registry-windows aqua i program=argd version=0.5.2
May  9 15:10:15.548 INF testing program=argd version=0.5.2 os=windows arch=arm64
May  9 15:10:15.548 INF + /usr/bin/docker exec -w /workspace aqua-registry-windows bash -c rm aqua-checksums.json 2>/dev/null || : program=argd version=0.5.2
May  9 15:10:15.583 INF + /usr/bin/docker exec -w /workspace -e AQUA_GOOS=windows -e AQUA_GOARCH=arm64 -e AQUA_GITHUB_TOKEN= aqua-registry-windows aqua i program=argd version=0.5.2
May  9 15:10:15.632 INF Updating registry.yaml program=argd version=0.5.2
```

Executed the package:

```sh
❯ docker exec -w /workspace \
    -e AQUA_GOOS=linux \
    -e AQUA_GOARCH=amd64 \
    aqua-registry sh -c 'aqua i >/tmp/vector-aqua-i.log && vector --version'
vector 0.55.0 (x86_64-unknown-linux-musl cf8de83 2026-04-22 14:31:18.008404048)
```

## Notes

Recent Vector releases no longer publish `darwin/amd64` assets, so the latest override supports `darwin/arm64` only.

AI assistance was used to scaffold, inspect, and test this change. I reviewed the generated configuration and test results.

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)
