### PR TITLE
feat(supernovae-st/nika): update to 0.105.0, add GitHub artifact attestations config

### DIFF
--- a/pkgs/supernovae-st/nika/pkg.yaml
+++ b/pkgs/supernovae-st/nika/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: supernovae-st/nika@v0.104.0
+  - name: supernovae-st/nika@v0.105.0

--- a/pkgs/supernovae-st/nika/pkg.yaml
+++ b/pkgs/supernovae-st/nika/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: supernovae-st/nika@v0.105.0
+  - name: supernovae-st/nika
+    version: v0.104.0

--- a/pkgs/supernovae-st/nika/registry.yaml
+++ b/pkgs/supernovae-st/nika/registry.yaml
@@ -8,6 +8,19 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.80.0-alpha.4")
         no_asset: true
+      - version_constraint: semver("<= 0.104.0")
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
         format: tar.gz
@@ -18,6 +31,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
         supported_envs:
           - linux
           - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -88064,6 +88064,19 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.80.0-alpha.4")
         no_asset: true
+      - version_constraint: semver("<= 0.104.0")
+        asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: nika-{{.OS}}-{{.Arch}}-{{trimV .Version}}.{{.Format}}
         format: tar.gz
@@ -88074,6 +88087,8 @@ packages:
           type: github_release
           asset: SHA256SUMS
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
https://github.com/supernovae-st/nika/attestations?q=sort%3Acreated-asc&after=23657454
    
There are attestations available for some older releases besides the newest 0.105.0 too, but only in a range that is excluded from the package config.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
