### PR TITLE
fix(getsops/sops): use sigstore bundle for v3.13.0+

### DIFF
--- a/pkgs/getsops/sops/pkg.yaml
+++ b/pkgs/getsops/sops/pkg.yaml
@@ -1,7 +1,9 @@
 packages:
-  - name: getsops/sops@v3.12.2
+  - name: getsops/sops@v3.13.3
   - name: getsops/sops
     version: v3.9.4
+  - name: getsops/sops
+    version: v3.8.0-rc.1
   - name: getsops/sops
     version: v3.7.3
   - name: getsops/sops

--- a/pkgs/getsops/sops/pkg.yaml
+++ b/pkgs/getsops/sops/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: getsops/sops@v3.13.3
   - name: getsops/sops
+    version: v3.12.2
+  - name: getsops/sops
     version: v3.9.4
   - name: getsops/sops
     version: v3.8.0-rc.1

--- a/pkgs/getsops/sops/registry.yaml
+++ b/pkgs/getsops/sops/registry.yaml
@@ -3,11 +3,22 @@ packages:
   - type: github_release
     repo_owner: getsops
     repo_name: sops
-    aliases:
-      - name: mozilla/sops
     description: Simple and flexible tool for managing secrets
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v3.8.0-rc.1"
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+        slsa_provenance:
+          type: github_release
+          asset: provenance.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}
       - version_constraint: semver("<= 3.7.1")
         asset: sops-{{.Version}}.{{.OS}}
         format: raw
@@ -31,16 +42,6 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
-              - --signature
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
-              - --certificate-identity-regexp
-              - https://github.com/getsops
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl
@@ -54,16 +55,6 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
-              - --signature
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
-              - --certificate-identity-regexp
-              - https://github.com/getsops
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl

--- a/pkgs/getsops/sops/registry.yaml
+++ b/pkgs/getsops/sops/registry.yaml
@@ -3,6 +3,8 @@ packages:
   - type: github_release
     repo_owner: getsops
     repo_name: sops
+    aliases:
+      - name: mozilla/sops
     description: Simple and flexible tool for managing secrets
     version_constraint: "false"
     version_overrides:
@@ -42,12 +44,45 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl
         overrides:
           - goos: windows
             asset: sops-{{.Version}}
+      - version_constraint: semver("<= 3.12.2")
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: sops-{{.Version}}.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}.{{.Arch}}
       - version_constraint: "true"
         asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
         format: raw
@@ -55,6 +90,15 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: sops-{{.Version}}.checksums.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl

--- a/pkgs/getsops/sops/registry.yaml
+++ b/pkgs/getsops/sops/registry.yaml
@@ -15,6 +15,16 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: provenance.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -41053,6 +41053,8 @@ packages:
   - type: github_release
     repo_owner: getsops
     repo_name: sops
+    aliases:
+      - name: mozilla/sops
     description: Simple and flexible tool for managing secrets
     version_constraint: "false"
     version_overrides:
@@ -41092,12 +41094,45 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl
         overrides:
           - goos: windows
             asset: sops-{{.Version}}
+      - version_constraint: semver("<= 3.12.2")
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+        slsa_provenance:
+          type: github_release
+          asset: sops-{{.Version}}.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}.{{.Arch}}
       - version_constraint: "true"
         asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
         format: raw
@@ -41105,6 +41140,15 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: sops-{{.Version}}.checksums.sigstore.json
+            opts:
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -41053,11 +41053,22 @@ packages:
   - type: github_release
     repo_owner: getsops
     repo_name: sops
-    aliases:
-      - name: mozilla/sops
     description: Simple and flexible tool for managing secrets
     version_constraint: "false"
     version_overrides:
+      - version_constraint: Version == "v3.8.0-rc.1"
+        asset: sops-{{.Version}}.{{.OS}}.{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: sops-{{.Version}}.checksums.txt
+          algorithm: sha256
+        slsa_provenance:
+          type: github_release
+          asset: provenance.intoto.jsonl
+        overrides:
+          - goos: windows
+            asset: sops-{{.Version}}
       - version_constraint: semver("<= 3.7.1")
         asset: sops-{{.Version}}.{{.OS}}
         format: raw
@@ -41081,16 +41092,6 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
-              - --signature
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
-              - --certificate-identity-regexp
-              - https://github.com/getsops
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl
@@ -41104,16 +41105,6 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
-          cosign:
-            opts:
-              - --certificate
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
-              - --signature
-              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
-              - --certificate-identity-regexp
-              - https://github.com/getsops
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: sops-{{.Version}}.intoto.jsonl

--- a/registry.yaml
+++ b/registry.yaml
@@ -41065,6 +41065,16 @@ packages:
           type: github_release
           asset: sops-{{.Version}}.checksums.txt
           algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.pem
+              - --signature
+              - https://github.com/getsops/sops/releases/download/{{.Version}}/sops-{{.Version}}.checksums.sig
+              - --certificate-identity-regexp
+              - https://github.com/getsops
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         slsa_provenance:
           type: github_release
           asset: provenance.intoto.jsonl


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

SOPS v3.13.0 replaced the detached checksum signature and certificate assets:

```text
sops-v3.12.2.checksums.sig
sops-v3.12.2.checksums.pem
```

with a Sigstore bundle:

```text
sops-v3.13.0.checksums.sigstore.json
```

The existing default override continued requesting the removed `.pem` and `.sig` assets, causing every platform test in #56265 to fail with HTTP 404.

The asset transition was introduced by [getsops/sops#2082](https://github.com/getsops/sops/pull/2082), which updated the release process for cosign v3.

This change:

- preserves detached-signature verification through v3.12.2
- uses the Sigstore bundle for v3.13.0 and later
- keeps v3.12.2 pinned alongside the latest version so both verification branches are tested
- preserves the `mozilla/sops` compatibility alias
- includes the generator's dedicated v3.8.0-rc.1 override for its different provenance asset

This supersedes the package update in #56265.

The package was regenerated with:

```console
$ aqua exec -- argd s -B getsops/sops
```

The generator removed Cosign verification and the compatibility alias. The generated scaffold commit is preserved, with the focused verification and compatibility corrections in a follow-up commit.

## Verification

Targeted package installation tests for both v3.13.2 and v3.13.3 passed SLSA and Cosign bundle verification on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64:

```console
$ aqua exec -- argd t getsops/sops
PASSED: SLSA verification passed
Verified OK
```

```console
$ docker exec -w /workspace aqua-registry sops --version
sops 3.13.2
```

```console
$ aqua exec -- conftest test --combine pkgs/getsops/sops/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI assistance: Codex was used to investigate, regenerate, and validate the change. The output was reviewed and refined before submission.