### PR TITLE
feat(oxc-project/oxc/oxlint): scaffold oxc-project/oxc/oxlint

### DIFF
--- a/pkgs/oxc-project/oxc/oxlint/pkg.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/pkg.yaml
@@ -1,5 +1,13 @@
 packages:
-  - name: oxc-project/oxc/oxlint@oxlint_v1.16.0
+  - name: oxc-project/oxc/oxlint@apps_v1.69.0
+  - name: oxc-project/oxc/oxlint
+    version: apps_v1.51.0
+  - name: oxc-project/oxc/oxlint
+    version: apps_v1.46.0
+  - name: oxc-project/oxc/oxlint
+    version: apps_v1.43.0
+  - name: oxc-project/oxc/oxlint
+    version: oxlint_v1.16.0
   - name: oxc-project/oxc/oxlint
     version: oxlint_v0.2.2
   - name: oxc-project/oxc/oxlint

--- a/pkgs/oxc-project/oxc/oxlint/pkg.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/pkg.yaml
@@ -11,4 +11,6 @@ packages:
   - name: oxc-project/oxc/oxlint
     version: oxlint_v0.2.2
   - name: oxc-project/oxc/oxlint
-    version: oxlint_v0.0.3
+    version: oxlint_v0.0.19
+  - name: oxc-project/oxc/oxlint
+    version: oxlint_v0.0.8

--- a/pkgs/oxc-project/oxc/oxlint/registry.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/registry.yaml
@@ -5,15 +5,60 @@ packages:
     repo_owner: oxc-project
     repo_name: oxc
     description: The linter for oxc
+    version_filter: 'Version matches "^apps_v" || Version matches "^oxlint_v"'
+    files:
+      - name: oxlint
+        src: "{{.AssetWithoutExt}}"
     version_constraint: "false"
-    version_prefix: oxlint_v
     version_overrides:
-      - version_constraint: semver(">= 1.17.0")
+      - version_constraint: Version == "apps_v1.47.0"
+        no_asset: true
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.43.0", trimPrefix(Version, "apps_v"))'
+        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.51.0", trimPrefix(Version, "apps_v"))'
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.53.0", trimPrefix(Version, "apps_v"))'
+        no_asset: true
+      - version_constraint: 'Version startsWith "apps_v"'
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion(">= 1.17.0", trimPrefix(Version, "oxlint_v"))'
         error_message: |
-          aqua can't support oxlint 1.17.0 or later. 
-          > Newer versions of Oxlint require node.js. There isn’t a native executable alternative anymore.
+          aqua can't support oxlint 1.17.0 or later.
+          > Newer versions of Oxlint require node.js. There isn't a native executable alternative anymore.
           https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
-      - version_constraint: semver("<= 0.0.8")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -23,7 +68,8 @@ packages:
           windows: win32
       - version_constraint: Version == "oxlint_v0.0.9"
         no_asset: true
-      - version_constraint: semver("<= 0.0.19")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -33,7 +79,8 @@ packages:
           windows: win32
       - version_constraint: Version == "oxlint_v0.1.1"
         no_asset: true
-      - version_constraint: semver("<= 0.2.2")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.2.2", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -45,7 +92,8 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: "true"
+      - version_constraint: 'Version startsWith "oxlint_v"'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:

--- a/pkgs/oxc-project/oxc/oxlint/registry.yaml
+++ b/pkgs/oxc-project/oxc/oxlint/registry.yaml
@@ -11,53 +11,9 @@ packages:
         src: "{{.AssetWithoutExt}}"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "apps_v1.47.0"
