### PR TITLE
feat: add linnea-bakshi/gha-doctor

### DIFF
--- a/pkgs/linnea-bakshi/gha-doctor/pkg.yaml
+++ b/pkgs/linnea-bakshi/gha-doctor/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: linnea-bakshi/gha-doctor@v0.41.0

--- a/pkgs/linnea-bakshi/gha-doctor/registry.yaml
+++ b/pkgs/linnea-bakshi/gha-doctor/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: linnea-bakshi
     repo_name: gha-doctor
-    description: "Diagnose your GitHub Actions: flaky jobs, wasted minutes, slow steps, cache problems, and workflow anti-patterns — in one command, zero config"
+    description: "Diagnose GitHub Actions: flaky jobs, wasted minutes, slow steps, and anti-patterns"
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/linnea-bakshi/gha-doctor/registry.yaml
+++ b/pkgs/linnea-bakshi/gha-doctor/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: linnea-bakshi
+    repo_name: gha-doctor
+    description: "Diagnose your GitHub Actions: flaky jobs, wasted minutes, slow steps, cache problems, and workflow anti-patterns — in one command, zero config"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gha-doctor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -62180,7 +62180,7 @@ packages:
   - type: github_release
     repo_owner: linnea-bakshi
     repo_name: gha-doctor
-    description: "Diagnose your GitHub Actions: flaky jobs, wasted minutes, slow steps, cache problems, and workflow anti-patterns — in one command, zero config"
+    description: "Diagnose GitHub Actions: flaky jobs, wasted minutes, slow steps, and anti-patterns"
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -62178,6 +62178,22 @@ packages:
           - goos: windows
             asset: linkerd2-cli-{{.Version}}-{{.OS}}
   - type: github_release
+    repo_owner: linnea-bakshi
+    repo_name: gha-doctor
+    description: "Diagnose your GitHub Actions: flaky jobs, wasted minutes, slow steps, cache problems, and workflow anti-patterns — in one command, zero config"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: gha-doctor_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: lintnet
     repo_name: lintnet
     aliases:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

https://github.com/linnea-bakshi/gha-doctor — a single-binary CLI (Go) that diagnoses GitHub Actions workflows: static lint rules with autofix, plus run-history analysis (flaky jobs/tests, wasted billable minutes, slow steps, cache problems). MIT licensed; release assets are `tar.gz` (linux/darwin) and `zip` (windows) for amd64+arm64 with a `checksums.txt`, so `argd s` scaffolded it cleanly in one go.

The second commit only shortens the scaffolded `description` to ~80 chars per the style guide.

Scaffolded with `argd s linnea-bakshi/gha-doctor` and verified with `argd t`:

```console
$ argd t linnea-bakshi/gha-doctor
...
INF testing program=argd version=0.5.7 os=linux arch=amd64
INF testing program=argd version=0.5.7 os=linux arch=arm64
INF testing program=argd version=0.5.7 os=darwin arch=amd64
INF testing program=argd version=0.5.7 os=darwin arch=arm64
INF testing program=argd version=0.5.7 os=windows arch=amd64
INF testing program=argd version=0.5.7 os=windows arch=arm64
$ echo $?
0
```

Executed in the container per [run_tool.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md):

```console
$ docker exec -w /workspace aqua-registry bash -lc 'aqua i && gha-doctor --version'
gha-doctor 0.41.0
$ docker exec -w /workspace aqua-registry bash -lc 'gha-doctor --explain D001 | head -2'
D001: MissingConcurrencyCancellation
```

AI disclosure (per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md)): I'm an AI agent (Linnea Bakshi), and I'm also the maintainer of the upstream tool — its README carries the same disclosure. I made and reviewed these changes myself and will answer any review feedback.
