### PR TITLE
feat: add twitchdev/twitch-cli

### DIFF
--- a/pkgs/twitchdev/twitch-cli/pkg.yaml
+++ b/pkgs/twitchdev/twitch-cli/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: twitchdev/twitch-cli@v1.1.24
+  - name: twitchdev/twitch-cli
+    version: v1.1.6
+  - name: twitchdev/twitch-cli
+    version: v1.1.3
+  - name: twitchdev/twitch-cli
+    version: 1.1.1
+  - name: twitchdev/twitch-cli
+    version: 0.2.1

--- a/pkgs/twitchdev/twitch-cli/registry.yaml
+++ b/pkgs/twitchdev/twitch-cli/registry.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: twitchdev
+    repo_name: twitch-cli
+    description: The official Twitch CLI to make developing on Twitch easier
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.1.3"
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.2.1")
+        asset: twitch-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: twitch-{{.OS}}-10.6-{{.Arch}}
+          - goos: windows
+            asset: twitch-{{.OS}}-4.0-{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.1")
+        asset: twitch-cli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.6")
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/twitchdev/twitch-cli/registry.yaml
+++ b/pkgs/twitchdev/twitch-cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: twitchdev
     repo_name: twitch-cli
     description: The official Twitch CLI to make developing on Twitch easier
+    files:
+      - name: twitch
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.1.3"
@@ -65,6 +67,9 @@ packages:
       - version_constraint: semver("<= 1.1.6")
         asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: twitch
+            src: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/twitch
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -85,6 +90,9 @@ packages:
       - version_constraint: "true"
         asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: twitch
+            src: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/twitch
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -93659,6 +93659,8 @@ packages:
     repo_owner: twitchdev
     repo_name: twitch-cli
     description: The official Twitch CLI to make developing on Twitch easier
+    files:
+      - name: twitch
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.1.3"
@@ -93720,6 +93722,9 @@ packages:
       - version_constraint: semver("<= 1.1.6")
         asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: twitch
+            src: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/twitch
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
@@ -93740,6 +93745,9 @@ packages:
       - version_constraint: "true"
         asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: twitch
+            src: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}/twitch
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/registry.yaml
+++ b/registry.yaml
@@ -93656,6 +93656,104 @@ packages:
       - darwin
       - linux
   - type: github_release
+    repo_owner: twitchdev
+    repo_name: twitch-cli
+    description: The official Twitch CLI to make developing on Twitch easier
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.1.3"
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.2.1")
+        asset: twitch-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        overrides:
+          - goos: darwin
+            asset: twitch-{{.OS}}-10.6-{{.Arch}}
+          - goos: windows
+            asset: twitch-{{.OS}}-4.0-{{.Arch}}
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.1")
+        asset: twitch-cli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.1.6")
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: twitch-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: twpayne
     repo_name: chezmoi
     description: Manage your dotfiles across multiple diverse machines, securely


### PR DESCRIPTION
[twitchdev/twitch-cli](https://github.com/twitchdev/twitch-cli): The official Twitch CLI to make developing on Twitch easier

```sh
aqua g -i twitchdev/twitch-cli
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ twitch help
A simple CLI tool for the New Twitch API and Webhook products.

Usage:
  twitch [command]

Available Commands:
  api         Used to interface with the Twitch API
  configure   Configures your Twitch CLI with your Client ID and Secret
  event       Used to interface with EventSub topics.
  help        Help about any command
  mock-api    Used to interface with the mock Twitch API.
  token       Logs into Twitch and returns an access token according to your client id/secret in the configuration.
  version     Returns the current version of the CLI.

Flags:
      --config string   config file (default is /root/.config/twitch-cli/.twitch-cli.env)
  -h, --help            help for twitch

Use "twitch [command] --help" for more information about a command.
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/twitchdev/twitch-cli/internal/util.areWeRunningLatestVersion()
	/go/src/github.com/twitchdev/twitch-cli/internal/util/version_checker.go:121 +0x567
github.com/twitchdev/twitch-cli/internal/util.CheckForUpdatesAndPrintNotice()
	/go/src/github.com/twitchdev/twitch-cli/internal/util/version_checker.go:46 +0x145
github.com/twitchdev/twitch-cli/cmd.Execute()
	/go/src/github.com/twitchdev/twitch-cli/cmd/root.go:33 +0x65
main.main()
	/go/src/github.com/twitchdev/twitch-cli/main.go:54 +0x2aa
```

The panic shown above is "not related to this package configuration" - it is an upstream bug in the `twitch` binary itself, not an issue with aqua or this registry entry.

Why it's unrelated to aqua

  - The command itself works correctly - `twitch help` prints its usage as expected. The panic happens *after* the command, inside the binary's own post-command update check (`CheckForUpdatesAndPrintNotice` → `areWeRunningLatestVersion`).
  - The panic only occurs when the embedded version string is empty, which happens with a plain `go build` / source build (note the `/go/src/...` paths in the trace). The official GoReleaser release artifacts have the version baked in and
  do not panic.
  - aqua's job — download, extract, and place the binary on `$PATH` — is working. `argd t twitchdev/twitch-cli` passes for all environments (linux / darwin / windows × amd64 / arm64) with no errors.

  So this is an upstream `twitchdev/twitch-cli` issue, not something to fix in this registry config.


If files such as configuration file are needed, please share them.
None.

Reference

- [twitch-cli Release](https://github.com/twitchdev/twitch-cli/releases)