### PR TITLE
fix(anthropics/claude-code): get versions from GitHub Releases

### DIFF
--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -6,7 +6,6 @@ packages:
     description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
     files:
       - name: claude
-    version_source: github_tag
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v2.1.88"

--- a/registry.yaml
+++ b/registry.yaml
@@ -13612,7 +13612,6 @@ packages:
     description: Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands
     files:
       - name: claude
-    version_source: github_tag
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v2.1.88"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## What

Remove `version_source: github_tag` from `anthropics/claude-code` so that versions are fetched from GitHub Releases (the default) instead of Git tags. The repository root `registry.yaml` is updated with the same one-line change.

## Why

anthropics/claude-code publishes a GitHub Release for effectively every tag (171 Releases for 174 tags as of 2026-07-18, covering everything since the first tag `v2.0.73`). Even though the binaries are hosted on Google Cloud Storage rather than attached to GitHub Releases, the Releases themselves exist and can serve as the version source.

Git tags carry no timestamps, while Releases do. This matters for tools consuming this registry. For example, mise's aqua backend supports [`minimum_release_age`](https://mise.jdx.dev/configuration/settings.html#minimum_release_age) (supply-chain protection that holds back newly published versions, like Renovate's minimum release age), but it cannot work for this package because the tag-based version list has no timestamps ([mise `src/backend/aqua.rs`](https://github.com/jdx/mise/blob/main/src/backend/aqua.rs)):

```rust
if let Some("github_tag") = pkg.version_source.as_deref() {
    // Tags don't have created_at timestamps or a prerelease flag
    let versions = github::list_tags(&format!("{}/{}", pkg.repo_owner, pkg.repo_name)).await?;
    return Ok(versions.into_iter().map(|v| (v, None, false)).collect());
}
```

With Releases as the version source, timestamps become available and the protection works.

The 3 tags that have no corresponding Release:

- `v2.1.88` — yanked version: the GCS binary returns 404 and it is already excluded via `no_asset: true` (the override is kept for explicit installs). With this change it also naturally disappears from version listings.
- `v2.1.0`, `v2.1.120` — GCS binaries exist but there is no GitHub Release, so these two no longer appear in version listings. Installing them by specifying the version explicitly still works because the download URL is templated.

## Verification

Run on macOS arm64 at 2026-07-18 04:03 UTC, with this PR's `pkgs/anthropics/claude-code/registry.yaml` as a local registry.

`aqua g` resolves the latest version from Releases (aqua v2.62.0):

```console
$ cat aqua.yaml
registries:
  - name: local
    type: local
    path: registry.yaml
packages: []
$ aqua g local,anthropics/claude-code
- name: anthropics/claude-code@v2.1.214
  registry: local
```

Install and execution work with the modified registry (mise 2026.7.5):

```console
$ MISE_AQUA_REGISTRIES="file:///path/to/modified/registry.yaml" mise x aqua:anthropics/claude-code@2.1.210 -- claude --version
2.1.210 (Claude Code)
```

mise's `minimum_release_age` becomes effective:

```console
# before (version_source: github_tag): no timestamps, so the filter passes everything
$ MISE_MINIMUM_RELEASE_AGE=3d mise latest aqua:anthropics/claude-code
2.1.214

# after (this change): v2.1.211 / v2.1.212 / v2.1.214, all released within the
# last 3 days, are correctly held back; v2.1.210 (2026-07-14T23:45Z) is resolved
$ MISE_AQUA_REGISTRIES="file:///path/to/modified/registry.yaml" MISE_MINIMUM_RELEASE_AGE=3d mise latest aqua:anthropics/claude-code
2.1.210
```

## AI disclosure

This change was investigated and prepared with Claude Code, per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). I reviewed and tested the content and take responsibility for it.
