### PR TITLE
ci: update macos to 26

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -103,13 +103,13 @@ jobs:
           - runs-on: ubuntu-24.04
             goos: ""
             goarch: ""
-          - runs-on: macos-15-intel
+          - runs-on: macos-26-intel
             goos: ""
             goarch: ""
           - runs-on: ubuntu-24.04-arm
             goos: ""
             goarch: ""
-          - runs-on: macos-14
+          - runs-on: macos-26
             goos: ""
             goarch: ""
           - runs-on: windows-latest


### PR DESCRIPTION
- https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/
- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md