### PR TITLE
feat(haskell/ghcup-hs): add checksum configuration

### DIFF
--- a/pkgs/haskell/ghcup-hs/registry.yaml
+++ b/pkgs/haskell/ghcup-hs/registry.yaml
@@ -15,3 +15,7 @@ packages:
       windows: mingw64
     files:
       - name: ghcup
+    checksum:
+      type: http
+      url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/SHA256SUMS
+      algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -47028,6 +47028,10 @@ packages:
       windows: mingw64
     files:
       - name: ghcup
+    checksum:
+      type: http
+      url: https://downloads.haskell.org/~ghcup/{{trimV .Version}}/SHA256SUMS
+      algorithm: sha256
   - type: github_release
     repo_owner: hasura
     repo_name: graphql-engine


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add a `checksum` block to `haskell/ghcup-hs` pointing at the combined `SHA256SUMS` file ghcup publishes per version directory. I also confirmed `SHA256SUMS` is published for every real release from v0.1.5 through v0.2.6.2, so enabling checksums does not break old-version installs.

This PR was written with the help of Claude (added as a commit co-author).
