### PR TITLE
Add coder/boo

### DIFF
--- a/pkgs/coder/boo/pkg.yaml
+++ b/pkgs/coder/boo/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: coder/boo@v0.5.18
+  - name: coder/boo
+    version: v0.0.4

--- a/pkgs/coder/boo/registry.yaml
+++ b/pkgs/coder/boo/registry.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: coder
+    repo_name: boo
+    description: A GNU screen style terminal multiplexer built on libghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: ghostscreen-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: boo-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/coder/boo/registry.yaml
+++ b/pkgs/coder/boo/registry.yaml
@@ -9,6 +9,8 @@ packages:
       - version_constraint: semver("<= 0.0.4")
         asset: ghostscreen-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ghostscreen
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -17,9 +19,6 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        files:
-          - name: boo
-            src: ghostscreen
         supported_envs:
           - linux
           - darwin

--- a/pkgs/coder/boo/registry.yaml
+++ b/pkgs/coder/boo/registry.yaml
@@ -17,6 +17,9 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        files:
+          - name: boo
+            src: ghostscreen
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -26733,6 +26733,8 @@ packages:
       - version_constraint: semver("<= 0.0.4")
         asset: ghostscreen-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ghostscreen
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -26741,9 +26743,6 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
-        files:
-          - name: boo
-            src: ghostscreen
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -26741,6 +26741,9 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        files:
+          - name: boo
+            src: ghostscreen
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -26726,6 +26726,40 @@ packages:
         src: test-reporter
   - type: github_release
     repo_owner: coder
+    repo_name: boo
+    description: A GNU screen style terminal multiplexer built on libghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.4")
+        asset: ghostscreen-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: boo-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
+    repo_owner: coder
     repo_name: coder
     description: Provision remote development environments via Terraform
     version_constraint: "false"


### PR DESCRIPTION
[coder/boo](https://github.com/coder/boo) - A GNU screen style terminal multiplexer built on libghostty

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Summary
- Add coder/boo to the registry using argd s output.
- Map old <= v0.0.4 ghostscreen assets to the boo command name.

## Validation
- argd t coder/boo

## AI usage
- Generated with assistance from OpenAI Codex.