### PR TITLE
Add dahlia/submark

### DIFF
--- a/pkgs/dahlia/submark/pkg.yaml
+++ b/pkgs/dahlia/submark/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: dahlia/submark@0.4.0
+  - name: dahlia/submark
+    version: 0.3.1
+  - name: dahlia/submark
+    version: 0.2.0
+  - name: dahlia/submark
+    version: 0.1.0

--- a/pkgs/dahlia/submark/registry.yaml
+++ b/pkgs/dahlia/submark/registry.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: submark
+    description: Extract a part from CommonMark/Markdown docs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.2.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          windows: win64
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -30095,6 +30095,57 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: dahlia
+    repo_name: submark
+    description: Extract a part from CommonMark/Markdown docs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.2.0"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          windows: win64
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver("<= 0.3.1")
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: submark-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          windows: win64
+        overrides:
+          - goos: windows
+            asset: submark-{{.OS}}
+  - type: github_release
     repo_owner: daichirata
     repo_name: hammer
     description: hammer is a command-line tool to schema management for Google Cloud Spanner


### PR DESCRIPTION
[dahlia/submark](https://github.com/dahlia/submark) - Extract a part from CommonMark/Markdown docs

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

This PR adds the `dahlia/submark` package (a tool to extract a part from CommonMark/Markdown docs) to the registry.

### Verification

Verified successfully using the `argd t dahlia/submark` command:

```
$ argd t dahlia/submark
Jun  5 17:56:00.467 INF Running Linux/Darwin tests program=argd version=0.5.4
...
Jun  5 17:56:00.643 INF testing program=argd version=0.5.4 os=linux arch=amd64
...
Jun  5 17:56:00.858 INF testing program=argd version=0.5.4 os=linux arch=arm64
...
Jun  5 17:56:01.053 INF testing program=argd version=0.5.4 os=darwin arch=amd64
...
Jun  5 17:56:01.250 INF testing program=argd version=0.5.4 os=darwin arch=arm64
...
Jun  5 17:56:01.620 INF Running Windows tests program=argd version=0.5.4
...
Jun  5 17:56:01.784 INF testing program=argd version=0.5.4 os=windows arch=amd64
...
Jun  5 17:56:01.978 INF testing program=argd version=0.5.4 os=windows arch=arm64
...
Jun  5 17:56:02.172 INF Updating registry.yaml program=argd version=0.5.4
```

### AI Usage Disclosure
This PR was created and verified by the Antigravity AI coding assistant (designed by Google DeepMind).
