### PR TITLE
fix(dathere/qsv): re-scaffold to fix stable release assets and legacy file paths

### DIFF
--- a/pkgs/dathere/qsv/pkg.yaml
+++ b/pkgs/dathere/qsv/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: dathere/qsv@16.1.0
+  - name: dathere/qsv@publish-testing
+  - name: dathere/qsv
+    version: 20.0.0
   - name: dathere/qsv
     version: 10.0.0
   - name: dathere/qsv
@@ -13,4 +15,32 @@ packages:
   - name: dathere/qsv
     version: 0.113.0
   - name: dathere/qsv
+    version: 0.109.0
+  - name: dathere/qsv
     version: 0.108.0
+  - name: dathere/qsv
+    version: 0.90.0
+  - name: dathere/qsv
+    version: 0.75.0
+  - name: dathere/qsv
+    version: 0.40.3
+  - name: dathere/qsv
+    version: 0.30.0
+  - name: dathere/qsv
+    version: 0.23.0
+  - name: dathere/qsv
+    version: 0.22.2
+  - name: dathere/qsv
+    version: 0.20.0
+  - name: dathere/qsv
+    version: 0.16.2
+  - name: dathere/qsv
+    version: 0.16.1
+  - name: dathere/qsv
+    version: 0.16.0
+  - name: dathere/qsv
+    version: 0.14.1
+  - name: dathere/qsv
+    version: 0.14.0
+  - name: dathere/qsv
+    version: 0.13.1

--- a/pkgs/dathere/qsv/pkg.yaml
+++ b/pkgs/dathere/qsv/pkg.yaml
@@ -1,7 +1,5 @@
 packages:
-  - name: dathere/qsv@publish-testing
-  - name: dathere/qsv
-    version: 20.0.0
+  - name: dathere/qsv@20.0.0
   - name: dathere/qsv
     version: 10.0.0
   - name: dathere/qsv

--- a/pkgs/dathere/qsv/registry.yaml
+++ b/pkgs/dathere/qsv/registry.yaml
@@ -8,7 +8,7 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
+      - version_constraint: Version in ["publish-testing", "0.26.0", "0.131.1"]
         error_message: This version isn't supported.
       - version_constraint: Version == "0.13.1"
         asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -94,7 +94,24 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "0.23.0"
