### PR TITLE
feat: add radiosilence/fastmail-cli

### DIFF
--- a/pkgs/radiosilence/fastmail-cli/pkg.yaml
+++ b/pkgs/radiosilence/fastmail-cli/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: radiosilence/fastmail-cli@v2.2.2
+  - name: radiosilence/fastmail-cli
+    version: v1.6.0

--- a/pkgs/radiosilence/fastmail-cli/registry.yaml
+++ b/pkgs/radiosilence/fastmail-cli/registry.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: radiosilence
+    repo_name: fastmail-cli
+    description: CLI and MCP server for Fastmail — email, contacts, masked email, attachments, text extraction. JMAP + CardDAV + GraphQL
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.0")
+        asset: fastmail-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: fastmail-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -75991,6 +75991,33 @@ packages:
           - name: raco
             src: racket/raco
   - type: github_release
+    repo_owner: radiosilence
+    repo_name: fastmail-cli
+    description: CLI and MCP server for Fastmail — email, contacts, masked email, attachments, text extraction. JMAP + CardDAV + GraphQL
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.6.0")
+        asset: fastmail-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: fastmail-cli-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases


### PR DESCRIPTION
Add [`radiosilence/fastmail-cli`](https://github.com/radiosilence/fastmail-cli) — CLI and MCP server for Fastmail (JMAP/CardDAV).

Generated with `argd scaffold`. Latest ships linux/amd64 + darwin (arm64/x86_64); `darwin` uses `aarch64` naming, handled via a goos override.