### PR TITLE
feat(snyk/cli): musl libc variant

### DIFF
--- a/pkgs/snyk/cli/registry.yaml
+++ b/pkgs/snyk/cli/registry.yaml
@@ -52,6 +52,21 @@ packages:
           - goos: linux
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            goarch: arm64
+            asset: snyk-alpine-{{.Arch}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            replacements:
+              linux: alpine
           - goos: darwin
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}

--- a/pkgs/snyk/cli/registry.yaml
+++ b/pkgs/snyk/cli/registry.yaml
@@ -64,6 +64,10 @@ packages:
           - goos: linux
             variants:
               - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
                 value: musl
             replacements:
               linux: alpine

--- a/registry.yaml
+++ b/registry.yaml
@@ -85225,6 +85225,10 @@ packages:
           - goos: linux
             variants:
               - key: libc
+                value: glibc
+          - goos: linux
+            variants:
+              - key: libc
                 value: musl
             replacements:
               linux: alpine

--- a/registry.yaml
+++ b/registry.yaml
@@ -85213,6 +85213,21 @@ packages:
           - goos: linux
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            goarch: arm64
+            asset: snyk-alpine-{{.Arch}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+            replacements:
+              linux: alpine
           - goos: darwin
             goarch: arm64
             asset: snyk-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
https://github.com/snyk/cli/releases

I'm still new to variants, but I guess for snyk/cli it could look something like this.

Invoking `snyk` in the aqua-registry-alpine container locally yields an exec format error, because apparently it resolves to the arm64 binary that was installed in the container last. My system is an amd64 glibc one, Ubuntu. There is also an amd64 binary in the aqua-registry-alpine container and it starts fine.

Not sure if `argd con` can be used to enter the alpine container. I'm manually docker exec'ing bash to enter it.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
