### PR TITLE
Add `dahlia/hongdown`

### DIFF
--- a/pkgs/dahlia/hongdown/pkg.yaml
+++ b/pkgs/dahlia/hongdown/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: dahlia/hongdown@0.4.1

--- a/pkgs/dahlia/hongdown/registry.yaml
+++ b/pkgs/dahlia/hongdown/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: hongdown
+    description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/dahlia/hongdown/registry.yaml
+++ b/pkgs/dahlia/hongdown/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: "true"
         asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: hongdown
+            src: hongdown-{{.Arch}}-{{.OS}}/hongdown
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30009,6 +30009,9 @@ packages:
       - version_constraint: "true"
         asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
+        files:
+          - name: hongdown
+            src: hongdown-{{.Arch}}-{{.OS}}/hongdown
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30001,6 +30001,24 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: dahlia
+    repo_name: hongdown
+    description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: daichirata
     repo_name: hammer
     description: hammer is a command-line tool to schema management for Google Cloud Spanner


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

---

This adds `dahlia/hongdown`, a Markdown formatter that enforces Hong Minhee's Markdown style conventions.

The package was scaffolded with `argd s dahlia/hongdown`. I added an explicit `files[].src` entry because the release archives contain the executable under a top-level archive directory such as `hongdown-x86_64-unknown-linux-musl/`.

Verification:

```console
$ argd t dahlia/hongdown
...
INF Updating registry.yaml program=argd version=0.5.4
```

```console
$ aqua exec -- conftest test --combine pkgs/dahlia/hongdown/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ npx --yes prettier -w pkgs/dahlia/hongdown/*.yaml
pkgs/dahlia/hongdown/pkg.yaml 9ms (unchanged)
pkgs/dahlia/hongdown/registry.yaml 3ms (unchanged)
```

I also installed and ran the command through a local registry configuration:

```console
$ aqua exec -- hongdown --version
hongdown 0.4.1
```

AI assistance was used to inspect the generated registry entry and draft this PR description. The resulting changes and verification were reviewed before submission.