+      - version_constraint: Version in ["apps_v1.47.0", "oxlint_v0.0.9", "oxlint_v0.1.1"]
         no_asset: true
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.43.0", trimPrefix(Version, "apps_v"))'
-        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-          windows: win32
-        overrides:
-          - goos: darwin
-            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.51.0", trimPrefix(Version, "apps_v"))'
-        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.53.0", trimPrefix(Version, "apps_v"))'
-        no_asset: true
-      - version_constraint: 'Version startsWith "apps_v"'
-        version_prefix: apps_v
-        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion(">= 1.17.0", trimPrefix(Version, "oxlint_v"))'
-        error_message: |
-          aqua can't support oxlint 1.17.0 or later.
-          > Newer versions of Oxlint require node.js. There isn't a native executable alternative anymore.
-          https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.0.8")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
@@ -66,9 +22,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.0.9"
-        no_asset: true
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.0.19")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
@@ -77,9 +31,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.1.1"
-        no_asset: true
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.2.2", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.2.2")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -92,7 +44,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: 'Version startsWith "oxlint_v"'
+      - version_constraint: semver("< 1.17.0")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -110,3 +62,59 @@ packages:
         replacements:
           amd64: x64
           windows: win32
+      - version_constraint: semver(">= 1.17.0")
+        version_prefix: oxlint_v
+        error_message: |
+          This version is unavailable.
+          < 1.17.0: The version prefix is oxlint_v e.g. oxlint_v1.16.0
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v e.g. apps_v1.28.0
+      - version_constraint: semver("< 1.28.0")
+        version_prefix: apps_v
+        error_message: |
+          The version was too old. Please ugrade to 1.28.0 or later.
+          < 1.17.0: The version prefix is oxlint_v
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v
+      - version_constraint: semver("<= 1.43.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 1.51.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.53.0")
+        version_prefix: apps_v
+        no_asset: true
+      - version_constraint: "true"
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -71592,15 +71592,60 @@ packages:
     repo_owner: oxc-project
     repo_name: oxc
     description: The linter for oxc
+    version_filter: 'Version matches "^apps_v" || Version matches "^oxlint_v"'
+    files:
+      - name: oxlint
+        src: "{{.AssetWithoutExt}}"
     version_constraint: "false"
-    version_prefix: oxlint_v
     version_overrides:
-      - version_constraint: semver(">= 1.17.0")
+      - version_constraint: Version == "apps_v1.47.0"
+        no_asset: true
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.43.0", trimPrefix(Version, "apps_v"))'
+        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.51.0", trimPrefix(Version, "apps_v"))'
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.53.0", trimPrefix(Version, "apps_v"))'
+        no_asset: true
+      - version_constraint: 'Version startsWith "apps_v"'
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion(">= 1.17.0", trimPrefix(Version, "oxlint_v"))'
         error_message: |
-          aqua can't support oxlint 1.17.0 or later. 
-          > Newer versions of Oxlint require node.js. There isn’t a native executable alternative anymore.
+          aqua can't support oxlint 1.17.0 or later.
+          > Newer versions of Oxlint require node.js. There isn't a native executable alternative anymore.
           https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
-      - version_constraint: semver("<= 0.0.8")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -71610,7 +71655,8 @@ packages:
           windows: win32
       - version_constraint: Version == "oxlint_v0.0.9"
         no_asset: true
-      - version_constraint: semver("<= 0.0.19")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
           - name: oxlint
@@ -71620,7 +71666,8 @@ packages:
           windows: win32
       - version_constraint: Version == "oxlint_v0.1.1"
         no_asset: true
-      - version_constraint: semver("<= 0.2.2")
+      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.2.2", trimPrefix(Version, "oxlint_v"))'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -71632,7 +71679,8 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: "true"
+      - version_constraint: 'Version startsWith "oxlint_v"'
+        version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -71598,53 +71598,9 @@ packages:
         src: "{{.AssetWithoutExt}}"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "apps_v1.47.0"
+      - version_constraint: Version in ["apps_v1.47.0", "oxlint_v0.0.9", "oxlint_v0.1.1"]
         no_asset: true
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.43.0", trimPrefix(Version, "apps_v"))'
-        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-          windows: win32
-        overrides:
-          - goos: darwin
-            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
-          - goos: windows
-            format: zip
-            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.51.0", trimPrefix(Version, "apps_v"))'
-        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: 'Version startsWith "apps_v" && semverWithVersion("<= 1.53.0", trimPrefix(Version, "apps_v"))'
-        no_asset: true
-      - version_constraint: 'Version startsWith "apps_v"'
-        version_prefix: apps_v
-        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion(">= 1.17.0", trimPrefix(Version, "oxlint_v"))'
-        error_message: |
-          aqua can't support oxlint 1.17.0 or later.
-          > Newer versions of Oxlint require node.js. There isn't a native executable alternative anymore.
-          https://github.com/oxc-project/oxc/discussions/14452#discussioncomment-14631344
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.8", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.0.8")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
@@ -71653,9 +71609,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.0.9"
-        no_asset: true
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.0.19", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.0.19")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}
         files:
