### PR TITLE
feat: add sholdee/crd-schema-publisher

### DIFF
--- a/pkgs/sholdee/crd-schema-publisher/pkg.yaml
+++ b/pkgs/sholdee/crd-schema-publisher/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sholdee/crd-schema-publisher@v2026.519.317

--- a/pkgs/sholdee/crd-schema-publisher/registry.yaml
+++ b/pkgs/sholdee/crd-schema-publisher/registry.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sholdee
+    repo_name: crd-schema-publisher
+    description: Browsable CRD docs and IDE validation schemas, straight from your Kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2026.424.75813")
+        no_asset: true
+      - version_constraint: "true"
+        asset: crd-schema-publisher-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums-sha256.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/sholdee/crd-schema-publisher/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums-sha256.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/sholdee/crd-schema-publisher/registry.yaml
+++ b/pkgs/sholdee/crd-schema-publisher/registry.yaml
@@ -17,8 +17,8 @@ packages:
           algorithm: sha256
           cosign:
             opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/sholdee/crd-schema-publisher/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:

--- a/registry.yaml
+++ b/registry.yaml
@@ -80486,8 +80486,8 @@ packages:
           algorithm: sha256
           cosign:
             opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/sholdee/crd-schema-publisher/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-identity
+              - https://github.com/sholdee/crd-schema-publisher/.github/workflows/release.yaml@refs/heads/main
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
             bundle:

--- a/registry.yaml
+++ b/registry.yaml
@@ -80470,6 +80470,33 @@ packages:
           asset: tparagen_{{trimV .Version}}_checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: sholdee
+    repo_name: crd-schema-publisher
+    description: Browsable CRD docs and IDE validation schemas, straight from your Kubernetes cluster
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 2026.424.75813")
+        no_asset: true
+      - version_constraint: "true"
+        asset: crd-schema-publisher-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums-sha256.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/sholdee/crd-schema-publisher/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums-sha256.txt.sigstore.json
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: showwin
     repo_name: speedtest-go
     asset: speedtest-go_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

Add [`sholdee/crd-schema-publisher`](https://github.com/sholdee/crd-schema-publisher), a CLI that generates Kubernetes CRD JSON schemas and browsable documentation pages.

## Verification

```sh
argd t sholdee/crd-schema-publisher
conftest test pkgs/sholdee/crd-schema-publisher/*.yaml
npx --yes prettier -w pkgs/sholdee/crd-schema-publisher/*.yaml
git diff --check
```

`conftest` result:

```text
28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions
```

Local execution per `docs/run_tool.md`:

```sh
AQUA_GLOBAL_CONFIG=$PWD/aqua-all.yaml aqua exec -- crd-schema-publisher --version
AQUA_GLOBAL_CONFIG=$PWD/aqua-all.yaml aqua exec -- crd-schema-publisher --help
```

Result:

```text
Verified OK
v2026.519.317
```

`--help` printed the expected command list.