### PR TITLE
feat: add jfernandez/bpftop

### DIFF
--- a/pkgs/jfernandez/bpftop/pkg.yaml
+++ b/pkgs/jfernandez/bpftop/pkg.yaml
@@ -2,3 +2,5 @@ packages:
   - name: jfernandez/bpftop@v0.9.0
   - name: jfernandez/bpftop
     version: v0.5.1
+  - name: jfernandez/bpftop
+    version: v0.5.0

--- a/pkgs/jfernandez/bpftop/pkg.yaml
+++ b/pkgs/jfernandez/bpftop/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: jfernandez/bpftop@v0.9.0
+  - name: jfernandez/bpftop
+    version: v0.5.1

--- a/pkgs/jfernandez/bpftop/registry.yaml
+++ b/pkgs/jfernandez/bpftop/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: jfernandez
+    repo_name: bpftop
+    description: bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.1")
+      - version_constraint: "true"
+        asset: bpftop-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux

--- a/pkgs/jfernandez/bpftop/registry.yaml
+++ b/pkgs/jfernandez/bpftop/registry.yaml
@@ -3,10 +3,26 @@ packages:
   - type: github_release
     repo_owner: jfernandez
     repo_name: bpftop
-    description: bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program
+    description: A dynamic real-time view of running eBPF programs
+    files:
+      - name: bpftop
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.5.1")
+      - version_constraint: semver("<= 0.5.0")
+        asset: bpftop
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.5.1"
+        asset: bpftop
+        format: raw
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: bpftop_aarch64
+        supported_envs:
+          - linux/amd64
+          - linux/arm64
       - version_constraint: "true"
         asset: bpftop-{{.Arch}}-{{.OS}}
         format: raw
@@ -15,4 +31,5 @@ packages:
           arm64: aarch64
           linux: unknown-linux-gnu
         supported_envs:
-          - linux
+          - linux/amd64
+          - linux/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -50406,10 +50406,26 @@ packages:
   - type: github_release
     repo_owner: jfernandez
     repo_name: bpftop
-    description: bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program
+    description: A dynamic real-time view of running eBPF programs
+    files:
+      - name: bpftop
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.5.1")
+      - version_constraint: semver("<= 0.5.0")
+        asset: bpftop
+        format: raw
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "v0.5.1"
+        asset: bpftop
+        format: raw
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: bpftop_aarch64
+        supported_envs:
+          - linux/amd64
+          - linux/arm64
       - version_constraint: "true"
         asset: bpftop-{{.Arch}}-{{.OS}}
         format: raw
@@ -50418,7 +50434,8 @@ packages:
           arm64: aarch64
           linux: unknown-linux-gnu
         supported_envs:
-          - linux
+          - linux/amd64
+          - linux/arm64
   - type: github_release
     repo_owner: jiro4989
     repo_name: ojosama

--- a/registry.yaml
+++ b/registry.yaml
@@ -50404,6 +50404,22 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: jfernandez
+    repo_name: bpftop
+    description: bpftop provides a dynamic real-time view of running eBPF programs. It displays the average runtime, events per second, and estimated total CPU % for each program
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.5.1")
+      - version_constraint: "true"
+        asset: bpftop-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+  - type: github_release
     repo_owner: jiro4989
     repo_name: ojosama
     description: テキストを壱百満天原サロメお嬢様風の口調に変換します


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## What

Add `jfernandez/bpftop`.

## Verification

```sh
aqua exec -- argd t jfernandez/bpftop
```

Result: passed for linux/amd64, linux/arm64, darwin, and windows install checks.

```sh
aqua exec -- conftest test pkgs/jfernandez/bpftop/registry.yaml pkgs/jfernandez/bpftop/pkg.yaml
```

Result: 28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions.

## Notes

`bpftop` is Linux-only. The registry config handles older release asset variants:

- `v0.5.2+`: arch-qualified raw binaries
- `v0.5.1`: `bpftop` for amd64 and `bpftop_aarch64` for arm64
- `<= v0.5.0`: `bpftop` for amd64 only