### PR TITLE
feat(grafana/flint): add musl Linux assets

### DIFF
--- a/pkgs/grafana/flint/registry.yaml
+++ b/pkgs/grafana/flint/registry.yaml
@@ -23,6 +23,16 @@ packages:
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:

--- a/registry.yaml
+++ b/registry.yaml
@@ -45815,6 +45815,16 @@ packages:
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:


### PR DESCRIPTION
Add libc-aware Linux asset selection for `grafana/flint` so aqua users on musl Linux can use the new x86_64 and aarch64 musl release archives.

The glibc override is intentionally listed first to preserve behavior for aqua versions before libc variants were supported. The corresponding x86_64 and aarch64 musl assets are available in [Flint v0.22.10](https://github.com/grafana/flint/releases/tag/v0.22.10), so this PR is ready.

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - [x] Avoid force push
  - [x] This updates an existing package; `argd s` is not applicable
- [x] Install and execute the package and confirm if the package works well

## Validation

- `npm exec --yes prettier@3.8.2 -- --check pkgs/grafana/flint/registry.yaml registry.yaml` — passed
- installed `grafana/flint@v0.22.10` through the PR registry and successfully ran `flint linters` on Linux/glibc
- YAML formatting is unchanged apart from the intended overrides
- `argd t grafana/flint` could not run because Docker is unavailable in this environment

