### PR TITLE
feat: add tidewave-ai/tidewave_app

### DIFF
--- a/pkgs/tidewave-ai/tidewave_app/pkg.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: tidewave-ai/tidewave_app@v0.4.4
-  - name: tidewave-ai/tidewave_app
-    version: v0.4.0

--- a/pkgs/tidewave-ai/tidewave_app/pkg.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: tidewave-ai/tidewave_app@v0.4.4
+  - name: tidewave-ai/tidewave_app
+    version: v0.4.0

--- a/pkgs/tidewave-ai/tidewave_app/registry.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: tidewave-ai
     repo_name: tidewave_app
-    description: Tidewave Desktop app and CLI
+    description: Tidewave is the coding agent for full-stack web app development
     files:
       - name: tidewave
     version_constraint: "false"

--- a/pkgs/tidewave-ai/tidewave_app/registry.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tidewave-ai
+    repo_name: tidewave_app
+    description: Tidewave is the coding agent for full-stack web app development
+    asset: tidewave-cli-{{.Arch}}-{{.OS}}
+    format: raw
+    files:
+      - name: tidewave
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64

--- a/pkgs/tidewave-ai/tidewave_app/registry.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/registry.yaml
@@ -3,18 +3,18 @@ packages:
   - type: github_release
     repo_owner: tidewave-ai
     repo_name: tidewave_app
-    description: Tidewave is the coding agent for full-stack web app development
-    asset: tidewave-cli-{{.Arch}}-{{.OS}}
-    format: raw
+    description: Tidewave Desktop app and CLI
     files:
       - name: tidewave
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tidewave-cli-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc

--- a/pkgs/tidewave-ai/tidewave_app/scaffold.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/scaffold.yaml
@@ -1,9 +1,4 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-# Other than name is optional. All initial values are just examples.
 name: tidewave-ai/tidewave_app
-# version_filter: not (Version matches "-rc$")
-# version_prefix: cli-
 all_assets_filter: not (Asset matches "app-")

--- a/pkgs/tidewave-ai/tidewave_app/scaffold.yaml
+++ b/pkgs/tidewave-ai/tidewave_app/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: tidewave-ai/tidewave_app
+# version_filter: not (Version matches "-rc$")
+# version_prefix: cli-
+all_assets_filter: not (Asset matches "app-")

--- a/registry.yaml
+++ b/registry.yaml
@@ -90471,7 +90471,7 @@ packages:
   - type: github_release
     repo_owner: tidewave-ai
     repo_name: tidewave_app
-    description: Tidewave Desktop app and CLI
+    description: Tidewave is the coding agent for full-stack web app development
     files:
       - name: tidewave
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -90471,21 +90471,21 @@ packages:
   - type: github_release
     repo_owner: tidewave-ai
     repo_name: tidewave_app
-    description: Tidewave is the coding agent for full-stack web app development
-    asset: tidewave-cli-{{.Arch}}-{{.OS}}
-    format: raw
+    description: Tidewave Desktop app and CLI
     files:
       - name: tidewave
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-      windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - windows/amd64
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tidewave-cli-{{.Arch}}-{{.OS}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
   - type: github_release
     repo_owner: tilt-dev
     repo_name: ctlptl

--- a/registry.yaml
+++ b/registry.yaml
@@ -90469,6 +90469,24 @@ packages:
       asset: "{{.Asset}}.sha256"
       algorithm: sha256
   - type: github_release
+    repo_owner: tidewave-ai
+    repo_name: tidewave_app
+    description: Tidewave is the coding agent for full-stack web app development
+    asset: tidewave-cli-{{.Arch}}-{{.OS}}
+    format: raw
+    files:
+      - name: tidewave
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    supported_envs:
+      - darwin
+      - linux
+      - windows/amd64
+  - type: github_release
     repo_owner: tilt-dev
     repo_name: ctlptl
     description: Making local Kubernetes clusters fun and easy to set up


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Package

[tidewave-ai/tidewave_app](https://github.com/tidewave-ai/tidewave_app) — Tidewave is the coding agent for full-stack web app development.

Installs the `tidewave` CLI (`tidewave-cli-*` release asset) as a single binary on `$PATH`.

- `type: github_release`, `format: raw`
- `supported_envs`: `darwin`, `linux`, `windows/amd64`

## Verification

Scaffolded with `argd s` and tested with `argd t`:

```
$ argd t tidewave-ai/tidewave_app
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

AI use: used Opus 4.8; I reviewed the output and ran the test commands manually:
- `conftest test pkgs/tidewave-ai/tidewave_app/*.yaml`
- `prettier -w pkgs/tidewave-ai/tidewave_app/*.yaml`
