### PR TITLE
fix: point glossia.ai/cli to object storage

### DIFF
--- a/pkgs/glossia.ai/cli/pkg.yaml
+++ b/pkgs/glossia.ai/cli/pkg.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: glossia.ai/cli
+    version: cli-v0.17.0
+  - name: glossia.ai/cli
+    version: cli-v0.16.0
+  - name: glossia.ai/cli
+    version: cli-v0.14.1

--- a/pkgs/glossia.ai/cli/registry.yaml
+++ b/pkgs/glossia.ai/cli/registry.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - name: glossia.ai/cli
-    type: github_release
-    repo_owner: glossia
-    repo_name: glossia
+    type: http
     aliases:
       - name: glossia/cli
     description: Localize like you ship software

--- a/pkgs/glossia.ai/cli/registry.yaml
+++ b/pkgs/glossia.ai/cli/registry.yaml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: github_release
+  - name: glossia.ai/cli
+    type: github_release
     repo_owner: glossia
-    repo_name: cli
+    repo_name: glossia
     aliases:
-      - name: glossia.ai/cli
+      - name: glossia/cli
     description: Localize like you ship software
     files:
       - name: glossia
@@ -26,15 +27,17 @@ packages:
           url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/SHA256SUMS
           algorithm: sha256
       - version_constraint: "true"
-        asset: glossia-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
+        version_prefix: cli-v
+        type: http
         windows_arm_emulation: true
+        url: https://releases.glossia.ai/cli/{{.SemVer}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
           amd64: x64
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
+        format: tar.gz
         overrides:
           - goos: windows
             format: zip
+        checksum:
+          type: http
+          url: https://releases.glossia.ai/cli/{{.SemVer}}/SHA256SUMS
+          algorithm: sha256

--- a/pkgs/glossia/cli/pkg.yaml
+++ b/pkgs/glossia/cli/pkg.yaml
@@ -1,4 +1,0 @@
-packages:
-  - name: glossia/cli@0.16.0
-  - name: glossia/cli
-    version: cli-v0.14.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -41735,9 +41735,7 @@ packages:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
   - name: glossia.ai/cli
-    type: github_release
-    repo_owner: glossia
-    repo_name: glossia
+    type: http
     aliases:
       - name: glossia/cli
     description: Localize like you ship software

--- a/registry.yaml
+++ b/registry.yaml
@@ -41734,11 +41734,12 @@ packages:
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
           signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
-  - type: github_release
+  - name: glossia.ai/cli
+    type: github_release
     repo_owner: glossia
-    repo_name: cli
+    repo_name: glossia
     aliases:
-      - name: glossia.ai/cli
+      - name: glossia/cli
     description: Localize like you ship software
     files:
       - name: glossia
@@ -41760,18 +41761,20 @@ packages:
           url: https://glossia-releases.t3.storage.dev/cli/{{.SemVer}}/SHA256SUMS
           algorithm: sha256
       - version_constraint: "true"
-        asset: glossia-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
+        version_prefix: cli-v
+        type: http
         windows_arm_emulation: true
+        url: https://releases.glossia.ai/cli/{{.SemVer}}/glossia-{{.OS}}-{{.Arch}}.{{.Format}}
         replacements:
           amd64: x64
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
+        format: tar.gz
         overrides:
           - goos: windows
             format: zip
+        checksum:
+          type: http
+          url: https://releases.glossia.ai/cli/{{.SemVer}}/SHA256SUMS
+          algorithm: sha256
   - type: github_release
     repo_owner: go-acme
     repo_name: lego


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## What changed

This moves Glossia's command line interface package from the closed `glossia/cli` GitHub release source to public object storage at `https://releases.glossia.ai/cli/<version>/`.

The canonical package name is now `glossia.ai/cli`; `glossia/cli` remains an alias for existing users. The registry entry is modeled as a plain `http` package so public installs do not depend on private GitHub repository metadata.

## Why

The Glossia repository is private, so aqua-registry cannot rely on GitHub Releases to discover or fetch public versions. The command line interface archives are now published to public object storage, and the registry needs to resolve archives from that public endpoint.

## Approach

The modern release path points to `releases.glossia.ai` with a `cli/` prefix, while versions before `cli-v0.15.1` keep using the legacy object storage endpoint. `cli-v0.16.0` was backfilled to `releases.glossia.ai` so the existing tested modern release remains installable without private GitHub access.

## Impact

Existing `glossia/cli` users can continue using the alias. New users can use `glossia.ai/cli`, and installs of tested versions resolve through public URLs instead of private GitHub release assets.

## Verification

```sh
mise exec aqua@latest -- aqua exec -- argd gr
mise exec aqua@latest -- aqua exec -- conftest test --combine pkgs/glossia.ai/cli/*
mise exec aqua@latest -- aqua exec -- argd t glossia.ai/cli
```

`argd t glossia.ai/cli` tested linux amd64, linux arm64, darwin amd64, darwin arm64, windows amd64, and windows arm64 successfully with `AQUA_GITHUB_TOKEN` empty in the containerized install checks.

I also verified the legacy alias directly with a local registry configuration:

```sh
AQUA_ROOT_DIR="$tmp_root/root" mise exec aqua@latest -- aqua -c aqua-alias-test.yaml i
AQUA_ROOT_DIR="$tmp_root/root" mise exec aqua@latest -- aqua -c aqua-alias-test.yaml exec -- glossia --help
```

The command printed Glossia help output for `glossia/cli@cli-v0.17.0`.

## Artificial intelligence disclosure

I used Codex to help prepare this change and reviewed the generated output before opening this pull request.
