### PR TITLE
fix(dahlia/hongdown): handle tarball layout change in 0.4.3

### DIFF
--- a/pkgs/dahlia/hongdown/pkg.yaml
+++ b/pkgs/dahlia/hongdown/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: dahlia/hongdown@0.4.2
+  - name: dahlia/hongdown@0.4.3
+  - name: dahlia/hongdown
+    version: 0.4.2

--- a/pkgs/dahlia/hongdown/registry.yaml
+++ b/pkgs/dahlia/hongdown/registry.yaml
@@ -6,12 +6,26 @@ packages:
     description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.2")
         asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
           - name: hongdown
             src: hongdown-{{.Arch}}-{{.OS}}/hongdown
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: hongdown
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -30050,12 +30050,26 @@ packages:
     description: A Markdown formatter that enforces Hong Minhee's Markdown style conventions
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.2")
         asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.bz2
         files:
           - name: hongdown
             src: hongdown-{{.Arch}}-{{.OS}}/hongdown
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hongdown-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.bz2
+        files:
+          - name: hongdown
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
Closes #54782.

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

From version 0.4.3, the release tarball of `dahlia/hongdown` changed its layout: the binary is now placed directly at the archive root instead of inside a `hongdown-<arch>-<os>/` subdirectory.

This PR splits `version_overrides` into two branches:

- `semver("<= 0.4.2")`: keeps the existing directory-prefixed `src` path
- `"true"` (>= 0.4.3): omits `src`, letting aqua fall back to `name` (top-level binary)

`pkg.yaml` is updated to add `0.4.3` so CI exercises the new layout, while `0.4.2` is retained (using the `version:` field convention) to guard against regressions in the old layout.

### Verification

```
$ argd t dahlia/hongdown
```

Tested on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 — all passed for both 0.4.2 and 0.4.3.

---

This PR was created with assistance from Claude Code (claude-sonnet-4-6).