### PR TITLE
fix(uutils/coreutils): use GNU Windows archive

### DIFF
--- a/pkgs/uutils/coreutils/pkg.yaml
+++ b/pkgs/uutils/coreutils/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: uutils/coreutils@0.6.0
+  - name: uutils/coreutils@0.9.0
   - name: uutils/coreutils
     version: 0.6.0
   - name: uutils/coreutils

--- a/pkgs/uutils/coreutils/pkg.yaml
+++ b/pkgs/uutils/coreutils/pkg.yaml
@@ -5,6 +5,8 @@ packages:
   - name: uutils/coreutils
     version: 0.5.0
   - name: uutils/coreutils
+    version: 0.1.0
+  - name: uutils/coreutils
     version: 0.0.28
   - name: uutils/coreutils
     version: 0.0.27

--- a/pkgs/uutils/coreutils/registry.yaml
+++ b/pkgs/uutils/coreutils/registry.yaml
@@ -188,7 +188,7 @@ packages:
         files:
           - name: coreutils
             src: coreutils-{{.Arch}}-{{.OS}}/coreutils
-      - version_constraint: semver("< 0.7.0")
+      - version_constraint: semver("<= 0.6.0")
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:

--- a/pkgs/uutils/coreutils/registry.yaml
+++ b/pkgs/uutils/coreutils/registry.yaml
@@ -199,6 +199,12 @@ packages:
           windows: pc-windows-msvc
         overrides:
           - goos: windows
+            goarch: amd64
+            format: zip
+            replacements:
+              windows: pc-windows-gnu
+          - goos: windows
+            goarch: arm64
             format: zip
         files:
           - name: coreutils

--- a/pkgs/uutils/coreutils/registry.yaml
+++ b/pkgs/uutils/coreutils/registry.yaml
@@ -188,6 +188,21 @@ packages:
         files:
           - name: coreutils
             src: coreutils-{{.Arch}}-{{.OS}}/coreutils
+      - version_constraint: semver("< 0.7.0")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: "true"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -96653,7 +96653,7 @@ packages:
         files:
           - name: coreutils
             src: coreutils-{{.Arch}}-{{.OS}}/coreutils
-      - version_constraint: semver("< 0.7.0")
+      - version_constraint: semver("<= 0.6.0")
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -96653,6 +96653,21 @@ packages:
         files:
           - name: coreutils
             src: coreutils-{{.Arch}}-{{.OS}}/coreutils
+      - version_constraint: semver("< 0.7.0")
+        asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: coreutils
+            src: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}/coreutils
       - version_constraint: "true"
         asset: coreutils-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -96664,6 +96664,12 @@ packages:
           windows: pc-windows-msvc
         overrides:
           - goos: windows
+            goarch: amd64
+            format: zip
+            replacements:
+              windows: pc-windows-gnu
+          - goos: windows
+            goarch: arm64
             format: zip
         files:
           - name: coreutils


### PR DESCRIPTION
## Summary

- use the `x86_64-pc-windows-gnu` archive for Windows AMD64 starting with 0.7.0
- preserve the MSVC Windows mapping for releases before 0.7.0 and for Windows ARM64
- add 0.1.0 and 0.9.0 regression coverage without dropping the existing historical pins

## Why

[uutils/coreutils#10903](https://github.com/uutils/coreutils/pull/10903) changed the x86_64 MSVC release archive to contain individual static executables instead of the `coreutils.exe` multicall binary. Starting with 0.7.0, aqua therefore could not find the configured executable in that archive.

Upstream continues to publish the multicall binary in the x86_64 GNU Windows archive, so releases from 0.7.0 onward select that archive for Windows AMD64. Because `version_overrides` is first-match-wins, an explicit `< 0.7.0` branch keeps unlisted historical releases such as 0.1.0 on the MSVC archive instead of letting the final `true` fallback apply the new GNU mapping to them.

This supersedes updater PRs #50017, #51657, and #54676.

## Verification

Direct aqua reproduction with aqua 2.62.1 on `windows/amd64`:

```console
$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua -c old.yaml install
INF download and unarchive the package package_name=uutils/coreutils package_version=0.1.0 registry=local
$ find ... -name coreutils.exe
.../coreutils-0.1.0-x86_64-pc-windows-msvc/coreutils.exe

$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua -c new.yaml install
INF download and unarchive the package package_name=uutils/coreutils package_version=0.9.0 registry=local
$ find ... -name coreutils.exe
.../coreutils-0.9.0-x86_64-pc-windows-gnu/coreutils.exe
```

Full package matrix:

```console
$ argd t uutils/coreutils
...
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF download and unarchive the package package_name=uutils/coreutils package_version=0.1.0 registry=standard
INF testing os=windows arch=arm64
```

Policy and formatting checks:

```console
$ conftest test --combine pkgs/uutils/coreutils/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/uutils/coreutils/pkg.yaml pkgs/uutils/coreutils/registry.yaml registry.yaml
All matched files use Prettier code style!
```

AI assistance was used to investigate the CI failure and prepare this change.
