### PR TITLE
fix(version-fox/vfox): use sigstore bundle for v1.0.10+

### DIFF
--- a/pkgs/version-fox/vfox/pkg.yaml
+++ b/pkgs/version-fox/vfox/pkg.yaml
@@ -2,3 +2,9 @@ packages:
   - name: version-fox/vfox@v1.0.11
   - name: version-fox/vfox
     version: v1.0.8
+  - name: version-fox/vfox
+    version: v0.2.4
+  - name: version-fox/vfox
+    version: v0.2.3
+  - name: version-fox/vfox
+    version: v0.1.0

--- a/pkgs/version-fox/vfox/pkg.yaml
+++ b/pkgs/version-fox/vfox/pkg.yaml
@@ -1,8 +1,4 @@
 packages:
-  - name: version-fox/vfox@v1.0.8
+  - name: version-fox/vfox@v1.0.11
   - name: version-fox/vfox
-    version: v0.2.4
-  - name: version-fox/vfox
-    version: v0.2.3
-  - name: version-fox/vfox
-    version: v0.1.0
+    version: v1.0.8

--- a/pkgs/version-fox/vfox/registry.yaml
+++ b/pkgs/version-fox/vfox/registry.yaml
@@ -3,17 +3,38 @@ packages:
   - type: github_release
     repo_owner: version-fox
     repo_name: vfox
-    description: A cross-platform and extendable version manager with support for Java, Node.js, Flutter, .Net & more
+    description: A cross-platform and extendable version manager with support for Java, Node.js, Golang, Python, Flutter, .NET & more
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.5"
         no_asset: true
+      - version_constraint: semver("<= 1.0.8")
+        asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        files:
-          - name: vfox
-            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -25,13 +46,12 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "https://github\\.com/version-fox/vfox/\\.github/workflows/go-releaser\\.yml@.*"
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
-              - --signature
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
-              - --certificate
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/version-fox/vfox/registry.yaml
+++ b/pkgs/version-fox/vfox/registry.yaml
@@ -11,6 +11,9 @@ packages:
       - version_constraint: semver("<= 1.0.8")
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: vfox
+            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -35,6 +38,9 @@ packages:
       - version_constraint: "true"
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: vfox
+            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -97606,17 +97606,38 @@ packages:
   - type: github_release
     repo_owner: version-fox
     repo_name: vfox
-    description: A cross-platform and extendable version manager with support for Java, Node.js, Flutter, .Net & more
+    description: A cross-platform and extendable version manager with support for Java, Node.js, Golang, Python, Flutter, .NET & more
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.2.5"
         no_asset: true
+      - version_constraint: semver("<= 1.0.8")
+        asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - --certificate-identity-regexp
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+              - --signature
+              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        files:
-          - name: vfox
-            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -97628,13 +97649,12 @@ packages:
           cosign:
             opts:
               - --certificate-identity-regexp
-              - "https://github\\.com/version-fox/vfox/\\.github/workflows/go-releaser\\.yml@.*"
+              - "^https://github\\.com/version-fox/vfox/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
               - --certificate-oidc-issuer
-              - "https://token.actions.githubusercontent.com"
-              - --signature
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.sig
-              - --certificate
-              - https://github.com/version-fox/vfox/releases/download/{{.Version}}/checksums.txt.pem
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -97614,6 +97614,9 @@ packages:
       - version_constraint: semver("<= 1.0.8")
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: vfox
+            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64
@@ -97638,6 +97641,9 @@ packages:
       - version_constraint: "true"
         asset: vfox_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: vfox
+            src: "{{.AssetWithoutExt}}/vfox"
         replacements:
           amd64: x86_64
           arm64: aarch64


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

vfox v1.0.10 replaced the detached checksum certificate and signature assets:

```text
checksums.txt.pem
checksums.txt.sig
```

with a Sigstore bundle:

```text
checksums.txt.sigstore.json
```

The existing default override continued treating the bundle as a PEM certificate, causing the linux/arm64 test in #52929 to fail during Cosign verification with:

```text
loading cert: error during PEM decoding
```

The release change followed [version-fox/vfox#647](https://github.com/version-fox/vfox/pull/647), which upgraded the release workflow to Cosign v3, and [version-fox/vfox@3bdb604](https://github.com/version-fox/vfox/commit/3bdb604d6c346c2eeefc2aed8ad75f21d572fa25), which changed GoReleaser signing to emit the bundle.

This change:

- preserves detached certificate/signature verification through v1.0.8
- uses the Sigstore bundle for v1.0.10 and later
- tests v1.0.11 and keeps v1.0.8 plus the existing older regression versions pinned
- preserves the required archive subdirectory in `files[].src`

This supersedes the package updates in #52084 and #52929.

The package was regenerated with:

```console
$ aqua exec -- argd s version-fox/vfox
```

The generator identified the signing boundary and bundle configuration. Its generated archive path omitted the release archive's top-level directory, so that path and the existing regression versions were restored in a focused follow-up. The root registry was regenerated with `argd gr`.

## Verification

After clearing the package cache, `argd t` downloaded and verified v1.0.11, v1.0.8, v0.2.4, v0.2.3, and v0.1.0 on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64. Both the bundle and detached-signature verification paths reported `Verified OK`.

```console
$ aqua exec -- argd rmp version-fox/vfox
$ aqua exec -- argd t version-fox/vfox
Verified OK
```

```console
$ aqua exec -- conftest test --combine pkgs/version-fox/vfox/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ aqua exec -- prettier --check pkgs/version-fox/vfox/pkg.yaml pkgs/version-fox/vfox/registry.yaml registry.yaml
Checking formatting...
All matched files use Prettier code style!
```

```console
$ docker exec aqua-registry /root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/version-fox/vfox/v1.0.11/vfox_1.0.11_linux_x86_64.tar.gz/vfox_1.0.11_linux_x86_64/vfox --version
vfox version 1.0.11
```

AI assistance: Codex was used to investigate, regenerate, and validate the change. The output was reviewed and refined before submission.
