### PR TITLE
fix(kellyjonbrazil/jc): support v1.25.7

### DIFF
--- a/pkgs/kellyjonbrazil/jc/pkg.yaml
+++ b/pkgs/kellyjonbrazil/jc/pkg.yaml
@@ -1,10 +1,8 @@
 packages:
-  - name: kellyjonbrazil/jc@v1.25.6
+  - name: kellyjonbrazil/jc@v1.25.7
   - name: kellyjonbrazil/jc
-    version: v1.21.0
+    version: v1.25.6
   - name: kellyjonbrazil/jc
-    version: v1.20.4
+    version: v1.25.0
   - name: kellyjonbrazil/jc
-    version: v1.19.0
-  - name: kellyjonbrazil/jc
-    version: v1.13.4
+    version: v1.18.8

--- a/pkgs/kellyjonbrazil/jc/registry.yaml
+++ b/pkgs/kellyjonbrazil/jc/registry.yaml
@@ -4,30 +4,54 @@ packages:
     repo_owner: kellyjonbrazil
     repo_name: jc
     description: CLI tool and python library that converts the output of popular command-line tools, file-types, and common strings to JSON, YAML, or Dictionaries. This allows piping of output to tools like jq and simplifying automation scripts
-    asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-        asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        files:
-          - name: jc
-            src: jc-{{trimV .Version}}-windows/jc.exe
-    replacements:
-      amd64: x86_64
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    version_constraint: semver(">= 1.21.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.19.0")
+      - version_constraint: semver("<= 1.18.8")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.25.0")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
         overrides:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
-      - version_constraint: semver("< 1.19.0")
-        overrides: []
         supported_envs:
-          - linux/amd64
           - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.25.6")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+      - version_constraint: "true"
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64

--- a/pkgs/kellyjonbrazil/jc/registry.yaml
+++ b/pkgs/kellyjonbrazil/jc/registry.yaml
@@ -25,6 +25,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
         supported_envs:
           - darwin
           - windows
@@ -39,6 +42,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
       - version_constraint: "true"
         asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -51,6 +57,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
         supported_envs:
           - linux
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -55850,33 +55850,57 @@ packages:
     repo_owner: kellyjonbrazil
     repo_name: jc
     description: CLI tool and python library that converts the output of popular command-line tools, file-types, and common strings to JSON, YAML, or Dictionaries. This allows piping of output to tools like jq and simplifying automation scripts
-    asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.gz
-    overrides:
-      - goos: windows
-        format: zip
-        asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
-        files:
-          - name: jc
-            src: jc-{{trimV .Version}}-windows/jc.exe
-    replacements:
-      amd64: x86_64
-    supported_envs:
-      - darwin
-      - amd64
-    rosetta2: true
-    version_constraint: semver(">= 1.21.0")
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver(">= 1.19.0")
+      - version_constraint: semver("<= 1.18.8")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.25.0")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
         overrides:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
-      - version_constraint: semver("< 1.19.0")
-        overrides: []
         supported_envs:
-          - linux/amd64
           - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.25.6")
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+        overrides:
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+      - version_constraint: "true"
+        asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: windows
+            format: zip
+            asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
   - type: github_release
     repo_owner: kentaro-m
     repo_name: md2confl

--- a/registry.yaml
+++ b/registry.yaml
@@ -55871,6 +55871,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
         supported_envs:
           - darwin
           - windows
@@ -55885,6 +55888,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
       - version_constraint: "true"
         asset: jc-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -55897,6 +55903,9 @@ packages:
           - goos: windows
             format: zip
             asset: jc-{{trimV .Version}}-{{.OS}}.{{.Format}}
+            files:
+              - name: jc
+                src: jc-{{trimV .Version}}-windows/jc
         supported_envs:
           - linux
           - darwin/arm64


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

The [jc v1.25.7 release](https://github.com/kellyjonbrazil/jc/releases/tag/v1.25.7) publishes a Darwin aarch64 archive but does not include a Darwin x86_64 archive. The previous registry configuration requested the x86_64 archive on both Intel and Apple Silicon Macs because it used Rosetta 2.

Regenerate the package with:

```console
$ aqua exec -- argd s -B kellyjonbrazil/jc
```

The generated configuration uses the native Darwin aarch64 archive for v1.25.7 and marks Darwin amd64 unsupported for this version. It also refreshes the pinned test versions to cover each generated version-override boundary. The follow-up commit preserves jc's nested Windows archive path, using aqua's extension-independent `files[].src` form.

This materially addresses the updater failure in #55635.

## Verification

```console
$ aqua exec -- argd t kellyjonbrazil/jc
# Passed Linux amd64/arm64, Darwin amd64/arm64, and Windows amd64/arm64 installation tests

$ aqua exec -- conftest test --combine pkgs/kellyjonbrazil/jc/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI assistance was used to investigate the failure, review the generated configuration, and prepare this pull request. I reviewed and tested the resulting changes.
