### PR TITLE
feat: add Mic92/nixfmt-rs

### DIFF
--- a/pkgs/Mic92/nixfmt-rs/pkg.yaml
+++ b/pkgs/Mic92/nixfmt-rs/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Mic92/nixfmt-rs@0.5.1

--- a/pkgs/Mic92/nixfmt-rs/registry.yaml
+++ b/pkgs/Mic92/nixfmt-rs/registry.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Mic92
+    repo_name: nixfmt-rs
+    description: A from-scratch Rust reimplementation of nixfmt that produces byte-identical output to the Haskell original
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: nixfmt-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/pkgs/Mic92/nixfmt-rs/registry.yaml
+++ b/pkgs/Mic92/nixfmt-rs/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: Mic92
     repo_name: nixfmt-rs
     description: Rust reimplementation of nixfmt with byte-identical output
+    files:
+      - name: nixfmt
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.1.1"
@@ -21,6 +23,8 @@ packages:
           - goos: linux
             replacements:
               amd64: x86_64
+        github_artifact_attestations:
+          signer_workflow: Mic92/nixfmt-rs/.github/workflows/release-assets.yml
         supported_envs:
           - linux
           - darwin/arm64

--- a/pkgs/Mic92/nixfmt-rs/registry.yaml
+++ b/pkgs/Mic92/nixfmt-rs/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: Mic92
     repo_name: nixfmt-rs
-    description: A from-scratch Rust reimplementation of nixfmt that produces byte-identical output to the Haskell original
+    description: Rust reimplementation of nixfmt with byte-identical output
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.1.1"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5765,7 +5765,7 @@ packages:
   - type: github_release
     repo_owner: Mic92
     repo_name: nixfmt-rs
-    description: A from-scratch Rust reimplementation of nixfmt that produces byte-identical output to the Haskell original
+    description: Rust reimplementation of nixfmt with byte-identical output
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.1.1"

--- a/registry.yaml
+++ b/registry.yaml
@@ -5766,6 +5766,8 @@ packages:
     repo_owner: Mic92
     repo_name: nixfmt-rs
     description: Rust reimplementation of nixfmt with byte-identical output
+    files:
+      - name: nixfmt
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "0.1.1"
@@ -5783,6 +5785,8 @@ packages:
           - goos: linux
             replacements:
               amd64: x86_64
+        github_artifact_attestations:
+          signer_workflow: Mic92/nixfmt-rs/.github/workflows/release-assets.yml
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -5763,6 +5763,30 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: Mic92
+    repo_name: nixfmt-rs
+    description: A from-scratch Rust reimplementation of nixfmt that produces byte-identical output to the Haskell original
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "0.1.1"
+        no_asset: true
+      - version_constraint: "true"
+        asset: nixfmt-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+  - type: github_release
     repo_owner: Mikescher
     repo_name: better-docker-ps
     description: Because `docker ps` is annoying and does not fit my monitor/terminal width


### PR DESCRIPTION
[Mic92/nixfmt-rs](https://github.com/Mic92/nixfmt-rs) - Rust reimplementation of nixfmt with byte-identical output

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Adds `Mic92/nixfmt-rs`.

Verification:

```console
$ AQUA_GHTKN_ENABLED=true aqua exec -- argd t Mic92/nixfmt-rs
# exit 0

$ aqua exec -- conftest test --combine pkgs/Mic92/nixfmt-rs/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ docker exec aqua-registry sh -c 'bin=/root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/Mic92/nixfmt-rs/0.5.1/nixfmt-aarch64-linux/nixfmt-aarch64-linux; printf "let x=1; in x\n" | "$bin" -'
let
  x = 1;
in
x

$ printf 'let x=1; in x\n' | /private/tmp/codex-aqua-nixfmt-rs/nixfmt-aarch64-darwin -
let
  x = 1;
in
x
```

AI assistance: This PR was prepared with Codex assistance. I reviewed the changes and take responsibility for the content.
