### PR TITLE
feat(haskell/ghcup-hs): support Windows

### DIFF
--- a/pkgs/haskell/ghcup-hs/registry.yaml
+++ b/pkgs/haskell/ghcup-hs/registry.yaml
@@ -15,8 +15,3 @@ packages:
       windows: mingw64
     files:
       - name: ghcup
-        src: "{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}"
-    supported_envs:
-      - linux
-      - darwin
-      - windows

--- a/pkgs/haskell/ghcup-hs/registry.yaml
+++ b/pkgs/haskell/ghcup-hs/registry.yaml
@@ -5,15 +5,18 @@ packages:
     repo_name: ghcup-hs
     url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}
     format: raw
+    windows_arm_emulation: true
     link: https://www.haskell.org/ghcup/
     description: GHCup is an installer for the general purpose language Haskell
     replacements:
       arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
+      windows: mingw64
     files:
       - name: ghcup
         src: "{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}"
     supported_envs:
       - linux
       - darwin
+      - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -46680,18 +46680,21 @@ packages:
     repo_name: ghcup-hs
     url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}
     format: raw
+    windows_arm_emulation: true
     link: https://www.haskell.org/ghcup/
     description: GHCup is an installer for the general purpose language Haskell
     replacements:
       arm64: aarch64
       amd64: x86_64
       darwin: apple-darwin
+      windows: mingw64
     files:
       - name: ghcup
         src: "{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}"
     supported_envs:
       - linux
       - darwin
+      - windows
   - type: github_release
     repo_owner: hasura
     repo_name: graphql-engine

--- a/registry.yaml
+++ b/registry.yaml
@@ -46690,11 +46690,6 @@ packages:
       windows: mingw64
     files:
       - name: ghcup
-        src: "{{.Arch}}-{{.OS}}-ghcup-{{trimV .Version}}"
-    supported_envs:
-      - linux
-      - darwin
-      - windows
   - type: github_release
     repo_owner: hasura
     repo_name: graphql-engine


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## What

Add Windows support to the existing `haskell/ghcup-hs` package.

Upstream publishes a Windows build (`x86_64-mingw64`) that the registry definition didn't expose, as `supported_envs` was limited to `linux` and `darwin`.
This makes the Windows binary installable via aqua, both in x64 systems and arm64 through emulation.

## Verification

Tested natively on `windows/amd64` using the package's `registry.yaml` as a local registry:

```console
$ aqua install
INF download and unarchive the package env=windows/amd64 package_name=haskell/ghcup-hs package_version=v0.2.6.0 registry=local

$ aqua which ghcup
...\pkgs\http\downloads.haskell.org\~ghcup\0.2.6.0\x86_64-mingw64-ghcup-0.2.6.0.exe\x86_64-mingw64-ghcup-0.2.6.0.exe

$ aqua exec -- ghcup --version
The GHCup Haskell installer, version v0.2.6.0
```

## AI disclosure

This change was prepared with the help of Claude Code, added as a commit co-author. I have reviewed the change and take responsibility for it.
