### PR TITLE
[codex] feat: add grafana/gcx

### DIFF
--- a/pkgs/grafana/gcx/pkg.yaml
+++ b/pkgs/grafana/gcx/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: grafana/gcx@v0.4.0
+  - name: grafana/gcx
+    version: v0.2.0

--- a/pkgs/grafana/gcx/registry.yaml
+++ b/pkgs/grafana/gcx/registry.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: gcx
+    description: A CLI for managing Grafana Cloud resources. Optimized for agentic usage
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: gcx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gcx_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gcx_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gcx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -43302,6 +43302,37 @@ packages:
             asset: alloy-{{.OS}}-{{.Arch}}.exe.{{.Format}}
   - type: github_release
     repo_owner: grafana
+    repo_name: gcx
+    description: A CLI for managing Grafana Cloud resources. Optimized for agentic usage
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.2.0"
+        asset: gcx_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: gcx_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: gcx_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gcx_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: grafana
     repo_name: grafana-kiosk
     description: Kiosk Utility for Grafana
     rosetta2: true


### PR DESCRIPTION
## Summary
- add `grafana/gcx` to the Aqua registry
- include package metadata for current and legacy release asset layouts
- update the generated root `registry.yaml`

## Why
`grafana/gcx` is a Grafana CLI distributed via GitHub Releases and should be installable via Aqua.

## Validation
- `conftest test pkgs/grafana/gcx/*.yaml`
- scaffolded with `argd s --local -B grafana/gcx`
