### PR TITLE
fix: update alltuner/mise-completions-sync command name

### DIFF
--- a/pkgs/alltuner/mise-completions-sync/pkg.yaml
+++ b/pkgs/alltuner/mise-completions-sync/pkg.yaml
@@ -1,5 +1,6 @@
 packages:
   - name: alltuner/mise-completions-sync@v0.5.7
-  - name: alltuner/mise-completions-sync@v0.5.6
+  - name: alltuner/mise-completions-sync
+    version: v0.5.6
   - name: alltuner/mise-completions-sync
     version: v0.5.1

--- a/pkgs/alltuner/mise-completions-sync/pkg.yaml
+++ b/pkgs/alltuner/mise-completions-sync/pkg.yaml
@@ -1,4 +1,5 @@
 packages:
+  - name: alltuner/mise-completions-sync@v0.5.7
   - name: alltuner/mise-completions-sync@v0.5.6
   - name: alltuner/mise-completions-sync
     version: v0.5.1

--- a/pkgs/alltuner/mise-completions-sync/registry.yaml
+++ b/pkgs/alltuner/mise-completions-sync/registry.yaml
@@ -26,9 +26,22 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.5.6")
+        asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: misecompsync
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -11823,9 +11823,22 @@ packages:
               linux: unknown-linux-gnu
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.5.6")
+        asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: mise-completions-sync-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: misecompsync
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Summary

`alltuner/mise-completions-sync` renamed its binary to `misecompsync` in v0.5.7.

This updates the registry so:

- v0.5.6 and older supported releases keep installing `mise-completions-sync`
- v0.5.7 and newer releases install `misecompsync`
- `pkg.yaml` includes v0.5.7 so the new command-name branch is covered

## Verification

Release archive contents:

```console
$ tar -tzf mise-completions-sync-aarch64-apple-darwin.tar.gz # v0.5.6
mise-completions-sync

$ tar -tzf mise-completions-sync-aarch64-apple-darwin.tar.gz # v0.5.7
misecompsync
```

Registry checks:

```console
$ aqua exec -- conftest test --combine pkgs/alltuner/mise-completions-sync/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ aqua exec -- argd t alltuner/mise-completions-sync
# passed
# v0.5.7 command=misecompsync
# v0.5.6 command=mise-completions-sync
```

Runtime check with the local registry:

```console
$ aqua exec -- misecompsync --help
# executed successfully for alltuner/mise-completions-sync@v0.5.7
```
