### PR TITLE
add grafana/otel-checker

### DIFF
--- a/pkgs/grafana/otel-checker/pkg.yaml
+++ b/pkgs/grafana/otel-checker/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: grafana/otel-checker@v0.3.2

--- a/pkgs/grafana/otel-checker/registry.yaml
+++ b/pkgs/grafana/otel-checker/registry.yaml
@@ -11,6 +11,8 @@ packages:
       - version_constraint: "true"
         asset: otel-checker_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        github_artifact_attestations:
+          signer_workflow: grafana/otel-checker/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: checksums.txt

--- a/pkgs/grafana/otel-checker/registry.yaml
+++ b/pkgs/grafana/otel-checker/registry.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: grafana
+    repo_name: otel-checker
+    description: Otel Me If It's Right project
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: otel-checker_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -46416,6 +46416,8 @@ packages:
       - version_constraint: "true"
         asset: otel-checker_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        github_artifact_attestations:
+          signer_workflow: grafana/otel-checker/.github/workflows/release.yml
         checksum:
           type: github_release
           asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -46407,6 +46407,24 @@ packages:
             format: zip
   - type: github_release
     repo_owner: grafana
+    repo_name: otel-checker
+    description: Otel Me If It's Right project
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.3.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: otel-checker_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: grafana
     repo_name: tanka
     description: Flexible, reusable and concise configuration for Kubernetes
     files:


### PR DESCRIPTION
[grafana/otel-checker](https://github.com/grafana/otel-checker) checks whether OpenTelemetry instrumentation is implemented correctly.

## What changed

- add `grafana/otel-checker` to the aqua registry
- include package metadata under `pkgs/grafana/otel-checker/`
- verify release assets with SHA-256 checksums and GitHub Artifact Attestations
- merge the generated entry into the top-level `registry.yaml`

## Why

`grafana/otel-checker` started publishing binary release artifacts in `v0.3.2`, so it can now be installed via aqua.

## Impact

Users can install otel-checker from the aqua registry starting with `grafana/otel-checker@v0.3.2`.

## Validation

Scaffolded with:

```console
$ argd s --local -B grafana/otel-checker
```

Linted with:

```console
$ conftest test --combine pkgs/grafana/otel-checker/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx --yes prettier --check pkgs/grafana/otel-checker/pkg.yaml pkgs/grafana/otel-checker/registry.yaml
All matched files use Prettier code style!
```

Verified `aqua i` for Linux, macOS, and Windows on amd64 and arm64. Each release asset passed checksum and GitHub Artifact Attestation verification. Also smoke-tested the native binary:

```console
$ otel-checker version
otel-checker 0.3.2
```

This change was prepared with OpenAI Codex and reviewed before submission.
