### PR TITLE
feat: add whisper-sec/whisper-cli

### DIFF
--- a/pkgs/whisper-sec/whisper-cli/pkg.yaml
+++ b/pkgs/whisper-sec/whisper-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: whisper-sec/whisper-cli@v0.124.3

--- a/pkgs/whisper-sec/whisper-cli/registry.yaml
+++ b/pkgs/whisper-sec/whisper-cli/registry.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: whisper-sec
+    repo_name: whisper-cli
+    description: Give your agent a real, routable Whisper IPv6 identity — one command. The official Whisper CLI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: whisper-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/pkgs/whisper-sec/whisper-cli/registry.yaml
+++ b/pkgs/whisper-sec/whisper-cli/registry.yaml
@@ -3,7 +3,9 @@ packages:
   - type: github_release
     repo_owner: whisper-sec
     repo_name: whisper-cli
-    description: Give your agent a real, routable Whisper IPv6 identity — one command. The official Whisper CLI
+    description: Official CLI to give your agent a real, routable Whisper IPv6 identity
+    files:
+      - name: whisper
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -98014,7 +98014,9 @@ packages:
   - type: github_release
     repo_owner: whisper-sec
     repo_name: whisper-cli
-    description: Give your agent a real, routable Whisper IPv6 identity — one command. The official Whisper CLI
+    description: Official CLI to give your agent a real, routable Whisper IPv6 identity
+    files:
+      - name: whisper
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -98012,6 +98012,19 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: whisper-sec
+    repo_name: whisper-cli
+    description: Give your agent a real, routable Whisper IPv6 identity — one command. The official Whisper CLI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: whisper-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+  - type: github_release
     repo_owner: windvalley
     repo_name: gossh
     description: A high-performance and high-concurrency ssh tool written in Go. It is 10 times faster than Ansible. If you need much more performance and better ease of use, you will love it


### PR DESCRIPTION
[whisper-sec/whisper-cli](https://github.com/whisper-sec/whisper-cli) - Official CLI to give your agent a real, routable Whisper IPv6 identity

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Add `whisper-sec/whisper-cli`

`whisper` is the official Whisper CLI — it gives an agent a real, routable IPv6 identity in one command. Public, MIT-licensed: https://github.com/whisper-sec/whisper-cli

### Entry

Scaffolded with `argd s whisper-sec/whisper-cli`, then `files: [{name: whisper}]` added (the released binary is invoked as `whisper`, not the repo name) and the description shortened. Releases ship raw per-OS/arch binaries `whisper-<os>-<arch>` (Windows `.exe`) with a matching `<asset>.sha256` for each, across darwin/linux/windows x amd64/arm64.

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
packages:
  - type: github_release
    repo_owner: whisper-sec
    repo_name: whisper-cli
    description: Official CLI to give your agent a real, routable Whisper IPv6 identity
    files:
      - name: whisper
    version_constraint: "false"
    version_overrides:
      - version_constraint: "true"
        asset: whisper-{{.OS}}-{{.Arch}}
        format: raw
        checksum:
          type: github_release
          asset: "{{.Asset}}.sha256"
          algorithm: sha256
```

### Verification

`argd t whisper-sec/whisper-cli` — installs cleanly on all six platforms (linux/darwin/windows x amd64/arm64):

```
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF create a symbolic link package_name=whisper-sec/whisper-cli package_version=v0.124.3 command=whisper
```

End-to-end install + run via aqua using this registry entry:

```
$ aqua which whisper
.../pkgs/github_release/github.com/whisper-sec/whisper-cli/v0.124.3/whisper-linux-arm64/whisper-linux-arm64

$ aqua exec -- whisper --version
whisper version 0.124.3
```

`conftest test --combine` -> 14 tests, 14 passed, 0 failures. JSON-schema validation passes.



---
_AI-assistance disclosure (per this project's `docs/ai.md`): this package entry was prepared with AI assistance (Claude Code / Claude Opus 4.8); it is reviewed and maintained by Whisper Security. The `whisper` CLI itself is MIT-licensed and human-authored._
