### PR TITLE
feat: add dyoshikawa/rulesync

### DIFF
--- a/pkgs/dyoshikawa/rulesync/pkg.yaml
+++ b/pkgs/dyoshikawa/rulesync/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: dyoshikawa/rulesync@v14.1.0
+  - name: dyoshikawa/rulesync
+    version: v5.5.1
+  - name: dyoshikawa/rulesync
+    version: v4.0.0
+  - name: dyoshikawa/rulesync
+    version: v3.17.1

--- a/pkgs/dyoshikawa/rulesync/pkg.yaml
+++ b/pkgs/dyoshikawa/rulesync/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: dyoshikawa/rulesync@v14.1.0
+  - name: dyoshikawa/rulesync@v14.2.0
+  - name: dyoshikawa/rulesync
+    version: v14.1.0
   - name: dyoshikawa/rulesync
     version: v5.5.1
   - name: dyoshikawa/rulesync

--- a/pkgs/dyoshikawa/rulesync/registry.yaml
+++ b/pkgs/dyoshikawa/rulesync/registry.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: dyoshikawa
+    repo_name: rulesync
+    description: A Utility CLI for AI Coding Agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v6.7.1"
+        no_asset: true
+      - version_constraint: semver("<= 3.14.0")
+        no_asset: true
+      - version_constraint: semver("<= 3.17.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 4.0.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 5.5.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/pkgs/dyoshikawa/rulesync/registry.yaml
+++ b/pkgs/dyoshikawa/rulesync/registry.yaml
@@ -46,10 +46,22 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 14.1.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
       - version_constraint: "true"
         asset: rulesync-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: dyoshikawa/rulesync/.github/workflows/publish-assets.yml
         replacements:
           amd64: x64
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -35999,10 +35999,22 @@ packages:
           - linux
           - darwin/arm64
           - windows/amd64
+      - version_constraint: semver("<= 14.1.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
       - version_constraint: "true"
         asset: rulesync-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
+        github_artifact_attestations:
+          signer_workflow: dyoshikawa/rulesync/.github/workflows/publish-assets.yml
         replacements:
           amd64: x64
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -35954,6 +35954,62 @@ packages:
               - name: zencode-exec
                 src: zenroom-{{.OS}}/zencode-exec
   - type: github_release
+    repo_owner: dyoshikawa
+    repo_name: rulesync
+    description: A Utility CLI for AI Coding Agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v6.7.1"
+        no_asset: true
+      - version_constraint: semver("<= 3.14.0")
+        no_asset: true
+      - version_constraint: semver("<= 3.17.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 4.0.0")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 5.5.1")
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: rulesync-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: earendil-works
     repo_name: pi
     description: Interactive coding agent CLI


### PR DESCRIPTION
## Check List

- [x] Read CONTRIBUTING.md
  - Avoid force push
  - Use `argd s` command when adding new packages
- [x] Install and execute the package and confirm if the package works well

## Package

[dyoshikawa/rulesync](https://github.com/dyoshikawa/rulesync) — A Utility CLI for AI Coding Agents

- `type: github_release`, `format: raw`, checksum via `SHA256SUMS`
- version_overrides: binaries start at v3.15.0, windows added in v3.18.0, `rulesync-darwin-x64` missing in v4.0.1 - v5.5.1, v6.7.1 has no assets (verified against all 277 releases)
- Related: dyoshikawa/rulesync#2346

## Verification

Scaffolded with `argd s "dyoshikawa/rulesync"` (no manual edits). Container tests passed on all platforms, testing v3.17.1 / v4.0.0 / v5.5.1 / v14.1.0. Also installed and executed on macOS arm64:

```console
$ aqua exec -- rulesync --version
14.1.0
```

## AI usage disclosure

Scaffolded and verified with the help of Claude Code (Fable 5), per docs/ai.md. I reviewed the output and own it.