@@ -71664,9 +71618,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: Version == "oxlint_v0.1.1"
-        no_asset: true
-      - version_constraint: 'Version startsWith "oxlint_v" && semverWithVersion("<= 0.2.2", trimPrefix(Version, "oxlint_v"))'
+      - version_constraint: semver("<= 0.2.2")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -71679,7 +71631,7 @@ packages:
         replacements:
           amd64: x64
           windows: win32
-      - version_constraint: 'Version startsWith "oxlint_v"'
+      - version_constraint: semver("< 1.17.0")
         version_prefix: oxlint_v
         asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -71697,6 +71649,62 @@ packages:
         replacements:
           amd64: x64
           windows: win32
+      - version_constraint: semver(">= 1.17.0")
+        version_prefix: oxlint_v
+        error_message: |
+          This version is unavailable.
+          < 1.17.0: The version prefix is oxlint_v e.g. oxlint_v1.16.0
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v e.g. apps_v1.28.0
+      - version_constraint: semver("< 1.28.0")
+        version_prefix: apps_v
+        error_message: |
+          The version was too old. Please ugrade to 1.28.0 or later.
+          < 1.17.0: The version prefix is oxlint_v
+          >= 1.17.0, < 1.28.0: These versions are unavailable
+          >= 1.28.0: The version prefix is apps_v
+      - version_constraint: semver("<= 1.43.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: darwin
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: oxlint-{{.OS}}-{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 1.51.0")
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.53.0")
+        version_prefix: apps_v
+        no_asset: true
+      - version_constraint: "true"
+        version_prefix: apps_v
+        asset: oxlint-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: oxipng
     repo_name: oxipng


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Summary

oxc-project/oxc changed the release tag naming convention for oxlint from `oxlint_vX.Y.Z` to `apps_vX.Y.Z` (e.g. `apps_v1.69.0`).

This PR updates the oxlint package configuration to support the new tag format.

<details><summary>oxc release</summary>
<p>

```console
$ gh release list --repo oxc-project/oxc --limit=100
TITLE                            TYPE         TAG NAME         PUBLISHED         
oxc crates_v0.135.0                           crates_v0.135.0  about 4 days ago
oxlint v1.69.0 & oxfmt v0.54.0   Latest       apps_v1.69.0     about 4 days ago
oxlint v1.68.0 & oxfmt v0.53.0                apps_v1.68.0     about 11 days ago
oxc crates_v0.134.0                           crates_v0.134.0  about 11 days ago
oxlint v1.67.0 & oxfmt v0.52.0                apps_v1.67.0     about 17 days ago
oxc crates_v0.133.0                           crates_v0.133.0  about 17 days ago
oxlint v1.66.0 & oxfmt v0.51.0                apps_v1.66.0     about 24 days ago
oxc crates_v0.132.0                           crates_v0.132.0  about 25 days ago
oxlint v1.65.0 & oxfmt v0.50.0                apps_v1.65.0     about 28 days ago
oxc crates_v0.131.0                           crates_v0.131.0  about 28 days ago
oxlint v1.64.0 & oxfmt v0.49.0                apps_v1.64.0     about 1 month ago
oxc crates_v0.130.0                           crates_v0.130.0  about 1 month ago
oxlint v1.63.0 & oxfmt v0.48.0                apps_v1.63.0     about 1 month ago
oxc crates_v0.129.0                           crates_v0.129.0  about 1 month ago
oxlint v1.62.0 & oxfmt v0.47.0                apps_v1.62.0     about 1 month ago
oxc crates_v0.128.0                           crates_v0.128.0  about 1 month ago
oxlint v1.61.0 & oxfmt v0.46.0                apps_v1.61.0     about 1 month ago
oxc crates_v0.127.0                           crates_v0.127.0  about 1 month ago
oxc crates_v0.126.0                           crates_v0.126.0  about 1 month ago
oxlint v1.60.0 & oxfmt v0.45.0                apps_v1.60.0     about 2 months ago
oxc crates_v0.125.0                           crates_v0.125.0  about 2 months ago
oxlint v1.59.0 & oxfmt v0.44.0                apps_v1.59.0     about 2 months ago
oxc crates_v0.124.0                           crates_v0.124.0  about 2 months ago
oxlint v1.58.0 & oxfmt v0.43.0                apps_v1.58.0     about 2 months ago
oxc crates_v0.123.0                           crates_v0.123.0  about 2 months ago
oxlint v1.57.0 & oxfmt v0.42.0                apps_v1.57.0     about 2 months ago
oxc crates_v0.122.0                           crates_v0.122.0  about 2 months ago
oxc crates_v0.121.0                           crates_v0.121.0  about 2 months ago
oxlint v1.56.0 & oxfmt v0.41.0                apps_v1.56.0     about 2 months ago
oxc crates_v0.120.0                           crates_v0.120.0  about 2 months ago
oxc crates_v0.119.0                           crates_v0.119.0  about 3 months ago
oxlint v1.55.0 & oxfmt v0.40.0                apps_v1.55.0     about 3 months ago
oxlint v1.54.0 & oxfmt v0.39.0                apps_v1.54.0     about 3 months ago
oxc crates_v0.118.0                           crates_v0.118.0  about 3 months ago
oxlint v1.53.0 & oxfmt v0.38.0                apps_v1.53.0     about 3 months ago
oxlint v1.52.0 & oxfmt v0.37.0                apps_v1.52.0     about 3 months ago
oxc crates_v0.117.0                           crates_v0.117.0  about 3 months ago
oxlint v1.51.0 & oxfmt v0.36.0                apps_v1.51.0     about 3 months ago
oxc crates_v0.116.0                           crates_v0.116.0  about 3 months ago
oxlint v1.50.0 & oxfmt v0.35.0                apps_v1.50.0     about 3 months ago
oxc crates_v0.115.0                           crates_v0.115.0  about 3 months ago
oxlint v1.49.0 & oxfmt v0.34.0                apps_v1.49.0     about 3 months ago
oxlint v1.48.0 & oxfmt v0.33.0                apps_v1.48.0     about 3 months ago
oxc crates_v0.114.0                           crates_v0.114.0  about 3 months ago
oxlint v1.47.0 & oxfmt v0.32.0                apps_v1.47.0     about 4 months ago
oxlint v1.46.0 & oxfmt v0.31.0                apps_v1.46.0     about 4 months ago
oxc crates_v0.113.0                           crates_v0.113.0  about 4 months ago
oxlint v1.43.0 & oxfmt v0.28.0                apps_v1.43.0     about 4 months ago
oxc crates_v0.112.0                           crates_v0.112.0  about 4 months ago
oxlint v1.42.0 & oxfmt v0.27.0                apps_v1.42.0     about 4 months ago
oxc crates_v0.111.0                           crates_v0.111.0  about 4 months ago
oxlint v1.41.0 & oxfmt v0.26.0                apps_v1.41.0     about 4 months ago
oxc crates_v0.110.0                           crates_v0.110.0  about 4 months ago
oxlint v1.40.0 & oxfmt v0.25.0                apps_v1.40.0     about 4 months ago
oxc crates_v0.109.0                           crates_v0.109.0  about 4 months ago
oxlint v1.39.0 & oxfmt v0.24.0                apps_v1.39.0     about 5 months ago
oxc crates_v0.108.0                           crates_v0.108.0  about 5 months ago
oxlint v1.38.0 & oxfmt v0.23.0                apps_v1.38.0     about 5 months ago
oxlint v1.37.0 & oxfmt v0.22.0                apps_v1.37.0     about 5 months ago
oxc crates_v0.107.0                           crates_v0.107.0  about 5 months ago
oxlint v1.36.0 & oxfmt v0.21.0                apps_v1.36.0     about 5 months ago
oxc crates_v0.106.0                           crates_v0.106.0  about 5 months ago
oxlint v1.35.0 & oxfmt v0.20.0                apps_v1.35.0     about 5 months ago
oxc crates_v0.105.0                           crates_v0.105.0  about 5 months ago
oxlint v1.34.0 & oxfmt v0.19.0                apps_v1.34.0     about 5 months ago
oxc crates_v0.104.0                           crates_v0.104.0  about 5 months ago
oxc crates_v0.103.0                           crates_v0.103.0  about 5 months ago
oxlint v1.33.0 & oxfmt v0.18.0                apps_v1.33.0     about 5 months ago
oxlint v1.32.0 & oxfmt v0.17.0                apps_v1.32.0     about 6 months ago
oxc crates_v0.102.0                           crates_v0.102.0  about 6 months ago
oxc crates_v0.101.0                           crates_v0.101.0  about 6 months ago
oxlint v1.31.0 & oxfmt v0.16.0                apps_v1.31.0     about 6 months ago
oxc crates_v0.100.0                           crates_v0.100.0  about 6 months ago
oxlint v1.30.0 & oxfmt v0.15.0                apps_v1.30.0     about 6 months ago
oxc crates_v0.99.0                            crates_v0.99.0   about 6 months ago
oxlint v1.29.0 & oxfmt v0.14.0                apps_v1.29.0     about 6 months ago
oxc crates_v0.98.0                            crates_v0.98.0   about 6 months ago
oxlint v1.28.0 & oxfmt v0.13.0                apps_v1.28.0     about 7 months ago
oxlint v1.27.0 && oxfmt v0.12.0               oxlint_v1.27.0   about 7 months ago
oxfmt v0.11.0                    Pre-release  oxfmt_v0.11.0    about 7 months ago
oxfmt v0.10.0                    Pre-release  oxfmt_v0.10.0    about 7 months ago
oxlint v1.26.0                                oxlint_v1.26.0   about 7 months ago
oxlint v1.25.0                                oxlint_v1.25.0   about 7 months ago
oxfmt v0.9.0                     Pre-release  oxfmt_v0.9.0     about 7 months ago
oxlint v1.24.0                                oxlint_v1.24.0   about 7 months ago
oxfmt v0.8.0                     Pre-release  oxfmt_v0.8.0     about 7 months ago
oxfmt v0.7.0                     Pre-release  oxfmt_v0.7.0     about 7 months ago
oxfmt v0.6.0                     Pre-release  oxfmt_v0.6.0     about 7 months ago
oxfmt v0.5.0                     Pre-release  oxfmt_v0.5.0     about 8 months ago
oxlint v1.23.0                                oxlint_v1.23.0   about 8 months ago
oxfmt v0.4.0                     Pre-release  oxfmt_v0.4.0     about 8 months ago
oxlint v1.22.0                                oxlint_v1.22.0   about 8 months ago
oxlint v1.21.0                                oxlint_v1.21.0   about 8 months ago
oxlint v1.20.0                                oxlint_v1.20.0   about 8 months ago
oxlint v1.19.0                                oxlint_v1.19.0   about 8 months ago
oxlint v1.18.0                                oxlint_v1.18.0   about 8 months ago
oxlint v1.17.0                                oxlint_v1.17.0   about 8 months ago
oxfmt v0.3.0                     Pre-release  oxfmt_v0.3.0     about 8 months ago
oxlint v1.16.0                                oxlint_v1.16.0   about 8 months ago
oxfmt v0.2.0                     Pre-release  oxfmt_v0.2.0     about 8 months ago
```

</p>
</details> 

## Background

oxlint releases previously used `oxlint_vX.Y.Z` tags. Starting from a certain version, oxc switched to `apps_vX.Y.Z` tags.

### No Asset Versions

- [apps_v1.47.0](https://github.com/oxc-project/oxc/releases/tag/apps_v1.47.0)
- [apps_v1.52.0](https://github.com/oxc-project/oxc/releases/tag/apps_v1.52.0)
- [apps_v1.53.0](https://github.com/oxc-project/oxc/releases/tag/apps_v1.53.0)