### PR TITLE
feat(nao1215/gup): cosign and attestations config, update to1.5.0

### DIFF
--- a/pkgs/nao1215/gup/pkg.yaml
+++ b/pkgs/nao1215/gup/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: nao1215/gup@v1.4.0
+  - name: nao1215/gup@v1.5.0
+  - name: nao1215/gup
+    version: v1.4.0
   - name: nao1215/gup
     version: v0.22.0

--- a/pkgs/nao1215/gup/pkg.yaml
+++ b/pkgs/nao1215/gup/pkg.yaml
@@ -3,4 +3,6 @@ packages:
   - name: nao1215/gup
     version: v1.4.0
   - name: nao1215/gup
+    version: v1.3.0
+  - name: nao1215/gup
     version: v0.22.0

--- a/pkgs/nao1215/gup/registry.yaml
+++ b/pkgs/nao1215/gup/registry.yaml
@@ -23,6 +23,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.4.0")
+        asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -30,6 +40,16 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/nao1215/gup/releases/download/{{.Version}}/checksums.txt.pem
+              - --signature
+              - https://github.com/nao1215/gup/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate-identity
+              - https://github.com/nao1215/gup/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/nao1215/gup/registry.yaml
+++ b/pkgs/nao1215/gup/registry.yaml
@@ -23,6 +23,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.3.0")
+        asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 1.4.0")
         asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -30,6 +40,8 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: nao1215/gup/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip
@@ -50,6 +62,8 @@ packages:
               - https://github.com/nao1215/gup/.github/workflows/release.yml@refs/tags/{{.Version}}
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+        github_artifact_attestations:
+          signer_workflow: nao1215/gup/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -66970,6 +66970,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.4.0")
+        asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -66977,6 +66987,16 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/nao1215/gup/releases/download/{{.Version}}/checksums.txt.pem
+              - --signature
+              - https://github.com/nao1215/gup/releases/download/{{.Version}}/checksums.txt.sig
+              - --certificate-identity
+              - https://github.com/nao1215/gup/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -66970,6 +66970,16 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 1.3.0")
+        asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 1.4.0")
         asset: gup_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -66977,6 +66987,8 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: nao1215/gup/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip
@@ -66997,6 +67009,8 @@ packages:
               - https://github.com/nao1215/gup/.github/workflows/release.yml@refs/tags/{{.Version}}
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+        github_artifact_attestations:
+          signer_workflow: nao1215/gup/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
- https://github.com/nao1215/gup/releases/tag/v1.5.0
- https://github.com/nao1215/gup/attestations?q=sort%3Acreated-asc

Note: I'm getting failures accessing rekor.sigstore.dev locally, both in tests as well as in the browser. Assuming it's something temporary.

```
error during command execution: searching log query: Post "https://rekor.sigstore.dev/api/v1/log/entries/retrieve": giving up after 4 attempt(s): Post "https://rekor.sigstore.dev/api/v1/log/entries/retrieve": remote error: tls: handshake failure
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
