### PR TITLE
feat: add google.com/antigravity-cli

### DIFF
--- a/pkgs/google.com/antigravity-cli/pkg.yaml
+++ b/pkgs/google.com/antigravity-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google.com/antigravity-cli@

--- a/pkgs/google.com/antigravity-cli/pkg.yaml
+++ b/pkgs/google.com/antigravity-cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: google.com/antigravity-cli@
+  - name: google.com/antigravity-cli@1.0.0-5288553236791296

--- a/pkgs/google.com/antigravity-cli/registry.yaml
+++ b/pkgs/google.com/antigravity-cli/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: google.com
+    repo_name: antigravity-cli

--- a/pkgs/google.com/antigravity-cli/registry.yaml
+++ b/pkgs/google.com/antigravity-cli/registry.yaml
@@ -4,76 +4,39 @@ packages:
     name: google.com/antigravity-cli
     description: Google's agentic development platform CLI companion
     link: https://antigravity.google/download
-    url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
     format: tar.gz
     files:
       - name: agy
         src: antigravity
     checksum:
       type: http
-      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json
+      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
       file_format: regexp
       algorithm: sha512
       pattern:
         checksum: '"sha512": "([0-9a-f]{128})"'
     overrides:
       - goos: linux
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
+      - goos: linux
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: darwin
         goarch: amd64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_amd64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: darwin
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: windows
         goarch: amd64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
         format: raw
         files:
           - name: agy
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_amd64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: windows
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
         format: raw
         files:
           - name: agy
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
-    supported_envs:
-      - linux
-      - darwin
-      - windows

--- a/pkgs/google.com/antigravity-cli/registry.yaml
+++ b/pkgs/google.com/antigravity-cli/registry.yaml
@@ -1,5 +1,79 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
-    repo_owner: google.com
-    repo_name: antigravity-cli
+  - type: http
+    name: google.com/antigravity-cli
+    description: Google's agentic development platform CLI companion
+    link: https://antigravity.google/download
+    url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
+    format: tar.gz
+    files:
+      - name: agy
+        src: antigravity
+    checksum:
+      type: http
+      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: '"sha512": "([0-9a-f]{128})"'
+    overrides:
+      - goos: linux
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: darwin
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_amd64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: darwin
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: windows
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
+        format: raw
+        files:
+          - name: agy
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_amd64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: windows
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
+        format: raw
+        files:
+          - name: agy
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+    supported_envs:
+      - linux
+      - darwin
+      - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -43282,79 +43282,42 @@ packages:
     name: google.com/antigravity-cli
     description: Google's agentic development platform CLI companion
     link: https://antigravity.google/download
-    url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
     format: tar.gz
     files:
       - name: agy
         src: antigravity
     checksum:
       type: http
-      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json
+      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
       file_format: regexp
       algorithm: sha512
       pattern:
         checksum: '"sha512": "([0-9a-f]{128})"'
     overrides:
       - goos: linux
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
+      - goos: linux
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: darwin
         goarch: amd64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_amd64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: darwin
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: windows
         goarch: amd64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
         format: raw
         files:
           - name: agy
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_amd64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
       - goos: windows
         goarch: arm64
         url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
         format: raw
         files:
           - name: agy
-        checksum:
-          type: http
-          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_arm64.json
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            checksum: '"sha512": "([0-9a-f]{128})"'
-    supported_envs:
-      - linux
-      - darwin
-      - windows
   - type: github_release
     repo_owner: google
     repo_name: addlicense

--- a/registry.yaml
+++ b/registry.yaml
@@ -43279,6 +43279,9 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: google.com
+    repo_name: antigravity-cli
+  - type: github_release
     repo_owner: google
     repo_name: addlicense
     description: A program which ensures source code files have copyright license headers by scanning directory patterns recursively

--- a/registry.yaml
+++ b/registry.yaml
@@ -43278,9 +43278,83 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: github_release
-    repo_owner: google.com
-    repo_name: antigravity-cli
+  - type: http
+    name: google.com/antigravity-cli
+    description: Google's agentic development platform CLI companion
+    link: https://antigravity.google/download
+    url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
+    format: tar.gz
+    files:
+      - name: agy
+        src: antigravity
+    checksum:
+      type: http
+      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json
+      file_format: regexp
+      algorithm: sha512
+      pattern:
+        checksum: '"sha512": "([0-9a-f]{128})"'
+    overrides:
+      - goos: linux
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: darwin
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_amd64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: darwin
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: windows
+        goarch: amd64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
+        format: raw
+        files:
+          - name: agy
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_amd64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+      - goos: windows
+        goarch: arm64
+        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
+        format: raw
+        files:
+          - name: agy
+        checksum:
+          type: http
+          url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/windows_arm64.json
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: '"sha512": "([0-9a-f]{128})"'
+    supported_envs:
+      - linux
+      - darwin
+      - windows
   - type: github_release
     repo_owner: google
     repo_name: addlicense


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Description

[Antigravity CLI](https://antigravity.google/download) is a Google's agentic coding platform called Antigravity via CLI.

Within 30 days, [all gemini cli users are forced to migrate to this](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) . So we need to manage this with aqua, mise and more.
