### PR TITLE
feat: add mpyw/suve

### DIFF
--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mpyw/suve@v1.3.3

--- a/pkgs/mpyw/suve/registry.yaml
+++ b/pkgs/mpyw/suve/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 1.3.3")
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          # The Linux GUI build links against webkit2gtk at runtime, so it can't
+          # run on headless machines. Ship the dependency-free CLI-only static
+          # build on Linux instead (the archive still exposes a `suve` binary).
+          - goos: linux
+            asset: suve-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -65896,6 +65896,27 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 1.3.3")
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          # The Linux GUI build links against webkit2gtk at runtime, so it can't
+          # run on headless machines. Ship the dependency-free CLI-only static
+          # build on Linux instead (the archive still exposes a `suve` binary).
+          - goos: linux
+            asset: suve-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: mr-karan
     repo_name: doggo
     description: ":dog: Command-line DNS Client for Humans. Written in Golang"


### PR DESCRIPTION
## Package

[`mpyw/suve`](https://github.com/mpyw/suve) — **S**ecret **U**nified **V**ersioning **E**xplorer, a Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration.

## Notes

- **Per-OS asset selection:** macOS/Windows install the self-contained GUI build (`suve_*`), while Linux installs the **dependency-free CLI-only static build** (`suve-cli_*`). The Linux GUI build links against `webkit2gtk` at runtime and cannot run on headless machines, so the CLI-only static binary is used there; the archive still exposes a `suve` command.
- **Integrity:** verified via the release `checksums.txt` (SHA-256). The project does not publish SLSA/cosign/GitHub attestations, so only checksum verification is configured.
- **`version_constraint: >= 1.3.3`:** earlier releases shipped the binary without the executable bit inside the archive (a since-fixed release-pipeline bug), so they are intentionally unsupported.

Installed and ran (`suve --version`) locally via aqua on darwin/arm64 (GUI build) and linux/arm64 (CLI-only static, on a bare container with no webkit) — both resolve the correct asset and pass checksum verification.