### PR TITLE
fix(mikefarah/yq): use native Darwin arm64 assets

### DIFF
--- a/pkgs/mikefarah/yq/pkg.yaml
+++ b/pkgs/mikefarah/yq/pkg.yaml
@@ -3,24 +3,8 @@ packages:
   - name: mikefarah/yq
     version: v4.52.5
   - name: mikefarah/yq
-    version: v4.52.2
+    version: v4.35.1
   - name: mikefarah/yq
-    version: v4.48.1
-  - name: mikefarah/yq
-    version: v4.45.1
-  - name: mikefarah/yq
-    version: v4.34.2
-  - name: mikefarah/yq
-    version: v4.16.1
+    version: v4.9.6
   - name: mikefarah/yq
     version: v4.9.5
-  - name: mikefarah/yq
-    version: 4.0.0
-  - name: mikefarah/yq
-    version: 3.2.0
-  - name: mikefarah/yq
-    version: 2.1.0
-  - name: mikefarah/yq
-    version: 1.13.1
-  - name: mikefarah/yq
-    version: "1.3"

--- a/pkgs/mikefarah/yq/pkg.yaml
+++ b/pkgs/mikefarah/yq/pkg.yaml
@@ -3,6 +3,24 @@ packages:
   - name: mikefarah/yq
     version: v4.52.5
   - name: mikefarah/yq
-    version: v4.35.1
+    version: v4.52.2
+  - name: mikefarah/yq
+    version: v4.48.1
+  - name: mikefarah/yq
+    version: v4.45.1
+  - name: mikefarah/yq
+    version: v4.34.2
+  - name: mikefarah/yq
+    version: v4.16.1
   - name: mikefarah/yq
     version: v4.9.5
+  - name: mikefarah/yq
+    version: 4.0.0
+  - name: mikefarah/yq
+    version: 3.2.0
+  - name: mikefarah/yq
+    version: 2.1.0
+  - name: mikefarah/yq
+    version: 1.13.1
+  - name: mikefarah/yq
+    version: "1.3"

--- a/pkgs/mikefarah/yq/registry.yaml
+++ b/pkgs/mikefarah/yq/registry.yaml
@@ -3,137 +3,43 @@ packages:
   - type: github_release
     repo_owner: mikefarah
     repo_name: yq
