### PR TITLE
fix(tldr-pages/tlrc): use native Darwin arm64 assets

### DIFF
--- a/pkgs/tldr-pages/tlrc/pkg.yaml
+++ b/pkgs/tldr-pages/tlrc/pkg.yaml
@@ -1,4 +1,8 @@
 packages:
   - name: tldr-pages/tlrc@v1.13.1
   - name: tldr-pages/tlrc
+    version: v1.13.0
+  - name: tldr-pages/tlrc
+    version: v1.12.0
+  - name: tldr-pages/tlrc
     version: v1.9.2

--- a/pkgs/tldr-pages/tlrc/registry.yaml
+++ b/pkgs/tldr-pages/tlrc/registry.yaml
@@ -25,13 +25,32 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.13.0")
         asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        github_artifact_attestations:
+          signer_workflow: tldr-pages/tlrc/.github/workflows/build-release.yml
+      - version_constraint: "true"
+        asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -93157,13 +93157,32 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.13.0")
         asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         windows_arm_emulation: true
         replacements:
           amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+        github_artifact_attestations:
+          signer_workflow: tldr-pages/tlrc/.github/workflows/build-release.yml
+      - version_constraint: "true"
+        asset: tlrc-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc


### PR DESCRIPTION
## Problem

On Apple Silicon, the registry still applies `rosetta2: true` to current `tldr-pages/tlrc` releases. aqua therefore selects the x86_64 macOS asset even though tlrc has shipped native arm64 assets since v1.13.0.

Reproduced with aqua v2.61.0 on darwin/arm64 using registry v4.538.0:

```yaml
registries:
  - type: standard
    ref: v4.538.0
packages:
  - name: tldr-pages/tlrc@v1.13.1
```

```console
$ aqua which tldr
.../tlrc-v1.13.1-x86_64-apple-darwin.tar.gz/tldr
```

This caused `tldr --update` to fail with `Bad CPU type in executable` in the reported environment.

tlrc added `aarch64-apple-darwin` release assets in [tldr-pages/tlrc#152](https://github.com/tldr-pages/tlrc/pull/152). v1.13.0 is the first release containing them.

## Change

- Keep Rosetta selection for versions before v1.13.0
- Select `aarch64-apple-darwin` for v1.13.0 and newer
- Preserve existing Windows ARM emulation, Linux support policy, and artifact attestation
- Pin v1.12.0 and v1.13.0 so both sides of the boundary are tested

## Verification

```console
$ aqua exec -- conftest test --combine pkgs/tldr-pages/tlrc/registry.yaml pkgs/tldr-pages/tlrc/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ mise run argd-t
# Passed installation checks for v1.9.2, v1.12.0, v1.13.0, and v1.13.1
# across linux/amd64, darwin/amd64, darwin/arm64, and windows/amd64.

$ mise run tart-darwin-setup
$ mise run tart-darwin-sync
$ mise run argd-t-darwin
# Installed and verified v1.13.1 on darwin/arm64; `tldr --help` succeeded.
```

Direct aqua resolution on darwin/arm64:

```text
v1.9.2  -> tlrc-v1.9.2-x86_64-apple-darwin.tar.gz
v1.12.0 -> tlrc-v1.12.0-x86_64-apple-darwin.tar.gz
v1.13.0 -> tlrc-v1.13.0-aarch64-apple-darwin.tar.gz
v1.13.1 -> tlrc-v1.13.1-aarch64-apple-darwin.tar.gz
```

`file` reports the v1.13.0 and v1.13.1 binaries as Mach-O arm64. `tldr --update` completed successfully with the native v1.13.1 binary.

`argd gr` was also run twice; the second run produced the same root `registry.yaml`.

## AI disclosure

OpenAI Codex assisted with investigation, implementation, and verification. I reviewed the changes and take responsibility for them.
