### PR TITLE
fix(str4d/age-plugin-yubikey): re-scaffold for v0.5.1

### DIFF
--- a/pkgs/str4d/age-plugin-yubikey/pkg.yaml
+++ b/pkgs/str4d/age-plugin-yubikey/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: str4d/age-plugin-yubikey@v0.5.0
+  - name: str4d/age-plugin-yubikey@v0.5.1
+  - name: str4d/age-plugin-yubikey
+    version: v0.5.0
   - name: str4d/age-plugin-yubikey
     version: v0.4.0
   - name: str4d/age-plugin-yubikey

--- a/pkgs/str4d/age-plugin-yubikey/registry.yaml
+++ b/pkgs/str4d/age-plugin-yubikey/registry.yaml
@@ -36,19 +36,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.4.0")
-        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v0.5.1"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -71,6 +58,6 @@ packages:
           - goos: windows
             format: zip
         supported_envs:
-          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
+          - amd64

--- a/pkgs/str4d/age-plugin-yubikey/registry.yaml
+++ b/pkgs/str4d/age-plugin-yubikey/registry.yaml
@@ -5,6 +5,9 @@ packages:
     repo_name: age-plugin-yubikey
     description: YubiKey plugin for age
     version_constraint: "false"
+    files:
+      - name: age-plugin-yubikey
+        src: age-plugin-yubikey/age-plugin-yubikey
     version_overrides:
       - version_constraint: Version == "v0.5.0"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}

--- a/pkgs/str4d/age-plugin-yubikey/registry.yaml
+++ b/pkgs/str4d/age-plugin-yubikey/registry.yaml
@@ -49,7 +49,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.5.1"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
@@ -59,5 +59,18 @@ packages:
           - goos: darwin
             format: tar.gz
         supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
           - darwin
           - windows/amd64

--- a/pkgs/str4d/age-plugin-yubikey/registry.yaml
+++ b/pkgs/str4d/age-plugin-yubikey/registry.yaml
@@ -5,10 +5,20 @@ packages:
     repo_name: age-plugin-yubikey
     description: YubiKey plugin for age
     version_constraint: "false"
-    files:
-      - name: age-plugin-yubikey
-        src: age-plugin-yubikey/age-plugin-yubikey
     version_overrides:
+      - version_constraint: Version == "v0.5.0"
+        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
       - version_constraint: semver("<= 0.3.0")
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -34,17 +44,17 @@ packages:
             format: zip
         supported_envs:
           - darwin
+          - windows
           - amd64
       - version_constraint: "true"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zip
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
         overrides:
-          - goos: windows
-            format: zip
+          - goos: darwin
+            format: tar.gz
         supported_envs:
-          - darwin/arm64
-          - linux/amd64
-          - windows
+          - darwin
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -84185,19 +84185,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.4.0")
-        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
       - version_constraint: Version == "v0.5.1"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -84220,9 +84207,9 @@ packages:
           - goos: windows
             format: zip
         supported_envs:
-          - linux/amd64
           - darwin
-          - windows/amd64
+          - windows
+          - amd64
   - type: github_release
     repo_owner: str4d
     repo_name: rage

--- a/registry.yaml
+++ b/registry.yaml
@@ -84154,10 +84154,20 @@ packages:
     repo_name: age-plugin-yubikey
     description: YubiKey plugin for age
     version_constraint: "false"
-    files:
-      - name: age-plugin-yubikey
-        src: age-plugin-yubikey/age-plugin-yubikey
     version_overrides:
+      - version_constraint: Version == "v0.5.0"
+        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
       - version_constraint: semver("<= 0.3.0")
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -84183,20 +84193,20 @@ packages:
             format: zip
         supported_envs:
           - darwin
+          - windows
           - amd64
       - version_constraint: "true"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
+        format: zip
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
         overrides:
-          - goos: windows
-            format: zip
+          - goos: darwin
+            format: tar.gz
         supported_envs:
-          - darwin/arm64
-          - linux/amd64
-          - windows
+          - darwin
+          - windows/amd64
   - type: github_release
     repo_owner: str4d
     repo_name: rage

--- a/registry.yaml
+++ b/registry.yaml
@@ -84154,6 +84154,9 @@ packages:
     repo_name: age-plugin-yubikey
     description: YubiKey plugin for age
     version_constraint: "false"
+    files:
+      - name: age-plugin-yubikey
+        src: age-plugin-yubikey/age-plugin-yubikey
     version_overrides:
       - version_constraint: Version == "v0.5.0"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -84198,7 +84198,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: Version == "v0.5.1"
         asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
@@ -84208,6 +84208,19 @@ packages:
           - goos: darwin
             format: tar.gz
         supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: "true"
+        asset: age-plugin-yubikey-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
           - darwin
           - windows/amd64
   - type: github_release


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Re-scaffold `str4d/age-plugin-yubikey` for `v0.5.1`.

`v0.5.1` dropped the Linux asset and publishes only Darwin arm64/x86_64 plus Windows x86_64. This supersedes the bot update that failed while trying to install a non-existent Linux asset.

Related:

- Supersedes #51741
- Initial scaffold: #47719

Manual change after `argd s`:

- Restore `files[].src: age-plugin-yubikey/age-plugin-yubikey`; the generated config pointed at the archive directory instead of the binary.

Verification:

```console
$ argd s str4d/age-plugin-yubikey
[feat/str4d/age-plugin-yubikey 50dc641242] feat(str4d/age-plugin-yubikey): scaffold str4d/age-plugin-yubikey
...
ERR check file_src is correct ... error="check file_src is correct: exe_path is directory"
```

```console
$ conftest test --combine pkgs/str4d/age-plugin-yubikey/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ argd t str4d/age-plugin-yubikey
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

Execution smoke test on the Linux container needs `libpcsclite1`, which is not preinstalled in the registry test container:

```console
$ docker exec -w /workspace aqua-registry bash -lc 'apt-get update && apt-get install -y libpcsclite1'
...
Setting up libpcsclite1:amd64 ...

$ docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=amd64 aqua-registry aqua exec -- age-plugin-yubikey --version
age-plugin-yubikey 0.5.0
```

AI assistance: OpenAI Codex was used to prepare this PR; I reviewed and tested the changes.
