### PR TITLE
fix(mr-karan/doggo): add version override for v1.2.0 asset naming change

### DIFF
--- a/pkgs/mr-karan/doggo/pkg.yaml
+++ b/pkgs/mr-karan/doggo/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: mr-karan/doggo@v1.1.7
+  - name: mr-karan/doggo@v1.2.0
   - name: mr-karan/doggo
     version: v0.5.7
   - name: mr-karan/doggo

--- a/pkgs/mr-karan/doggo/pkg.yaml
+++ b/pkgs/mr-karan/doggo/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: mr-karan/doggo@v1.2.0
   - name: mr-karan/doggo
+    version: v1.1.7
+  - name: mr-karan/doggo
     version: v0.5.7
   - name: mr-karan/doggo
     version: v0.4.1

--- a/pkgs/mr-karan/doggo/registry.yaml
+++ b/pkgs/mr-karan/doggo/registry.yaml
@@ -30,24 +30,7 @@ packages:
           type: github_release
           asset: doggo_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-      - version_constraint: semver(">= 1.2.0")
-        asset: doggo-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: doggo
-            src: "{{.AssetWithoutExt}}/doggo"
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          386: i386
-        checksum:
-          type: github_release
-          asset: doggo_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.1.7")
         asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -66,3 +49,18 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: doggo-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: doggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/pkgs/mr-karan/doggo/registry.yaml
+++ b/pkgs/mr-karan/doggo/registry.yaml
@@ -30,6 +30,23 @@ packages:
           type: github_release
           asset: doggo_{{trimV .Version}}_checksums.txt
           algorithm: sha256
+      - version_constraint: semver(">= 1.2.0")
+        asset: doggo-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: doggo
+            src: "{{.AssetWithoutExt}}/doggo"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          386: i386
+        checksum:
+          type: github_release
+          asset: doggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -65696,7 +65696,7 @@ packages:
           type: github_release
           asset: doggo_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.1.7")
         asset: doggo_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -65715,6 +65715,21 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: "true"
+        asset: doggo-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: doggo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: mrjackwills
     repo_name: oxker


### PR DESCRIPTION
Doggo v1.2.0 changed its release asset naming from versioned (`doggo_{{version}}_{{OS}}_{{Arch}}.tar.gz`) to versionless (`doggo-{{os}}-{{arch}}.tar.gz`) with lowercase OS names and aarch64/i386 arch naming.

Added a version override for >= 1.2.0 in `pkgs/mr-karan/doggo/registry.yaml` using the new asset pattern with appropriate replacements for the architecture rename (amd64→x86_64, arm64→aarch64, 386→i386). The existing catch-all continues handling older versions.

Updated `pkg.yaml` to test against v1.2.0.

**Note:** The root `registry.yaml` needs regeneration via `argd gr` before merging.

*This PR was generated with the assistance of an AI coding agent.*