### PR TITLE
feat: add sderosiaux/launchdeck

### DIFF
--- a/pkgs/sderosiaux/launchdeck/pkg.yaml
+++ b/pkgs/sderosiaux/launchdeck/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: sderosiaux/launchdeck@
+  - name: sderosiaux/launchdeck@v0.1.3

--- a/pkgs/sderosiaux/launchdeck/pkg.yaml
+++ b/pkgs/sderosiaux/launchdeck/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: sderosiaux/launchdeck@

--- a/pkgs/sderosiaux/launchdeck/registry.yaml
+++ b/pkgs/sderosiaux/launchdeck/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sderosiaux
+    repo_name: launchdeck
+    description: Unified macOS service console for launchd and Homebrew
+    asset: launchdeck-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+    supported_envs:
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256

--- a/pkgs/sderosiaux/launchdeck/registry.yaml
+++ b/pkgs/sderosiaux/launchdeck/registry.yaml
@@ -12,6 +12,9 @@ packages:
       darwin: apple-darwin
     supported_envs:
       - darwin
+    files:
+      - name: launchdeck
+        src: launchdeck-{{.Arch}}-{{.OS}}/launchdeck
     checksum:
       type: github_release
       asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -81105,6 +81105,22 @@ packages:
           - goos: windows
             asset: yj
   - type: github_release
+    repo_owner: sderosiaux
+    repo_name: launchdeck
+    description: Unified macOS service console for launchd and Homebrew
+    asset: launchdeck-{{.Arch}}-{{.OS}}.{{.Format}}
+    format: tar.gz
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: apple-darwin
+    supported_envs:
+      - darwin
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+  - type: github_release
     repo_owner: sdslabs
     repo_name: gasper
     asset: gasper_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -81116,6 +81116,9 @@ packages:
       darwin: apple-darwin
     supported_envs:
       - darwin
+    files:
+      - name: launchdeck
+        src: launchdeck-{{.Arch}}-{{.OS}}/launchdeck
     checksum:
       type: github_release
       asset: checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Adds `sderosiaux/launchdeck`, a Darwin-only GitHub release package for the `launchdeck` binary.

Validation:

```console
$ aqua exec -- conftest test --combine pkgs/sderosiaux/launchdeck/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

macOS install and execute testing was completed for this package.

`argd t` was intentionally not run for the final verification because this registry entry is Darwin-only (`supported_envs: [darwin]`) and upstream publishes only Darwin release archives. The registry uses the nested archive path `launchdeck-{{.Arch}}-{{.OS}}/launchdeck` and the upstream `checksums.txt` sha256 file.

This PR was prepared with assistance from Codex.
