### PR TITLE
Add felixgwilliams/nbwipers

### DIFF
--- a/pkgs/felixgwilliams/nbwipers/pkg.yaml
+++ b/pkgs/felixgwilliams/nbwipers/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: felixgwilliams/nbwipers@v0.6.2
+  - name: felixgwilliams/nbwipers
+    version: v0.3.6

--- a/pkgs/felixgwilliams/nbwipers/registry.yaml
+++ b/pkgs/felixgwilliams/nbwipers/registry.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: felixgwilliams
+    repo_name: nbwipers
+    description: nbwipers is a command line tool to wipe clean jupyter notebooks, written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.6")
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36987,6 +36987,45 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: felixgwilliams
+    repo_name: nbwipers
+    description: nbwipers is a command line tool to wipe clean jupyter notebooks, written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.6")
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: nbwipers-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: ffuf
     repo_name: ffuf
     description: Fast web fuzzer written in Go


### PR DESCRIPTION
#54329 [felixgwilliams/nbwipers](https://github.com/felixgwilliams/nbwipers) - nbwipers is a command line tool to wipe clean jupyter notebooks, written in Rust

## Package

- Repo: https://github.com/felixgwilliams/nbwipers
- Description: nbwipers is a command line tool to wipe clean jupyter notebooks, written in Rust

## Verification

```
argd t felixgwilliams/nbwipers
```

All platforms passed (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64).

## AI Usage

Scaffolded with `argd s felixgwilliams/nbwipers`. Reviewed and verified by [@sanemat](https://github.com/sanemat).

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>