### PR TITLE
feat: add checkstyle/checkstyle

### DIFF
--- a/pkgs/checkstyle/checkstyle/pkg.yaml
+++ b/pkgs/checkstyle/checkstyle/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: checkstyle/checkstyle@checkstyle-13.8.0

--- a/pkgs/checkstyle/checkstyle/registry.yaml
+++ b/pkgs/checkstyle/checkstyle/registry.yaml
@@ -4,6 +4,5 @@ packages:
     repo_owner: checkstyle
     repo_name: checkstyle
     description: A development tool for checking Java source code against a coding standard
-    asset: "{{.Version}}-all.jar"
-    format: raw
-    complete_windows_ext: false
+    version_prefix: checkstyle-
+    asset: checkstyle-{{.SemVer}}-all.jar

--- a/pkgs/checkstyle/checkstyle/registry.yaml
+++ b/pkgs/checkstyle/checkstyle/registry.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: checkstyle
+    repo_name: checkstyle
+    description: A development tool for checking Java source code against a coding standard
+    asset: "{{.Version}}-all.jar"
+    format: raw
+    complete_windows_ext: false

--- a/registry.yaml
+++ b/registry.yaml
@@ -25108,9 +25108,8 @@ packages:
     repo_owner: checkstyle
     repo_name: checkstyle
     description: A development tool for checking Java source code against a coding standard
-    asset: "{{.Version}}-all.jar"
-    format: raw
-    complete_windows_ext: false
+    asset: checkstyle-{{.SemVer}}-all.jar
+    version_prefix: checkstyle-
   - type: github_release
     repo_owner: chenjiandongx
     repo_name: kubectl-images

--- a/registry.yaml
+++ b/registry.yaml
@@ -25105,6 +25105,13 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: checkstyle
+    repo_name: checkstyle
+    description: A development tool for checking Java source code against a coding standard
+    asset: "{{.Version}}-all.jar"
+    format: raw
+    complete_windows_ext: false
+  - type: github_release
     repo_owner: chenjiandongx
     repo_name: kubectl-images
     description: Show container images used in the cluster

--- a/registry.yaml
+++ b/registry.yaml
@@ -25108,8 +25108,8 @@ packages:
     repo_owner: checkstyle
     repo_name: checkstyle
     description: A development tool for checking Java source code against a coding standard
-    asset: checkstyle-{{.SemVer}}-all.jar
     version_prefix: checkstyle-
+    asset: checkstyle-{{.SemVer}}-all.jar
   - type: github_release
     repo_owner: chenjiandongx
     repo_name: kubectl-images


### PR DESCRIPTION
[checkstyle/checkstyle](https://github.com/checkstyle/checkstyle) - A development tool for checking Java source code against a coding standard

## Summary

Add `checkstyle/checkstyle` as a platform-independent raw JAR package from GitHub Releases.

## Validation

- `argd s checkstyle/checkstyle` (scaffold command invoked; container phase unavailable in the external sandbox)
- `conftest test --combine pkgs/checkstyle/checkstyle/*`
- Prettier validation
- local Aqua install of `checkstyle-13.8.0`
- `java -jar <installed-jar> -V` reports Checkstyle 13.8.0
