### PR TITLE
feat(ImageMagick/ImageMagick): support linux/amd64

### DIFF
--- a/pkgs/ImageMagick/ImageMagick/pkg.yaml
+++ b/pkgs/ImageMagick/ImageMagick/pkg.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: ImageMagick/ImageMagick@7.1.2-24
-  - name: ImageMagick/ImageMagick@7.1.2-23
-  - name: ImageMagick/ImageMagick@7.1.2-22
-  - name: ImageMagick/ImageMagick@7.1.2-21
-  - name: ImageMagick/ImageMagick@7.1.2-20
-  - name: ImageMagick/ImageMagick@7.1.2-19
-  - name: ImageMagick/ImageMagick@7.1.2-18
+  - name: ImageMagick/ImageMagick
+    version: 7.1.2-19
+  - name: ImageMagick/ImageMagick
+    version: 7.1.2-18

--- a/pkgs/ImageMagick/ImageMagick/pkg.yaml
+++ b/pkgs/ImageMagick/ImageMagick/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
   - name: ImageMagick/ImageMagick@7.1.2-24
+  - name: ImageMagick/ImageMagick@7.1.2-23
+  - name: ImageMagick/ImageMagick@7.1.2-22
+  - name: ImageMagick/ImageMagick@7.1.2-21
+  - name: ImageMagick/ImageMagick@7.1.2-20
+  - name: ImageMagick/ImageMagick@7.1.2-19
+  - name: ImageMagick/ImageMagick@7.1.2-18

--- a/pkgs/ImageMagick/ImageMagick/registry.yaml
+++ b/pkgs/ImageMagick/ImageMagick/registry.yaml
@@ -4,21 +4,74 @@ packages:
     repo_owner: ImageMagick
     repo_name: ImageMagick
     description: ImageMagick is a free and open-source software suite for displaying, creating, converting, modifying, and editing raster images
-    search_words:
-      - Windows AMD64 Only
-    supported_envs:
-      - windows/amd64
-    asset: ImageMagick-{{trimV .Version}}-portable-Q16-HDRI-{{.Arch}}.{{.Format}}
-    format: 7z
-    replacements:
-      amd64: x64
-      arm64: arm64
-    files:
-      - name: compare
-      - name: composite
-      - name: conjure
-      - name: identify
-      - name: magick
-      - name: mogrify
-      - name: montage
-      - name: stream
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 7.1.2-18")
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: Version == "7.1.2-19"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        # slsa_provenance:
+        #   type: github_release
+        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: "true"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        # slsa_provenance:
+        #   type: github_release
+        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
+        supported_envs:
+          - windows/amd64
+          - linux/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream

--- a/pkgs/ImageMagick/ImageMagick/registry.yaml
+++ b/pkgs/ImageMagick/ImageMagick/registry.yaml
@@ -30,9 +30,6 @@ packages:
       - version_constraint: Version == "7.1.2-19"
         github_artifact_attestations:
           signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
-        # slsa_provenance:
-        #   type: github_release
-        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
         supported_envs:
           - windows/amd64
         overrides:
@@ -51,9 +48,6 @@ packages:
       - version_constraint: "true"
         github_artifact_attestations:
           signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
-        # slsa_provenance:
-        #   type: github_release
-        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
         supported_envs:
           - windows/amd64
           - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4152,24 +4152,77 @@ packages:
     repo_owner: ImageMagick
     repo_name: ImageMagick
     description: ImageMagick is a free and open-source software suite for displaying, creating, converting, modifying, and editing raster images
-    search_words:
-      - Windows AMD64 Only
-    supported_envs:
-      - windows/amd64
-    asset: ImageMagick-{{trimV .Version}}-portable-Q16-HDRI-{{.Arch}}.{{.Format}}
-    format: 7z
-    replacements:
-      amd64: x64
-      arm64: arm64
-    files:
-      - name: compare
-      - name: composite
-      - name: conjure
-      - name: identify
-      - name: magick
-      - name: mogrify
-      - name: montage
-      - name: stream
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 7.1.2-18")
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: Version == "7.1.2-19"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        # slsa_provenance:
+        #   type: github_release
+        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
+        supported_envs:
+          - windows/amd64
+        overrides:
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
+      - version_constraint: "true"
+        github_artifact_attestations:
+          signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
+        # slsa_provenance:
+        #   type: github_release
+        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
+        supported_envs:
+          - windows/amd64
+          - linux/amd64
+        overrides:
+          - goos: linux
+            format: raw
+            asset: ImageMagick-{{.Version}}-gcc-x86_64.AppImage
+            files:
+              - name: magick
+          - goos: windows
+            asset: ImageMagick-{{.Version}}-portable-Q16-HDRI-x64.{{.Format}}
+            format: 7z
+            files:
+              - name: compare
+              - name: composite
+              - name: conjure
+              - name: identify
+              - name: magick
+              - name: mogrify
+              - name: montage
+              - name: stream
   - type: github_release
     repo_owner: IohannRabeson
     repo_name: tmignore-rs

