### PR TITLE
feat(FairwindsOps/pluto): add support for newer FairwindOps/pluto releases using cosign bundles

### DIFF
--- a/pkgs/FairwindsOps/pluto/pkg.yaml
+++ b/pkgs/FairwindsOps/pluto/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: FairwindsOps/pluto@v5.23.5
+  - name: FairwindsOps/pluto@v5.24.0
+  - name: FairwindsOps/pluto
+    version: v5.23.5
   - name: FairwindsOps/pluto
     version: v5.21.6
   - name: FairwindsOps/pluto

--- a/pkgs/FairwindsOps/pluto/registry.yaml
+++ b/pkgs/FairwindsOps/pluto/registry.yaml
@@ -66,7 +66,7 @@ packages:
               - https://artifacts.fairwinds.com/cosign.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
-      - version_constraint: "true"
+      - version_constraint: semver("<=5.23.5")
         asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -79,3 +79,17 @@ packages:
               - https://artifacts.fairwinds.com/cosign-p256.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
+      - version_constraint: "true"
+        asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --key
+              - https://artifacts.fairwinds.com/cosign-p256.pub

--- a/registry.yaml
+++ b/registry.yaml
@@ -3301,7 +3301,7 @@ packages:
               - https://artifacts.fairwinds.com/cosign.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
-      - version_constraint: "true"
+      - version_constraint: semver("<=5.23.5")
         asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -3314,6 +3314,20 @@ packages:
               - https://artifacts.fairwinds.com/cosign-p256.pub
               - --signature
               - https://github.com/FairwindsOps/pluto/releases/download/{{.Version}}/checksums.txt.sig
+      - version_constraint: "true"
+        asset: pluto_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --key
+              - https://artifacts.fairwinds.com/cosign-p256.pub
   - type: github_release
     repo_owner: FairwindsOps
     repo_name: polaris


### PR DESCRIPTION
Starting with [v5.24.0](https://github.com/FairwindsOps/pluto/releases/tag/v5.24.0) FairwindsOps/pluto uses the new cosign bundle format, so this PR updates the registry.yaml to handle newer FairwindsOps/pluto releases so that checkum checks can succeed.

Prior to the fix:

```sh
May 19 07:03:48.873 INF Verification by Cosign failed temporarily, retrying program=aqua version="" env=linux/amd64 package_name=FairwindsOps/pluto package_version=v5.24.0 package_registry=standard checksum_env=linux/amd64 retry_count=4 wait_time=258ms
Error: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest {"code":400,"message":"verifying signature: ecdsa: Invalid IEEE_P1363 encoded bytes"}
error during command execution: searching log query: [POST /api/v1/log/entries/retrieve][400] searchLogQueryBadRequest {"code":400,"message":"verifying signature: ecdsa: Invalid IEEE_P1363 encoded bytes"}
May 19 07:03:50.212 ERR update checksums program=aqua version="" env=linux/amd64 package_name=FairwindsOps/pluto package_version=v5.24.0 package_registry=standard cosign_opts="--key, https://artifacts.fairwinds.com/cosign-p256.pub, --signature, https://github.com/FairwindsOps/pluto/releases/download/v5.24.0/checksums.txt.sig" target=/tmp/996915878 error="verify the checksum file: verify the checksum file: verify a file with Cosign: verify a signature file with Cosign: verify with Cosign"
```

With the fix applied:

```sh
May 19 07:51:00.818 INF updating a package checksum program=aqua version="" env=linux/amd64 package_name=FairwindsOps/pluto package_version=v5.24.0 package_registry=standard
May 19 07:51:01.169 INF verifying a file with Cosign program=aqua version="" env=linux/amd64 package_name=FairwindsOps/pluto package_version=v5.24.0 package_registry=standard checksum_env=darwin/amd64
Verified OK
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
