### PR TITLE
Add `dahlia/gukhanmun`

### DIFF
--- a/pkgs/dahlia/gukhanmun/pkg.yaml
+++ b/pkgs/dahlia/gukhanmun/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dahlia/gukhanmun@0.1.0

--- a/pkgs/dahlia/gukhanmun/registry.yaml
+++ b/pkgs/dahlia/gukhanmun/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: gukhanmun
+    description: A Rust/JavaScript library and CLI tool that converts mixed-script Korean text into hangul-only text
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/dahlia/gukhanmun/registry.yaml
+++ b/pkgs/dahlia/gukhanmun/registry.yaml
@@ -3,12 +3,17 @@ packages:
   - type: github_release
     repo_owner: dahlia
     repo_name: gukhanmun
-    description: A Rust/JavaScript library and CLI tool that converts mixed-script Korean text into hangul-only text
+    description: Convert mixed-script Korean text into hangul-only text
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: gukhanmun
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun
+          - name: gukhanmun-mkdict
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun-mkdict
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30003,12 +30003,17 @@ packages:
   - type: github_release
     repo_owner: dahlia
     repo_name: gukhanmun
-    description: A Rust/JavaScript library and CLI tool that converts mixed-script Korean text into hangul-only text
+    description: Convert mixed-script Korean text into hangul-only text
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: gukhanmun
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun
+          - name: gukhanmun-mkdict
+            src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun-mkdict
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30001,6 +30001,24 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: dahlia
+    repo_name: gukhanmun
+    description: A Rust/JavaScript library and CLI tool that converts mixed-script Korean text into hangul-only text
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: daichirata
     repo_name: hammer
     description: hammer is a command-line tool to schema management for Google Cloud Spanner


### PR DESCRIPTION
[dahlia/gukhanmun](https://github.com/dahlia/gukhanmun) - Convert mixed-script Korean text into hangul-only text

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

---

This adds `dahlia/gukhanmun`, a CLI for converting mixed-script Korean text into hangul-only text.

The package was scaffolded with `argd s dahlia/gukhanmun`. I added explicit `files[].src` entries because the release archives contain the executables under a top-level archive directory. The package exposes both commands shipped in the archive:

- `gukhanmun`
- `gukhanmun-mkdict`

Verification:

```console
$ argd t dahlia/gukhanmun
...
INF Updating registry.yaml program=argd version=0.5.4
```

```console
$ aqua exec -- conftest test --combine pkgs/dahlia/gukhanmun/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ npx --yes prettier -w pkgs/dahlia/gukhanmun/*.yaml
pkgs/dahlia/gukhanmun/pkg.yaml 10ms (unchanged)
pkgs/dahlia/gukhanmun/registry.yaml 3ms (unchanged)
```

I also installed and ran the commands through a local registry configuration:

```console
$ aqua exec -- gukhanmun --version
gukhanmun 0.1.0

$ aqua exec -- gukhanmun-mkdict --version
gukhanmun-mkdict 0.1.0
```

AI assistance was used to inspect the generated registry entry and draft this PR description. The resulting changes and verification were reviewed before submission.
