### PR TITLE
fix(jenkins-x/jx): use sigstore bundle for v3.17.10+

### DIFF
--- a/pkgs/jenkins-x/jx/pkg.yaml
+++ b/pkgs/jenkins-x/jx/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: jenkins-x/jx@v3.17.6
+  - name: jenkins-x/jx@v3.17.57
+  - name: jenkins-x/jx
+    version: v3.17.6
   - name: jenkins-x/jx
     version: v3.10.182
   - name: jenkins-x/jx

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -107,7 +107,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.17.6")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -125,6 +125,26 @@ packages:
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.sig
               - --certificate
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.pem
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: jx-checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/jenkins-x/jx/.github/workflows/jenkins-x-release.yaml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/jenkins-x/jx/registry.yaml
+++ b/pkgs/jenkins-x/jx/registry.yaml
@@ -128,6 +128,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: Version in ["v3.17.7", "v3.17.8", "v3.17.9"]
+        no_asset: true
       - version_constraint: "true"
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -52394,7 +52394,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.17.6")
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -52412,6 +52412,26 @@ packages:
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.sig
               - --certificate
               - https://github.com/jenkins-x/jx/releases/download/{{.Version}}/jx-checksums.txt.pem
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: jx-checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: jx-checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/jenkins-x/jx/.github/workflows/jenkins-x-release.yaml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -52415,6 +52415,8 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: Version in ["v3.17.7", "v3.17.8", "v3.17.9"]
+        no_asset: true
       - version_constraint: "true"
         asset: jx-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
Supersedes #57085 and the older updater PRs blocked by the same release-signing change.

## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## What this PR does

[jenkins-x/jx#8978](https://github.com/jenkins-x/jx/pull/8978) migrated the GoReleaser signing configuration to Cosign 3 bundles. `v3.17.6` still publishes `jx-checksums.txt.pem` and `jx-checksums.txt.sig`; `v3.17.7` through `v3.17.9` have no release assets; and `v3.17.10+` publishes `jx-checksums.txt.sigstore.json` instead.

The current registry always requests the detached certificate and signature, so newer releases fail with:

```text
Error: loading verifier from key opts: loading cert: loading URL https://github.com/jenkins-x/jx/releases/download/v3.17.45/jx-checksums.txt.pem: server returned HTTP 404
```

This change:

- keeps detached `.pem`/`.sig` verification through `v3.17.6`;
- uses `checksum.cosign.bundle` for current releases;
- tests `v3.17.57` on the new path while preserving `v3.17.6` as a regression case.

## Verification

Direct aqua installation with a minimal local registry config, aqua `v2.62.1`, Linux/amd64:

```console
$ aqua policy allow aqua-policy.yaml
$ aqua install
INF verifying a file with Cosign package_name=jenkins-x/jx package_version=v3.17.57 registry=local
INF verifying a file with Cosign package_name=jenkins-x/jx package_version=v3.17.6 registry=local
Verified OK
Verified OK
```

Full package matrix:

```console
$ aqua exec -- argd t jenkins-x/jx
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
```

The command exited successfully and verified both signing branches on all supported test environments.

```console
$ aqua exec -- conftest test --combine pkgs/jenkins-x/jx/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI was used to investigate and prepare this change. I reviewed the release boundary, registry configuration, generated registry update, and verification results.