### PR TITLE
feat(goccy/bigquery-emulator): fix 0.7.0+, GitHub artifact attestations config

### DIFF
--- a/pkgs/goccy/bigquery-emulator/pkg.yaml
+++ b/pkgs/goccy/bigquery-emulator/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: goccy/bigquery-emulator@v0.7.0
   - name: goccy/bigquery-emulator
+    version: v0.6.6
+  - name: goccy/bigquery-emulator
     version: v0.1.2

--- a/pkgs/goccy/bigquery-emulator/pkg.yaml
+++ b/pkgs/goccy/bigquery-emulator/pkg.yaml
@@ -1,4 +1,4 @@
 packages:
-  - name: goccy/bigquery-emulator@v0.6.6
+  - name: goccy/bigquery-emulator@v0.7.0
   - name: goccy/bigquery-emulator
     version: v0.1.2

--- a/pkgs/goccy/bigquery-emulator/registry.yaml
+++ b/pkgs/goccy/bigquery-emulator/registry.yaml
@@ -26,3 +26,5 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: goccy/bigquery-emulator/\.github/workflows/release\.yml

--- a/pkgs/goccy/bigquery-emulator/registry.yaml
+++ b/pkgs/goccy/bigquery-emulator/registry.yaml
@@ -12,10 +12,17 @@ packages:
         rosetta2: true
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: bigquery-emulator-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: "true"
+        asset: bigquery-emulator_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -41961,6 +41961,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+        github_artifact_attestations:
+          signer_workflow: goccy/bigquery-emulator/\.github/workflows/release\.yml
   - name: goccy/go-yaml/ycat
     type: go_build
     repo_owner: goccy

--- a/registry.yaml
+++ b/registry.yaml
@@ -41947,13 +41947,20 @@ packages:
         rosetta2: true
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: bigquery-emulator-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: "true"
+        asset: bigquery-emulator_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        overrides:
+          - goos: windows
+            format: zip
   - name: goccy/go-yaml/ycat
     type: go_build
     repo_owner: goccy


### PR DESCRIPTION
- https://github.com/goccy/bigquery-emulator/releases/tag/v0.7.0
- https://github.com/goccy/bigquery-emulator/attestations?q=sort%3Acreated-asc

Includes and closes https://github.com/aquaproj/aqua-registry/pull/53981

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
