### PR TITLE
fix(ekristen/aws-nuke): support sigstore bundles

### DIFF
--- a/pkgs/ekristen/aws-nuke/pkg.yaml
+++ b/pkgs/ekristen/aws-nuke/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: ekristen/aws-nuke@v3.64.2
+  - name: ekristen/aws-nuke@v3.66.0
+  - name: ekristen/aws-nuke
+    version: v3.64.2
   - name: ekristen/aws-nuke
     version: v3.0.0-beta.7
   - name: ekristen/aws-nuke

--- a/pkgs/ekristen/aws-nuke/registry.yaml
+++ b/pkgs/ekristen/aws-nuke/registry.yaml
@@ -58,27 +58,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver(">= 3.64.4")
-        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity
-              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: checksums.txt.sigstore.json
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.64.2")
         asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -96,6 +76,26 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/ekristen/aws-nuke/registry.yaml
+++ b/pkgs/ekristen/aws-nuke/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Remove all the resources from an AWS account
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.64.3"]
+      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.53.0", "v3.62.1", "v3.63.0", "v3.64.3"]
         no_asset: true
       - version_constraint: Version == "v2.17.0-ek.1"
         asset: aws-nuke-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/ekristen/aws-nuke/registry.yaml
+++ b/pkgs/ekristen/aws-nuke/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Remove all the resources from an AWS account
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0"]
+      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.64.3"]
         no_asset: true
       - version_constraint: Version == "v2.17.0-ek.1"
         asset: aws-nuke-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -55,6 +55,26 @@ packages:
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/cosign.pub
               - --signature
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver(">= 3.64.4")
+        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36198,7 +36198,7 @@ packages:
     description: Remove all the resources from an AWS account
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.64.3"]
+      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.53.0", "v3.62.1", "v3.63.0", "v3.64.3"]
         no_asset: true
       - version_constraint: Version == "v2.17.0-ek.1"
         asset: aws-nuke-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -36198,7 +36198,7 @@ packages:
     description: Remove all the resources from an AWS account
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0"]
+      - version_constraint: Version in ["v3.0.0-beta.25", "v3.0.0-beta.44", "v3.0.0-beta.56", "v3.46.0", "v3.64.3"]
         no_asset: true
       - version_constraint: Version == "v2.17.0-ek.1"
         asset: aws-nuke-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
@@ -36247,6 +36247,26 @@ packages:
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/cosign.pub
               - --signature
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver(">= 3.64.4")
+        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36250,27 +36250,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: semver(">= 3.64.4")
-        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-          cosign:
-            opts:
-              - --certificate-identity
-              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
-              - --certificate-oidc-issuer
-              - https://token.actions.githubusercontent.com
-            bundle:
-              type: github_release
-              asset: checksums.txt.sigstore.json
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.64.2")
         asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -36288,6 +36268,26 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/ekristen/aws-nuke/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: aws-nuke-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity
+              - "https://github.com/ekristen/aws-nuke/.github/workflows/goreleaser.yml@refs/tags/{{.Version}}"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
## Summary

- mark v3.64.3 as unavailable because its GitHub release has no assets
- bound the legacy `.pem` and `.sig` verification path through v3.64.2
- make the final fallback use the current `checksums.txt.sigstore.json` release format
- test both v3.66.0 and the retained v3.64.2 regression case

This supersedes the updater PRs #53985, #54084, #54512, and #57159.

## Upstream context

[ekristen/aws-nuke#954](https://github.com/ekristen/aws-nuke/pull/954) upgraded the release workflow to Cosign Installer v4. The resulting [v3.64.3 release](https://github.com/ekristen/aws-nuke/releases/tag/v3.64.3) contains no assets. [ekristen/aws-nuke#960](https://github.com/ekristen/aws-nuke/pull/960) then changed the GoReleaser signing configuration from detached `.pem`/`.sig` files to Sigstore bundles; v3.64.4 is the first release that publishes `checksums.txt.sigstore.json`.

## Reproduction

Environment:

- aqua 2.62.1
- Linux x86_64

`aqua.yaml`:

```yaml
registries:
  - type: standard
    ref: v4.541.0
checksum:
  enabled: true
packages:
  - name: ekristen/aws-nuke@v3.66.0
```

Command:

```console
$ aqua i
Error: loading verifier from key opts: loading cert: loading URL https://github.com/ekristen/aws-nuke/releases/download/v3.66.0/checksums.txt.pem: server returned HTTP 404
ERR install the package package_name=ekristen/aws-nuke package_version=v3.66.0 error="verify with Cosign"
```

Expected: aqua installs aws-nuke and verifies its checksum signature. Actual: the registry requests detached signature assets that upstream no longer publishes.

## Verification

```console
$ mise x aqua:aquaproj/registry-tool@v0.5.5 -- argd t ekristen/aws-nuke
# Linux amd64/arm64, Darwin amd64/arm64, and Windows amd64/arm64 completed
# v3.66.0 bundle verification: Verified OK
# v3.64.2 legacy verification: Verified OK
```

```console
$ mise x aqua:open-policy-agent/conftest@v0.68.2 -- conftest test --combine pkgs/ekristen/aws-nuke/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/ekristen/aws-nuke/pkg.yaml pkgs/ekristen/aws-nuke/registry.yaml registry.yaml
All matched files use Prettier code style!
```

## AI usage

This pull request was prepared with Codex and reviewed before submission.
