### PR TITLE
fix(npm/cli): drop broken Windows support

### DIFF
--- a/pkgs/npm/cli/registry.yaml
+++ b/pkgs/npm/cli/registry.yaml
@@ -5,6 +5,9 @@ packages:
     repo_name: cli
     description: the package manager for JavaScript
     version_filter: Version matches "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    supported_envs:
+      - darwin
+      - linux
     url: https://registry.npmjs.org/npm/-/npm-{{trimV .Version}}.tgz
     format: tar.gz
     files:
@@ -12,10 +15,3 @@ packages:
         src: package/bin/npm-cli.js
       - name: npx
         src: package/bin/npx-cli.js
-    overrides:
-      - goos: windows
-        files:
-          - name: npm
-            src: package/bin/npm.cmd
-          - name: npx
-            src: package/bin/npx.cmd

--- a/registry.yaml
+++ b/registry.yaml
@@ -67724,6 +67724,9 @@ packages:
     repo_name: cli
     description: the package manager for JavaScript
     version_filter: Version matches "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    supported_envs:
+      - darwin
+      - linux
     url: https://registry.npmjs.org/npm/-/npm-{{trimV .Version}}.tgz
     format: tar.gz
     files:
@@ -67731,13 +67734,6 @@ packages:
         src: package/bin/npm-cli.js
       - name: npx
         src: package/bin/npx-cli.js
-    overrides:
-      - goos: windows
-        files:
-          - name: npm
-            src: package/bin/npm.cmd
-          - name: npx
-            src: package/bin/npx.cmd
   - type: github_archive
     repo_owner: npryce
     repo_name: adr-tools


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - [x] :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#force-push)
  - [x] :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#generate-registryyaml-by-argd-s)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Summary

- Set `npm/cli` `supported_envs` to `darwin` and `linux`.
- Remove the Windows `npm.cmd` / `npx.cmd` file overrides from the standalone npm tarball package.
- Regenerate the root `registry.yaml` with `argd gr`.

## Investigation

The npm package tarballs for npm 10.9.2 and 11.15.0 include `package/bin/npm.cmd` and `package/bin/npx.cmd`, but those wrappers are for the Node/global npm layout. They look for `node_modules/npm/bin/npm-cli.js` relative to the wrapper directory. That path exists for Node-bundled npm and for `npm install -g npm`, but it does not exist when aqua extracts the standalone `npm/cli` tarball as `package/bin/npm.cmd`.

This means `npm/cli` should not claim Windows support as a standalone aqua package. On Windows, mise should use its existing `npm:npm` backend fallback instead.

Related investigation: https://github.com/jdx/mise/discussions/10089
Companion mise registry PR: https://github.com/jdx/mise/pull/10101

## Verification

```console
$ AQUA_CONFIG=aqua.yaml AQUA_DISABLE_POLICY=true aqua exec -- argd t npm/cli
...
INFO[0002] test version                                   package_name=npm/cli program=npm version=11.15.0
INFO[0002] test version                                   package_name=npm/cli program=npx version=11.15.0
...
```

The generated test matrix skips `npm/cli` on Windows after this change.

```console
$ AQUA_CONFIG=aqua.yaml AQUA_DISABLE_POLICY=true aqua exec -- conftest test --combine pkgs/npm/cli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

Direct Linux smoke with `nodejs/node@v22.13.0` and `npm/cli@v10.9.2`:

```console
$ PATH="$tmp/root/bin:$PATH" npm --version
10.9.2
$ PATH="$tmp/root/bin:$PATH" npx --version
10.9.2
```

Direct Windows platform skip check:

```console
$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua i
INFO[0000] create a symbolic link                        command=aqua-proxy package_name=aquaproj/aqua-proxy package_version=v2.2.0 program=aqua-proxy registry=standard
```

AI assistance: Codex was used for investigation and drafting; I reviewed the changes and verification results.
