### PR TITLE
feat: add suzuki-shunsuke/langcheck

### DIFF
--- a/pkgs/suzuki-shunsuke/langcheck/pkg.yaml
+++ b/pkgs/suzuki-shunsuke/langcheck/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: suzuki-shunsuke/langcheck@v0.0.1

--- a/pkgs/suzuki-shunsuke/langcheck/registry.yaml
+++ b/pkgs/suzuki-shunsuke/langcheck/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: suzuki-shunsuke
+    repo_name: langcheck
+    description: langcheck is a CLI for checking if disallowed characters are included in files and texts. This is useful to prevent coding agents from using disallowed characters in code, commit messages, issues, pull requests, and so on
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: langcheck_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: langcheck_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/langcheck/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: langcheck_checksums.txt.sigstore.json
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/suzuki-shunsuke/langcheck/registry.yaml
+++ b/pkgs/suzuki-shunsuke/langcheck/registry.yaml
@@ -15,16 +15,18 @@ packages:
           algorithm: sha256
           cosign:
             opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/langcheck/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
             bundle:
               type: github_release
               asset: langcheck_checksums.txt.sigstore.json
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -88927,6 +88927,34 @@ packages:
               - https://github.com/suzuki-shunsuke/github-comment/releases/download/{{.Version}}/github-comment_{{trimV .Version}}_checksums.txt.pem
   - type: github_release
     repo_owner: suzuki-shunsuke
+    repo_name: langcheck
+    description: langcheck is a CLI for checking if disallowed characters are included in files and texts. This is useful to prevent coding agents from using disallowed characters in code, commit messages, issues, pull requests, and so on
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: langcheck_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: langcheck_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/langcheck/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: langcheck_checksums.txt.sigstore.json
+        slsa_provenance:
+          type: github_release
+          asset: multiple.intoto.jsonl
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: suzuki-shunsuke
     repo_name: matchfile
     description: CLI tool to check file paths are matched to the condition
     version_constraint: "false"

--- a/registry.yaml
+++ b/registry.yaml
@@ -88940,16 +88940,18 @@ packages:
           algorithm: sha256
           cosign:
             opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/suzuki-shunsuke/langcheck/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+              - --certificate-identity-regexp
+              - "^https://github\\.com/suzuki-shunsuke/go-release-workflow/\\.github/workflows/release\\.yaml@.+$"
             bundle:
               type: github_release
               asset: langcheck_checksums.txt.sigstore.json
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
+        github_artifact_attestations:
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
[suzuki-shunsuke/langcheck](https://github.com/suzuki-shunsuke/langcheck): langcheck is a CLI for checking if disallowed characters are included in files and texts. This is useful to prevent coding agents from using disallowed characters in code, commit messages, issues, pull requests, and so on

```sh
aqua g -i suzuki-shunsuke/langcheck
```