### PR TITLE
refactor(watchexec/watchexec): use sha512 checksums

### DIFF
--- a/pkgs/watchexec/watchexec/registry.yaml
+++ b/pkgs/watchexec/watchexec/registry.yaml
@@ -177,8 +177,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
@@ -196,8 +196,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -98690,8 +98690,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip
@@ -98709,8 +98709,8 @@ packages:
           windows: pc-windows-msvc
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
+          asset: "{{.Asset}}.sha512"
+          algorithm: sha512
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
Refs https://github.com/aquaproj/aqua/pull/4971

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
