### PR TITLE
fix(astral-sh/uv): GitHub artifact attestations missing for 0.11.9

### DIFF
--- a/pkgs/astral-sh/uv/registry.yaml
+++ b/pkgs/astral-sh/uv/registry.yaml
@@ -55,7 +55,7 @@ packages:
             format: zip
             files:
               - name: uv
-      - version_constraint: semver("<= 0.9.7") || Version == "0.9.11"
+      - version_constraint: semver("<= 0.9.7") || Version in ["0.9.11", "0.11.9"]
         asset: uv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -16153,7 +16153,7 @@ packages:
             format: zip
             files:
               - name: uv
-      - version_constraint: semver("<= 0.9.7") || Version == "0.9.11"
+      - version_constraint: semver("<= 0.9.7") || Version in ["0.9.11", "0.11.9"]
         asset: uv-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true


### PR DESCRIPTION
https://github.com/astral-sh/uv/releases/tag/0.11.9

> Note due to a timeout publishing to crates.io, the GitHub portion of
> this release was published manually by a maintainer using the
> artifacts built in CI. Consequently, GitHub attestations will not
> be available.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
