### PR TITLE
chore: update mpyw/suve description to CLI/TUI/GUI

### DIFF
--- a/pkgs/mpyw/suve/registry.yaml
+++ b/pkgs/mpyw/suve/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: mpyw
     repo_name: suve
-    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    description: Git-like CLI/TUI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("< 1.6.1")

--- a/registry.yaml
+++ b/registry.yaml
@@ -66418,7 +66418,7 @@ packages:
   - type: github_release
     repo_owner: mpyw
     repo_name: suve
-    description: Git-like CLI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
+    description: Git-like CLI/TUI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("< 1.6.1")


### PR DESCRIPTION
## Summary

suve v1.9.0 added a keyboard-driven **TUI mode** (`--tui`, built on Bubble Tea), which ships in every build variant. The upstream repository description was updated accordingly and now reads:

> Git-like CLI/TUI/GUI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration

This PR syncs the registry `description` to match (`CLI/GUI` → `CLI/TUI/GUI`). It is a one-line, description-only change; asset/version resolution is untouched.

## Verification

This change only edits the `description` string, so it has no effect on package resolution or installation. I did not run `argd t` because the change cannot alter install behavior — the asset templates, `version_overrides`, and platform overrides are all unchanged (diff is a single line).

I intentionally did **not** bump the version in `pkg.yaml` (`mpyw/suve@v1.8.5`), per the contributor guide: `pkg.yaml` is test data and the version there is owned by the aqua-registry-updater bot. Manual version bumps are out of scope for this PR.

## AI disclosure

Prepared with the help of an AI coding agent (Claude Code); reviewed and owned by me.