### PR TITLE
feat(aquasecurity/trivy): upgrade to 0.71.2, GitHub artifact attestations config

### DIFF
--- a/pkgs/aquasecurity/trivy/pkg.yaml
+++ b/pkgs/aquasecurity/trivy/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: aquasecurity/trivy@v0.71.2
   - name: aquasecurity/trivy
+    version: v0.69.3
+  - name: aquasecurity/trivy
     version: v0.20.0
   - name: aquasecurity/trivy
     version: v0.16.0

--- a/pkgs/aquasecurity/trivy/pkg.yaml
+++ b/pkgs/aquasecurity/trivy/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: aquasecurity/trivy@v0.70.0
+  - name: aquasecurity/trivy@v0.71.2
   - name: aquasecurity/trivy
     version: v0.20.0
   - name: aquasecurity/trivy

--- a/pkgs/aquasecurity/trivy/registry.yaml
+++ b/pkgs/aquasecurity/trivy/registry.yaml
@@ -64,6 +64,32 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 0.70.0")
+        asset: trivy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: trivy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: trivy_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
       - version_constraint: "true"
         asset: trivy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -86,6 +112,8 @@ packages:
               - https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/{{.Version}}
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+        github_artifact_attestations:
+          signer_workflow: aquasecurity/trivy/.github/workflows/reusable-release.yaml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -14717,6 +14717,32 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("< 0.70.0")
+        asset: trivy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: 64bit
+          arm64: ARM64
+          darwin: macOS
+          linux: Linux
+        checksum:
+          type: github_release
+          asset: trivy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: trivy_{{trimV .Version}}_checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
       - version_constraint: "true"
         asset: trivy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -14739,6 +14765,8 @@ packages:
               - https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/{{.Version}}
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+        github_artifact_attestations:
+          signer_workflow: aquasecurity/trivy/.github/workflows/reusable-release.yaml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/attestations?q=sort%3Acreated-asc

The problem encountered at https://github.com/aquaproj/aqua-registry/pull/53645#issuecomment-4434920294 seems to have gone away, at least per local testing.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
