### PR TITLE
Add vjeantet/alerter

### DIFF
--- a/pkgs/vjeantet/alerter/pkg.yaml
+++ b/pkgs/vjeantet/alerter/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: vjeantet/alerter@v26.5
+  - name: vjeantet/alerter
+    version: "004"

--- a/pkgs/vjeantet/alerter/registry.yaml
+++ b/pkgs/vjeantet/alerter/registry.yaml
@@ -14,6 +14,6 @@ packages:
           - darwin
       - version_constraint: "true"
         asset: alerter-{{trimV .Version}}.{{.Format}}
-        format: pkg
+        format: zip
         supported_envs:
-          - darwin
+          - darwin/arm64

--- a/pkgs/vjeantet/alerter/registry.yaml
+++ b/pkgs/vjeantet/alerter/registry.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: vjeantet
+    repo_name: alerter
+    description: Send User Alert Notification on MacOS from the command-line
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 4.0.0")
+        asset: alerter_v{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: alerter-{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -94140,9 +94140,9 @@ packages:
           - darwin
       - version_constraint: "true"
         asset: alerter-{{trimV .Version}}.{{.Format}}
-        format: pkg
+        format: zip
         supported_envs:
-          - darwin
+          - darwin/arm64
   - type: github_release
     repo_owner: vladimirvivien
     repo_name: ktop

--- a/registry.yaml
+++ b/registry.yaml
@@ -94127,6 +94127,23 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: vjeantet
+    repo_name: alerter
+    description: Send User Alert Notification on MacOS from the command-line
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 4.0.0")
+        asset: alerter_v{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: alerter-{{trimV .Version}}.{{.Format}}
+        format: pkg
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: vladimirvivien
     repo_name: ktop
     description: A top-like tool for your Kubernetes clusters


### PR DESCRIPTION
#53732 [vjeantet/alerter](https://github.com/vjeantet/alerter) - Send User Alert Notification on MacOS from the command-line @TyceHerrman

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Add `vjeantet/alerter` as a GitHub release package.

Notes:
- Published `v26.2` through `v26.5` are arm64-only, so the modern override is limited to `darwin/arm64`.
- Pre-26 releases (`1.0.1` and earlier, including release `004` / `Built on Bigsur`) publish only ZIP assets named `alerter_v..._darwin_amd64.zip`, so the older override keeps that asset pattern and Rosetta path.

Verification:
- `aqua exec -- argd t vjeantet/alerter`
- `aqua exec -- conftest test --combine pkgs/vjeantet/alerter/registry.yaml pkgs/vjeantet/alerter/pkg.yaml`
  - `14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions`
- `aqua exec -- conftest test registry.yaml`
  - `14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions`
- Install and execute with a temporary aqua config using the local registry:
  - `AQUA_ROOT_DIR=/private/tmp/aqua-alerter-smoke-codex/aqua-root AQUA_DISABLE_POLICY=true aqua -c /private/tmp/aqua-alerter-smoke-codex/aqua.yaml i`
    - `exit 0`
    - installed `vjeantet/alerter@v26.5` from `alerter-26.5.zip`
  - `AQUA_ROOT_DIR=/private/tmp/aqua-alerter-smoke-codex/aqua-root AQUA_DISABLE_POLICY=true aqua -c /private/tmp/aqua-alerter-smoke-codex/aqua.yaml exec -- alerter --title "aqua-registry smoke test" --message "vjeantet/alerter works" --timeout 5`
    - `exit 0`
    - output: `@TIMEOUT`
- Inspected release binary architectures:
  - `004`: ZIP `alerter` is `x86_64+arm64`
  - `v26.2` through `v26.5`: ZIP and PKG `alerter` binaries are `arm64`

AI assistance was used; commits include the Codex co-author trailer.
