### PR TITLE
fix(openbao): support v2.6.0 release assets

### DIFF
--- a/pkgs/openbao/openbao/bao/pkg.yaml
+++ b/pkgs/openbao/openbao/bao/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: openbao/openbao/bao@v2.5.5
+  - name: openbao/openbao/bao@v2.6.0
+  - name: openbao/openbao/bao
+    version: v2.5.5
   - name: openbao/openbao/bao
     version: v2.5.0-beta20251125
   - name: openbao/openbao/bao

--- a/pkgs/openbao/openbao/bao/registry.yaml
+++ b/pkgs/openbao/openbao/bao/registry.yaml
@@ -81,7 +81,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.5.5")
         asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -102,6 +102,25 @@ packages:
             bundle:
               type: github_release
               asset: checksums-{{.OS}}.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: openbao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/(tags/.*|heads/release/.*)$'
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -70777,7 +70777,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.5.5")
         asset: bao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -70798,6 +70798,25 @@ packages:
             bundle:
               type: github_release
               asset: checksums-{{.OS}}.txt.sigstore.json
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: openbao_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - '^https://github\.com/openbao/openbao/\.github/workflows/release\.yml@refs/(tags/.*|heads/release/.*)$'
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
## Summary

- use OpenBao's new lowercase `openbao_*` release assets from v2.6.0 onward
- use the consolidated `checksums.txt` and Sigstore bundle introduced in v2.6.0
- trust signatures from OpenBao's exact release workflow on tag refs and `release/*` branches
- preserve the existing `bao_*` configuration through v2.5.5 and retain v2.5.5 regression coverage

## Root cause

OpenBao v2.6.0 renamed release archives such as `bao_2.5.5_Linux_x86_64.tar.gz` to `openbao_2.6.0_linux_amd64.tar.gz`. It also consolidated per-OS checksum files into `checksums.txt` and signed the bundle from `refs/heads/release/2.6.x`. The existing package therefore could not locate or verify v2.6.0, which is also blocking the automated version update in #57023.

## Verification

```console
$ argd lsa openbao/openbao v2.6.0
openbao_2.6.0_linux_amd64.tar.gz
openbao_2.6.0_linux_arm64.tar.gz
openbao_2.6.0_darwin_amd64.tar.gz
openbao_2.6.0_darwin_arm64.tar.gz
openbao_2.6.0_windows_amd64.zip
openbao_2.6.0_windows_arm64.zip
```

```console
$ conftest test pkgs/openbao/openbao/bao/pkg.yaml pkgs/openbao/openbao/bao/registry.yaml
28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ argd t openbao/openbao/bao
```

The package matrix passed for Linux amd64/arm64, Darwin amd64/arm64, and Windows amd64/arm64. The v2.6.0 checksum and Sigstore verification passed on every platform.

This PR was created with assistance from an AI coding agent and reviewed and validated before submission.
