### PR TITLE
fix(supabase/cli): use `checksums.txt` for v2.99.0 and later

### DIFF
--- a/pkgs/supabase/cli/pkg.yaml
+++ b/pkgs/supabase/cli/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: supabase/cli@v2.111.0
   - name: supabase/cli
+    version: v2.98.0
+  - name: supabase/cli
     version: v1.126.0
   - name: supabase/cli
     version: v1.27.10

--- a/pkgs/supabase/cli/registry.yaml
+++ b/pkgs/supabase/cli/registry.yaml
@@ -26,10 +26,17 @@ packages:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.98.0")
         asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
           algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -88555,12 +88555,19 @@ packages:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.98.0")
         asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
           type: github_release
           asset: supabase_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+      - version_constraint: "true"
+        asset: supabase_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
           algorithm: sha256
   - type: github_release
     repo_owner: superbrothers


### PR DESCRIPTION
Close #58064

## Changes

Upstream renamed the checksum asset to a fixed `checksums.txt` in `v2.99.0`,
so the declared `supabase_{{trimV .Version}}_checksums.txt` no longer exists.

I split the last `version_constraint: "true"` branch in two: `semver("<= 2.98.0")`
keeps the old asset name, and `"true"` uses `checksums.txt`. Only the
`checksum.asset` field differs between them.

I also added `v2.98.0` to `pkg.yaml`, because the new `semver("<= 2.98.0")`
branch would otherwise ship untested — the listed versions are `v2.111.0`,
which matches `"true"`, and four `v1.x` versions, which the earlier branches
match first. Happy to drop that file if you would rather not grow the test
matrix.

## How I tested

`conftest test --combine pkgs/supabase/cli/*` — 14 passed.
`argd t supabase/cli` — passed on darwin and windows (amd64 / arm64).

Recent aqua falls back to downloading every asset when the checksum file is
missing, which masks the problem, so I also compared both definitions with
aqua v2.56.6:

```console
# before
$ aqua upc -prune
ERR update checksums package_name=supabase/cli package_version=v2.111.0 \
  error="download a checksum file: the asset isn't found: supabase_2.111.0_checksums.txt"

# after
$ aqua upc -prune
INF updating a package checksum package_name=supabase/cli package_version=v2.111.0
```

## Note

`v2.99.0` itself stays uninstallable for an unrelated reason: it has no
version-less assets, so the `asset` template does not resolve. They returned
in `v2.100.0`. I kept this focused on the checksum asset name.

I used an AI agent (Claude Code) to investigate and prepare this change. I
reviewed and verified the result myself.
