### PR TITLE
fix: prevent bat-extras downgrade

### DIFF
--- a/pkgs/eth-p/bat-extras/registry.yaml
+++ b/pkgs/eth-p/bat-extras/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_owner: eth-p
     repo_name: bat-extras
     description: Bash scripts that integrate bat with various command line tools
+    version_filter: Version matches "^v\\d{4}\\.\\d{2}\\.\\d{2}$"
     version_constraint: "false"
     supported_envs:
       - linux
@@ -24,6 +25,8 @@ packages:
       - name: bat-modules
         src: bin/bat-modules
     version_overrides:
+      - version_constraint: semver("<= 2020.10.05")
+        no_asset: true
       - version_constraint: semver("<= 2023.03.21")
         asset: bat-extras-{{ trimV .Version | replace "." "" }}.zip
       - version_constraint: semver("<= 2024.02.12")

--- a/registry.yaml
+++ b/registry.yaml
@@ -37111,6 +37111,7 @@ packages:
     repo_owner: eth-p
     repo_name: bat-extras
     description: Bash scripts that integrate bat with various command line tools
+    version_filter: Version matches "^v\\d{4}\\.\\d{2}\\.\\d{2}$"
     version_constraint: "false"
     supported_envs:
       - linux
@@ -37131,6 +37132,8 @@ packages:
       - name: bat-modules
         src: bin/bat-modules
     version_overrides:
+      - version_constraint: semver("<= 2020.10.05")
+        no_asset: true
       - version_constraint: semver("<= 2023.03.21")
         asset: bat-extras-{{ trimV .Version | replace "." "" }}.zip
       - version_constraint: semver("<= 2024.02.12")


### PR DESCRIPTION
## Summary

- restrict updater candidates to dotted date tags such as `v2024.08.24`
- mark releases through `v2020.10.05` as unavailable because their archives do not contain the full configured command set
- regenerate the root registry

## Why

The upstream repository has legacy compact tags (`v20190117`, `v20200401`, and `v20200408`) alongside dotted date tags. SemVer ordering treats `v20200408` as newer than `v2024.08.24`, so the updater opened #43165 as an apparent upgrade even though it is a downgrade. The narrow `version_filter` accepts only dotted date tags and prevents these erroneous updater PRs without broadly filtering old dotted releases.

The `no_asset` boundary does not remove support aqua-registry previously provided. This package was added in October 2025 by #43065 with `v2024.08.24` as its current/test version, so the earlier releases were never supported or tested by this registry entry. The `v2020.10.05` archive lacks `bin/batpipe`, one of the commands configured by the entry. `v2021.03.30` is the immediately following release and its archive contains every configured command, including `batpipe`, so `semver("<= 2020.10.05")` is the precise unsupported boundary.

I tested adding `v2020.10.05` to `pkg.yaml` using the updater-safe long syntax, but `argd t` correctly rejects a `no_asset` version with `error="no asset is released for this version"`. Therefore the unavailable branch cannot be an installation test pin; all existing supported-version pins are preserved.

## Verification

```console
$ mise x aqua:aquaproj/registry-tool@v0.5.5 -- argd gr
# exit status 0

$ mise x aqua:open-policy-agent/conftest@v0.68.2 -- conftest test --combine pkgs/eth-p/bat-extras/*.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ mise x aqua:aquaproj/registry-tool@v0.5.5 -- argd t eth-p/bat-extras
# exit status 0
# tested linux/amd64, linux/arm64, darwin/amd64, darwin/arm64,
# windows/amd64, and windows/arm64
```

AI was used to investigate the release history, inspect archive contents, implement the change, and run validation. I reviewed and take responsibility for the result.