### PR TITLE
feat: add supernovae-st/nika

### DIFF
--- a/pkgs/supernovae-st/nika/pkg.yaml
+++ b/pkgs/supernovae-st/nika/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: supernovae-st/nika@v0.99.0

--- a/pkgs/supernovae-st/nika/registry.yaml
+++ b/pkgs/supernovae-st/nika/registry.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: supernovae-st
+    repo_name: nika
+    description: Workflow language and runner for AI jobs - one .nika.yaml file, statically checked before any token is spent, hash-chained run traces
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.80.0-alpha.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -87600,6 +87600,27 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: supernovae-st
+    repo_name: nika
+    description: Workflow language and runner for AI jobs - one .nika.yaml file, statically checked before any token is spent, hash-chained run traces
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.80.0-alpha.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: superfly
     repo_name: flyctl
     description: Command line tools for fly.io services

--- a/registry.yaml
+++ b/registry.yaml
@@ -87600,27 +87600,6 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
-    repo_owner: supernovae-st
-    repo_name: nika
-    description: Workflow language and runner for AI jobs - one .nika.yaml file, statically checked before any token is spent, hash-chained run traces
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.80.0-alpha.4")
-        no_asset: true
-      - version_constraint: "true"
-        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x64
-          darwin: macos
-        checksum:
-          type: github_release
-          asset: SHA256SUMS
-          algorithm: sha256
-        supported_envs:
-          - linux
-          - darwin
-  - type: github_release
     repo_owner: superfly
     repo_name: flyctl
     description: Command line tools for fly.io services
@@ -87774,6 +87753,27 @@ packages:
         overrides:
           - goos: windows
             format: zip
+  - type: github_release
+    repo_owner: supernovae-st
+    repo_name: nika
+    description: Workflow language and runner for AI jobs - one .nika.yaml file, statically checked before any token is spent, hash-chained run traces
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.80.0-alpha.4")
+        no_asset: true
+      - version_constraint: "true"
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - type: github_release
     repo_owner: superradcompany
     repo_name: microsandbox


### PR DESCRIPTION
Adds [nika](https://github.com/supernovae-st/nika) — a workflow language and runner for AI jobs (one `.nika.yaml` file per job, statically checked before any token is spent, hash-chained run traces). Single static Rust binary released as GitHub tarballs with a `SHA256SUMS` asset (macos/linux × arm64/x64).

Install proven locally against this exact registry entry before opening the PR: `aqua i` downloads v0.99.0, verifies the SHA256SUMS checksum, and `nika --version` runs green (darwin/arm64). Early releases (≤ 0.80.0-alpha.4) carry no assets, hence the `no_asset` override; the generated scaffold's checksum pick was corrected from `MCPB.sha256` (the MCP-bundle sums) to `SHA256SUMS` (the tarball sums).

Full disclosure: I'm the author. Weekly release cadence, latest v0.99.0 (2026-07-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)