### PR TITLE
feat: support antigravity-cli GitHub Releases

### DIFF
--- a/pkgs/google-antigravity/antigravity-cli/pkg.yaml
+++ b/pkgs/google-antigravity/antigravity-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: google-antigravity/antigravity-cli@1.0.4

--- a/pkgs/google-antigravity/antigravity-cli/registry.yaml
+++ b/pkgs/google-antigravity/antigravity-cli/registry.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - type: github_release
-    name: google.com/antigravity-cli
     repo_owner: google-antigravity
     repo_name: antigravity-cli
+    aliases:
+      - name: google.com/antigravity-cli
     description: Google Antigravity CLI companion
-    link: https://antigravity.google/download
     asset: agy_cli_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:

--- a/pkgs/google-antigravity/antigravity-cli/registry.yaml
+++ b/pkgs/google-antigravity/antigravity-cli/registry.yaml
@@ -17,6 +17,3 @@ packages:
     overrides:
       - goos: windows
         format: zip
-        files:
-          - name: agy
-            src: antigravity

--- a/pkgs/google.com/antigravity-cli/pkg.yaml
+++ b/pkgs/google.com/antigravity-cli/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: google.com/antigravity-cli@1.0.0-5288553236791296
+  - name: google.com/antigravity-cli@1.0.4

--- a/pkgs/google.com/antigravity-cli/pkg.yaml
+++ b/pkgs/google.com/antigravity-cli/pkg.yaml
@@ -1,2 +1,0 @@
-packages:
-  - name: google.com/antigravity-cli@1.0.4

--- a/pkgs/google.com/antigravity-cli/registry.yaml
+++ b/pkgs/google.com/antigravity-cli/registry.yaml
@@ -1,42 +1,22 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: http
+  - type: github_release
     name: google.com/antigravity-cli
-    description: Google's agentic development platform CLI companion
+    repo_owner: google-antigravity
+    repo_name: antigravity-cli
+    description: Google Antigravity CLI companion
     link: https://antigravity.google/download
+    asset: agy_cli_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: agy
         src: antigravity
-    checksum:
-      type: http
-      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
-      file_format: regexp
-      algorithm: sha512
-      pattern:
-        checksum: '"sha512": "([0-9a-f]{128})"'
+    replacements:
+      amd64: x64
+      darwin: mac
     overrides:
-      - goos: linux
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
-      - goos: linux
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
-      - goos: darwin
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
-      - goos: darwin
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
       - goos: windows
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
-        format: raw
+        format: zip
         files:
           - name: agy
-      - goos: windows
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
-        format: raw
-        files:
-          - name: agy
+            src: antigravity

--- a/registry.yaml
+++ b/registry.yaml
@@ -43559,46 +43559,26 @@ packages:
         supported_envs:
           - linux
           - darwin
-  - type: http
+  - type: github_release
     name: google.com/antigravity-cli
-    description: Google's agentic development platform CLI companion
+    repo_owner: google-antigravity
+    repo_name: antigravity-cli
+    description: Google Antigravity CLI companion
     link: https://antigravity.google/download
+    asset: agy_cli_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: agy
         src: antigravity
-    checksum:
-      type: http
-      url: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/{{.OS}}_{{.Arch}}.json
-      file_format: regexp
-      algorithm: sha512
-      pattern:
-        checksum: '"sha512": "([0-9a-f]{128})"'
+    replacements:
+      amd64: x64
+      darwin: mac
     overrides:
-      - goos: linux
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-x64/cli_linux_x64.tar.gz
-      - goos: linux
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/linux-arm/cli_linux_arm64.tar.gz
-      - goos: darwin
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-x64/cli_mac_x64.tar.gz
-      - goos: darwin
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/darwin-arm/cli_mac_arm64.tar.gz
       - goos: windows
-        goarch: amd64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-x64/cli_windows_x64.exe
-        format: raw
+        format: zip
         files:
           - name: agy
-      - goos: windows
-        goarch: arm64
-        url: https://storage.googleapis.com/antigravity-public/antigravity-cli/{{.Version}}/windows-arm/cli_windows_arm64.exe
-        format: raw
-        files:
-          - name: agy
+            src: antigravity
   - type: github_release
     repo_owner: google
     repo_name: addlicense

--- a/registry.yaml
+++ b/registry.yaml
@@ -43560,11 +43560,11 @@ packages:
           - linux
           - darwin
   - type: github_release
-    name: google.com/antigravity-cli
     repo_owner: google-antigravity
     repo_name: antigravity-cli
+    aliases:
+      - name: google.com/antigravity-cli
     description: Google Antigravity CLI companion
-    link: https://antigravity.google/download
     asset: agy_cli_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -43576,9 +43576,6 @@ packages:
     overrides:
       - goos: windows
         format: zip
-        files:
-          - name: agy
-            src: antigravity
   - type: github_release
     repo_owner: google
     repo_name: addlicense


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

[With GitHub Releases supported in v1.0.4](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.0.4) , now we can update automatically upgrade `google.com/antigravity-cli` . 

## AI Usage

This PR was associated with Codex CLI, but I checked manually.