### PR TITLE
Add dahlia/seonbi

### DIFF
--- a/pkgs/dahlia/seonbi/pkg.yaml
+++ b/pkgs/dahlia/seonbi/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: dahlia/seonbi@0.5.0
+  - name: dahlia/seonbi
+    version: 0.4.0
+  - name: dahlia/seonbi
+    version: 0.2.3

--- a/pkgs/dahlia/seonbi/registry.yaml
+++ b/pkgs/dahlia/seonbi/registry.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dahlia
+    repo_name: seonbi
+    description: SmartyPants for Korean language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -30096,6 +30096,54 @@ packages:
             format: zip
   - type: github_release
     repo_owner: dahlia
+    repo_name: seonbi
+    description: SmartyPants for Korean language
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.3")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: seonbi-{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.bz2
+        replacements:
+          amd64: x86_64
+          darwin: macos
+          windows: win64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: seonbi-{{.Version}}.{{.OS}}.{{.Format}}
+  - type: github_release
+    repo_owner: dahlia
     repo_name: submark
     description: Extract a part from CommonMark/Markdown docs
     version_constraint: "false"


### PR DESCRIPTION
[dahlia/seonbi](https://github.com/dahlia/seonbi) - SmartyPants for Korean language

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

This PR adds the `dahlia/seonbi` package (SmartyPants for Korean language) to the registry.

### Verification

Verified successfully using the `argd t dahlia/seonbi` command:

```
$ argd t dahlia/seonbi
Jun  5 18:01:24.022 INF Running Linux/Darwin tests program=argd version=0.5.4
...
Jun  5 18:01:24.252 INF testing program=argd version=0.5.4 os=linux arch=amd64
...
Jun  5 18:01:24.491 INF testing program=argd version=0.5.4 os=linux arch=arm64
...
Jun  5 18:01:24.685 INF testing program=argd version=0.5.4 os=darwin arch=amd64
...
Jun  5 18:01:24.899 INF testing program=argd version=0.5.4 os=darwin arch=arm64
...
Jun  5 18:01:25.307 INF Running Windows tests program=argd version=0.5.4
...
Jun  5 18:01:25.490 INF testing program=argd version=0.5.4 os=windows arch=amd64
...
Jun  5 18:01:25.710 INF testing program=argd version=0.5.4 os=windows arch=arm64
...
Jun  5 18:01:25.887 INF Updating registry.yaml program=argd version=0.5.4
```

### AI Usage Disclosure
This PR was created and verified by the Antigravity AI coding assistant (designed by Google DeepMind).
