### PR TITLE
fix(FiloSottile/age): add support for darwin/amd64

### DIFF
--- a/pkgs/FiloSottile/age/pkg.yaml
+++ b/pkgs/FiloSottile/age/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: FiloSottile/age@v1.3.1
   - name: FiloSottile/age
+    version: v1.2.1
+  - name: FiloSottile/age
     version: v1.0.0-rc.1
   - name: FiloSottile/age
     version: v1.0.0-beta2

--- a/pkgs/FiloSottile/age/pkg.yaml
+++ b/pkgs/FiloSottile/age/pkg.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: FiloSottile/age@v1.3.1
   - name: FiloSottile/age
-    version: v1.2.1
-  - name: FiloSottile/age
     version: v1.0.0-rc.1
   - name: FiloSottile/age
     version: v1.0.0-beta2

--- a/pkgs/FiloSottile/age/registry.yaml
+++ b/pkgs/FiloSottile/age/registry.yaml
@@ -4,11 +4,6 @@ packages:
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability
-    files:
-      - name: age
-        src: age/age
-      - name: age-keygen
-        src: age/age-keygen
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0-beta1"
@@ -31,13 +26,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 1.2.1")
-        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: "true"
         asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -45,9 +33,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - linux
-          - darwin
-          - windows
-        github_artifact_attestations:
-          signer_workflow: FiloSottile/age/.github/workflows/build.yml

--- a/pkgs/FiloSottile/age/registry.yaml
+++ b/pkgs/FiloSottile/age/registry.yaml
@@ -4,6 +4,11 @@ packages:
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability
+    files:
+      - name: age
+        src: age/age
+      - name: age-keygen
+        src: age/age-keygen
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0-beta1"
@@ -26,10 +31,34 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.2.1")
+        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.3.1"
+        # https://github.com/FiloSottile/age/pull/676
+        # https://github.com/FiloSottile/age/commit/10561a774f9f6de47c8d23ddc58537b6a18b083d
+        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: FiloSottile/age/.github/workflows/build.yml
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            goarch: amd64
+            github_artifact_attestations:
+              signer_workflow: FiloSottile/age/.github/workflows/darwin-amd64-backfill.yml
       - version_constraint: "true"
         asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: FiloSottile/age/.github/workflows/build.yml
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/FiloSottile/age/registry.yaml
+++ b/pkgs/FiloSottile/age/registry.yaml
@@ -47,7 +47,7 @@ packages:
             format: zip
         supported_envs:
           - linux
-          - darwin/arm64
+          - darwin
           - windows
         github_artifact_attestations:
           signer_workflow: FiloSottile/age/.github/workflows/build.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -3536,6 +3536,11 @@ packages:
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability
+    files:
+      - name: age
+        src: age/age
+      - name: age-keygen
+        src: age/age-keygen
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0-beta1"
@@ -3558,10 +3563,34 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.2.1")
+        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.3.1"
+        # https://github.com/FiloSottile/age/pull/676
+        # https://github.com/FiloSottile/age/commit/10561a774f9f6de47c8d23ddc58537b6a18b083d
+        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: FiloSottile/age/.github/workflows/build.yml
+        overrides:
+          - goos: windows
+            format: zip
+          - goos: darwin
+            goarch: amd64
+            github_artifact_attestations:
+              signer_workflow: FiloSottile/age/.github/workflows/darwin-amd64-backfill.yml
       - version_constraint: "true"
         asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: FiloSottile/age/.github/workflows/build.yml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -3579,7 +3579,7 @@ packages:
             format: zip
         supported_envs:
           - linux
-          - darwin/arm64
+          - darwin
           - windows
         github_artifact_attestations:
           signer_workflow: FiloSottile/age/.github/workflows/build.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -3536,11 +3536,6 @@ packages:
     repo_owner: FiloSottile
     repo_name: age
     description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability
-    files:
-      - name: age
-        src: age/age
-      - name: age-keygen
-        src: age/age-keygen
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0-beta1"
@@ -3563,13 +3558,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver("<= 1.2.1")
-        asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: "true"
         asset: age-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -3577,12 +3565,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - linux
-          - darwin
-          - windows
-        github_artifact_attestations:
-          signer_workflow: FiloSottile/age/.github/workflows/build.yml
   - type: github_release
     repo_owner: FiloSottile
     repo_name: mkcert


### PR DESCRIPTION
https://github.com/FiloSottile/age
https://github.com/aquaproj/aqua-registry/blob/main/pkgs/FiloSottile/age/registry.yaml
https://github.com/aquaproj/aqua-registry/blob/main/pkgs/FiloSottile/age/pkg.yaml

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

FiloSotille/age do release darwin assets for both `arm64` and `amd64`. I have removed the filter to only allow `arm64`.