-    description: yq is a portable command-line YAML, JSON, XML, CSV, TOML, HCL  and properties processor
+    description: yq is a portable command-line YAML processor
+    asset: yq_{{.OS}}_{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.3.0")
-        asset: yaml_{{.OS}}_{{.Arch}}
-        format: raw
+      - version_constraint: semver("< 4.9.6")
         rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.13.1")
-        asset: yaml_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
-      - version_constraint: semver("<= 2.1.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
-      - version_constraint: semver("<= 3.2.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-      - version_constraint: semver("<= 4.0.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-      - version_constraint: semver("<= 4.9.5")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.16.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.34.2")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums_hashes_order
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.45.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.48.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.52.2")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+      - version_constraint: semver("< 4.35.1")
+      - version_constraint: semver("< 4.53.0")
         checksum:
           type: github_release
           asset: checksums-bsd
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.52.5")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
+            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
+            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
       - version_constraint: "true"
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
         checksum:
           type: github_release
-          asset: checksums
-          algorithm: sha256
+          asset: checksums-bsd
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
+            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
+            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
           cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/mikefarah/yq/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
-              asset: checksums.bundle
-        overrides:
-          - goos: windows
-            format: zip
+              asset: checksums-bsd.bundle
+            opts:
+              - --certificate-identity
+              - https://github.com/mikefarah/yq/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com

--- a/pkgs/mikefarah/yq/registry.yaml
+++ b/pkgs/mikefarah/yq/registry.yaml
@@ -3,44 +3,137 @@ packages:
   - type: github_release
     repo_owner: mikefarah
     repo_name: yq
-    description: yq is a portable command-line YAML processor
-    asset: yq_{{.OS}}_{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    description: yq is a portable command-line YAML, JSON, XML, CSV, TOML, HCL  and properties processor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 4.35.1")
+      - version_constraint: semver("<= 1.3.0")
+        asset: yaml_{{.OS}}_{{.Arch}}
+        format: raw
         rosetta2: true
-      - version_constraint: semver("< 4.53.0")
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.1")
+        asset: yaml_{{.OS}}_{{.Arch}}
+        format: raw
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 2.1.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 3.2.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 4.0.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+      - version_constraint: semver("<= 4.9.5")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.16.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.34.2")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums_hashes_order
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.45.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.48.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.52.2")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums-bsd
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
-            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
-            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.52.5")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
-        rosetta2: true
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
-          asset: checksums-bsd
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
-            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
-            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
+          asset: checksums
+          algorithm: sha256
           cosign:
-            bundle:
-              type: github_release
-              asset: checksums-bsd.bundle
             opts:
-              - --certificate-identity
-              - https://github.com/mikefarah/yq/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-identity-regexp
+              - "^https://github\\.com/mikefarah/yq/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.bundle
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -64591,47 +64591,140 @@ packages:
   - type: github_release
     repo_owner: mikefarah
     repo_name: yq
-    description: yq is a portable command-line YAML processor
-    asset: yq_{{.OS}}_{{.Arch}}
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
+    description: yq is a portable command-line YAML, JSON, XML, CSV, TOML, HCL  and properties processor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 4.35.1")
+      - version_constraint: semver("<= 1.3.0")
+        asset: yaml_{{.OS}}_{{.Arch}}
+        format: raw
         rosetta2: true
-      - version_constraint: semver("< 4.53.0")
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.13.1")
+        asset: yaml_{{.OS}}_{{.Arch}}
+        format: raw
         rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 2.1.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          arm64: arm
+      - version_constraint: semver("<= 3.2.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 4.0.0")
+        asset: yq_{{.OS}}_{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+      - version_constraint: semver("<= 4.9.5")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.16.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.34.2")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums_hashes_order
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.45.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.48.1")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.52.2")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums-bsd
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
-            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
-            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 4.52.5")
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
-        rosetta2: true
+        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
-          asset: checksums-bsd
-          file_format: regexp
-          algorithm: sha512
-          pattern:
-            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
-            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
-            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
+          asset: checksums
+          algorithm: sha256
           cosign:
-            bundle:
-              type: github_release
-              asset: checksums-bsd.bundle
             opts:
-              - --certificate-identity
-              - https://github.com/mikefarah/yq/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-identity-regexp
+              - "^https://github\\.com/mikefarah/yq/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.bundle
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: miku
     repo_name: zek

--- a/registry.yaml
+++ b/registry.yaml
@@ -64591,140 +64591,46 @@ packages:
   - type: github_release
     repo_owner: mikefarah
     repo_name: yq
-    description: yq is a portable command-line YAML, JSON, XML, CSV, TOML, HCL  and properties processor
+    description: yq is a portable command-line YAML processor
+    asset: yq_{{.OS}}_{{.Arch}}
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.3.0")
-        asset: yaml_{{.OS}}_{{.Arch}}
-        format: raw
+      - version_constraint: semver("< 4.9.6")
         rosetta2: true
-        windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.13.1")
-        asset: yaml_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
-      - version_constraint: semver("<= 2.1.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        replacements:
-          arm64: arm
-      - version_constraint: semver("<= 3.2.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-      - version_constraint: semver("<= 4.0.0")
-        asset: yq_{{.OS}}_{{.Arch}}
-        format: raw
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-      - version_constraint: semver("<= 4.9.5")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.16.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.34.2")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums_hashes_order
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.45.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.48.1")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.52.2")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+      - version_constraint: semver("< 4.35.1")
+      - version_constraint: semver("< 4.53.0")
         checksum:
           type: github_release
           asset: checksums-bsd
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 4.52.5")
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: checksums
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
+            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
+            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
       - version_constraint: "true"
-        asset: yq_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
         checksum:
           type: github_release
-          asset: checksums
-          algorithm: sha256
+          asset: checksums-bsd
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            # rhash bsd format, https://rhash.sourceforge.io/manpage.php#sect6
+            checksum: ^SHA512\s+\([^)]+\)\s+=\s+([A-Fa-f0-9]{128})$
+            file: ^SHA512\s+\(([^)]+)\)\s+=\s+[A-Fa-f0-9]{128}$
           cosign:
-            opts:
-              - --certificate-identity-regexp
-              - "^https://github\\.com/mikefarah/yq/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
             bundle:
               type: github_release
-              asset: checksums.bundle
-        overrides:
-          - goos: windows
-            format: zip
+              asset: checksums-bsd.bundle
+            opts:
+              - --certificate-identity
+              - https://github.com/mikefarah/yq/.github/workflows/release.yml@refs/tags/{{.Version}}
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: miku
     repo_name: zek


### PR DESCRIPTION
## Summary

Use yq's native Darwin ARM64 assets starting with v4.9.6 while retaining the Rosetta 2 fallback for older releases.

This fixes the architecture selected by both aqua and consumers of aqua-registry such as mise. Reported in [jdx/mise discussion #10994](https://github.com/jdx/mise/discussions/10994).

## Root cause

[mikefarah/yq#859](https://github.com/mikefarah/yq/pull/859) added Darwin ARM64 builds, first released in [v4.9.6](https://github.com/mikefarah/yq/releases/tag/v4.9.6). The registry originally kept `rosetta2: true` in the fallback override for versions below the base `>= 4.9.6` constraint, so native ARM64 assets were selected for supported versions.

[aqua-registry#56126](https://github.com/aquaproj/aqua-registry/pull/56126) changed the package to `version_constraint: "false"` with checksum-specific overrides. Each override retained `rosetta2: true`, which made Darwin ARM64 resolve to `yq_darwin_amd64` for every version.

## Reproduction

Environment:

- Host: Linux/amd64
- aqua: v2.60.2
- Target: Darwin/arm64 via `AQUA_GOOS` and `AQUA_GOARCH`
- aqua-registry: v4.537.0

```yaml
registries:
  - type: standard
    ref: v4.537.0
packages:
  - name: mikefarah/yq@v4.53.3
```

```console
$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua i
INF download and unarchive the package env=darwin/arm64 package_name=mikefarah/yq package_version=v4.53.3

$ file "$AQUA_ROOT_DIR/pkgs/github_release/github.com/mikefarah/yq/v4.53.3/yq_darwin_amd64/yq_darwin_amd64"
Mach-O 64-bit x86_64 executable
```

Expected: `yq_darwin_arm64`, a Mach-O 64-bit arm64 executable.

## Generation and manual correction

The scaffold output is preserved in its own signed commit, as required:

```console
$ argd s mikefarah/yq
[feat/mikefarah/yq 0bb9780d17] feat(mikefarah/yq): scaffold mikefarah/yq
```

The generated archive/checksum configuration did not install successfully, so the following signed commit restores the existing raw-asset/checksum configuration and splits the Rosetta override at v4.9.6.

## Verification

```console
$ conftest test --combine pkgs/mikefarah/yq/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ argd t mikefarah/yq
# Passed linux/amd64, linux/arm64, darwin/amd64, darwin/arm64,
# windows/amd64, and windows/arm64 installation tests.
```

The Darwin/ARM64 test installs:

```text
v4.9.5/yq_darwin_amd64/yq_darwin_amd64
v4.9.6/yq_darwin_arm64/yq_darwin_arm64
v4.35.1/yq_darwin_arm64/yq_darwin_arm64
v4.52.5/yq_darwin_arm64/yq_darwin_arm64
v4.53.3/yq_darwin_arm64/yq_darwin_arm64
```

AI was used to investigate the regression, prepare the change, and review the test evidence. I reviewed and take responsibility for the submitted result.
