### PR TITLE
fix(jreleaser/jreleaser): support v1.25.0

### DIFF
--- a/pkgs/jreleaser/jreleaser/pkg.yaml
+++ b/pkgs/jreleaser/jreleaser/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: jreleaser/jreleaser@v1.24.0
+  - name: jreleaser/jreleaser@v1.25.0
   - name: jreleaser/jreleaser
     version: v1.16.0
   - name: jreleaser/jreleaser

--- a/pkgs/jreleaser/jreleaser/pkg.yaml
+++ b/pkgs/jreleaser/jreleaser/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: jreleaser/jreleaser@v1.25.0
   - name: jreleaser/jreleaser
+    version: v1.24.0
+  - name: jreleaser/jreleaser
     version: v1.16.0
   - name: jreleaser/jreleaser
     version: v1.10.0

--- a/pkgs/jreleaser/jreleaser/registry.yaml
+++ b/pkgs/jreleaser/jreleaser/registry.yaml
@@ -13,6 +13,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -24,6 +27,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -35,6 +41,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -45,6 +54,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -56,10 +68,13 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.24.0")
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -67,3 +82,25 @@ packages:
         overrides:
           - goos: windows
             replacements: {}
+        slsa_provenance:
+          type: github_release
+          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
+          source_tag: "-"
+      - version_constraint: "true"
+        asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/{{.AssetWithoutExt}}"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: osx
+        overrides:
+          - goos: windows
+            replacements: {}
+        slsa_provenance:
+          type: github_release
+          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
+          source_tag: "-"

--- a/pkgs/jreleaser/jreleaser/registry.yaml
+++ b/pkgs/jreleaser/jreleaser/registry.yaml
@@ -13,9 +13,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -27,9 +24,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -41,9 +35,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -54,9 +45,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -72,9 +60,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -82,7 +67,3 @@ packages:
         overrides:
           - goos: windows
             replacements: {}
-        slsa_provenance:
-          type: github_release
-          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
-          source_tag: "-"

--- a/registry.yaml
+++ b/registry.yaml
@@ -53882,9 +53882,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53896,9 +53893,6 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53910,9 +53904,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53923,9 +53914,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53941,9 +53929,6 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
-        files:
-          - name: jreleaser
-            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -53951,10 +53936,6 @@ packages:
         overrides:
           - goos: windows
             replacements: {}
-        slsa_provenance:
-          type: github_release
-          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
-          source_tag: "-"
   - name: jreleaser/jreleaser/standalone
     type: github_release
     repo_owner: jreleaser

--- a/registry.yaml
+++ b/registry.yaml
@@ -53882,6 +53882,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53893,6 +53896,9 @@ packages:
         format: zip
         rosetta2: true
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53904,6 +53910,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         rosetta2: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53914,6 +53923,9 @@ packages:
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           darwin: osx
@@ -53925,10 +53937,13 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.24.0")
         asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: zip
         windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/jreleaser"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -53936,6 +53951,28 @@ packages:
         overrides:
           - goos: windows
             replacements: {}
+        slsa_provenance:
+          type: github_release
+          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
+          source_tag: "-"
+      - version_constraint: "true"
+        asset: jreleaser-native-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        files:
+          - name: jreleaser
+            src: "{{.AssetWithoutExt}}/bin/{{.AssetWithoutExt}}"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: osx
+        overrides:
+          - goos: windows
+            replacements: {}
+        slsa_provenance:
+          type: github_release
+          asset: jreleaser-all-{{trimV .Version}}.intoto.jsonl
+          source_tag: "-"
   - name: jreleaser/jreleaser/standalone
     type: github_release
     repo_owner: jreleaser


### PR DESCRIPTION
## Summary

- preserve the existing `bin/jreleaser` mapping through v1.24.0
- map v1.25.0 and later to the platform-qualified executable inside the native archive
- retain v1.24.0 as regression coverage while testing v1.25.0 as the latest version

## Why

JReleaser v1.25.0 changed the executable inside native archives from `bin/jreleaser` to `bin/jreleaser-native-<version>-<os>-<arch>`. The existing registry mapping therefore caused aqua to report `check file_src is correct` on every platform in #56200.

## Upstream change

This came from the native-image archive refactor for [jreleaser/jreleaser#2106](https://github.com/jreleaser/jreleaser/issues/2106), implemented directly in [jreleaser/jreleaser@1404462](https://github.com/jreleaser/jreleaser/commit/14044621fb4bd1775cd3008d9c4432bb7066d0ce) rather than through a pull request. v1.25.0 is the first release containing that change.

## Verification

Scaffolded the updated release first:

```console
$ mise x 'aqua:aquaproj/registry-tool@0.5.5' -- argd s -B jreleaser/jreleaser
...
package_version=v1.25.0
error="check file_src is correct"
```

After applying the version-specific mapping, I isolated v1.25.0 and ran the full `argd t` platform matrix:

```console
$ mise x 'aqua:aquaproj/registry-tool@0.5.5' -- argd t jreleaser/jreleaser
...
testing os=linux arch=amd64
PASSED: SLSA verification passed
testing os=linux arch=arm64
PASSED: SLSA verification passed
testing os=darwin arch=amd64
PASSED: SLSA verification passed
testing os=darwin arch=arm64
PASSED: SLSA verification passed
testing os=windows arch=amd64
PASSED: SLSA verification passed
testing os=windows arch=arm64
```

The historical version pins were restored after the isolated platform test. The full local bulk install reached and verified v1.25.0 but was terminated with exit 137 while installing all regression versions concurrently; CI remains the verification for the complete combined set.

```console
$ mise x 'aqua:open-policy-agent/conftest@0.68.2' -- conftest test --combine pkgs/jreleaser/jreleaser/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI assistance: Codex helped investigate the archive-layout change, generate and review the configuration update, and run the validation commands. I reviewed the resulting changes and test output.