### PR TITLE
feat(borghei/ink): scaffold borghei/ink

### DIFF
--- a/pkgs/borghei/ink/pkg.yaml
+++ b/pkgs/borghei/ink/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: borghei/ink@v0.6.7
+  - name: borghei/ink
+    version: v0.2.2

--- a/pkgs/borghei/ink/registry.yaml
+++ b/pkgs/borghei/ink/registry.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: borghei
+    repo_name: ink
+    description: Terminal markdown reader with syntax highlighting, inline images, and themes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+      - version_constraint: "true"
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -21007,6 +21007,28 @@ packages:
         github_artifact_attestations:
           signer_workflow: borgbackup/borg/.github/workflows/ci.yml
   - type: github_release
+    repo_owner: borghei
+    repo_name: ink
+    description: Terminal markdown reader with syntax highlighting, inline images, and themes
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.2")
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+      - version_constraint: "true"
+        asset: ink-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: boyter
     repo_name: scc
     description: "Sloc, Cloc and Code: scc is a very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go"


### PR DESCRIPTION
Adds [borghei/ink](https://github.com/borghei/ink) — a terminal markdown reader (single static binary `ink`, MIT).

Scaffolded with `argd s borghei/ink` (argd 0.5.5); only hand edit afterwards was trimming `description` to one short sentence per the style guide. Assets are raw binaries named `ink-{{.OS}}-{{.Arch}}` with `darwin` published as `macos`; `SHA256SUMS` exists from v0.5.0 onward so the checksum block applies to the `> 0.2.2` override; no windows/arm64 asset, so `windows_arm_emulation` is set.

## Verification

`argd t borghei/ink` — exit 0, both pinned versions (v0.2.2, v0.6.7) installed for darwin/linux/windows × amd64/arm64:

```
INF testing os=darwin arch=amd64
INF download and unarchive the package env=darwin/amd64 package_name=borghei/ink package_version=v0.2.2
INF download and unarchive the package env=darwin/amd64 package_name=borghei/ink package_version=v0.6.7
INF testing os=windows arch=amd64
INF create a symbolic link env=windows/amd64 package_name=borghei/ink package_version=v0.6.7 command=ink
INF Running Windows tests ... (windows/arm64 via emulation)
```

Executed inside the aqua-registry Linux container:

```
$ ink --version && uname -sm
ink 0.6.7
Linux aarch64
```

AI disclosure per docs/ai.md: scaffolded and tested with the help of Claude Code (co-authored on the commit); I'm the tool's author and own the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)