### PR TITLE
feat: add planetscale/ghcommit

### DIFF
--- a/pkgs/planetscale/ghcommit/pkg.yaml
+++ b/pkgs/planetscale/ghcommit/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: planetscale/ghcommit@v0.1.49

--- a/pkgs/planetscale/ghcommit/registry.yaml
+++ b/pkgs/planetscale/ghcommit/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: planetscale
+    repo_name: ghcommit
+    description: Use GitHub's GraphQL API to commit files to a GitHub repository
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghcommit_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -74768,6 +74768,22 @@ packages:
       asset: pscale_{{trimV .Version}}_checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: planetscale
+    repo_name: ghcommit
+    description: Use GitHub's GraphQL API to commit files to a GitHub repository
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ghcommit_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: plexsystems
     repo_name: sinker
     description: A tool to sync images from one container registry to another


### PR DESCRIPTION
## Summary

Add `planetscale/ghcommit` — a CLI that uses GitHub's GraphQL API to commit files to a GitHub repository.

- Upstream: https://github.com/planetscale/ghcommit
- Type: `github_release`, `format: tar.gz`, checksum via `checksums.txt` (sha256)
- `supported_envs: [linux, darwin]` (upstream ships darwin/linux for amd64/arm64; no Windows build)

## Verification

Installed and executed with `aqua` against the local registry:

```console
$ aqua i
INF create a symbolic link package_name=planetscale/ghcommit package_version=v0.1.49 command=ghcommit
# checksum verification via checksums.txt passed

$ aqua exec -- ghcommit --help
Usage:
  ghcommit [OPTIONS]

Application Options:
  -a, --add=        Added or modified file to commit. ...
  -m, --message=    Commit message [$GHCOMMIT_MESSAGE]
  -r, --repository= Owner/Repository to commit to. [$GHCOMMIT_REPOSITORY]
  -b, --branch=     Branch to commit to. [$GHCOMMIT_BRANCH]
```

The `tar.gz` asset contains the `ghcommit` binary at the archive root, so no `files[]` block is required.

## AI usage disclosure

This package was scaffolded and reviewed with the help of Claude Code (Opus 4.8), per docs/ai.md. The configuration has been reviewed and is owned by the submitter.
