### PR TITLE
feat: update oracle.com/sqlcl to reference github metadata repo for releases and checksums

### DIFF
--- a/pkgs/oracle.com/sqlcl/registry.yaml
+++ b/pkgs/oracle.com/sqlcl/registry.yaml
@@ -4,8 +4,7 @@ packages:
     name: oracle.com/sqlcl
     repo_owner: jasonlyle88
     repo_name: sqlcl-releases
-    version_prefix: v
-    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.SemVer}}.zip
+    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
     format: zip
     link: https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/
     description: Oracle SQLcl command-line interface for Oracle Database
@@ -13,8 +12,8 @@ packages:
       - name: sql
         src: sqlcl/bin/sql
     checksum:
-      type: http
-      url: https://github.com/jasonlyle88/sqlcl-releases/releases/download/v{{.SemVer}}/sqlcl-{{.SemVer}}.zip.sha256
+      type: github_release
+      asset: sqlcl-{{.Version}}.zip.sha256
       algorithm: sha256
       file_format: regexp
       pattern:

--- a/pkgs/oracle.com/sqlcl/registry.yaml
+++ b/pkgs/oracle.com/sqlcl/registry.yaml
@@ -2,7 +2,21 @@
 packages:
   - type: http
     name: oracle.com/sqlcl
-    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
+    repo_owner: jasonlyle88
+    repo_name: sqlcl-releases
+    version_prefix: v
+    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.SemVer}}.zip
+    format: zip
+    link: https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/
+    description: Oracle SQLcl command-line interface for Oracle Database
     files:
       - name: sql
         src: sqlcl/bin/sql
+    checksum:
+      type: http
+      url: https://github.com/jasonlyle88/sqlcl-releases/releases/download/v{{.SemVer}}/sqlcl-{{.SemVer}}.zip.sha256
+      algorithm: sha256
+      file_format: regexp
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -70583,8 +70583,7 @@ packages:
     name: oracle.com/sqlcl
     repo_owner: jasonlyle88
     repo_name: sqlcl-releases
-    version_prefix: v
-    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.SemVer}}.zip
+    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
     format: zip
     link: https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/
     description: Oracle SQLcl command-line interface for Oracle Database
@@ -70592,8 +70591,8 @@ packages:
       - name: sql
         src: sqlcl/bin/sql
     checksum:
-      type: http
-      url: https://github.com/jasonlyle88/sqlcl-releases/releases/download/v{{.SemVer}}/sqlcl-{{.SemVer}}.zip.sha256
+      type: github_release
+      asset: sqlcl-{{.Version}}.zip.sha256
       algorithm: sha256
       file_format: regexp
       pattern:

--- a/registry.yaml
+++ b/registry.yaml
@@ -70581,10 +70581,24 @@ packages:
           - amd64
   - type: http
     name: oracle.com/sqlcl
-    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.Version}}.zip
+    repo_owner: jasonlyle88
+    repo_name: sqlcl-releases
+    version_prefix: v
+    url: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-{{.SemVer}}.zip
+    format: zip
+    link: https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/
+    description: Oracle SQLcl command-line interface for Oracle Database
     files:
       - name: sql
         src: sqlcl/bin/sql
+    checksum:
+      type: http
+      url: https://github.com/jasonlyle88/sqlcl-releases/releases/download/v{{.SemVer}}/sqlcl-{{.SemVer}}.zip.sha256
+      algorithm: sha256
+      file_format: regexp
+      pattern:
+        checksum: ^(\b[A-Fa-f0-9]{64}\b)
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: orangekame3
     repo_name: stree


### PR DESCRIPTION
https://github.com/jasonlyle88/sqlcl-releases

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Oracle SQLcl does not expose their release metadata in a friendly way. However, I recently created a repo that will maintain this by scraping their release pages automatically via github actions and generate github releases. The releases are just metadata and does not contain the artifact to avoid stepping on any T&Cs, so this is still an `http` type package that goes directly to oracle for the download. However version discovery and checksum information can all be discovered from my metadata repo.

```
conftest test --combine pkgs/oracle.com/sqlcl/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

argd t oracle.com/sqlcl
passed for linux amd64/arm64, darwin amd64/arm64, windows amd64/arm64
```

I am disclosing AI usage in the course of this PR as well. I use `mise`, so I'm not very familiar with `aqua` directly. So for such a small change it was easier to have the AI figure out the testing 🤷🏼‍♂️

closes #55214 