### PR TITLE
feat(tedilabs/tfvault): scaffold tedilabs/tfvault

### DIFF
--- a/pkgs/tedilabs/tfvault/pkg.yaml
+++ b/pkgs/tedilabs/tfvault/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tedilabs/tfvault@v0.2.0

--- a/pkgs/tedilabs/tfvault/registry.yaml
+++ b/pkgs/tedilabs/tfvault/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tedilabs
+    repo_name: tfvault
+    description: A Terraform credentials helper to fetch secrets from several secret backends (OS keyring, environment variables, pass)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tfvault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -91236,6 +91236,22 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: tedilabs
+    repo_name: tfvault
+    description: A Terraform credentials helper to fetch secrets from several secret backends (OS keyring, environment variables, pass)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tfvault_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: tektoncd
     repo_name: cli
     description: A CLI for interacting with Tekton


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

[tfvault](https://github.com/tedilabs/tfvault) is a universal Terraform credentials helper with pluggable secret backends (OS keyring, pass/gopass, environment variables).

Scaffolded with `argd s tedilabs/tfvault` (container tests passed for linux/darwin, amd64/arm64; no windows assets, so `supported_envs` excludes it). Verified locally with a `type: local` registry:

```console
$ aqua exec -- tfvault version
tfvault 0.2.0 (commit 4ec178b, built 2026-07-14T02:19:34Z)
```