### PR TITLE
fix(DataDog/pup): correct cosign certificate identity to DataDog/pup

### DIFF
--- a/pkgs/DataDog/pup/pkg.yaml
+++ b/pkgs/DataDog/pup/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: DataDog/pup@v0.58.0
+  - name: DataDog/pup@v0.58.6
+  - name: DataDog/pup
+    version: v0.58.0
   - name: DataDog/pup
     version: v0.21.0

--- a/pkgs/DataDog/pup/registry.yaml
+++ b/pkgs/DataDog/pup/registry.yaml
@@ -21,6 +21,29 @@ packages:
           type: github_release
           asset: pup_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: semver("<= 0.58.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/DataDog/pup/registry.yaml
+++ b/pkgs/DataDog/pup/registry.yaml
@@ -35,7 +35,7 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "^https://github\\.com/DataDog/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:

--- a/registry.yaml
+++ b/registry.yaml
@@ -2382,6 +2382,29 @@ packages:
           type: github_release
           asset: pup_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: semver("<= 0.58.0")
+        asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: pup_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: pup_{{trimV .Version}}_checksums.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: pup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -2396,7 +2396,7 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "^https://github\\.com/datadog-labs/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - "^https://github\\.com/DataDog/pup/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

The repository transfer in #53361 updated `repo_owner` from `datadog-labs` to `DataDog` and renamed the package directory, but the cosign `--certificate-identity-regexp` was left pointing at `datadog-labs/pup`. That breaks verification for new releases signed by the `DataDog/pup` workflow (e.g. #53530's bump to v0.58.6 fails with that exact error on `test / test / test (ubuntu-24.04)`).

However, the upstream `pup` GitHub repository was transferred from `datadog-labs/pup` to `DataDog/pup` between v0.58.0 and v0.58.2 (v0.58.1 was never published), so the two regexes are both correct for different version ranges:

```
v0.21.0 .. v0.58.0  → signed by github.com/datadog-labs/pup
v0.58.2 .. v0.58.6+ → signed by github.com/DataDog/pup
```

So this PR splits the existing `version_overrides` so the legacy regex still applies for `<= 0.58.0` and the new regex applies for everything after, and expands `pkg.yaml` to install one version from each of the three branches (`v0.21.0`, `v0.58.0`, `v0.58.6`) so the test job covers all three paths.