### PR TITLE
feat(CycloneDX/cdxgen): add cdxgen package

### DIFF
--- a/pkgs/CycloneDX/cdxgen/pkg.yaml
+++ b/pkgs/CycloneDX/cdxgen/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: CycloneDX/cdxgen@v12.6.0
+  - name: CycloneDX/cdxgen
+    version: v12.0.0

--- a/pkgs/CycloneDX/cdxgen/pkg.yaml
+++ b/pkgs/CycloneDX/cdxgen/pkg.yaml
@@ -2,3 +2,5 @@ packages:
   - name: CycloneDX/cdxgen@v12.6.0
   - name: CycloneDX/cdxgen
     version: v12.0.0
+  - name: CycloneDX/cdxgen
+    version: v11.9.0

--- a/pkgs/CycloneDX/cdxgen/registry.yaml
+++ b/pkgs/CycloneDX/cdxgen/registry.yaml
@@ -4,10 +4,17 @@ packages:
     repo_owner: CycloneDX
     repo_name: cdxgen
     description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
-    version_filter: (Version startsWith "v12.") and not (Version contains "-")
+    version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v12.0.0"
+      - version_constraint: semver("<= 11.9.0")
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 12.0.0")
         asset: cdxgen-{{.OS}}-{{.Arch}}
         format: raw
         checksum:

--- a/pkgs/CycloneDX/cdxgen/registry.yaml
+++ b/pkgs/CycloneDX/cdxgen/registry.yaml
@@ -4,7 +4,7 @@ packages:
     repo_owner: CycloneDX
     repo_name: cdxgen
     description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
-    version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
+    version_filter: semver(">= 11.5.0") and not (Version contains "-")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 11.9.0")

--- a/pkgs/CycloneDX/cdxgen/registry.yaml
+++ b/pkgs/CycloneDX/cdxgen/registry.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: CycloneDX
+    repo_name: cdxgen
+    description: Creates CycloneDX Bill of Materials (BOM) for your projects from source and container images. Supports many languages and package managers. Integrate in your CI/CD pipeline with automatic submission to Dependency Track server
+    version_filter: (Version startsWith "v12.") and not (Version contains "-")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v12.0.0"
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/CycloneDX/cdxgen/registry.yaml
+++ b/pkgs/CycloneDX/cdxgen/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: CycloneDX
     repo_name: cdxgen
-    description: Creates CycloneDX Bill of Materials (BOM) for your projects from source and container images. Supports many languages and package managers. Integrate in your CI/CD pipeline with automatic submission to Dependency Track server
+    description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
     version_filter: (Version startsWith "v12.") and not (Version contains "-")
     version_constraint: "false"
     version_overrides:

--- a/pkgs/CycloneDX/cdxgen/scaffold.yaml
+++ b/pkgs/CycloneDX/cdxgen/scaffold.yaml
@@ -1,5 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
 name: CycloneDX/cdxgen
-version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
-all_assets_filter: (Asset startsWith "cdxgen-") and not (Asset contains "slim") and not (Asset contains "oci-image") and not (Asset contains "postbuild") and not (Asset contains "dist.zip") and not (Asset contains "musl")
+version_filter: semver(">= 11.5.0") and not (Version contains "-")
+all_assets_filter: |
+  let words = ["slim", "oci-image", "postbuild", "dist.zip", "musl"];
+  Asset startsWith "cdxgen-" and not any(words, {Asset matches #})

--- a/pkgs/CycloneDX/cdxgen/scaffold.yaml
+++ b/pkgs/CycloneDX/cdxgen/scaffold.yaml
@@ -1,0 +1,5 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: CycloneDX/cdxgen
+version_filter: (Version startsWith "v12.") and not (Version contains "-")
+all_assets_filter: (Asset startsWith "cdxgen-") and not (Asset contains "slim") and not (Asset contains "oci-image") and not (Asset contains "postbuild") and not (Asset contains "dist.zip") and not (Asset contains "musl")

--- a/pkgs/CycloneDX/cdxgen/scaffold.yaml
+++ b/pkgs/CycloneDX/cdxgen/scaffold.yaml
@@ -1,5 +1,5 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
 name: CycloneDX/cdxgen
-version_filter: (Version startsWith "v12.") and not (Version contains "-")
+version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
 all_assets_filter: (Asset startsWith "cdxgen-") and not (Asset contains "slim") and not (Asset contains "oci-image") and not (Asset contains "postbuild") and not (Asset contains "dist.zip") and not (Asset contains "musl")

--- a/registry.yaml
+++ b/registry.yaml
@@ -2410,6 +2410,31 @@ packages:
           - amd64
   - type: github_release
     repo_owner: CycloneDX
+    repo_name: cdxgen
+    description: Creates CycloneDX Bill of Materials (BOM) for your projects from source and container images. Supports many languages and package managers. Integrate in your CI/CD pipeline with automatic submission to Dependency Track server
+    version_filter: (Version startsWith "v12.") and not (Version contains "-")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v12.0.0"
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+  - type: github_release
+    repo_owner: CycloneDX
     repo_name: cyclonedx-cli
     description: CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions
     files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -2412,7 +2412,7 @@ packages:
     repo_owner: CycloneDX
     repo_name: cdxgen
     description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
-    version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
+    version_filter: semver(">= 11.5.0") and not (Version contains "-")
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 11.9.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -2411,7 +2411,7 @@ packages:
   - type: github_release
     repo_owner: CycloneDX
     repo_name: cdxgen
-    description: Creates CycloneDX Bill of Materials (BOM) for your projects from source and container images. Supports many languages and package managers. Integrate in your CI/CD pipeline with automatic submission to Dependency Track server
+    description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
     version_filter: (Version startsWith "v12.") and not (Version contains "-")
     version_constraint: "false"
     version_overrides:

--- a/registry.yaml
+++ b/registry.yaml
@@ -2412,10 +2412,17 @@ packages:
     repo_owner: CycloneDX
     repo_name: cdxgen
     description: Creates CycloneDX Bill of Materials (BOM) from source code and container images
-    version_filter: (Version startsWith "v12.") and not (Version contains "-")
+    version_filter: (semver(">= 11.5.0")) and not (Version contains "-")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v12.0.0"
+      - version_constraint: semver("<= 11.9.0")
+        asset: cdxgen-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+      - version_constraint: semver("<= 12.0.0")
         asset: cdxgen-{{.OS}}-{{.Arch}}
         format: raw
         checksum:


### PR DESCRIPTION
[CycloneDX/cdxgen](https://github.com/CycloneDX/cdxgen) - Creates CycloneDX Bill of Materials (BOM) from source code and container images

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Add cdxgen, a CLI tool from OWASP for generating CyclonDX SBOM:s.