### PR TITLE
fix(dahlia/gukhanmun): handle tarball layout change in 0.1.2

### DIFF
--- a/pkgs/dahlia/gukhanmun/pkg.yaml
+++ b/pkgs/dahlia/gukhanmun/pkg.yaml
@@ -1,3 +1,4 @@
 packages:
   - name: dahlia/gukhanmun@0.1.2
-  - name: dahlia/gukhanmun@0.1.1
+  - name: dahlia/gukhanmun
+    version: 0.1.1

--- a/pkgs/dahlia/gukhanmun/pkg.yaml
+++ b/pkgs/dahlia/gukhanmun/pkg.yaml
@@ -1,2 +1,3 @@
 packages:
+  - name: dahlia/gukhanmun@0.1.2
   - name: dahlia/gukhanmun@0.1.1

--- a/pkgs/dahlia/gukhanmun/registry.yaml
+++ b/pkgs/dahlia/gukhanmun/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Convert mixed-script Korean text into hangul-only text
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.1.1")
         asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
@@ -14,6 +14,21 @@ packages:
             src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun
           - name: gukhanmun-mkdict
             src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun-mkdict
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: gukhanmun
+          - name: gukhanmun-mkdict
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30027,7 +30027,7 @@ packages:
     description: Convert mixed-script Korean text into hangul-only text
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.1.1")
         asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
@@ -30035,6 +30035,21 @@ packages:
             src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun
           - name: gukhanmun-mkdict
             src: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}/gukhanmun-mkdict
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gukhanmun-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: gukhanmun
+          - name: gukhanmun-mkdict
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
Close #54781

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

From version 0.1.2, the release tarball of `dahlia/gukhanmun` changed its layout: binaries are now placed directly at the archive root instead of inside a `gukhanmun-<version>-<arch>-<os>/` subdirectory.

This PR splits `version_overrides` into two branches:

- `semver("<= 0.1.1")`: keeps the existing directory-prefixed `src` paths
- `"true"` (>= 0.1.2): omits `src`, letting aqua fall back to `name` (top-level binary)

`pkg.yaml` is updated to add `0.1.2` so CI exercises the new layout, while `0.1.1` is retained to guard against regressions in the old layout.

### Verification

```
$ argd t dahlia/gukhanmun
```

Tested on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 — all passed for both 0.1.1 and 0.1.2.

---

This PR was created with assistance from Claude Code (claude-sonnet-4-6).