### PR TITLE
feat: add radiosilence/nano-web

### DIFF
--- a/pkgs/radiosilence/nano-web/pkg.yaml
+++ b/pkgs/radiosilence/nano-web/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: radiosilence/nano-web@v1.4.2
+  - name: radiosilence/nano-web
+    version: v1.1.1
+  - name: radiosilence/nano-web
+    version: v1.0.5
+  - name: radiosilence/nano-web
+    version: v0.12.1

--- a/pkgs/radiosilence/nano-web/pkg.yaml
+++ b/pkgs/radiosilence/nano-web/pkg.yaml
@@ -1,8 +1,4 @@
 packages:
   - name: radiosilence/nano-web@v1.4.2
   - name: radiosilence/nano-web
-    version: v1.1.1
-  - name: radiosilence/nano-web
-    version: v1.0.5
-  - name: radiosilence/nano-web
-    version: v0.12.1
+    version: v1.2.0

--- a/pkgs/radiosilence/nano-web/registry.yaml
+++ b/pkgs/radiosilence/nano-web/registry.yaml
@@ -4,45 +4,16 @@ packages:
     repo_owner: radiosilence
     repo_name: nano-web
     description: Ultra-fast in-memory static file server for SPAs and static content
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v1.0.5"
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-      - version_constraint: semver("<= 0.12.1")
-        asset: nano-web-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.1.1")
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
-      - version_constraint: "true"
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-        overrides:
-          - goos: linux
-            asset: nano-web-{{.OS}}-{{.Arch}}-musl
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
+    version_constraint: semver(">= 1.2.0")
+    asset: nano-web-{{.OS}}-{{.Arch}}
+    format: raw
+    windows_arm_emulation: true
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: linux
+        asset: nano-web-{{.OS}}-{{.Arch}}-musl
+    supported_envs:
+      - linux
+      - darwin/arm64
+      - windows/amd64

--- a/pkgs/radiosilence/nano-web/registry.yaml
+++ b/pkgs/radiosilence/nano-web/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: radiosilence
+    repo_name: nano-web
+    description: Ultra-fast in-memory static file server for SPAs and static content
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.5"
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+      - version_constraint: semver("<= 0.12.1")
+        asset: nano-web-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.1.1")
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: nano-web-{{.OS}}-{{.Arch}}-musl
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64

--- a/pkgs/radiosilence/nano-web/scaffold.yaml
+++ b/pkgs/radiosilence/nano-web/scaffold.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: radiosilence/nano-web
+# nano-web ships both glibc and musl Linux binaries for each arch.
+# aqua maps one asset per platform, so drop the glibc ("-gnu") variants and
+# keep the statically-linked musl builds (run on Alpine/distroless too).
+all_assets_filter: 'not (Asset endsWith "-gnu")'

--- a/registry.yaml
+++ b/registry.yaml
@@ -75991,6 +75991,52 @@ packages:
           - name: raco
             src: racket/raco
   - type: github_release
+    repo_owner: radiosilence
+    repo_name: nano-web
+    description: Ultra-fast in-memory static file server for SPAs and static content
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.5"
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+      - version_constraint: semver("<= 0.12.1")
+        asset: nano-web-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.1.1")
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: nano-web-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            asset: nano-web-{{.OS}}-{{.Arch}}-musl
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases

--- a/registry.yaml
+++ b/registry.yaml
@@ -75994,48 +75994,19 @@ packages:
     repo_owner: radiosilence
     repo_name: nano-web
     description: Ultra-fast in-memory static file server for SPAs and static content
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v1.0.5"
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-      - version_constraint: semver("<= 0.12.1")
-        asset: nano-web-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.1.1")
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
-      - version_constraint: "true"
-        asset: nano-web-{{.OS}}-{{.Arch}}
-        format: raw
-        windows_arm_emulation: true
-        replacements:
-          darwin: macos
-        overrides:
-          - goos: linux
-            asset: nano-web-{{.OS}}-{{.Arch}}-musl
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows/amd64
+    version_constraint: semver(">= 1.2.0")
+    asset: nano-web-{{.OS}}-{{.Arch}}
+    format: raw
+    windows_arm_emulation: true
+    replacements:
+      darwin: macos
+    overrides:
+      - goos: linux
+        asset: nano-web-{{.OS}}-{{.Arch}}-musl
+    supported_envs:
+      - linux
+      - darwin/arm64
+      - windows/amd64
   - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot


### PR DESCRIPTION
Add [`radiosilence/nano-web`](https://github.com/radiosilence/nano-web) — ultra-fast in-memory static file server for SPAs.

Generated with `argd scaffold`, then floored at `>= 1.2.0`: earlier releases shipped an inconsistent tar.gz+raw mix and pre-musl naming. From v1.2.0 the assets are raw binaries — musl Linux (amd64/arm64, static so Alpine/distroless work), macos-arm64, and a Windows .exe. Tested against v1.2.0 and v1.4.2.