### PR TITLE
fix(smallstep/cli): use sigstore bundle for v0.30.0+

### DIFF
--- a/pkgs/smallstep/cli/pkg.yaml
+++ b/pkgs/smallstep/cli/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: smallstep/cli@v0.29.0
   - name: smallstep/cli
+    version: v0.30.6
+  - name: smallstep/cli
     version: v0.24.4
   - name: smallstep/cli
     version: v0.22.0

--- a/pkgs/smallstep/cli/pkg.yaml
+++ b/pkgs/smallstep/cli/pkg.yaml
@@ -1,7 +1,7 @@
 packages:
-  - name: smallstep/cli@v0.29.0
+  - name: smallstep/cli@v0.30.6
   - name: smallstep/cli
-    version: v0.30.6
+    version: v0.29.0
   - name: smallstep/cli
     version: v0.24.4
   - name: smallstep/cli

--- a/pkgs/smallstep/cli/registry.yaml
+++ b/pkgs/smallstep/cli/registry.yaml
@@ -10,7 +10,7 @@ packages:
         src: step_{{.OS}}_{{.Arch}}/bin/step
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4"]
+      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4", "v0.30.3-rc1"]
         no_asset: true
       - version_constraint: Version == "v0.0.1"
         asset: step_{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/pkgs/smallstep/cli/registry.yaml
+++ b/pkgs/smallstep/cli/registry.yaml
@@ -106,7 +106,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.29.0")
         asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -123,6 +123,25 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/smallstep/cli/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/smallstep/workflows/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -84622,7 +84622,7 @@ packages:
         src: step_{{.OS}}_{{.Arch}}/bin/step
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4"]
+      - version_constraint: Version in ["v0.15.1", "v0.27.0", "v0.28.1", "v0.28.4", "v0.30.3-rc1"]
         no_asset: true
       - version_constraint: Version == "v0.0.1"
         asset: step_{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -84718,7 +84718,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.29.0")
         asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -84735,6 +84735,25 @@ packages:
               - https://token.actions.githubusercontent.com
               - --signature
               - https://github.com/smallstep/cli/releases/download/{{.Version}}/checksums.txt.sig
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: step_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+            opts:
+              - --certificate-identity
+              - https://github.com/smallstep/workflows/.github/workflows/goreleaser.yml@refs/heads/main
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
         overrides:
           - goos: windows
             format: zip


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Why

[smallstep/cli#1554](https://github.com/smallstep/cli/pull/1554) changed the release signing command for v0.30.0+ from detached `.pem` and `.sig` files to `checksums.txt.sigstore.json` bundles. The registry still requests the removed detached assets, causing updater PR [#55257](https://github.com/aquaproj/aqua-registry/pull/55257) to fail on every tested platform.

## What

- Keep detached certificate/signature verification through v0.29.0.
- Verify `checksums.txt.sigstore.json` for v0.30.0 and later.
- Track v0.30.6 as the updater-managed primary test version and keep v0.29.0 as an explicit regression pin for the old signing path.

## Verification

Direct aqua reproduction on Linux/amd64 with aqua v2.62.1:

```console
$ AQUA_CONFIG=.ai/aqua-step.yaml AQUA_ROOT_DIR=/tmp/aqua-step-root aqua i
Verified OK
$ AQUA_CONFIG=.ai/aqua-step.yaml AQUA_ROOT_DIR=/tmp/aqua-step-root aqua exec -- step version
Smallstep CLI/0.30.6 (linux/amd64)
```

Direct signature verification with cosign v3.1.2:

```console
$ cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.sig [...] checksums.txt  # v0.29.0
Verified OK
$ cosign verify-blob --bundle checksums.txt.sigstore.json [...] checksums.txt  # v0.30.6
Verified OK
```

Full registry test:

```console
$ aqua exec -- argd t smallstep/cli
# v0.30.6, v0.29.0, and every existing regression pin install successfully on
# linux/amd64, linux/arm64, darwin/amd64, darwin/arm64,
# windows/amd64, and windows/arm64
# exit status 0
```

Lint and formatting:

```console
$ mise x conftest@0.68.2 -- conftest test --combine pkgs/smallstep/cli/pkg.yaml pkgs/smallstep/cli/registry.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
$ mise exec -- prettier --check pkgs/smallstep/cli/pkg.yaml pkgs/smallstep/cli/registry.yaml registry.yaml
All matched files use Prettier code style!
```

## AI usage

OpenAI Codex was used to investigate the CI failure and prepare the change. I reviewed and verified the result.
