### PR TITLE
fix(haskell/cabal/cabal-install): support v3.18.1.0

### DIFF
--- a/pkgs/haskell/cabal/cabal-install/pkg.yaml
+++ b/pkgs/haskell/cabal/cabal-install/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: haskell/cabal/cabal-install@cabal-install-v3.16.1.0
+  - name: haskell/cabal/cabal-install@cabal-install-v3.18.1.0
+  - name: haskell/cabal/cabal-install
+    version: cabal-install-v3.16.1.0
   - name: haskell/cabal/cabal-install
     version: cabal-install-v3.16.0.0
   - name: haskell/cabal/cabal-install

--- a/pkgs/haskell/cabal/cabal-install/registry.yaml
+++ b/pkgs/haskell/cabal/cabal-install/registry.yaml
@@ -192,7 +192,7 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.16.1.0")
         url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}-alpine3_12.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
@@ -213,3 +213,20 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
+      - version_constraint: "true"
+        url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: linux-unknown
+          windows: mingw64
+        checksum:
+          type: http
+          url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -48047,7 +48047,7 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
-      - version_constraint: "true"
+      - version_constraint: semver("<= 3.16.1.0")
         url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}-alpine3_12.{{.Format}}
         format: tar.xz
         windows_arm_emulation: true
@@ -48068,6 +48068,23 @@ packages:
             format: zip
             url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
             replacements: {}
+      - version_constraint: "true"
+        url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/cabal-install-{{.SemVer}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.xz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: linux-unknown
+          windows: mingw64
+        checksum:
+          type: http
+          url: https://downloads.haskell.org/~cabal/cabal-install-{{.SemVer}}/SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: http
     repo_owner: haskell
     repo_name: ghcup-hs


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

---

## Description

`cabal-install` version  `3.18.1.0` renamed its release artifacts. Linux artifacts now use
the `linux-unknown` suffix, causing the previous `alpine3_12` URL to return `404`.

Add a version override for the new naming scheme while preserving support for
`3.16.1.0` and earlier, similarly to what was done in https://github.com/aquaproj/aqua-registry/pull/46225.

## Verification

Environment:

- aqua 2.62.1
- argd 0.5.7
- Linux amd64

`argd` output snippet:

```txt
INF testing program=argd version=0.5.7 os=linux arch=amd64
INF + /usr/bin/docker exec -w /workspace aqua-registry bash -c rm aqua-checksums.json 2>/dev/null || : program=argd version=0.5.7
INF + /usr/bin/docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=amd64 -e AQUA_GITHUB_TOKEN= aqua-registry aqua i program=argd version=0.5.7
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.13 registry=""
INF create a symbolic link program=aqua version=2.62.2 env=linux/amd64 package_name=aqua-proxy package_version=v1.2.13 registry=""
INF create a symbolic link program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.18.1.0 command=cabal
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.1.1 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.16.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.16.0.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.18.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.2.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.18.1.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.16.1.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.2.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.1.1 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.16.0.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.12.1.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.14.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.3.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.2.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.1.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.2.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.12.1.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.3.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.10.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.6.2.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.6.2.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.6.0.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.4.1.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.2.0.0 registry=standard
INF download and unarchive the package program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.0.0.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.6.0.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.2.0.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.0.0.0 registry=standard
INF downloading a checksum file program=aqua version=2.62.2 env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.4.1.0 registry=standard
```

### Direct aqua execution

Minimal `aqua.yaml`:

```yaml
registries:
  - name: standard
    type: local
    path: registry.yaml
packages:
  - name: haskell/cabal/cabal-install
    version: cabal-install-v3.18.1.0
```

```console
$ aqua exec -- cabal --numeric-version
aqua version 2.62.1
INF download and unarchive the package env=linux/amd64 package_name=haskell/cabal/cabal-install package_version=cabal-install-v3.18.1.0
3.18.1.0
```

Expected: package installs and reports version `3.18.1.0`.
Actual: package installs successfully and reports version `3.18.1.0`.

## AI usage

AI agents were used to investigate, implement, and validate this change.
I reviewed the resulting changes, understand them, and take responsibility for them.

Closes https://github.com/aquaproj/aqua-registry/pull/57955.