### PR TITLE
feat: add lexfrei/claudeline

### DIFF
--- a/pkgs/lexfrei/claudeline/pkg.yaml
+++ b/pkgs/lexfrei/claudeline/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: lexfrei/claudeline@v1.5.0

--- a/pkgs/lexfrei/claudeline/registry.yaml
+++ b/pkgs/lexfrei/claudeline/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: lexfrei
+    repo_name: claudeline
+    description: Claude Code statusline with real usage limits from Anthropic API
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: claudeline_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -60106,6 +60106,21 @@ packages:
         supported_envs:
           - linux/amd64
   - type: github_release
+    repo_owner: lexfrei
+    repo_name: claudeline
+    description: Claude Code statusline with real usage limits from Anthropic API
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: claudeline_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: liamg
     repo_name: comet
     description: Command line tool to help you use conventional commit messages (https://www.conventionalcommits.org)


### PR DESCRIPTION
[claudeline](https://github.com/lexfrei/claudeline) is a Claude Code statusline that shows real usage limits from the Anthropic API.

Generated with `argd s lexfrei/claudeline`.

- Type: `github_release`
- Asset: `claudeline_{{.OS}}_{{.Arch}}.tar.gz`
- Checksum: `checksums.txt` (sha256)
- `supported_envs: [darwin]` — upstream currently ships darwin amd64/arm64 release assets only (Go project via GoReleaser). Linux/Windows can be added once upstream publishes those assets.

`conftest test` passes (28/28) and `argd s` container tests pass on darwin amd64/arm64.