### PR TITLE
feat: add Staffbase/gq

### DIFF
--- a/pkgs/Staffbase/gq/pkg.yaml
+++ b/pkgs/Staffbase/gq/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Staffbase/gq@v0.0.1

--- a/pkgs/Staffbase/gq/registry.yaml
+++ b/pkgs/Staffbase/gq/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Staffbase
+    repo_name: gq
+    description: CLI and MCP server for querying logs and metrics via Grafana datasource proxy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7639,6 +7639,26 @@ packages:
       - name: go-timeout
         src: timeout_{{.Version}}_{{.OS}}_{{.Arch}}/go-timeout
   - type: github_release
+    repo_owner: Staffbase
+    repo_name: gq
+    description: CLI and MCP server for querying logs and metrics via Grafana datasource proxy
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: Stranger6667
     repo_name: jsonschema
     description: A high-performance JSON Schema validator for Rust


### PR DESCRIPTION
add [gq](https://github.com/Staffbase/gq) — CLI and MCP server for querying logs and metrics via Grafana's datasource proxy.

Scaffolded with `argd scaffold Staffbase/gq`. Tested locally via argd's container tests on darwin/linux × amd64/arm64.



## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] Install and execute the package and confirm if the package works well

<!-- Please write the description here -->
