### PR TITLE
fix(sholdee/crd-schema-publisher): verify artifact attestations

### DIFF
--- a/pkgs/sholdee/crd-schema-publisher/registry.yaml
+++ b/pkgs/sholdee/crd-schema-publisher/registry.yaml
@@ -11,6 +11,8 @@ packages:
       - version_constraint: "true"
         asset: crd-schema-publisher-{{.OS}}-{{.Arch}}
         format: raw
+        github_artifact_attestations:
+          signer_workflow: sholdee/crd-schema-publisher/.github/workflows/release.yaml
         checksum:
           type: github_release
           asset: checksums-sha256.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -80520,6 +80520,8 @@ packages:
       - version_constraint: "true"
         asset: crd-schema-publisher-{{.OS}}-{{.Arch}}
         format: raw
+        github_artifact_attestations:
+          signer_workflow: sholdee/crd-schema-publisher/.github/workflows/release.yaml
         checksum:
           type: github_release
           asset: checksums-sha256.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

Enable GitHub Artifact Attestations verification for `sholdee/crd-schema-publisher`.

The package already verifies the checksum manifest with Cosign; this adds binary provenance verification from the release workflow.

## Verification

```sh
argd t sholdee/crd-schema-publisher
conftest test pkgs/sholdee/crd-schema-publisher/*.yaml
git diff --check
```

`argd t` verified GitHub Artifact Attestations and Cosign checksums:

```text
verify GitHub Artifact Attestations
Verified OK
```

Runtime check:

```sh
aqua exec -- crd-schema-publisher --help
```

`--help` printed the expected command list.