### PR TITLE
Add yvgude/lean-ctx

### DIFF
--- a/pkgs/yvgude/lean-ctx/pkg.yaml
+++ b/pkgs/yvgude/lean-ctx/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: yvgude/lean-ctx@v3.9.12
+  - name: yvgude/lean-ctx
+    version: v3.1.5
+  - name: yvgude/lean-ctx
+    version: v2.4.0
+  - name: yvgude/lean-ctx
+    version: v1.7.0
+  - name: yvgude/lean-ctx
+    version: vscode-v0.2.0

--- a/pkgs/yvgude/lean-ctx/pkg.yaml
+++ b/pkgs/yvgude/lean-ctx/pkg.yaml
@@ -6,5 +6,3 @@ packages:
     version: v2.4.0
   - name: yvgude/lean-ctx
     version: v1.7.0
-  - name: yvgude/lean-ctx
-    version: vscode-v0.2.0

--- a/pkgs/yvgude/lean-ctx/registry.yaml
+++ b/pkgs/yvgude/lean-ctx/registry.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: yvgude
+    repo_name: lean-ctx
+    description: Control what your AI can see. LeanCTX (Lean Context) is the context intelligence layer for AI agents — one local Rust binary that decides what they read, remembers what they learn, guards what they touch, and proves what they save. 60–90% fewer tokens as the receipt. 76 MCP tools, 30+ agents, local-first
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+      - version_constraint: semver("<= 1.6.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.7.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.4.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.1.5")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/yvgude/lean-ctx/registry.yaml
+++ b/pkgs/yvgude/lean-ctx/registry.yaml
@@ -3,10 +3,10 @@ packages:
   - type: github_release
     repo_owner: yvgude
     repo_name: lean-ctx
-    description: Control what your AI can see. LeanCTX (Lean Context) is the context intelligence layer for AI agents — one local Rust binary that decides what they read, remembers what they learn, guards what they touch, and proves what they save. 60–90% fewer tokens as the receipt. 76 MCP tools, 30+ agents, local-first
+    description: Local-first context intelligence layer for AI agents
+    version_filter: not (Version startsWith "vscode-")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.2.0")
       - version_constraint: semver("<= 1.6.0")
         no_asset: true
       - version_constraint: semver("<= 1.7.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -101539,10 +101539,10 @@ packages:
   - type: github_release
     repo_owner: yvgude
     repo_name: lean-ctx
-    description: Control what your AI can see. LeanCTX (Lean Context) is the context intelligence layer for AI agents — one local Rust binary that decides what they read, remembers what they learn, guards what they touch, and proves what they save. 60–90% fewer tokens as the receipt. 76 MCP tools, 30+ agents, local-first
+    description: Local-first context intelligence layer for AI agents
+    version_filter: not (Version startsWith "vscode-")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 0.2.0")
       - version_constraint: semver("<= 1.6.0")
         no_asset: true
       - version_constraint: semver("<= 1.7.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -101537,6 +101537,88 @@ packages:
       type: github_release
       asset: multiple.intoto.jsonl
   - type: github_release
+    repo_owner: yvgude
+    repo_name: lean-ctx
+    description: Control what your AI can see. LeanCTX (Lean Context) is the context intelligence layer for AI agents — one local Rust binary that decides what they read, remembers what they learn, guards what they touch, and proves what they save. 60–90% fewer tokens as the receipt. 76 MCP tools, 30+ agents, local-first
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.0")
+      - version_constraint: semver("<= 1.6.0")
+        no_asset: true
+      - version_constraint: semver("<= 1.7.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.4.0")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 3.1.5")
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: lean-ctx-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: zaghaghi
     repo_name: openapi-tui
     description: Terminal UI to list, browse and run APIs defined with openapi spec


### PR DESCRIPTION
[yvgude/lean-ctx](https://github.com/yvgude/lean-ctx) - Local-first context intelligence layer for AI agents

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add `yvgude/lean-ctx`, a local-first context intelligence layer for AI agents.

The upstream repository also publishes VS Code extension releases using `vscode-*` tags. The registry filters those tags so Aqua only selects CLI releases.

Validation:

- `argd t yvgude/lean-ctx` passed the installation matrix (run by the contributor)
- `aqua exec -- conftest test --combine pkgs/yvgude/lean-ctx/*` passed all 14 tests
- `lean-ctx --help` succeeded with the Darwin arm64 v3.9.12 release binary

The execution checklist remains open because the Linux binary was not separately smoke-tested after installation.

Codex assisted with diagnosis, the manual registry correction, validation, and this pull request. I reviewed the changes.
