### PR TITLE
Add SurgeDM/Surge

### DIFF
--- a/pkgs/SurgeDM/Surge/pkg.yaml
+++ b/pkgs/SurgeDM/Surge/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: SurgeDM/Surge@v0.8.6
+  - name: SurgeDM/Surge
+    version: v0.6.7
+  - name: SurgeDM/Surge
+    version: v0.1.0

--- a/pkgs/SurgeDM/Surge/registry.yaml
+++ b/pkgs/SurgeDM/Surge/registry.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: SurgeDM
+    repo_name: Surge
+    description: Blazing fast TUI download manager built in Go for power users
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: surge_{{trimV .Version}}-SNAPSHOT-b332004_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: surge_{{trimV .Version}}-SNAPSHOT-b332004_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.7")
+        asset: surge_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: surge_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: Surge_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: Surge_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/SurgeDM/Surge/registry.yaml
+++ b/pkgs/SurgeDM/Surge/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: SurgeDM
     repo_name: Surge
     description: Blazing fast TUI download manager built in Go for power users
+    files:
+      - name: surge
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -7535,6 +7535,8 @@ packages:
     repo_owner: SurgeDM
     repo_name: Surge
     description: Blazing fast TUI download manager built in Go for power users
+    files:
+      - name: surge
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -7532,6 +7532,42 @@ packages:
           - darwin/arm64
           - windows
   - type: github_release
+    repo_owner: SurgeDM
+    repo_name: Surge
+    description: Blazing fast TUI download manager built in Go for power users
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: surge_{{trimV .Version}}-SNAPSHOT-b332004_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: surge_{{trimV .Version}}-SNAPSHOT-b332004_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.7")
+        asset: surge_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: surge_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: Surge_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: Surge_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: TaKO8Ki
     repo_name: frum
     asset: frum-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Description

Add `SurgeDM/Surge` to aqua-registry.

The release archives contain the executable as `surge`, so the package explicitly installs the lower-case command name instead of deriving `Surge` from the repository name.

## Verification

```console
$ aqua exec -- conftest test --combine pkgs/SurgeDM/Surge/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ aqua exec -- argd t SurgeDM/Surge
Linux/Darwin and Windows tests passed.
Install logs showed command=surge.
```

```console
$ git diff --check
```

## AI disclosure

Codex assisted with preparing this pull request. I reviewed and verified the changes.
