### PR TITLE
fix(nektro/zigmod): restrict r101 and newer to Linux and macOS

### DIFF
--- a/pkgs/nektro/zigmod/pkg.yaml
+++ b/pkgs/nektro/zigmod/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: nektro/zigmod@r100
+  - name: nektro/zigmod@r104
+  - name: nektro/zigmod
+    version: r100

--- a/pkgs/nektro/zigmod/registry.yaml
+++ b/pkgs/nektro/zigmod/registry.yaml
@@ -5,9 +5,22 @@ packages:
     repo_name: zigmod
     description: Zig package manager
     version_prefix: "r"
-    asset: zigmod-{{.Arch}}-{{.OS}}
-    format: raw
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: macos
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 100")
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: "true"
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -68618,12 +68618,25 @@ packages:
     repo_name: zigmod
     description: Zig package manager
     version_prefix: "r"
-    asset: zigmod-{{.Arch}}-{{.OS}}
-    format: raw
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: macos
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 100")
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+      - version_constraint: "true"
+        asset: zigmod-{{.Arch}}-{{.OS}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - darwin
+          - linux
   - type: github_release
     repo_owner: neondatabase
     repo_name: neonctl


### PR DESCRIPTION
## Summary

zigmod stopped publishing Windows assets beginning with r101. Restrict r101 and newer to Linux and macOS while retaining Windows support for r100 and older.

Keep both r100 and r104 in `pkg.yaml` so CI exercises each `version_overrides` branch.

## Upstream cause

The upstream dependency update in [nektro/zigmod@1cdce9c](https://github.com/nektro/zigmod/commit/1cdce9c329527a6326be7033b64e6cda6a54c5f7) removed the Windows targets from the build and release workflow. macOS support was subsequently restored in [nektro/zigmod@386bfa8](https://github.com/nektro/zigmod/commit/386bfa83c0818fc4f0aafc4ac1a2a0dfaae33672) and [nektro/zigmod@d5d2b75](https://github.com/nektro/zigmod/commit/d5d2b751e297e1ec5e80b2ac29b7c23d746c761b), but Windows was not restored. Releases r101 through r104 therefore have no Windows assets.

This addresses the missing Windows asset failures in updater PRs #54666, #54779, and #55179.

## Verification

```console
$ mise x aqua:aquaproj/registry-tool@v0.5.5 -- argd t nektro/zigmod
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF download and unarchive the package env=windows/amd64 package_version=r100
INF testing os=windows arch=arm64
INF download and unarchive the package env=windows/arm64 package_version=r100
```

r100 and r104 install on Linux and macOS. On Windows, only r100 is selected and installs successfully.

```console
$ conftest test --combine pkgs/nektro/zigmod/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI was used to investigate the upstream release workflow and prepare this change; I reviewed and verified the result.
