### PR TITLE
fix(sigstore/gitsign): use sigstore bundle for v0.15.1+

### DIFF
--- a/pkgs/sigstore/gitsign/pkg.yaml
+++ b/pkgs/sigstore/gitsign/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
-  - name: sigstore/gitsign@v0.14.0
-  - name: sigstore/gitsign
-    version: v0.1.0
+  - name: sigstore/gitsign@v0.16.1

--- a/pkgs/sigstore/gitsign/pkg.yaml
+++ b/pkgs/sigstore/gitsign/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: sigstore/gitsign@v0.16.1
+  - name: sigstore/gitsign
+    version: v0.14.0
+  - name: sigstore/gitsign
+    version: v0.1.0

--- a/pkgs/sigstore/gitsign/registry.yaml
+++ b/pkgs/sigstore/gitsign/registry.yaml
@@ -25,6 +25,8 @@ packages:
             - https://token.actions.githubusercontent.com
             - --signature
             - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
+      - version_constraint: Version == "v0.15.0"
+        no_asset: true
       - version_constraint: "true"
         asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw

--- a/pkgs/sigstore/gitsign/registry.yaml
+++ b/pkgs/sigstore/gitsign/registry.yaml
@@ -15,13 +15,3 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        cosign:
-          opts:
-            - --certificate
-            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.pem
-            - --certificate-identity
-            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
-            - --certificate-oidc-issuer
-            - https://token.actions.githubusercontent.com
-            - --signature
-            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig

--- a/pkgs/sigstore/gitsign/registry.yaml
+++ b/pkgs/sigstore/gitsign/registry.yaml
@@ -8,6 +8,23 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.0.1-alpha")
         no_asset: true
+      - version_constraint: semver("<= 0.14.0")
+        asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        cosign:
+          opts:
+            - --certificate
+            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.pem
+            - --certificate-identity
+            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+            - --signature
+            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
       - version_constraint: "true"
         asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
@@ -15,3 +32,12 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity
+            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com

--- a/registry.yaml
+++ b/registry.yaml
@@ -83549,16 +83549,6 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        cosign:
-          opts:
-            - --certificate
-            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.pem
-            - --certificate-identity
-            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
-            - --certificate-oidc-issuer
-            - https://token.actions.githubusercontent.com
-            - --signature
-            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
   - type: github_release
     repo_owner: sigstore
     repo_name: rekor

--- a/registry.yaml
+++ b/registry.yaml
@@ -83542,6 +83542,23 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 0.0.1-alpha")
         no_asset: true
+      - version_constraint: semver("<= 0.14.0")
+        asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        cosign:
+          opts:
+            - --certificate
+            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.pem
+            - --certificate-identity
+            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
+            - --signature
+            - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
       - version_constraint: "true"
         asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
@@ -83549,6 +83566,15 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        cosign:
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.bundle"
+          opts:
+            - --certificate-identity
+            - https://github.com/sigstore/gitsign/.github/workflows/release.yml@refs/tags/{{.Version}}
+            - --certificate-oidc-issuer
+            - https://token.actions.githubusercontent.com
   - type: github_release
     repo_owner: sigstore
     repo_name: rekor

--- a/registry.yaml
+++ b/registry.yaml
@@ -83559,6 +83559,8 @@ packages:
             - https://token.actions.githubusercontent.com
             - --signature
             - https://github.com/sigstore/gitsign/releases/download/{{.Version}}/{{.Asset}}.sig
+      - version_constraint: Version == "v0.15.0"
+        no_asset: true
       - version_constraint: "true"
         asset: gitsign_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

gitsign v0.15.1 replaced the detached certificate and signature assets:

```text
gitsign_0.14.0_linux_amd64.pem
gitsign_0.14.0_linux_amd64.sig
```

with a Sigstore bundle:

```text
gitsign_0.15.1_linux_amd64.bundle
```

The existing default override continued requesting the removed `.pem` and `.sig` assets, causing every platform test in #55140 to fail during Cosign verification with:

```text
loading cert: error during PEM decoding
```

The asset transition was introduced by [sigstore/gitsign#800](https://github.com/sigstore/gitsign/pull/800), which migrated release signing to cosign v3’s bundle format.

This change:

- preserves detached certificate/signature verification through v0.14.0
- uses the Sigstore bundle for v0.15.1 and later
- updates the latest test version to v0.16.1
- keeps v0.14.0 and v0.1.0 pinned as regression coverage

This supersedes the package updates in #53087, #53373, and #55140.

The package was regenerated with:

```console
$ aqua exec -- argd s -B sigstore/gitsign
```

The generator removed Cosign verification. The generated scaffold commit is preserved, with the focused verification correction in a follow-up commit.

## Verification

After clearing the generated package cache, `argd t` downloaded and verified v0.16.1, v0.14.0, and v0.1.0 on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64. Both the bundle and detached-signature paths reported `Verified OK`.

```console
$ aqua exec -- argd rmp sigstore/gitsign
$ aqua exec -- argd t sigstore/gitsign
Verified OK
```

```console
$ aqua exec -- conftest test --combine pkgs/sigstore/gitsign/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ aqua exec -- prettier --check pkgs/sigstore/gitsign/pkg.yaml pkgs/sigstore/gitsign/registry.yaml registry.yaml
Checking formatting...
All matched files use Prettier code style!
```

```console
$ docker exec -w /workspace aqua-registry gitsign --version
gitsign version v0.16.1
```

AI assistance: Codex was used to investigate, regenerate, and validate the change. The output was reviewed and refined before submission.