### PR TITLE
Add sivchari/gopls-lazy

### DIFF
--- a/pkgs/sivchari/gopls-lazy/pkg.yaml
+++ b/pkgs/sivchari/gopls-lazy/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sivchari/gopls-lazy@v0.3.0

--- a/pkgs/sivchari/gopls-lazy/registry.yaml
+++ b/pkgs/sivchari/gopls-lazy/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sivchari
+    repo_name: gopls-lazy
+    description: An LSP proxy that lazily scopes gopls to open files, keeping large monorepos fast
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gopls-lazy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gopls-lazy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -82813,6 +82813,22 @@ packages:
             checksum:
               enabled: false
   - type: github_release
+    repo_owner: sivchari
+    repo_name: gopls-lazy
+    description: An LSP proxy that lazily scopes gopls to open files, keeping large monorepos fast
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gopls-lazy_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: gopls-lazy_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: six-ddc
     repo_name: plow
     description: A high-performance HTTP benchmarking tool that includes a real-time web UI and terminal display


### PR DESCRIPTION
[sivchari/gopls-lazy](https://github.com/sivchari/gopls-lazy) - An LSP proxy that lazily scopes gopls to open files, keeping large monorepos fast

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
