### PR TITLE
Add cliwright/whoiam

### DIFF
--- a/pkgs/cliwright/whoiam/pkg.yaml
+++ b/pkgs/cliwright/whoiam/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cliwright/whoiam@v0.6.2

--- a/pkgs/cliwright/whoiam/registry.yaml
+++ b/pkgs/cliwright/whoiam/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: cliwright
+    repo_name: whoiam
+    description: CLI tool for checking and validating your current AWS IAM identity
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: whoiam_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -25070,6 +25070,27 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: cliwright
+    repo_name: whoiam
+    description: CLI tool for checking and validating your current AWS IAM identity
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: whoiam_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: clog-tool
     repo_name: clog-cli
     description: Generate beautiful changelogs from your Git commit history


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
This PR would like to add the tool `whoiam` to the registry. 

This tool is a simple cli that validates you are authenticated with the intended AWS account before executing any commands. 

If the validation fails, the tool prevents running the command by exiting with a non-zero exit code. 

Official docs can be found -> [HERE](https://whoiam.cliwright.dev/)

This is my first PR contribution to an OSS project with a tool I have used for quite some time professionally. 🙏 