### PR TITLE
feat: add mpyw/suve

### DIFF
--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,3 +1,5 @@
 packages:
   - name: mpyw/suve@v1.3.3
+  - name: mpyw/suve@v1.3.2
+  - name: mpyw/suve@v1.3.1
   - name: mpyw/suve@v1.3.0

--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,5 +1,8 @@
 packages:
   - name: mpyw/suve@v1.3.3
-  - name: mpyw/suve@v1.3.2
-  - name: mpyw/suve@v1.3.1
-  - name: mpyw/suve@v1.3.0
+  - name: mpyw/suve
+    version: v1.3.2
+  - name: mpyw/suve
+    version: v1.3.1
+  - name: mpyw/suve
+    version: v1.3.0

--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mpyw/suve@v1.3.3

--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,2 +1,3 @@
 packages:
   - name: mpyw/suve@v1.3.3
+  - name: mpyw/suve@v1.3.0

--- a/pkgs/mpyw/suve/registry.yaml
+++ b/pkgs/mpyw/suve/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/mpyw/suve/registry.yaml
+++ b/pkgs/mpyw/suve/registry.yaml
@@ -6,6 +6,10 @@ packages:
     description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 1.3.0")
+        error_message: |
+          suve versions before v1.3.0 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.3.0 or later.
       - version_constraint: "true"
         asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -14,5 +18,10 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          # The Linux GUI build links against webkit2gtk at runtime, so it can't
+          # run on headless machines. Install the dependency-free CLI-only static
+          # build on Linux instead (the archive still exposes a `suve` binary).
+          - goos: linux
+            asset: suve-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -65896,6 +65896,22 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: mr-karan
     repo_name: doggo
     description: ":dog: Command-line DNS Client for Humans. Written in Golang"

--- a/registry.yaml
+++ b/registry.yaml
@@ -65901,6 +65901,10 @@ packages:
     description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 1.3.0")
+        error_message: |
+          suve versions before v1.3.0 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.3.0 or later.
       - version_constraint: "true"
         asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -65909,6 +65913,11 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          # The Linux GUI build links against webkit2gtk at runtime, so it can't
+          # run on headless machines. Install the dependency-free CLI-only static
+          # build on Linux instead (the archive still exposes a `suve` binary).
+          - goos: linux
+            asset: suve-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
           - goos: windows
             format: zip
   - type: github_release


### PR DESCRIPTION
## Package

[`mpyw/suve`](https://github.com/mpyw/suve) — **S**ecret **U**nified **V**ersioning **E**xplorer, a Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration.

## How this was made

- Scaffolded with `argd s mpyw/suve` (scaffold commit kept separate from manual changes, per CONTRIBUTING).
- Verified with `argd t mpyw/suve` — installs cleanly on darwin/amd64, darwin/arm64, windows/amd64, windows/arm64, and linux containers (tested v1.3.3 and the lower bound v1.3.0).

## Manual customizations (2nd commit)

- **Per-OS asset:** macOS/Windows install the self-contained GUI build (`suve_*`). On Linux the GUI build links against `webkit2gtk` at runtime and can't run on headless machines, so the **dependency-free CLI-only static build** (`suve-cli_*`) is installed there; the archive still exposes a `suve` command.
- **`version_constraint`:** supported from **v1.3.0** onward; earlier releases predate significant design changes and are rejected with an `error_message`.
- **Integrity:** `checksums.txt` (SHA-256). The project publishes no SLSA/cosign/GitHub attestations, so only checksum verification is configured.

> Disclosure: prepared with the help of an AI agent (Claude), added as a commit co-author. I've reviewed the changes and take responsibility for them.