### PR TITLE
feat: add colbymchenry/codegraph

### DIFF
--- a/pkgs/colbymchenry/codegraph/pkg.yaml
+++ b/pkgs/colbymchenry/codegraph/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: colbymchenry/codegraph@v1.1.6
+  - name: colbymchenry/codegraph
+    version: v0.9.3

--- a/pkgs/colbymchenry/codegraph/registry.yaml
+++ b/pkgs/colbymchenry/codegraph/registry.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: colbymchenry
+    repo_name: codegraph
+    description: Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.9.3")
+        asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/colbymchenry/codegraph/registry.yaml
+++ b/pkgs/colbymchenry/codegraph/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: colbymchenry
     repo_name: codegraph
-    description: Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local
+    description: Pre-indexed code knowledge graph for coding agents
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.0")
@@ -11,15 +11,24 @@ packages:
       - version_constraint: semver("<= 0.9.3")
         asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: codegraph
+            src: "{{.AssetWithoutExt}}/bin/codegraph"
         replacements:
           amd64: x64
           windows: win32
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: codegraph
+                src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"
       - version_constraint: "true"
         asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: codegraph
+            src: "{{.AssetWithoutExt}}/bin/codegraph"
         replacements:
           amd64: x64
           windows: win32
@@ -30,3 +39,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: codegraph
+                src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"

--- a/registry.yaml
+++ b/registry.yaml
@@ -27044,7 +27044,7 @@ packages:
   - type: github_release
     repo_owner: colbymchenry
     repo_name: codegraph
-    description: Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local
+    description: Pre-indexed code knowledge graph for coding agents
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.8.0")
@@ -27052,15 +27052,24 @@ packages:
       - version_constraint: semver("<= 0.9.3")
         asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: codegraph
+            src: "{{.AssetWithoutExt}}/bin/codegraph"
         replacements:
           amd64: x64
           windows: win32
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: codegraph
+                src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"
       - version_constraint: "true"
         asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: codegraph
+            src: "{{.AssetWithoutExt}}/bin/codegraph"
         replacements:
           amd64: x64
           windows: win32
@@ -27071,6 +27080,9 @@ packages:
         overrides:
           - goos: windows
             format: zip
+            files:
+              - name: codegraph
+                src: "{{.AssetWithoutExt}}/bin/codegraph.cmd"
   - type: github_release
     repo_owner: commercialhaskell
     repo_name: stack

--- a/registry.yaml
+++ b/registry.yaml
@@ -27042,6 +27042,36 @@ packages:
         asset: bombardier-{{.OS}}-{{.Arch}}
         format: raw
   - type: github_release
+    repo_owner: colbymchenry
+    repo_name: codegraph
+    description: Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.8.0")
+        no_asset: true
+      - version_constraint: semver("<= 0.9.3")
+        asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: codegraph-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: commercialhaskell
     repo_name: stack
     description: The Haskell Tool Stack


### PR DESCRIPTION
[colbymchenry/codegraph](https://github.com/colbymchenry/codegraph) - Pre-indexed code knowledge graph for coding agents

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Add `colbymchenry/codegraph`.

`argd s colbymchenry/codegraph` scaffolded the package. The generated configuration needed a follow-up fix because the release archives place the command wrapper under `bin/` inside the extracted archive:

- Unix: `{{.AssetWithoutExt}}/bin/codegraph`
- Windows: `{{.AssetWithoutExt}}/bin/codegraph.cmd`

## Verification

```console
$ aqua exec -- conftest test --combine pkgs/colbymchenry/codegraph/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ aqua exec -- argd t colbymchenry/codegraph
Passed Linux, Darwin, and Windows install tests.
```

Direct execution checks:

```console
$ docker exec aqua-registry /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/colbymchenry/codegraph/v1.1.6/codegraph-linux-arm64.tar.gz/codegraph-linux-arm64/bin/codegraph --version
1.1.6

$ docker exec aqua-registry /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/colbymchenry/codegraph/v0.9.3/codegraph-linux-arm64.tar.gz/codegraph-linux-arm64/bin/codegraph --version
0.9.3

$ /private/tmp/codex-codegraph-darwin-exec/codegraph-darwin-arm64/bin/codegraph --version
1.1.6
```

Implemented with assistance from Codex.
