### PR TITLE
chore(aqua-registry-updater): update list of archived projects

### DIFF
--- a/aqua-registry-updater.yaml
+++ b/aqua-registry-updater.yaml
@@ -25,7 +25,6 @@ ignore_packages:
   - sigstore/sget
   - suzuki-shunsuke/checkout-merged-branch-with-ci-info
   - suzuki-shunsuke/ci-renovate-config-validator
-  - suzuki-shunsuke/discussion-slack-notifier
   - xremap/xremap/hypr # https://github.com/xremap/xremap/pull/479
   - xremap/xremap/sway # https://github.com/xremap/xremap/pull/479
   # keep-sorted end
@@ -50,12 +49,14 @@ ignore_packages:
   - aquaproj/example-go-slsa-provenance
   - arrow2nd/nekome
   - astral-sh/rye
+  - aws/amazon-ecs-cli
   - aws/copilot-cli
   - awslabs/yesiscan
   - babarot/git-bump
   - babarot/stein
   - babarot/vtest
   - barthr/redo
+  - bufbuild/connect-go/protoc-gen-connect-go
   - bufbuild/protoc-gen-validate
   - caarlos0/fork-cleaner
   - caarlos0/mdtree
@@ -69,14 +70,18 @@ ignore_packages:
   - datreeio/datree
   - docker/hub-tool
   - dtan4/ghrls
+  - dylanaraps/neofetch
   - fabpot/local-php-security-checker
   - fastly/terrctl
   - fiatjaf/jiq
   - flatt-security/shisho
   - git-chglog/git-chglog
   - golang/mock
+  - google/wire
   - gptscript-ai/gptscript
   - grafana-cold-storage/grizzly
+  - hashicorp/levant
+  - hashicorp/waypoint
   - hidetatz/kubecolor
   - high-moctane/nextword
   - int128/kubectl-external-forward
@@ -89,9 +94,11 @@ ignore_packages:
   - kubewarden/kwctl
   - kvz/json2hcl
   - mattermost/mmctl
+  - minio/mc
   - minishift/minishift
   - mitchellh/golicense
   - mitchellh/gon
+  - mitchellh/gox
   - momaek/authy
   - neondatabase/neonctl
   - nucleuscloud/neosync
@@ -106,6 +113,7 @@ ignore_packages:
   - pulumi/esc
   - rancher/kim
   - rebuy-de/aws-nuke
+  - redhat-developer/odo
   - rgreinho/tfe-cli
   - segmentio/golines
   - siderolabs/theila

--- a/aqua-registry-updater.yaml
+++ b/aqua-registry-updater.yaml
@@ -36,8 +36,8 @@ ignore_packages:
   # archived
   # keep-sorted start
   - Azure/aks-engine
-  - BurntSushi/xsv
   - Builditluc/wiki-tui
+  - BurntSushi/xsv
   - Code-Hex/gqldoc
   - GoogleCloudPlatform/terraformer
   - GoogleCloudPlatform/terraformer/aws
@@ -65,8 +65,8 @@ ignore_packages:
   - compose/transporter
   - container-tools/spectrum
   - cybozu/assam
-  - datreeio/datree
   - datastax-archive/astra-cli
+  - datreeio/datree
   - docker/hub-tool
   - dtan4/ghrls
   - fabpot/local-php-security-checker
@@ -79,25 +79,25 @@ ignore_packages:
   - grafana-cold-storage/grizzly
   - hidetatz/kubecolor
   - high-moctane/nextword
-  - int128/yamlpatch
   - int128/kubectl-external-forward
+  - int128/yamlpatch
   - kawaz/authsock-filter
   - koki-develop/moview
-  - koluku/s3s
   - koki-develop/sheep
+  - koluku/s3s
   - kubernetes-retired/kubefed
   - kubewarden/kwctl
   - kvz/json2hcl
   - mattermost/mmctl
   - minishift/minishift
-  - mitchellh/gon
   - mitchellh/golicense
+  - mitchellh/gon
   - momaek/authy
   - neondatabase/neonctl
   - nucleuscloud/neosync
   - nvarner/typst-lsp
-  - openclarity/vmclarity
   - openclarity/kubeclarity
+  - openclarity/vmclarity
   - optiv/Mangle
   - pglet/pglet
   - praetorian-inc/gokart
@@ -113,22 +113,22 @@ ignore_packages:
   - spinnaker/spin
   - suzuki-shunsuke/akoi
   - suzuki-shunsuke/circleci-config-merge
-  - suzuki-shunsuke/discussion-slack-notifier
-  - suzuki-shunsuke/deny-self-approve
   - suzuki-shunsuke/dd-time
+  - suzuki-shunsuke/deny-self-approve
+  - suzuki-shunsuke/discussion-slack-notifier
   - suzuki-shunsuke/durl
   - suzuki-shunsuke/ghd2i
   - suzuki-shunsuke/git-rm-branch
-  - suzuki-shunsuke/renovate-issue-action
   - suzuki-shunsuke/matchfile
   - suzuki-shunsuke/migrate-urfave-cli-v3
+  - suzuki-shunsuke/renovate-issue-action
   - suzuki-shunsuke/tfaction-go
   - suzuki-shunsuke/yaml2json
   - suzuki-shunsuke/yodoc
   - tailor-platform/patterner
   - takumin/zizmor-bin
