### PR TITLE
fix(pnpm/pnpm): select musl assets on musl

### DIFF
--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -94,6 +94,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
       - version_constraint: semver("<= 11.0.6")
@@ -108,6 +117,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:
@@ -136,6 +154,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:

--- a/registry.yaml
+++ b/registry.yaml
@@ -75228,6 +75228,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
       - version_constraint: semver("<= 11.0.6")
@@ -75242,6 +75251,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:
@@ -75270,6 +75288,15 @@ packages:
           amd64: x64
           windows: win32
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
         github_artifact_attestations:


### PR DESCRIPTION
Fixes #57509

## Summary

- select pnpm's musl archives on musl-based Linux hosts for every stable v11 configuration branch
- keep the glibc override first so aqua versions older than v2.58.0 retain their previous behavior
- regenerate the combined registry

## Root cause

The pnpm registry entry selected `pnpm-linux-<arch>.tar.gz` for every Linux host. Although pnpm v11 publishes `pnpm-linux-<arch>-musl.tar.gz`, the entry had no libc variants describing that asset.

With this change, aqua v2.58.0 and newer detect the host libc and select the matching archive. The glibc entry remains the compatibility fallback for older aqua versions, which ignore variants.

The musl binary is dynamically linked and needs `libstdc++` and `libgcc` on a minimal Alpine installation.

## Upstream change

[pnpm/pnpm#11316](https://github.com/pnpm/pnpm/pull/11316) introduced the `pnpm-linux-<arch>-musl.tar.gz` GitHub release asset naming used by pnpm v11.

## Verification

```console
$ argd t pnpm/pnpm
...
INF key: libc detected, running tests on Alpine
...
INF Updating registry.yaml
```

This passed the Linux, Alpine, Darwin, and Windows installation matrix for amd64 and arm64. A direct Alpine test with aqua v2.62.1 selected `pnpm-linux-x64-musl.tar.gz` and ran pnpm v11.15.0 successfully.

```console
/root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/pnpm/pnpm/v11.15.0/pnpm-linux-x64-musl.tar.gz/pnpm
... dynamically linked, interpreter /lib/ld-musl-x86_64.so.1 ...
11.15.0
```

Also verified:

```console
$ conftest test --combine pkgs/pnpm/pnpm/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ aqua exec -- prettier --check pkgs/pnpm/pnpm/registry.yaml pkgs/pnpm/pnpm/pkg.yaml registry.yaml
All matched files use Prettier code style!
```

AI-assisted: Codex was used to prepare and review this change.