### PR TITLE
Add microsoft/winappCli

### DIFF
--- a/pkgs/microsoft/winappCli/pkg.yaml
+++ b/pkgs/microsoft/winappCli/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: microsoft/winappCli@v0.4.0
+  - name: microsoft/winappCli
+    version: v0.1.7
+  - name: microsoft/winappCli
+    version: v0.1.1
+  - name: microsoft/winappCli
+    version: v0.1.1-gui
+  - name: microsoft/winappCli
+    version: v0.1.0

--- a/pkgs/microsoft/winappCli/pkg.yaml
+++ b/pkgs/microsoft/winappCli/pkg.yaml
@@ -5,6 +5,4 @@ packages:
   - name: microsoft/winappCli
     version: v0.1.1
   - name: microsoft/winappCli
-    version: v0.1.1-gui
-  - name: microsoft/winappCli
     version: v0.1.0

--- a/pkgs/microsoft/winappCli/registry.yaml
+++ b/pkgs/microsoft/winappCli/registry.yaml
@@ -8,44 +8,24 @@ packages:
       - name: winapp
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.1.0"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+      - version_constraint: Version in ["v0.1.0", "v0.1.1"]
+        asset: winappcli-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
-        supported_envs:
-          - windows
-      - version_constraint: Version == "v0.1.1-gui"
-        asset: "{{.OS}}app-GUI_0.1.1.0_{{.Arch}}.msix"
-        format: raw
-        complete_windows_ext: false
-        replacements:
-          amd64: x64
-          windows: win
-        supported_envs:
-          - windows
-      - version_constraint: Version == "v0.1.1"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
-        format: zip
-        replacements:
-          amd64: x64
-          windows: win
         supported_envs:
           - windows
       - version_constraint: semver("<= 0.1.7")
-        asset: "{{.OS}}appcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}"
+        asset: winappcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
         supported_envs:
           - windows
       - version_constraint: "true"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        asset: winappcli-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
         supported_envs:
           - windows

--- a/pkgs/microsoft/winappCli/registry.yaml
+++ b/pkgs/microsoft/winappCli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: microsoft
     repo_name: winappCli
     description: winapp, the Windows App Development CLI, is a single command-line interface for managing Windows SDKs, packaging, generating app identity, manifests, certificates, and using build tools with any app framework
+    files:
+      - name: winapp
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"

--- a/pkgs/microsoft/winappCli/registry.yaml
+++ b/pkgs/microsoft/winappCli/registry.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: microsoft
+    repo_name: winappCli
+    description: winapp, the Windows App Development CLI, is a single command-line interface for managing Windows SDKs, packaging, generating app identity, manifests, certificates, and using build tools with any app framework
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: Version == "v0.1.1-gui"
+        asset: "{{.OS}}app-GUI_0.1.1.0_{{.Arch}}.msix"
+        format: raw
+        complete_windows_ext: false
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: Version == "v0.1.1"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: semver("<= 0.1.7")
+        asset: "{{.OS}}appcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: "true"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -63962,6 +63962,53 @@ packages:
           - goos: linux
             format: tar.gz
   - type: github_release
+    repo_owner: microsoft
+    repo_name: winappCli
+    description: winapp, the Windows App Development CLI, is a single command-line interface for managing Windows SDKs, packaging, generating app identity, manifests, certificates, and using build tools with any app framework
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: Version == "v0.1.1-gui"
+        asset: "{{.OS}}app-GUI_0.1.1.0_{{.Arch}}.msix"
+        format: raw
+        complete_windows_ext: false
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: Version == "v0.1.1"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: semver("<= 0.1.7")
+        asset: "{{.OS}}appcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+      - version_constraint: "true"
+        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        format: zip
+        replacements:
+          amd64: x64
+          windows: win
+        supported_envs:
+          - windows
+  - type: github_release
     repo_owner: mike-engel
     repo_name: jwt-cli
     description: A super fast CLI tool to decode and encode JWTs built in Rust

--- a/registry.yaml
+++ b/registry.yaml
@@ -63969,45 +63969,25 @@ packages:
       - name: winapp
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.1.0"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+      - version_constraint: Version in ["v0.1.0", "v0.1.1"]
+        asset: winappcli-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
-        supported_envs:
-          - windows
-      - version_constraint: Version == "v0.1.1-gui"
-        asset: "{{.OS}}app-GUI_0.1.1.0_{{.Arch}}.msix"
-        format: raw
-        complete_windows_ext: false
-        replacements:
-          amd64: x64
-          windows: win
-        supported_envs:
-          - windows
-      - version_constraint: Version == "v0.1.1"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
-        format: zip
-        replacements:
-          amd64: x64
-          windows: win
         supported_envs:
           - windows
       - version_constraint: semver("<= 0.1.7")
-        asset: "{{.OS}}appcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}"
+        asset: winappcli-{{trimV .Version}}-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
         supported_envs:
           - windows
       - version_constraint: "true"
-        asset: "{{.OS}}appcli-{{.Arch}}.{{.Format}}"
+        asset: winappcli-{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           amd64: x64
-          windows: win
         supported_envs:
           - windows
   - type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -63965,6 +63965,8 @@ packages:
     repo_owner: microsoft
     repo_name: winappCli
     description: winapp, the Windows App Development CLI, is a single command-line interface for managing Windows SDKs, packaging, generating app identity, manifests, certificates, and using build tools with any app framework
+    files:
+      - name: winapp
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"


### PR DESCRIPTION
[microsoft/winappCli](https://github.com/microsoft/winappCli) - winapp, the Windows App Development CLI, is a single command-line interface for managing Windows SDKs, packaging, generating app identity, manifests, certificates, and using build tools with any app framework

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
