### PR TITLE
Add VirusTotal/vt-cli

### DIFF
--- a/pkgs/VirusTotal/vt-cli/pkg.yaml
+++ b/pkgs/VirusTotal/vt-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: VirusTotal/vt-cli@1.3.1

--- a/pkgs/VirusTotal/vt-cli/pkg.yaml
+++ b/pkgs/VirusTotal/vt-cli/pkg.yaml
@@ -1,2 +1,3 @@
 packages:
   - name: VirusTotal/vt-cli@1.3.1
+  - name: VirusTotal/vt-cli@1.0.1

--- a/pkgs/VirusTotal/vt-cli/pkg.yaml
+++ b/pkgs/VirusTotal/vt-cli/pkg.yaml
@@ -1,3 +1,4 @@
 packages:
   - name: VirusTotal/vt-cli@1.3.1
-  - name: VirusTotal/vt-cli@1.0.1
+  - name: VirusTotal/vt-cli
+    version: "1.0.1"

--- a/pkgs/VirusTotal/vt-cli/registry.yaml
+++ b/pkgs/VirusTotal/vt-cli/registry.yaml
@@ -9,20 +9,20 @@ packages:
       - version_constraint: Version == "1.1.0"
         no_asset: true
       - version_constraint: "true"
-        asset: "{{.OS}}32.{{.Format}}"
+        asset: "{{.OS}}{{.Arch}}.{{.Format}}"
         format: zip
+        files:
+          - name: vt
         replacements:
           darwin: MacOSX
           linux: Linux
           windows: Windows
+          amd64: "64"
+          "386": "32"
         overrides:
-          - goos: linux
-            asset: "{{.OS}}64.{{.Format}}"
-            replacements:
-              amd64: x64
           - goos: darwin
             asset: "{{.OS}}.{{.Format}}"
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64

--- a/pkgs/VirusTotal/vt-cli/registry.yaml
+++ b/pkgs/VirusTotal/vt-cli/registry.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: VirusTotal
+    repo_name: vt-cli
+    description: VirusTotal Command Line Interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.1.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: "{{.OS}}32.{{.Format}}"
+        format: zip
+        replacements:
+          darwin: MacOSX
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: linux
+            asset: "{{.OS}}64.{{.Format}}"
+            replacements:
+              amd64: x64
+          - goos: darwin
+            asset: "{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/VirusTotal/vt-cli/registry.yaml
+++ b/pkgs/VirusTotal/vt-cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: VirusTotal
     repo_name: vt-cli
     description: VirusTotal Command Line Interface
+    files:
+      - name: vt
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "1.1.0"
@@ -13,16 +15,16 @@ packages:
         format: zip
         files:
           - name: vt
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           darwin: MacOSX
           linux: Linux
           windows: Windows
           amd64: "64"
-          "386": "32"
         overrides:
           - goos: darwin
             asset: "{{.OS}}.{{.Format}}"
         supported_envs:
-          - darwin/amd64
           - linux/amd64
-          - windows/amd64
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -8692,23 +8692,23 @@ packages:
       - version_constraint: Version == "1.1.0"
         no_asset: true
       - version_constraint: "true"
-        asset: "{{.OS}}32.{{.Format}}"
+        asset: "{{.OS}}{{.Arch}}.{{.Format}}"
         format: zip
+        files:
+          - name: vt
         replacements:
           darwin: MacOSX
           linux: Linux
           windows: Windows
+          amd64: "64"
+          "386": "32"
         overrides:
-          - goos: linux
-            asset: "{{.OS}}64.{{.Format}}"
-            replacements:
-              amd64: x64
           - goos: darwin
             asset: "{{.OS}}.{{.Format}}"
         supported_envs:
-          - darwin
-          - windows
-          - amd64
+          - darwin/amd64
+          - linux/amd64
+          - windows/amd64
   - type: github_release
     repo_owner: WebAssembly
     repo_name: binaryen

--- a/registry.yaml
+++ b/registry.yaml
@@ -8687,6 +8687,8 @@ packages:
     repo_owner: VirusTotal
     repo_name: vt-cli
     description: VirusTotal Command Line Interface
+    files:
+      - name: vt
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "1.1.0"
@@ -8696,19 +8698,19 @@ packages:
         format: zip
         files:
           - name: vt
+        rosetta2: true
+        windows_arm_emulation: true
         replacements:
           darwin: MacOSX
           linux: Linux
           windows: Windows
           amd64: "64"
-          "386": "32"
         overrides:
           - goos: darwin
             asset: "{{.OS}}.{{.Format}}"
         supported_envs:
-          - darwin/amd64
           - linux/amd64
-          - windows/amd64
+          - windows
   - type: github_release
     repo_owner: WebAssembly
     repo_name: binaryen

--- a/registry.yaml
+++ b/registry.yaml
@@ -8684,6 +8684,32 @@ packages:
               - name: vmalert-tool
                 src: vmalert-tool-windows-{{.Arch}}-prod.exe
   - type: github_release
+    repo_owner: VirusTotal
+    repo_name: vt-cli
+    description: VirusTotal Command Line Interface
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "1.1.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: "{{.OS}}32.{{.Format}}"
+        format: zip
+        replacements:
+          darwin: MacOSX
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: linux
+            asset: "{{.OS}}64.{{.Format}}"
+            replacements:
+              amd64: x64
+          - goos: darwin
+            asset: "{{.OS}}.{{.Format}}"
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: WebAssembly
     repo_name: binaryen
     description: Optimizer and compiler/toolchain library for WebAssembly


### PR DESCRIPTION
[VirusTotal/vt-cli](https://github.com/VirusTotal/vt-cli) - VirusTotal Command Line Interface

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add VirusTotal/vt-cli.

This registers the official VirusTotal CLI command as `vt`. The upstream release archives contain the executable named `vt`, and the supported amd64 release assets are `Linux64.zip`, `MacOSX.zip`, and `Windows64.zip`.

Verification:

```console
$ aqua exec -- argd t VirusTotal/vt-cli
INF download and unarchive the package env=linux/amd64 package_name=VirusTotal/vt-cli package_version=1.0.1
INF download and unarchive the package env=darwin/amd64 package_name=VirusTotal/vt-cli package_version=1.0.1
INF download and unarchive the package env=windows/amd64 package_name=VirusTotal/vt-cli package_version=1.0.1
INF Updating registry.yaml
```

```console
$ aqua exec -- conftest test --combine pkgs/VirusTotal/vt-cli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ /private/tmp/vt-darwin --help
Usage:
  vt [command]
```

```console
$ docker run --platform linux/amd64 --rm -v /private/tmp/vt-linux64:/vt:ro debian:bookworm-slim /vt --help
Usage:
  vt [command]
```

Implemented with assistance from Codex and reviewed before submission.
