### PR TITLE
feat: add openclaw/wacli

### DIFF
--- a/pkgs/openclaw/wacli/pkg.yaml
+++ b/pkgs/openclaw/wacli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: openclaw/wacli@v0.10.0
+  - name: openclaw/wacli
+    version: v0.9.1

--- a/pkgs/openclaw/wacli/pkg.yaml
+++ b/pkgs/openclaw/wacli/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: openclaw/wacli@v0.10.0
-  - name: openclaw/wacli
-    version: v0.9.1

--- a/pkgs/openclaw/wacli/registry.yaml
+++ b/pkgs/openclaw/wacli/registry.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: openclaw
+    repo_name: wacli
+    description: WhatsApp in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.2")
+        asset: wacli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: wacli
+        checksum:
+          type: github_release
+          asset: checksums-linux-windows.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - linux/arm64
+          - windows
+        overrides:
+          - goos: darwin
+            asset: wacli-macos-universal.{{.Format}}
+            checksum:
+              type: github_release
+              asset: checksums.txt
+              algorithm: sha256
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: wacli
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/openclaw/wacli/registry.yaml
+++ b/pkgs/openclaw/wacli/registry.yaml
@@ -6,21 +6,16 @@ packages:
     description: WhatsApp in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.10.0")
+      - version_constraint: semver("< 0.10.0")
+        error_message: Please upgrade to version 0.10.0 or higher
+      - version_constraint: "true"
         asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        files:
-          - name: wacli
+        windows_arm_emulation: true
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        supported_envs:
-          - darwin/amd64
-          - darwin/arm64
-          - linux/amd64
-          - linux/arm64
-          - windows/amd64
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/openclaw/wacli/registry.yaml
+++ b/pkgs/openclaw/wacli/registry.yaml
@@ -6,40 +6,21 @@ packages:
     description: WhatsApp in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.9.2")
-        asset: wacli-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: wacli
-        checksum:
-          type: github_release
-          asset: checksums-linux-windows.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - linux/amd64
-          - linux/arm64
-          - windows
-        overrides:
-          - goos: darwin
-            asset: wacli-macos-universal.{{.Format}}
-            checksum:
-              type: github_release
-              asset: checksums.txt
-              algorithm: sha256
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.10.0")
         asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         files:
           - name: wacli
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        supported_envs:
+          - darwin/amd64
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64
+          - windows/amd64
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -68930,40 +68930,21 @@ packages:
     description: WhatsApp in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.9.2")
-        asset: wacli-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        files:
-          - name: wacli
-        checksum:
-          type: github_release
-          asset: checksums-linux-windows.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - linux/amd64
-          - linux/arm64
-          - windows
-        overrides:
-          - goos: darwin
-            asset: wacli-macos-universal.{{.Format}}
-            checksum:
-              type: github_release
-              asset: checksums.txt
-              algorithm: sha256
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
+      - version_constraint: semver(">= 0.10.0")
         asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
         files:
           - name: wacli
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        supported_envs:
+          - darwin/amd64
+          - darwin/arm64
+          - linux/amd64
+          - linux/arm64
+          - windows/amd64
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -68925,6 +68925,49 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: openclaw
+    repo_name: wacli
+    description: WhatsApp in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.2")
+        asset: wacli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: wacli
+        checksum:
+          type: github_release
+          asset: checksums-linux-windows.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - linux/arm64
+          - windows
+        overrides:
+          - goos: darwin
+            asset: wacli-macos-universal.{{.Format}}
+            checksum:
+              type: github_release
+              asset: checksums.txt
+              algorithm: sha256
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: wacli
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: opencontainers
     repo_name: runc
     description: CLI tool for spawning and running containers according to the OCI specification

--- a/registry.yaml
+++ b/registry.yaml
@@ -68930,21 +68930,16 @@ packages:
     description: WhatsApp in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 0.10.0")
+      - version_constraint: semver("< 0.10.0")
+        error_message: Please upgrade to version 0.10.0 or higher
+      - version_constraint: "true"
         asset: wacli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        files:
-          - name: wacli
+        windows_arm_emulation: true
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        supported_envs:
-          - darwin/amd64
-          - darwin/arm64
-          - linux/amd64
-          - linux/arm64
-          - windows/amd64
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
#54103 [openclaw/wacli](https://github.com/openclaw/wacli) - WhatsApp in your terminal @dovocoder

## Summary
- Add openclaw/wacli as a GitHub release package.
- Support the current v0.10.0+ asset naming.
- Regenerate the root registry.yaml with argd gr.

## Verification
```console
$ gh pr list --repo aquaproj/aqua-registry --search "wacli" --state all --json number,title,state,url
[]
```

```console
$ PATH=/tmp/aqua-install:$PATH aqua exec -- argd gr
# exit 0, no output
```

```console
$ PATH=/tmp/aqua-install:$PATH aqua exec -- conftest test --combine pkgs/openclaw/wacli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ git diff --check
# exit 0, no output
```

I attempted to run the package scaffold/test commands, but this environment does not have Docker available:

```console
$ PATH=/tmp/aqua-install:$PATH aqua exec -- argd scaffold --no-create-branch openclaw/wacli
ERR argd failed ... required commands not found: docker

$ PATH=/tmp/aqua-install:$PATH aqua exec -- argd test openclaw/wacli
ERR argd failed ... exec: "docker": executable file not found in $PATH
```

## AI usage
I used an AI coding assistant to help draft and verify this change, then reviewed the generated files and validation output before opening this PR.
