### PR TITLE
fix(runs-on/cli): trim v for all versions <3.0.0

### DIFF
--- a/pkgs/runs-on/cli/pkg.yaml
+++ b/pkgs/runs-on/cli/pkg.yaml
@@ -3,7 +3,7 @@ packages:
   - name: runs-on/cli
     version: v3.0.1
   - name: runs-on/cli
-    version: v2.12.6
+    version: v2.12.8
   - name: runs-on/cli
     version: v0.1.5
   - name: runs-on/cli

--- a/pkgs/runs-on/cli/registry.yaml
+++ b/pkgs/runs-on/cli/registry.yaml
@@ -30,7 +30,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 2.12.6")
+      - version_constraint: semver("< 3.0.0")
         asset: roc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -78429,7 +78429,7 @@ packages:
         supported_envs:
           - linux
           - darwin
-      - version_constraint: semver("<= 2.12.6")
+      - version_constraint: semver("< 3.0.0")
         asset: roc_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         checksum:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

runs-on/cli version 2.12.8 was released and it, like 2.12.6, does not include the v prefix on the asset. This is causing failures when trying to install via mise:

```
  mise ERROR Failed to install aqua:runs-on/cli@2.12.8: no asset found: roc_v2.12.8_linux_amd64
  Available assets:
  checksums.txt
  roc_2.12.8_darwin_amd64
  roc_2.12.8_darwin_arm64
  roc_2.12.8_linux_amd64
  roc_2.12.8_linux_arm64
  roc_2.12.8_windows_amd64.exe
  roc_2.12.8_windows_arm64.exe
  mise ERROR Version: 2026.6.14 linux-x64 (2026-06-25)
```

Update the version constraint to match all versions less than 3.0.0.