### PR TITLE
feat: add ogulcancelik/herdr

### DIFF
--- a/pkgs/ogulcancelik/herdr/pkg.yaml
+++ b/pkgs/ogulcancelik/herdr/pkg.yaml
@@ -1,8 +1,6 @@
 packages:
-  - name: ogulcancelik/herdr@preview-2026-06-07-3c8f8dcb7774
+  - name: ogulcancelik/herdr@preview-2026-06-22-24c7377de01c
   - name: ogulcancelik/herdr
     version: preview-2026-06-05-1ce4213d9ebb
   - name: ogulcancelik/herdr
     version: v0.4.0
-  - name: ogulcancelik/herdr
-    version: v0.3.2

--- a/pkgs/ogulcancelik/herdr/pkg.yaml
+++ b/pkgs/ogulcancelik/herdr/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: ogulcancelik/herdr@preview-2026-06-07-3c8f8dcb7774
+  - name: ogulcancelik/herdr
+    version: preview-2026-06-05-1ce4213d9ebb
+  - name: ogulcancelik/herdr
+    version: v0.4.0
+  - name: ogulcancelik/herdr
+    version: v0.3.2

--- a/pkgs/ogulcancelik/herdr/pkg.yaml
+++ b/pkgs/ogulcancelik/herdr/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: ogulcancelik/herdr@preview-2026-06-22-24c7377de01c
+  - name: ogulcancelik/herdr@v0.7.1
+  - name: ogulcancelik/herdr
+    version: preview-2026-06-22-24c7377de01c
   - name: ogulcancelik/herdr
     version: preview-2026-06-05-1ce4213d9ebb
   - name: ogulcancelik/herdr

--- a/pkgs/ogulcancelik/herdr/registry.yaml
+++ b/pkgs/ogulcancelik/herdr/registry.yaml
@@ -15,16 +15,6 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: semver("<= 2026.0.0-06-05-1ce4213d9ebb")
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: "true"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/ogulcancelik/herdr/registry.yaml
+++ b/pkgs/ogulcancelik/herdr/registry.yaml
@@ -6,16 +6,6 @@ packages:
     description: agent multiplexer that lives in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.2")
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: Version == "v0.4.0"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/ogulcancelik/herdr/registry.yaml
+++ b/pkgs/ogulcancelik/herdr/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: ogulcancelik
+    repo_name: herdr
+    description: agent multiplexer that lives in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.2")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.4.0"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2026.0.0-06-05-1ce4213d9ebb")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            replacements: {}

--- a/pkgs/ogulcancelik/herdr/registry.yaml
+++ b/pkgs/ogulcancelik/herdr/registry.yaml
@@ -28,11 +28,10 @@ packages:
       - version_constraint: "true"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: macos
-        overrides:
-          - goos: windows
-            replacements: {}
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -68957,6 +68957,52 @@ packages:
       - name: exa
         src: bin/exa
   - type: github_release
+    repo_owner: ogulcancelik
+    repo_name: herdr
+    description: agent multiplexer that lives in your terminal
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.2")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.4.0"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 2026.0.0-06-05-1ce4213d9ebb")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            replacements: {}
+  - type: github_release
     repo_owner: ohkrab
     repo_name: krab
     description: Krab is a migration and automation tool for PostgreSQL based on HCL syntax

--- a/registry.yaml
+++ b/registry.yaml
@@ -68984,14 +68984,13 @@ packages:
       - version_constraint: "true"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw
-        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: macos
-        overrides:
-          - goos: windows
-            replacements: {}
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: ohkrab
     repo_name: krab

--- a/registry.yaml
+++ b/registry.yaml
@@ -68971,16 +68971,6 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: semver("<= 2026.0.0-06-05-1ce4213d9ebb")
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: "true"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -68962,16 +68962,6 @@ packages:
     description: agent multiplexer that lives in your terminal
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.3.2")
-        asset: herdr-{{.OS}}-{{.Arch}}
-        format: raw
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: macos
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: Version == "v0.4.0"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw


### PR DESCRIPTION
[ogulcancelik/herdr](https://github.com/ogulcancelik/herdr) - agent multiplexer that lives in your terminal

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Add [ogulcancelik/herdr](https://github.com/ogulcancelik/herdr): agent multiplexer that lives in your terminal.

The package was scaffolded with `argd s ogulcancelik/herdr`.
Windows assets appear to be beta/preview-only and are not available for all versions, so this registry entry excludes Windows and supports Linux and macOS.

Verification:

```console
$ conftest test pkgs/ogulcancelik/herdr/*.yaml
28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions

$ argd t ogulcancelik/herdr
# succeeded
```

I also confirmed the package runs locally before creating this PR.

AI assistance: prepared with Codex.
