### PR TITLE
fix: avoid pwsh proxy in Windows tests

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -138,6 +138,17 @@ jobs:
           AQUA_GITHUB_TOKEN: ${{github.token}}
 
       - name: Install packages for testing
+        if: runner.os != 'Windows'
+        run: aqua i
+        env:
+          AQUA_GOOS: ${{ matrix.env.goos }}
+          AQUA_GOARCH: ${{ matrix.env.goarch }}
+          AQUA_CONFIG: aqua/test.yaml
+          AQUA_GITHUB_TOKEN: ${{github.token}}
+
+      - name: Install packages for testing
+        if: runner.os == 'Windows'
+        shell: cmd
         run: aqua i
         env:
           AQUA_GOOS: ${{ matrix.env.goos }}

--- a/pkgs/PowerShell/PowerShell/pkg.yaml
+++ b/pkgs/PowerShell/PowerShell/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: PowerShell/PowerShell@v7.6.1
+  - name: PowerShell/PowerShell@v7.6.4
   - name: PowerShell/PowerShell
     version: v7.6.0-preview.4
   - name: PowerShell/PowerShell


### PR DESCRIPTION
## Summary

- Run the package installation step under `cmd` on Windows
- Retain the existing default shell on Linux and macOS
- Include the rebased PowerShell 7.6.4 update from #57333 so CI exercises the failing case

## Problem

The `aqua-installer` action runs `aqua i -l` before the package test step. For `PowerShell/PowerShell`, this creates an Aqua proxy at `AQUA_ROOT_DIR/bin/pwsh.exe`. The action also places `AQUA_ROOT_DIR/bin` at the front of `PATH`.

The following `run: aqua i` step does not specify a shell, so GitHub Actions resolves its default Windows shell by looking for `pwsh`. It finds the newly created Aqua proxy instead of the runner's system PowerShell:

```text
creating a hard link to aqua-proxy ... command=pwsh
shell: C:\Users\runneradmin\AppData\Local\aquaproj-aqua\bin\pwsh.EXE
```

The proxy re-enters Aqua while Actions is trying to start the step, producing repeated `aqua failed ... exe_name=pwsh.EXE` errors. The script containing `aqua i` never starts.

## Fix

Explicitly use `cmd` to launch the package installation step on Windows. This bypasses the `pwsh` proxy and allows the script to run:

```text
shell: C:\Windows\system32\cmd.EXE
```

Linux and macOS continue to use their existing default shells.

Closes #57524.

## Verification

- `aqua exec -- actionlint .github/workflows/wc-test.yaml`
- `prettier --check .github/workflows/wc-test.yaml`
- `mise x aqua:lintnet/lintnet@v1.0.0 -- lintnet lint`
- `mise x --no-deps aqua:aquaproj/registry-tool@0.5.5 -- argd t PowerShell/PowerShell`
- [Windows amd64 package test](https://github.com/aquaproj/aqua-registry/actions/runs/30026045973/job/89270715530): passed
- [Windows arm64 package test](https://github.com/aquaproj/aqua-registry/actions/runs/30026045973/job/89270715556): passed

`argd t` completed successfully for Linux, macOS, and Windows on amd64 and arm64.

AI was used to investigate the failure and prepare this change. I reviewed and validated the result.
