### PR TITLE
feat: add s0undt3ch/ToolR

### DIFF
--- a/pkgs/s0undt3ch/ToolR/pkg.yaml
+++ b/pkgs/s0undt3ch/ToolR/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: s0undt3ch/ToolR@v0.20.0
-  - name: s0undt3ch/ToolR
-    version: v0.11.1

--- a/pkgs/s0undt3ch/ToolR/pkg.yaml
+++ b/pkgs/s0undt3ch/ToolR/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: s0undt3ch/ToolR@v0.20.0
+  - name: s0undt3ch/ToolR
+    version: v0.11.1

--- a/pkgs/s0undt3ch/ToolR/registry.yaml
+++ b/pkgs/s0undt3ch/ToolR/registry.yaml
@@ -6,34 +6,20 @@ packages:
     description: In-project CLI tooling support
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.11.1")
-        asset: toolr-{{trimV .Version}}-cp311-cp311-many{{.OS}}_2_28_{{.Arch}}.whl
-        format: raw
-        windows_arm_emulation: true
-        complete_windows_ext: false
-        replacements:
-          amd64: x86_64
-          darwin: macosx
-          windows: win
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-          - goos: darwin
-            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_11_0_{{.Arch}}.whl
-          - goos: windows
-            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
-            replacements:
-              amd64: amd64
+      - version_constraint: semver("< 0.20.0")
+        error_message: Standalone binaries are available from v0.20.0; please use v0.20.0 or later
       - version_constraint: "true"
         asset: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: toolr
+            src: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}/toolr
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         checksum:
           type: github_release

--- a/pkgs/s0undt3ch/ToolR/registry.yaml
+++ b/pkgs/s0undt3ch/ToolR/registry.yaml
@@ -21,7 +21,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         checksum:
           type: github_release

--- a/pkgs/s0undt3ch/ToolR/registry.yaml
+++ b/pkgs/s0undt3ch/ToolR/registry.yaml
@@ -15,6 +15,8 @@ packages:
           - name: toolr
             src: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}/toolr
         windows_arm_emulation: true
+        github_artifact_attestations:
+          enabled: true
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/pkgs/s0undt3ch/ToolR/registry.yaml
+++ b/pkgs/s0undt3ch/ToolR/registry.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: s0undt3ch
+    repo_name: ToolR
+    description: In-project CLI tooling support
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.11.1")
+        asset: toolr-{{trimV .Version}}-cp311-cp311-many{{.OS}}_2_28_{{.Arch}}.whl
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: macosx
+          windows: win
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_11_0_{{.Arch}}.whl
+          - goos: windows
+            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
+            replacements:
+              amd64: amd64
+      - version_constraint: "true"
+        asset: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -78149,7 +78149,7 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-gnu
+          linux: unknown-linux-musl
           windows: pc-windows-msvc
         checksum:
           type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -78129,6 +78129,48 @@ packages:
       asset: smap_{{.Version}}--sha256_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: s0undt3ch
+    repo_name: ToolR
+    description: In-project CLI tooling support
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.11.1")
+        asset: toolr-{{trimV .Version}}-cp311-cp311-many{{.OS}}_2_28_{{.Arch}}.whl
+        format: raw
+        windows_arm_emulation: true
+        complete_windows_ext: false
+        replacements:
+          amd64: x86_64
+          darwin: macosx
+          windows: win
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_11_0_{{.Arch}}.whl
+          - goos: windows
+            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
+            replacements:
+              amd64: amd64
+      - version_constraint: "true"
+        asset: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: sachaos
     repo_name: go-life
     description: Terminal based Conway's Game of Life. Implemented in Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -78134,34 +78134,20 @@ packages:
     description: In-project CLI tooling support
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.11.1")
-        asset: toolr-{{trimV .Version}}-cp311-cp311-many{{.OS}}_2_28_{{.Arch}}.whl
-        format: raw
-        windows_arm_emulation: true
-        complete_windows_ext: false
-        replacements:
-          amd64: x86_64
-          darwin: macosx
-          windows: win
-        overrides:
-          - goos: linux
-            replacements:
-              arm64: aarch64
-          - goos: darwin
-            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_11_0_{{.Arch}}.whl
-          - goos: windows
-            asset: toolr-{{trimV .Version}}-cp311-cp311-{{.OS}}_{{.Arch}}.whl
-            replacements:
-              amd64: amd64
+      - version_constraint: semver("< 0.20.0")
+        error_message: Standalone binaries are available from v0.20.0; please use v0.20.0 or later
       - version_constraint: "true"
         asset: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: toolr
+            src: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}/toolr
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         checksum:
           type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -78143,6 +78143,8 @@ packages:
           - name: toolr
             src: toolr-{{trimV .Version}}-{{.Arch}}-{{.OS}}/toolr
         windows_arm_emulation: true
+        github_artifact_attestations:
+          enabled: true
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Overview

Adds [`s0undt3ch/ToolR`](https://github.com/s0undt3ch/ToolR) — in-project CLI tooling support. It installs a single `toolr` binary on `$PATH`.

## Notes for review

Scaffolded with `argd s` (first commit), then corrected in a follow-up commit:

- **Added `files.src`.** Each release archive nests the binary as `toolr-<version>-<arch>-<os>/toolr` (`/toolr.exe` on Windows), and the binary is lowercase `toolr` while the repo is `ToolR`, so a `files` block is required. The scaffolder can't auto-generate `files` (docs/error_handling.md). One block covers all platforms (aqua appends `.exe` on Windows).
- **Linux uses `unknown-linux-gnu`.** Releases ship both `gnu` and `musl` linux tarballs; this registry uses the glibc build.
- **Pre-`v0.20.0` releases return an `error_message`.** v0.9.0–v0.11.1 shipped only Python wheels (`.whl`), which aren't standalone binaries and are out of scope. Native binaries start at `v0.20.0`, so older versions get: _"Standalone binaries are available from v0.20.0; please use v0.20.0 or later"_ (same pattern as `Shopify/ejson`).

## Verification

`argd t s0undt3ch/ToolR` — passed on linux/darwin/windows × amd64/arm64; ended with `Updating registry.yaml`.
`conftest test --combine pkgs/s0undt3ch/ToolR/*` — `14 tests, 14 passed, 0 failures`.

## AI disclosure

Authored with Claude Code (Opus 4.7); recorded as `Co-Authored-By` on the fix commit. Output reviewed by me (the package's upstream author).