--- a/registry.yaml
+++ b/registry.yaml
@@ -4178,9 +4178,6 @@ packages:
       - version_constraint: Version == "7.1.2-19"
         github_artifact_attestations:
           signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
-        # slsa_provenance:
-        #   type: github_release
-        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
         supported_envs:
           - windows/amd64
         overrides:
@@ -4199,9 +4196,6 @@ packages:
       - version_constraint: "true"
         github_artifact_attestations:
           signer_workflow: ImageMagick/ImageMagick/.github/workflows/release.yml
-        # slsa_provenance:
-        #   type: github_release
-        #   asset: ImageMagick-{{trimV .Version}}.intoto.jsonl
         supported_envs:
           - windows/amd64
           - linux/amd64


### PR DESCRIPTION
```console
runner@runnervm3jyl0:~/work/aqua-registry/aqua-registry$ aqua exec -- magick --help               
Version: ImageMagick 7.1.2-24 Q16-HDRI x86_64 3c45ab0bf:20260525 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/license/
Features: Cipher DPC HDRI OpenMP(4.5) 
Delegates (built-in): bzlib djvu fontconfig freetype heic jbig jng jp2 jpeg lcms lqr lzma openexr png raqm tiff webp x xml zlib
Compiler: gcc (11.4)
Usage: magick tool [ {option} | {image} ... ] {output_image}
Usage: magick [ {option} | {image} ... ] {output_image}
       magick [ {option} | {image} ... ] -script {filename} [ {script_args} ...]

Image Settings:
  -adjoin              join images into a single multi-image file
  -affine matrix       affine transform matrix
  -alpha option        activate, deactivate, reset, or set the alpha channel
  -antialias           remove pixel-aliasing
  -authenticate password
                       decipher image with this password
  -attenuate value     lessen (or intensify) when adding noise to an image
  -background color    background color
  -bias value          add bias when convolving an image
  -black-point-compensation
                       use black point compensation
  -blue-primary point  chromaticity blue primary point
  -bordercolor color   border color
  -caption string      assign a caption to an image
  -clip                clip along the first path from the 8BIM profile
  -clip-mask filename  associate a clip mask with the image
  -clip-path id        clip along a named path from the 8BIM profile
  -colorspace type     alternate image colorspace
  -comment string      annotate image with comment
  -compose operator    set image composite operator
  -compress type       type of pixel compression when writing the image
  -define format:option
                       define one or more image format options
  -delay value         display the next image after pausing
  -density geometry    horizontal and vertical density of the image
  -depth value         image depth
  -direction type      render text right-to-left or left-to-right

# ...

                       evaluate an arithmetic, relational, or logical expression
  -flatten             flatten a sequence of images
  -fx expression       apply mathematical expression to an image channel(s)
  -hald-clut           apply a Hald color lookup table to the image
  -layers method       optimize, merge, or compare image layers
  -morph value         morph an image sequence
  -mosaic              create a mosaic from an image sequence
  -poly terms          build a polynomial from the image sequence and the corresponding
                       terms (coefficients and degree pairs).
  -print string        interpret string and print to console
  -process arguments   process the image with a custom image filter
  -smush geometry      smush an image sequence together
  -write filename      write images to this file

Image Stack Operators:
  -clone indexes       clone an image
  -delete indexes      delete the image from the image sequence
  -duplicate count,indexes
                       duplicate an image one or more times
  -insert index        insert last image into the image sequence
  -reverse             reverse image sequence
  -swap indexes        swap two images in the image sequence

Miscellaneous Options:
  -debug events        display copious debugging information
  -distribute-cache port
                       distributed pixel cache spanning one or more servers
  -help                print program options
  -list type           print a list of supported option arguments
  -log format          format of debugging information
  -usage               print program usage
  -version             print version information

By default, the image format of 'file' is determined by its magic
number.  To specify a particular image format, precede the filename
with an image format name and a colon (i.e. ps:image) or specify the
image type as the filename suffix (i.e. image.ps).  Specify 'file' as
'-' for standard input or output.
```