### PR TITLE
feat(isksss/isksh): add isksss/isksh

### DIFF
--- a/pkgs/isksss/isksh/pkg.yaml
+++ b/pkgs/isksss/isksh/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: isksss/isksh@v0.1.1

--- a/pkgs/isksss/isksh/registry.yaml
+++ b/pkgs/isksss/isksh/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: isksss
+    repo_name: isksh
+    description: A cross-platform POSIX-oriented shell written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: isksh-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -27313,27 +27313,6 @@ packages:
       - name: cc-test-reporter
         src: test-reporter
   - type: github_release
-    repo_owner: coder3101
-    repo_name: protols
-    description: Language Server for protocol buffers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.2.1")
-        no_asset: true
-      - version_constraint: "true"
-        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-  - type: github_release
     repo_owner: coder
     repo_name: boo
     description: A GNU screen style terminal multiplexer built on libghostty
@@ -27424,6 +27403,27 @@ packages:
             format: tar.gz
         github_artifact_attestations:
           signer_workflow: coder/coder/\.github/workflows/release\.yaml
+  - type: github_release
+    repo_owner: coder3101
+    repo_name: protols
+    description: Language Server for protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: codesenberg
     repo_name: bombardier

--- a/registry.yaml
+++ b/registry.yaml
@@ -27313,6 +27313,27 @@ packages:
       - name: cc-test-reporter
         src: test-reporter
   - type: github_release
+    repo_owner: coder3101
+    repo_name: protols
+    description: Language Server for protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: coder
     repo_name: boo
     description: A GNU screen style terminal multiplexer built on libghostty
@@ -27403,27 +27424,6 @@ packages:
             format: tar.gz
         github_artifact_attestations:
           signer_workflow: coder/coder/\.github/workflows/release\.yaml
-  - type: github_release
-    repo_owner: coder3101
-    repo_name: protols
-    description: Language Server for protocol buffers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.2.1")
-        no_asset: true
-      - version_constraint: "true"
-        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
   - type: github_release
     repo_owner: codesenberg
     repo_name: bombardier
@@ -50884,6 +50884,29 @@ packages:
       type: github_release
       asset: go-car_{{trimV .Version}}_checksums.txt
       algorithm: sha256
+  - type: github_release
+    repo_owner: isksss
+    repo_name: isksh
+    description: A cross-platform POSIX-oriented shell written in Rust
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: isksh-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - windows/amd64
   - type: github_release
     repo_owner: ismaelgv
     repo_name: rnr


### PR DESCRIPTION
[isksss/isksh](https://github.com/isksss/isksh) - A cross-platform POSIX-oriented shell written in Rust

## Summary

Add `isksss/isksh`, a cross-platform POSIX-oriented shell written in Rust.

The package configuration was generated with:

```console
argd s isksss/isksh
```

## Testing

```console
argd t isksss/isksh
conftest test --combine pkgs/isksss/isksh/pkg.yaml pkgs/isksss/isksh/registry.yaml
prettier --check pkgs/isksss/isksh/*.yaml
```

All tests passed for the supported Linux amd64, Linux arm64, and Windows amd64 release assets.

## AI disclosure

OpenAI Codex was used to run the documented scaffold and validation workflow and to draft this pull request. I reviewed the generated configuration and test results.