### PR TITLE
feat(tedilabs/ota): scaffold tedilabs/ota

### DIFF
--- a/pkgs/tedilabs/ota/pkg.yaml
+++ b/pkgs/tedilabs/ota/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: tedilabs/ota@v0.1.1

--- a/pkgs/tedilabs/ota/pkg.yaml
+++ b/pkgs/tedilabs/ota/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: tedilabs/ota@v0.1.1
+  - name: tedilabs/ota@v0.1.2

--- a/pkgs/tedilabs/ota/registry.yaml
+++ b/pkgs/tedilabs/ota/registry.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: tedilabs
+    repo_name: ota
+    description: k9s for Okta — a Go/Bubbletea TUI to inspect Okta admin resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ota_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -91368,6 +91368,25 @@ packages:
           - darwin
   - type: github_release
     repo_owner: tedilabs
+    repo_name: ota
+    description: k9s for Okta — a Go/Bubbletea TUI to inspect Okta admin resources
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ota_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: tedilabs
     repo_name: tfvault
     description: A Terraform credentials helper to fetch secrets from several secret backends (OS keyring, environment variables, pass)
     version_constraint: "false"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

[ota](https://github.com/tedilabs/ota) is a k9s-style terminal UI for Okta Workforce Identity, from the same org as the recently added `tedilabs/tfvault` (#56948).

The registry config is the unmodified `aqua gr tedilabs/ota` output (darwin assets are named `macos`, hence the `replacements`; windows ships amd64 zip only, hence `windows_arm_emulation` + the format override). Verified locally with a `type: local` registry:

```console
$ aqua exec -- ota --version
ota 0.1.2 (commit 2127dac, built 2026-07-20T07:06:32Z)
```