+      - version_constraint: Version in ["0.22.0", "0.22.1", "0.22.2"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version in ["0.23.0", "0.24.1", "0.25.2-beta"]
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -270,7 +287,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.20.0")
+      - version_constraint: semver("<= 0.21.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -287,23 +304,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.22.2")
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: qsv-{{.Version}}/qsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
       - version_constraint: semver("<= 0.40.3")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -314,6 +314,29 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+      - version_constraint: Version in ["0.65.0", "0.66.0", "0.67.0", "0.70.0", "0.72.0"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            goarch: arm64
+            files:
+              - name: qsv
+                src: qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv
       - version_constraint: semver("<= 0.75.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -380,7 +403,6 @@ packages:
       - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/pkgs/dathere/qsv/registry.yaml
+++ b/pkgs/dathere/qsv/registry.yaml
@@ -8,9 +8,14 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
+      - version_constraint: Version in ["publish-testing"]
+        error_message: This version isn't supported.
       - version_constraint: Version == "0.13.1"
         asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: xsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -62,10 +67,17 @@ packages:
       - version_constraint: Version == "0.16.1"
         asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           darwin: macos
+        overrides:
+          - goos: windows
+            files:
+              - name: qsv
         supported_envs:
           - darwin
           - windows
@@ -73,6 +85,9 @@ packages:
       - version_constraint: Version == "0.16.2"
         asset: qsv-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
         replacements:
           darwin: macos
         supported_envs:
@@ -82,6 +97,9 @@ packages:
       - version_constraint: Version == "0.23.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -255,6 +273,9 @@ packages:
       - version_constraint: semver("<= 0.20.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/{{.Arch}}-{{.OS}}/release/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -269,6 +290,9 @@ packages:
       - version_constraint: semver("<= 0.22.2")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -353,9 +377,10 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 20.0.0")
+      - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -377,21 +402,3 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}-testing.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu

--- a/pkgs/dathere/qsv/registry.yaml
+++ b/pkgs/dathere/qsv/registry.yaml
@@ -8,8 +8,122 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
-        error_message: This version isn't supported.
+      - version_constraint: Version == "0.13.1"
+        asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.14.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.14.1"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.zip.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.16.0"
+        asset: qsv-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.1"
+        asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.2"
+        asset: qsv-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.23.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "0.30.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.90.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: Version == "0.108.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -28,6 +142,25 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: Version == "0.109.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.113.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -119,6 +252,64 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 0.20.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.22.2")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.40.3")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.75.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.76.2")
+        no_asset: true
       - version_constraint: semver("<= 7.0.1")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -162,7 +353,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 16.1.0")
+      - version_constraint: semver("<= 20.0.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -30252,7 +30252,7 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
+      - version_constraint: Version in ["publish-testing", "0.26.0", "0.131.1"]
         error_message: This version isn't supported.
       - version_constraint: Version == "0.13.1"
         asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
@@ -30338,7 +30338,24 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: Version == "0.23.0"
+      - version_constraint: Version in ["0.22.0", "0.22.1", "0.22.2"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: Version in ["0.23.0", "0.24.1", "0.25.2-beta"]
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -30514,7 +30531,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 0.20.0")
+      - version_constraint: semver("<= 0.21.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         files:
@@ -30531,23 +30548,6 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: semver("<= 0.22.2")
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: zip
-        files:
-          - name: qsv
-            src: qsv-{{.Version}}/qsv
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
       - version_constraint: semver("<= 0.40.3")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30558,6 +30558,29 @@ packages:
           darwin: apple-darwin
           linux: unknown-linux-gnu
           windows: pc-windows-msvc
+      - version_constraint: Version in ["0.65.0", "0.66.0", "0.67.0", "0.70.0", "0.72.0"]
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            goarch: arm64
+            files:
+              - name: qsv
+                src: qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv
       - version_constraint: semver("<= 0.75.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30624,7 +30647,6 @@ packages:
       - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30252,8 +30252,122 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
-      - version_constraint: Version in ["publish-testing"]
-        error_message: This version isn't supported.
+      - version_constraint: Version == "0.13.1"
+        asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.14.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.14.1"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.zip.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: Version == "0.16.0"
+        asset: qsv-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.1"
+        asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.16.2"
+        asset: qsv-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: macos
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.23.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: Version == "0.30.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "0.90.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              amd64: x86_64
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              arm64: aarch64
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - windows/amd64
       - version_constraint: Version == "0.108.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30272,6 +30386,25 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: Version == "0.109.0"
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            asset: qsv-{{.Version}}-i686-{{.OS}}.{{.Format}}
       - version_constraint: Version == "0.113.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30363,6 +30496,64 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 0.20.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.22.2")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+      - version_constraint: semver("<= 0.40.3")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+      - version_constraint: semver("<= 0.75.0")
+        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.76.2")
+        no_asset: true
       - version_constraint: semver("<= 7.0.1")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
@@ -30406,7 +30597,7 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 16.1.0")
+      - version_constraint: semver("<= 20.0.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -30252,9 +30252,14 @@ packages:
     version_overrides:
       - version_constraint: Version in ["0.15.0", "0.24.0", "0.48.0", "0.61.3", "0.68.0", "0.93.0", "0.102.0"]
         no_asset: true
+      - version_constraint: Version in ["publish-testing"]
+        error_message: This version isn't supported.
       - version_constraint: Version == "0.13.1"
         asset: xsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: xsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -30306,10 +30311,17 @@ packages:
       - version_constraint: Version == "0.16.1"
         asset: qsv-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           darwin: macos
+        overrides:
+          - goos: windows
+            files:
+              - name: qsv
         supported_envs:
           - darwin
           - windows
@@ -30317,6 +30329,9 @@ packages:
       - version_constraint: Version == "0.16.2"
         asset: qsv-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/release/qsv
         replacements:
           darwin: macos
         supported_envs:
@@ -30326,6 +30341,9 @@ packages:
       - version_constraint: Version == "0.23.0"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -30499,6 +30517,9 @@ packages:
       - version_constraint: semver("<= 0.20.0")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: target/{{.Arch}}-{{.OS}}/release/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -30513,6 +30534,9 @@ packages:
       - version_constraint: semver("<= 0.22.2")
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        files:
+          - name: qsv
+            src: qsv-{{.Version}}/qsv
         rosetta2: true
         windows_arm_emulation: true
         replacements:
@@ -30597,9 +30621,10 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
-      - version_constraint: semver("<= 20.0.0")
+      - version_constraint: "true"
         asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: zip
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -30621,24 +30646,6 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: "true"
-        asset: qsv-{{.Version}}-{{.Arch}}-{{.OS}}-testing.{{.Format}}
-        format: zip
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
   - type: github_release
     repo_owner: datreeio
     repo_name: datree


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Re-scaffold `dathere/qsv` to fix updater failures, stable release assets, and legacy archive layouts.

Context:

- Updater PRs for recent stable versions failed because the generated latest branch expected `-testing` assets.
- Some historical qsv releases use different archive layouts, so their `files[].src` paths need version-bounded overrides.
- `publish-testing`, `0.26.0`, and `0.131.1` are marked unsupported because their upstream release artifacts do not install a normal `qsv` binary with this registry configuration.

What changed:

- Re-scaffolded with `argd s dathere/qsv`.
- Restored stable latest asset naming in the final `"true"` branch without widening `windows_arm_emulation` for current/future versions.
- Preserved legacy `files` boundaries for older archive layouts, including:
  - `0.13.1`: `qsv` command maps to the `xsv` asset
  - `0.16.1` and `0.16.2`: `target/release/qsv`
  - `<= 0.21.0`: `target/{{.Arch}}-{{.OS}}/release/qsv`
  - `0.22.0` to `0.25.2-beta`: `qsv-{{.Version}}/qsv`
  - selected `0.65.0` to `0.72.0` darwin/arm64 releases: nested `qsv-{{.Version}}-{{.Arch}}-{{.OS}}/qsv`

Related / superseded:

- Supersedes updater PRs: #53173, #52012, #51658, #50840, #49729

Verification:

```console
$ argd s dathere/qsv
...
ERR check file_src is correct ... package_version=0.23.0 ... exe_path isn't found
ERR check file_src is correct ... package_version=0.22.2 ... exe_path isn't found
ERR check file_src is correct ... package_version=0.20.0 ... exe_path isn't found
ERR check file_src is correct ... package_version=0.16.2 ... exe_path isn't found
ERR check file_src is correct ... package_version=0.16.1 ... exe_path isn't found
ERR check file_src is correct ... package_version=0.13.1 ... exe_path isn't found
```

```console
$ argd t dathere/qsv
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

```console
$ conftest test --combine pkgs/dathere/qsv/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
# temporary all-version pkg.yaml matrix, then reverted
$ argd t dathere/qsv
# 216 package/version entries tested; exit status 0; 0 ERR lines
```

```console
# local file:// registry validation through mise
$ MISE_AQUA_REGISTRY_URL=file:///home/risu/.ghr/github.com/risu729/aqua-registry mise ls-remote --no-versions-host aqua:dathere/qsv
3.0.0
...
20.0.0

$ MISE_AQUA_REGISTRY_URL=file:///home/risu/.ghr/github.com/risu729/aqua-registry mise x aqua:dathere/qsv@latest -- qsv --version
qsv 20.0.0-... prebuilt
```

AI assistance: OpenAI Codex was used to prepare this PR; I reviewed and tested the changes.
