### PR TITLE
fix(tailwindlabs/tailwindcss): use glibc binary for linux instead of musl

### DIFF
--- a/pkgs/tailwindlabs/tailwindcss/registry.yaml
+++ b/pkgs/tailwindlabs/tailwindcss/registry.yaml
@@ -53,3 +53,13 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl
+            variants:
+              - key: libc
+                value: musl

--- a/pkgs/tailwindlabs/tailwindcss/registry.yaml
+++ b/pkgs/tailwindlabs/tailwindcss/registry.yaml
@@ -53,6 +53,3 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl

--- a/registry.yaml
+++ b/registry.yaml
@@ -88230,9 +88230,6 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl
   - type: github_release
     repo_owner: tak848
     repo_name: ccgate

--- a/registry.yaml
+++ b/registry.yaml
@@ -88230,6 +88230,16 @@ packages:
           type: github_release
           asset: sha256sums.txt
           algorithm: sha256
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: tailwindcss-{{.OS}}-{{.Arch}}-musl
+            variants:
+              - key: libc
+                value: musl
   - type: github_release
     repo_owner: tak848
     repo_name: ccgate


### PR DESCRIPTION
The musl binary of tailwindcss does not static link musl:
```console
$ ldd ~/.local/share/aquaproj-aqua/pkgs/github_release/github.com/tailwindlabs/tailwindcss/v4.3.1/tailwindcss-linux-x64-musl/tailwindcss-linux-x64-musl
	linux-vdso.so.1 (0x00007fa588480000)
	libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007fa588000000)
	libc.musl-x86_64.so.1 => not found
	libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007fa588434000)
	libm.so.6 => /usr/lib/libm.so.6 (0x00007fa588301000)
	libc.so.6 => /usr/lib/libc.so.6 (0x00007fa587c00000)
	/lib/ld-musl-x86_64.so.1 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fa588482000)
```

Based on the [Style Guide](https://aquaproj.github.io/docs/develop-registry/registry-style-guide#2-when-the-musl-build-is-dynamic), use normal binary in the glibc environment and musl binary in the musl environment.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
