### PR TITLE
Add roie/ovw

### DIFF
--- a/pkgs/roie/ovw/pkg.yaml
+++ b/pkgs/roie/ovw/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: roie/ovw@v1.1.1

--- a/pkgs/roie/ovw/registry.yaml
+++ b/pkgs/roie/ovw/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: roie
+    repo_name: ovw
+    description: A terminal overview for your local projects
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ovw_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -76188,6 +76188,22 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: roie
+    repo_name: ovw
+    description: A terminal overview for your local projects
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ovw_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: rootless-containers
     repo_name: rootlesskit
     description: Linux-native "fake root" for implementing rootless containers


### PR DESCRIPTION
#53740 [roie/ovw](https://github.com/roie/ovw) - A terminal overview for your local projects @TyceHerrman

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add `roie/ovw`, a terminal overview for local projects.

Generated with `argd s` and verified locally.

Verification:

```console
$ AQUA_GHTKN_ENABLED=true aqua exec -- argd t roie/ovw
# passed for linux/darwin amd64/arm64 and windows amd64/arm64

$ aqua exec -- conftest test --combine pkgs/roie/ovw/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ docker exec aqua-registry /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/roie/ovw/v1.1.1/ovw_1.1.1_linux_arm64.tar.gz/ovw --help
# printed ovw help

$ /tmp/ovw-darwin-arm64-aqua-registry-test --help
# printed ovw help
```

AI assistance: Codex helped run local verification and draft this PR description; I reviewed the result.
