### PR TITLE
fix(microsoft/vscode): use zip format on Darwin

### DIFF
--- a/pkgs/microsoft/vscode/code/registry.yaml
+++ b/pkgs/microsoft/vscode/code/registry.yaml
@@ -8,18 +8,17 @@ packages:
     link: https://code.visualstudio.com/
     search_words:
       - visual studio code
-    url: https://update.code.visualstudio.com/{{trimV .Version}}/cli-{{.OS}}-{{.Arch}}/stable
-    replacements:
-      windows: win32
-      amd64: x64
-    format: tar.gz
-    append_ext: false
-    overrides:
-      - goos: darwin
-        format: zip
-      - goos: windows
-        format: zip
-    version_constraint: semver(">= 1.73.0")
+    version_constraint: "false"
     version_overrides:
       - version_constraint: semver("< 1.73.0")
         no_asset: true
+      - version_constraint: "true"
+        url: https://update.code.visualstudio.com/{{trimV .Version}}/cli-{{.OS}}-{{.Arch}}/stable
+        replacements:
+          windows: win32
+          amd64: x64
+        format: zip
+        append_ext: false
+        overrides:
+          - goos: linux
+            format: tar.gz

--- a/pkgs/microsoft/vscode/code/registry.yaml
+++ b/pkgs/microsoft/vscode/code/registry.yaml
@@ -15,6 +15,8 @@ packages:
     format: tar.gz
     append_ext: false
     overrides:
+      - goos: darwin
+        format: zip
       - goos: windows
         format: zip
     version_constraint: semver(">= 1.73.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -63814,21 +63814,20 @@ packages:
     link: https://code.visualstudio.com/
     search_words:
       - visual studio code
-    url: https://update.code.visualstudio.com/{{trimV .Version}}/cli-{{.OS}}-{{.Arch}}/stable
-    replacements:
-      windows: win32
-      amd64: x64
-    format: tar.gz
-    append_ext: false
-    overrides:
-      - goos: darwin
-        format: zip
-      - goos: windows
-        format: zip
-    version_constraint: semver(">= 1.73.0")
+    version_constraint: "false"
     version_overrides:
       - version_constraint: semver("< 1.73.0")
         no_asset: true
+      - version_constraint: "true"
+        url: https://update.code.visualstudio.com/{{trimV .Version}}/cli-{{.OS}}-{{.Arch}}/stable
+        replacements:
+          windows: win32
+          amd64: x64
+        format: zip
+        append_ext: false
+        overrides:
+          - goos: linux
+            format: tar.gz
   - type: github_release
     repo_owner: mike-engel
     repo_name: jwt-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -63821,6 +63821,8 @@ packages:
     format: tar.gz
     append_ext: false
     overrides:
+      - goos: darwin
+        format: zip
       - goos: windows
         format: zip
     version_constraint: semver(">= 1.73.0")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## What

Override the archive format for `microsoft/vscode/code` on Darwin from `tar.gz` to `zip`.

The generated root `registry.yaml` was updated with `argd gr`.

## Why

The VS Code CLI download endpoint returns a ZIP archive for Darwin. For example:

```console
$ file /tmp/vscode-cli-darwin-arm64
Zip archive data, at least v2.0 to extract, compression method=deflate
```

Without the override, aqua treats the downloaded archive as `tar.gz` and cannot extract it correctly.

## Verification

```console
$ argd t microsoft/vscode/code
```

The command successfully installed the configured test versions for Linux, Darwin, and Windows on amd64 and arm64.

## AI usage

Codex assisted with the registry change, verification, and PR preparation. The commits include a `Co-authored-by` trailer.
