### PR TITLE
feat: add callumalpass/tasknotes-tui

### DIFF
--- a/pkgs/callumalpass/tasknotes-tui/pkg.yaml
+++ b/pkgs/callumalpass/tasknotes-tui/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: callumalpass/tasknotes-tui@v0.1.3
+  - name: callumalpass/tasknotes-tui
+    version: v0.1.0

--- a/pkgs/callumalpass/tasknotes-tui/registry.yaml
+++ b/pkgs/callumalpass/tasknotes-tui/registry.yaml
@@ -3,6 +3,10 @@ packages:
   - type: github_release
     repo_owner: callumalpass
     repo_name: tasknotes-tui
+    description: Terminal interface for managing markdown-based tasks
+    files:
+      - name: tasknotes-tui
+        src: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}/tasknotes-tui
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/pkgs/callumalpass/tasknotes-tui/registry.yaml
+++ b/pkgs/callumalpass/tasknotes-tui/registry.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: callumalpass
+    repo_name: tasknotes-tui
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -22486,6 +22486,10 @@ packages:
   - type: github_release
     repo_owner: callumalpass
     repo_name: tasknotes-tui
+    description: Terminal interface for managing markdown-based tasks
+    files:
+      - name: tasknotes-tui
+        src: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}/tasknotes-tui
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/registry.yaml
+++ b/registry.yaml
@@ -22484,6 +22484,46 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: callumalpass
+    repo_name: tasknotes-tui
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: tasknotes-tui-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: cameron-martin
     repo_name: bazel-lsp
     description: A language server implementation for Bazel


### PR DESCRIPTION
[callumalpass/tasknotes-tui](https://github.com/callumalpass/tasknotes-tui) - Terminal interface for managing markdown-based tasks

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Added `callumalpass/tasknotes-tui`, a terminal interface for managing markdown-based tasks.

Verification:

- `aqua exec -- argd t callumalpass/tasknotes-tui`
- `aqua exec -- conftest test --combine pkgs/callumalpass/tasknotes-tui/*` (14 passed)
- `docker run --platform linux/amd64 --rm -v /private/tmp/codex-tasknotes-tui/tasknotes-tui-linux-amd64:/tasknotes-tui:ro debian:trixie-slim /tasknotes-tui --help`
- `/private/tmp/codex-tasknotes-tui/tasknotes-tui-darwin --help`

AI disclosure: prepared with assistance from Codex and reviewed before submission.
