### PR TITLE
Add Bearer/bearer

### DIFF
--- a/pkgs/Bearer/bearer/pkg.yaml
+++ b/pkgs/Bearer/bearer/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: Bearer/bearer@v2.0.2
+  - name: Bearer/bearer
+    version: v1.43.4
+  - name: Bearer/bearer
+    version: v0.24.0
+  - name: Bearer/bearer
+    version: v0.21.1
+  - name: Bearer/bearer
+    version: v0.20.1

--- a/pkgs/Bearer/bearer/pkg.yaml
+++ b/pkgs/Bearer/bearer/pkg.yaml
@@ -2,9 +2,3 @@ packages:
   - name: Bearer/bearer@v2.0.2
   - name: Bearer/bearer
     version: v1.43.4
-  - name: Bearer/bearer
-    version: v0.24.0
-  - name: Bearer/bearer
-    version: v0.21.1
-  - name: Bearer/bearer
-    version: v0.20.1

--- a/pkgs/Bearer/bearer/registry.yaml
+++ b/pkgs/Bearer/bearer/registry.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Bearer
+    repo_name: bearer
+    description: Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.20.1"
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: curio_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.21.1")
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.24.0")
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: curio_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.43.4")
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/Bearer/bearer/registry.yaml
+++ b/pkgs/Bearer/bearer/registry.yaml
@@ -6,40 +6,8 @@ packages:
     description: Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.20.1"
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: curio_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.21.1")
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: semver("<= 0.24.0")
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: curio_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
+        no_asset: true
       - version_constraint: semver("<= 1.43.4")
         asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -51,6 +19,9 @@ packages:
           - goos: linux
             format: tar.zst
             asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
         supported_envs:
           - linux/amd64
           - darwin
@@ -65,6 +36,9 @@ packages:
           - goos: linux
             format: tar.zst
             asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -987,6 +987,74 @@ packages:
           - windows
   - type: github_release
     repo_owner: Bearer
+    repo_name: bearer
+    description: Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.20.1"
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: curio_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.21.1")
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.24.0")
+        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: curio_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.43.4")
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: "true"
+        asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            format: tar.zst
+            asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: Bearer
     repo_name: gon
     description: Sign, notarize, and package macOS CLI tools and applications written in any language. Available as both a CLI and a Go library
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -991,40 +991,8 @@ packages:
     description: Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.20.1"
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: curio_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: semver("<= 0.21.1")
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - linux/amd64
-          - darwin
       - version_constraint: semver("<= 0.24.0")
-        asset: curio_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            format: tar.zst
-            asset: curio_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
+        no_asset: true
       - version_constraint: semver("<= 1.43.4")
         asset: bearer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -1036,6 +1004,9 @@ packages:
           - goos: linux
             format: tar.zst
             asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
         supported_envs:
           - linux/amd64
           - darwin
@@ -1050,6 +1021,9 @@ packages:
           - goos: linux
             format: tar.zst
             asset: bearer_{{trimV .Version}}_{{.OS}}-{{.Arch}}.pkg.{{.Format}}
+            files:
+              - name: bearer
+                src: usr/bin/bearer
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
#54433 [Bearer/bearer](https://github.com/Bearer/bearer) - Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks

## Summary

Add [Bearer/bearer](https://github.com/Bearer/bearer) — code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks.

## Package details

- Type: `github_release`
- Supported envs: `linux` (amd64, arm64), `darwin` (amd64, arm64)
- Versions `<= 0.24.0` (curio-era, project was renamed from curio) excluded via `no_asset: true`
- Linux archives use `.pkg.tar.zst` with binary at `usr/bin/bearer`; darwin uses `.tar.gz`
- Checksum verification via `checksums.txt` (sha256). Upstream does not provide cosign/SLSA.

## Verification

```
$ AQUA_GITHUB_TOKEN=... argd t Bearer/bearer
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

```
$ bearer version
bearer version 2.0.2, build 255b3d72c911000bfea9aaea5413d354c7220b10

$ bearer --help
Scan your source code to discover, filter and prioritize security and privacy risks.

Usage: bearer <command> [flags]

Available Commands:
	completion        Generate the autocompletion script for your shell
	scan              Scan a directory or file
	init              Write the default config to bearer.yml
	ignore            Manage ignored fingerprints
	version           Print the version
```

## AI disclosure

This PR was created with the assistance of Claude Code (claude-sonnet-4-6).