### PR TITLE
Add kbrdn1/gwm-cli

### DIFF
--- a/pkgs/kbrdn1/gwm-cli/pkg.yaml
+++ b/pkgs/kbrdn1/gwm-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kbrdn1/gwm-cli@v1.1.1

--- a/pkgs/kbrdn1/gwm-cli/registry.yaml
+++ b/pkgs/kbrdn1/gwm-cli/registry.yaml
@@ -4,6 +4,8 @@ packages:
     repo_owner: kbrdn1
     repo_name: gwm-cli
     description: git worktree manager — Rust CLI + ratatui TUI, native libgit2, per-repo bootstrap via .gwm.toml
+    files:
+      - name: gwm
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/kbrdn1/gwm-cli/registry.yaml
+++ b/pkgs/kbrdn1/gwm-cli/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: "true"
         asset: gwm-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gwm
+            src: "{{.AssetWithoutExt}}/gwm"
         windows_arm_emulation: true
         replacements:
           amd64: x86_64

--- a/pkgs/kbrdn1/gwm-cli/registry.yaml
+++ b/pkgs/kbrdn1/gwm-cli/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kbrdn1
+    repo_name: gwm-cli
+    description: git worktree manager — Rust CLI + ratatui TUI, native libgit2, per-repo bootstrap via .gwm.toml
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gwm-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -55770,6 +55770,29 @@ packages:
           - linux
           - darwin
   - type: github_release
+    repo_owner: kbrdn1
+    repo_name: gwm-cli
+    description: git worktree manager — Rust CLI + ratatui TUI, native libgit2, per-repo bootstrap via .gwm.toml
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gwm-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: kcl-lang
     repo_name: cli
     description: The KCL Command Line Interface (CLI)

--- a/registry.yaml
+++ b/registry.yaml
@@ -55773,6 +55773,8 @@ packages:
     repo_owner: kbrdn1
     repo_name: gwm-cli
     description: git worktree manager — Rust CLI + ratatui TUI, native libgit2, per-repo bootstrap via .gwm.toml
+    files:
+      - name: gwm
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -55778,6 +55778,9 @@ packages:
       - version_constraint: "true"
         asset: gwm-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: gwm
+            src: "{{.AssetWithoutExt}}/gwm"
         windows_arm_emulation: true
         replacements:
           amd64: x86_64


### PR DESCRIPTION
## Overview

Add [`kbrdn1/gwm-cli`](https://github.com/kbrdn1/gwm-cli) — a git worktree manager (TUI + CLI, native libgit2, per-repo `.gwm.toml` bootstrap).

The binary command is `gwm`. The release archives ship it as `gwm` inside a versioned directory (`gwm-v<ver>-<target>/gwm`), so the definition declares `files` with `name: gwm` and `src: {{.AssetWithoutExt}}/gwm` — the scaffolder defaulted to the repo name (`gwm-cli`) and a flat path, which is corrected in the second commit.

## Testing

- `argd t kbrdn1/gwm-cli` passes in containers for **linux, darwin, and windows** (amd64 + arm64; windows/arm64 via `windows_arm_emulation`).
- `conftest test pkgs/kbrdn1/gwm-cli/*.yaml` → 28/28 pass.
- `prettier` clean.
- Also validated end-to-end with a real `aqua` install on darwin/arm64 (`gwm --version` → `1.1.1`, checksum verified via the `.sha256` sidecars).

## AI disclosure

This PR was prepared with the help of AI (Claude Code); the second commit lists it as a co-author. I've reviewed the definition and take responsibility for it.