### PR TITLE
chore: drop support for mpyw/suve versions before v1.6.1

### DIFF
--- a/pkgs/mpyw/suve/pkg.yaml
+++ b/pkgs/mpyw/suve/pkg.yaml
@@ -1,8 +1,2 @@
 packages:
   - name: mpyw/suve@v1.6.1
-  - name: mpyw/suve
-    version: v1.3.2
-  - name: mpyw/suve
-    version: v1.3.1
-  - name: mpyw/suve
-    version: v1.3.0

--- a/pkgs/mpyw/suve/registry.yaml
+++ b/pkgs/mpyw/suve/registry.yaml
@@ -6,10 +6,10 @@ packages:
     description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 1.3.0")
+      - version_constraint: semver("< 1.6.1")
         error_message: |
-          suve versions before v1.3.0 are not supported by the aqua registry.
-          The project changed significantly in earlier releases; please use v1.3.0 or later.
+          suve versions before v1.6.1 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.6.1 or later.
       - version_constraint: "true"
         asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -66175,10 +66175,10 @@ packages:
     description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 1.3.0")
+      - version_constraint: semver("< 1.6.1")
         error_message: |
-          suve versions before v1.3.0 are not supported by the aqua registry.
-          The project changed significantly in earlier releases; please use v1.3.0 or later.
+          suve versions before v1.6.1 are not supported by the aqua registry.
+          The project changed significantly in earlier releases; please use v1.6.1 or later.
       - version_constraint: "true"
         asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## What

Raise the minimum supported version of `mpyw/suve` from v1.3.0 to **v1.6.1**, and drop
the now-unsupported v1.3.x test pins from `pkg.yaml`.

## Why

I'm the author of suve.

- **Pre-1.6.1 releases have serious Azure bugs.** Versions before v1.6.1 work fine on AWS
  (Parameter Store / Secrets Manager) and Google Cloud (Secret Manager), but contain a
  number of serious bugs on Azure (Key Vault / App Configuration). I don't want people
  installing those releases through aqua, so I'd like to drop support for anything below v1.6.1.
- **I misunderstood version pinning here.** When I first added the package I pinned several
  minor versions (v1.3.0–v1.3.2) in `pkg.yaml`, assuming the multi-version list was meant to
  enumerate major lines (1.x, 2.x, ...). I didn't realize minor/patch versions are bumped in
  place automatically by aqua-registry-updater, so those pins were unnecessary — and with
  support dropped they can no longer be installed anyway.

## Changes

- `pkgs/mpyw/suve/registry.yaml`: `version_constraint: semver("< 1.3.0")` → `semver("< 1.6.1")`; error_message versions bumped.
- `pkgs/mpyw/suve/pkg.yaml`: removed v1.3.0 / v1.3.1 / v1.3.2 pins; only the updater-tracked v1.6.1 remains.
- `registry.yaml`: regenerated via `argd gr`.

## Verification

- `conftest test pkgs/mpyw/suve/*.yaml` → 28 tests passed
- `prettier -c` → clean
- Installed against the modified local registry on darwin/arm64:
  - `mpyw/suve@v1.6.1` → installs successfully
  - `mpyw/suve@v1.3.0` → correctly rejected:
    ```
    suve versions before v1.6.1 are not supported by the aqua registry.
    The project changed significantly in earlier releases; please use v1.6.1 or later.
    ```

(The full-matrix container `argd t` isn't run here; CI covers it.)

## AI disclosure

Prepared with Claude Code (per docs/ai.md); reviewed and owned by me.
