### PR TITLE
Add sters/diffnest

### DIFF
--- a/pkgs/sters/diffnest/pkg.yaml
+++ b/pkgs/sters/diffnest/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: sters/diffnest@v1.7.0
+  - name: sters/diffnest
+    version: v1.4.0

--- a/pkgs/sters/diffnest/registry.yaml
+++ b/pkgs/sters/diffnest/registry.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: sters
+    repo_name: diffnest
+    description: A diff tool for structured data files like YAML, JSON
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.4.0")
+        asset: diffnest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: diffnest_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -86713,6 +86713,30 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: sters
+    repo_name: diffnest
+    description: A diff tool for structured data files like YAML, JSON
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.2.0"
+        no_asset: true
+      - version_constraint: semver("<= 1.4.0")
+        asset: diffnest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: diffnest_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        checksum:
+          type: github_release
+          asset: diffnest_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: stoplightio
     repo_name: spectral
     description: A flexible JSON/YAML linter for creating automated style guides, with baked in support for OpenAPI (v3.1, v3.0, and v2.0), Arazzo v1.0, as well as AsyncAPI v2.x


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [X] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add [sters/diffnest](https://github.com/sters/diffnest) — a diff tool for structured data files like YAML, JSON.

Scaffolded with `argd s "sters/diffnest"`; no manual edits.

### Verification

Tested with `argd s` (which runs the full container test matrix). All platforms
installed successfully:

- linux/amd64 ✅
- linux/arm64 ✅
- darwin/amd64 ✅
- darwin/arm64 ✅
- windows/amd64 ✅
- windows/arm64 ✅

Lint:

- `conftest test pkgs/sters/diffnest/*.yaml` → 28 tests, 28 passed, 0 failures
- `prettier -c pkgs/sters/diffnest/*.yaml` → all files use Prettier code style

### Notes on the config

The asset naming changed across releases, so `argd s` produced three
`version_overrides` branches:

- `v1.2.0` → `no_asset: true` (no release assets)
- `<= 1.4.0` → `diffnest_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz`
  (underscore separator, `amd64`/`arm64`)
- latest → `diffnest_{{trimV .Version}}_{{.OS}}-{{.Arch}}.tar.gz`
  (hyphen separator, `arm64` → `aarch64`)

### AI disclosure

This change was prepared with the assistance of Claude Code (per `docs/ai.md`).