### PR TITLE
feat: add radiosilence/koan

### DIFF
--- a/pkgs/radiosilence/koan/pkg.yaml
+++ b/pkgs/radiosilence/koan/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: radiosilence/koan@v0.23.3
+  - name: radiosilence/koan
+    version: v0.12.5

--- a/pkgs/radiosilence/koan/registry.yaml
+++ b/pkgs/radiosilence/koan/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: radiosilence
+    repo_name: koan
+    description: Bit-perfect terminal music player — Ratatui TUI, gapless playback, Subsonic/Navidrome streaming, spectrum analyzer, ReplayGain, lyrics, fb2k format strings. Pure Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.12.5")
+        asset: koan-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: koan-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -75991,6 +75991,29 @@ packages:
           - name: raco
             src: racket/raco
   - type: github_release
+    repo_owner: radiosilence
+    repo_name: koan
+    description: Bit-perfect terminal music player — Ratatui TUI, gapless playback, Subsonic/Navidrome streaming, spectrum analyzer, ReplayGain, lyrics, fb2k format strings. Pure Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.12.5")
+        asset: koan-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: "true"
+        asset: koan-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases


### PR DESCRIPTION
Add [`radiosilence/koan`](https://github.com/radiosilence/koan) — a bit-perfect terminal music player (Ratatui TUI, gapless playback, Subsonic/Navidrome streaming).

Generated with `argd scaffold`. Linux + macOS (arm64/x86_64) via tar.gz; no Windows assets upstream.