### PR TITLE
fix(ovh/venom): support Windows executable extension

### DIFF
--- a/pkgs/ovh/venom/pkg.yaml
+++ b/pkgs/ovh/venom/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: ovh/venom@v1.2.0
+  - name: ovh/venom@v1.4.0-beta.1
+  - name: ovh/venom
+    version: v1.2.0
   - name: ovh/venom
     version: v1.1.0-beta.2
   - name: ovh/venom

--- a/pkgs/ovh/venom/registry.yaml
+++ b/pkgs/ovh/venom/registry.yaml
@@ -10,10 +10,8 @@ packages:
         asset: venom-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
-        replacements:
-          arm64: arm
         supported_envs:
-          - linux
+          - linux/amd64
           - darwin
       - version_constraint: Version == "v0.21.1"
         asset: venom.{{.OS}}-{{.Arch}}
@@ -28,8 +26,10 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-        replacements:
-          arm64: arm
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.0.1")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/ovh/venom/registry.yaml
+++ b/pkgs/ovh/venom/registry.yaml
@@ -10,8 +10,10 @@ packages:
         asset: venom-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
+        replacements:
+          arm64: arm
         supported_envs:
-          - linux/amd64
+          - linux
           - darwin
       - version_constraint: Version == "v0.21.1"
         asset: venom.{{.OS}}-{{.Arch}}
@@ -26,10 +28,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        replacements:
+          arm64: arm
       - version_constraint: semver("<= 1.0.1")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw
@@ -46,8 +46,12 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.2.0")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: venom.{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -72912,8 +72912,10 @@ packages:
         asset: venom-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
+        replacements:
+          arm64: arm
         supported_envs:
-          - linux/amd64
+          - linux
           - darwin
       - version_constraint: Version == "v0.21.1"
         asset: venom.{{.OS}}-{{.Arch}}
@@ -72928,10 +72930,8 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
+        replacements:
+          arm64: arm
       - version_constraint: semver("<= 1.0.1")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw
@@ -72948,11 +72948,15 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.2.0")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: venom.{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: owenlamont
     repo_name: ryl

--- a/registry.yaml
+++ b/registry.yaml
@@ -72912,10 +72912,8 @@ packages:
         asset: venom-{{.OS}}-{{.Arch}}
         format: raw
         rosetta2: true
-        replacements:
-          arm64: arm
         supported_envs:
-          - linux
+          - linux/amd64
           - darwin
       - version_constraint: Version == "v0.21.1"
         asset: venom.{{.OS}}-{{.Arch}}
@@ -72930,8 +72928,10 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-        replacements:
-          arm64: arm
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
       - version_constraint: semver("<= 1.0.1")
         asset: venom.{{.OS}}-{{.Arch}}
         format: raw


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

[ovh/venom#792](https://github.com/ovh/venom/pull/792) changed Windows release binaries to include the `.exe` extension. v1.2.0 publishes `venom.windows-amd64`, while v1.3.0 and the current v1.4.0-beta.1 release publish `venom.windows-amd64.exe`.

The existing latest registry override explicitly set `complete_windows_ext: false`, so the updater PR requested the old extensionless filename from v1.3.0 and failed its Windows tests.

This change re-scaffolds the package and:

- retains extensionless Windows assets through v1.2.0;
- uses aqua's default `.exe` completion for v1.3.0 and later;
- tests v1.4.0-beta.1 while retaining v1.2.0 and all older version-override regression cases;
- applies the generator's ARM asset mappings for the historical v0.11.0 and v0.16.0 branches.

This supersedes updater PR #46644.

## Verification

The package was regenerated with:

```console
$ aqua exec -- argd s -B ovh/venom
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
```

A clean final package test passed the same six environment combinations:

```console
$ aqua exec -- argd t ovh/venom
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

```console
$ aqua exec -- conftest test --combine pkgs/ovh/venom/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/ovh/venom/pkg.yaml pkgs/ovh/venom/registry.yaml registry.yaml
All matched files use Prettier code style!
```

AI assistance: Codex was used to investigate, regenerate, and validate the change. I reviewed the upstream release boundary, generated registry configuration, and verification results.