-  - temporalio/tctl
   - teler-sh/teler
+  - temporalio/tctl
   - tenable/terrascan
   - tfmigrator/cli
   - thazelart/terraform-validator
@@ -136,8 +136,8 @@ ignore_packages:
   - trufflesecurity/driftwood
   - variadico/noti
   - vmware-archive/octant
-  - watchexec/cargo-watch
   - wasmerio/wapm-cli
+  - watchexec/cargo-watch
   # keep-sorted end
 
   # deleted

--- a/aqua-registry-updater.yaml
+++ b/aqua-registry-updater.yaml
@@ -35,16 +35,108 @@ ignore_packages:
 
   # archived
   # keep-sorted start
+  - Azure/aks-engine
+  - BurntSushi/xsv
+  - Builditluc/wiki-tui
+  - Code-Hex/gqldoc
+  - GoogleCloudPlatform/terraformer
+  - GoogleCloudPlatform/terraformer/aws
   - GoogleContainerTools/container-diff
-  # https://github.com/LukeChannings/deno-arm64/releases/tag/v1.40.4
-  # > This will be the final binary distribution from this repo.
-  # > Please go to denoland/deno for the official releases.
   - LukeChannings/deno-arm64
+  - Phantas0s/devdash
+  - Shopify/kubeaudit
+  - acorn-io/runtime
+  - allero-io/allero
+  - aquaproj/example-go-slsa-provenance
+  - arrow2nd/nekome
+  - astral-sh/rye
+  - aws/copilot-cli
+  - awslabs/yesiscan
+  - babarot/git-bump
+  - babarot/stein
+  - babarot/vtest
+  - barthr/redo
+  - bufbuild/protoc-gen-validate
+  - caarlos0/fork-cleaner
+  - caarlos0/mdtree
+  - charmbracelet/charm
+  - charmbracelet/mods
   - codeclimate/test-reporter
+  - compose/transporter
+  - container-tools/spectrum
+  - cybozu/assam
   - datreeio/datree
+  - datastax-archive/astra-cli
+  - docker/hub-tool
+  - dtan4/ghrls
+  - fabpot/local-php-security-checker
+  - fastly/terrctl
+  - fiatjaf/jiq
+  - flatt-security/shisho
+  - git-chglog/git-chglog
+  - golang/mock
+  - gptscript-ai/gptscript
+  - grafana-cold-storage/grizzly
+  - hidetatz/kubecolor
+  - high-moctane/nextword
+  - int128/yamlpatch
+  - int128/kubectl-external-forward
+  - kawaz/authsock-filter
+  - koki-develop/moview
+  - koluku/s3s
+  - koki-develop/sheep
+  - kubernetes-retired/kubefed
+  - kubewarden/kwctl
+  - kvz/json2hcl
+  - mattermost/mmctl
+  - minishift/minishift
+  - mitchellh/gon
+  - mitchellh/golicense
   - momaek/authy
+  - neondatabase/neonctl
+  - nucleuscloud/neosync
+  - nvarner/typst-lsp
+  - openclarity/vmclarity
+  - openclarity/kubeclarity
+  - optiv/Mangle
+  - pglet/pglet
+  - praetorian-inc/gokart
+  - praetorian-inc/noseyparker
+  - prometheus/promlens
+  - pulumi/esc
+  - rancher/kim
   - rebuy-de/aws-nuke
+  - rgreinho/tfe-cli
+  - segmentio/golines
+  - siderolabs/theila
+  - skanehira/tson
   - spinnaker/spin
+  - suzuki-shunsuke/akoi
+  - suzuki-shunsuke/circleci-config-merge
+  - suzuki-shunsuke/discussion-slack-notifier
+  - suzuki-shunsuke/deny-self-approve
+  - suzuki-shunsuke/dd-time
+  - suzuki-shunsuke/durl
+  - suzuki-shunsuke/ghd2i
+  - suzuki-shunsuke/git-rm-branch
+  - suzuki-shunsuke/renovate-issue-action
+  - suzuki-shunsuke/matchfile
+  - suzuki-shunsuke/migrate-urfave-cli-v3
+  - suzuki-shunsuke/tfaction-go
+  - suzuki-shunsuke/yaml2json
+  - suzuki-shunsuke/yodoc
+  - tailor-platform/patterner
+  - takumin/zizmor-bin
+  - temporalio/tctl
+  - teler-sh/teler
+  - tenable/terrascan
+  - tfmigrator/cli
+  - thazelart/terraform-validator
+  - thestormforge/optimize-controller
+  - trufflesecurity/driftwood
+  - variadico/noti
+  - vmware-archive/octant
+  - watchexec/cargo-watch
   - wasmerio/wapm-cli
   # keep-sorted end
 


### PR DESCRIPTION
I know next to nothing about aqua-registry-updater, but happened to notice the config file and list while looking for something else, and thought an update might be welcome.

Note: includes some packages I've reported as having moved -- if the registry pkg ends up being renamed for some of those, I suppose they can also be removed from here
- https://github.com/aquaproj/aqua-registry/issues/57281
- https://github.com/aquaproj/aqua-registry/issues/57322
- https://github.com/aquaproj/aqua-registry/issues/57325
- https://github.com/aquaproj/aqua-registry/issues/57326
- https://github.com/aquaproj/aqua-registry/issues/57327

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
