### PR TITLE
feat(charmbracelet/glow): cosign config

### DIFF
--- a/pkgs/charmbracelet/glow/pkg.yaml
+++ b/pkgs/charmbracelet/glow/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: charmbracelet/glow@v2.1.2
   - name: charmbracelet/glow
+    version: v2.1.1
+  - name: charmbracelet/glow
     version: v1.5.1
   - name: charmbracelet/glow
     version: v1.5.0

--- a/pkgs/charmbracelet/glow/registry.yaml
+++ b/pkgs/charmbracelet/glow/registry.yaml
@@ -99,6 +99,25 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 2.1.1")
+        asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: glow
+            src: "{{.AssetWithoutExt}}/glow"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -115,6 +134,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -24430,6 +24430,25 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 2.1.1")
+        asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: glow
+            src: "{{.AssetWithoutExt}}/glow"
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: glow_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -24446,6 +24465,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/charmbracelet/meta/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
https://github.com/charmbracelet/glow/releases

Same note as for vhs in https://github.com/aquaproj/aqua-registry/pull/56788#issue-4858676404, old style .sig and .pem in < 2.1.2 verify would fail with

 ```
Flag --certificate has been deprecated, please use --bundle with --trusted-root to provide the public certificate
Flag --signature has been deprecated, please use --bundle to provide a signature
Error: searching log query: Post "https://rekor.sigstore.dev/api/v1/log/entries/retrieve": giving up after 4 attempt(s): Post "https://rekor.sigstore.dev/api/v1/log/entries/retrieve": remote error: tls: handshake failure
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
