### PR TITLE
Add StanMarek/ghost-complete

### DIFF
--- a/pkgs/StanMarek/ghost-complete/pkg.yaml
+++ b/pkgs/StanMarek/ghost-complete/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: StanMarek/ghost-complete@v0.19.0

--- a/pkgs/StanMarek/ghost-complete/registry.yaml
+++ b/pkgs/StanMarek/ghost-complete/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: StanMarek
+    repo_name: ghost-complete
+    description: Terminal autocomplete engine inspired by Fig. PTY proxy, 709 specs, Rust. Built for Ghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghost-complete-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin

--- a/pkgs/StanMarek/ghost-complete/registry.yaml
+++ b/pkgs/StanMarek/ghost-complete/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: StanMarek
     repo_name: ghost-complete
-    description: Terminal autocomplete engine inspired by Fig. PTY proxy, 709 specs, Rust. Built for Ghostty
+    description: Terminal autocomplete engine with a PTY proxy and shell specifications for Ghostty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -17,5 +17,8 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        files:
+          - name: ghost-complete
+            src: ghost-complete-{{.Arch}}-{{.OS}}/ghost-complete
         supported_envs:
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -7964,6 +7964,25 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: StanMarek
+    repo_name: ghost-complete
+    description: Terminal autocomplete engine inspired by Fig. PTY proxy, 709 specs, Rust. Built for Ghostty
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghost-complete-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - darwin
+  - type: github_release
     repo_owner: Stranger6667
     repo_name: jsonschema
     description: A high-performance JSON Schema validator for Rust

--- a/registry.yaml
+++ b/registry.yaml
@@ -7966,7 +7966,7 @@ packages:
   - type: github_release
     repo_owner: StanMarek
     repo_name: ghost-complete
-    description: Terminal autocomplete engine inspired by Fig. PTY proxy, 709 specs, Rust. Built for Ghostty
+    description: Terminal autocomplete engine with a PTY proxy and shell specifications for Ghostty
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
@@ -7980,6 +7980,9 @@ packages:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
+        files:
+          - name: ghost-complete
+            src: ghost-complete-{{.Arch}}-{{.OS}}/ghost-complete
         supported_envs:
           - darwin
   - type: github_release


### PR DESCRIPTION
<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

Add `StanMarek/ghost-complete`, a terminal autocomplete engine for Ghostty.

The package is limited to Darwin because upstream currently publishes macOS release assets. Release archives contain the executable in a platform-named subdirectory, so `files.src` selects the nested binary.

## Verification

- `mise run argd-t`
  - Completed successfully with `argd` 0.5.5 across the installation matrix.
- `mise run argd-t-darwin`
  - Installed `StanMarek/ghost-complete@v0.19.0` from the local registry on `darwin/arm64`.
  - Resolved `/Users/admin/.local/share/aquaproj-aqua/bin/ghost-complete` and executed `ghost-complete --help` successfully.
- `aqua exec -- conftest test --combine pkgs/StanMarek/ghost-complete/pkg.yaml pkgs/StanMarek/ghost-complete/registry.yaml`
  - 14 tests passed, with 0 warnings, failures, or exceptions.

Implemented and reviewed with assistance from OpenAI Codex. I reviewed the generated configuration and take responsibility for the submitted changes.
