### PR TITLE
Add syntax-sh/lexicon-releases

### DIFF
--- a/pkgs/syntax-sh/lexicon-releases/pkg.yaml
+++ b/pkgs/syntax-sh/lexicon-releases/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: syntax-sh/lexicon-releases@v0.4.0
+  - name: syntax-sh/lexicon-releases
+    version: v0.1.2

--- a/pkgs/syntax-sh/lexicon-releases/registry.yaml
+++ b/pkgs/syntax-sh/lexicon-releases/registry.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: syntax-sh
+    repo_name: lexicon-releases
+    description: CLI that builds a shared, indexed cache of vendor library/API documentation for coding agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.2")
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: lexicon
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.0")
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: syntax-sh/lexicon-releases/.github/workflows/attest.yml
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64

--- a/pkgs/syntax-sh/lexicon-releases/registry.yaml
+++ b/pkgs/syntax-sh/lexicon-releases/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: syntax-sh
     repo_name: lexicon-releases
     description: CLI that builds a shared, indexed cache of vendor library/API documentation for coding agents
+    files:
+      - name: lexicon
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.2")

--- a/registry.yaml
+++ b/registry.yaml
@@ -89587,6 +89587,8 @@ packages:
     repo_owner: syntax-sh
     repo_name: lexicon-releases
     description: CLI that builds a shared, indexed cache of vendor library/API documentation for coding agents
+    files:
+      - name: lexicon
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.1.2")

--- a/registry.yaml
+++ b/registry.yaml
@@ -89584,6 +89584,90 @@ packages:
         format: raw
         windows_arm_emulation: true
   - type: github_release
+    repo_owner: syntax-sh
+    repo_name: lexicon-releases
+    description: CLI that builds a shared, indexed cache of vendor library/API documentation for coding agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.1.2")
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: lexicon
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.3.0")
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: lexicon-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: lexicon
+            src: "{{.AssetWithoutExt}}/lexicon"
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: syntax-sh/lexicon-releases/.github/workflows/attest.yml
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+  - type: github_release
     repo_owner: sysdiglabs
     repo_name: kube-psp-advisor
     description: Help building an adaptive and fine-grained pod security policy


### PR DESCRIPTION
## Overview

Adds [syntax-sh/lexicon-releases](https://github.com/syntax-sh/lexicon-releases) — prebuilt binary releases of **lexicon**, a CLI that builds a shared, indexed cache of vendor library/API documentation for coding agents (https://syntax.sh/lexicon). The source repo is private; releases (built by cargo-dist) are published to this public repo.

- Asset pattern: `lexicon-{{.Arch}}-{{.OS}}.tar.gz` (tar.xz + windows zip for <= 0.1.2), binary `lexicon` inside a `lexicon-<triple>/` top-level dir
- Per-asset `.sha256` checksums on every release
- `github_artifact_attestations` for v0.4.0+ (signer workflow: `syntax-sh/lexicon-releases/.github/workflows/attest.yml`)
- Supported: darwin (arm64/amd64), linux amd64, windows amd64 (arm emulation)

Scaffolded with `argd s`, tested with `argd t` (all container envs pass, including attestation verification), `conftest` 28/28, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)