### PR TITLE
fix(sharkdp/vivid): use native Apple Silicon assets

### DIFF
--- a/pkgs/sharkdp/vivid/registry.yaml
+++ b/pkgs/sharkdp/vivid/registry.yaml
@@ -23,7 +23,6 @@ packages:
       - darwin
       - linux
       - amd64
-    rosetta2: true
     files:
       - name: vivid
         src: vivid-{{.Version}}-{{.Arch}}-{{.OS}}/vivid
@@ -39,4 +38,11 @@ packages:
           - linux/amd64
           - darwin
         rosetta2: true
+      - version_constraint: semver(">= 0.8.0, < 0.11.0")
+        rosetta2: true
+      - version_constraint: semver("= 0.11.0")
+        asset: vivid-v0.10.1-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: vivid
+            src: vivid-v0.10.1-{{.Arch}}-{{.OS}}/vivid
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -82327,7 +82327,6 @@ packages:
       - darwin
       - linux
       - amd64
-    rosetta2: true
     files:
       - name: vivid
         src: vivid-{{.Version}}-{{.Arch}}-{{.OS}}/vivid
@@ -82343,6 +82342,13 @@ packages:
           - linux/amd64
           - darwin
         rosetta2: true
+      - version_constraint: semver(">= 0.8.0, < 0.11.0")
+        rosetta2: true
+      - version_constraint: semver("= 0.11.0")
+        asset: vivid-v0.10.1-{{.Arch}}-{{.OS}}.{{.Format}}
+        files:
+          - name: vivid
+            src: vivid-v0.10.1-{{.Arch}}-{{.OS}}/vivid
       - version_constraint: "true"
   - type: github_release
     repo_owner: sheepla


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Fix `sharkdp/vivid` asset selection on Apple Silicon systems without Rosetta 2.

[`v0.10.1`](https://github.com/sharkdp/vivid/releases/tag/v0.10.1) and earlier do not provide an aarch64 macOS asset, so these versions continue to select the x86_64 asset through Rosetta. [`v0.11.0`](https://github.com/sharkdp/vivid/releases/tag/v0.11.0) is the first release with an aarch64 macOS asset, so it and later versions select the native binary.

The v0.11.0 release assets and extracted directories are incorrectly named with `v0.10.1`. This change handles that release explicitly while retaining the normal asset template for [`v0.11.1`](https://github.com/sharkdp/vivid/releases/tag/v0.11.1) and later.

Linux and Windows mappings remain unchanged.

### Verification

- `aqua exec -- conftest test --combine pkgs/sharkdp/vivid/*`
  - 14 passed, 0 warnings, 0 failures
- `AQUA_GHTKN_ENABLED=true aqua exec -- argd t sharkdp/vivid`
  - exited successfully
- `darwin/arm64` resolution:
  - v0.10.1 -> `vivid-v0.10.1-x86_64-apple-darwin.tar.gz`
  - v0.11.0 -> `vivid-v0.10.1-aarch64-apple-darwin.tar.gz`
  - v0.11.1 -> `vivid-v0.11.1-aarch64-apple-darwin.tar.gz`
- Linux resolution:
  - amd64 -> `x86_64-unknown-linux-musl`
  - arm64 -> `aarch64-unknown-linux-gnu`
- Native Darwin smoke test in Tart:
  - installed `vivid` on `darwin/arm64`
  - `vivid --version` returned `vivid 0.11.1`
- Native host binary inspection:
  - `Mach-O 64-bit executable arm64`

Implemented with assistance from Codex. I reviewed and validated the change.
