### PR TITLE
fix(smithy-lang/smithy): use smithy.bat on Windows

### DIFF
--- a/pkgs/smithy-lang/smithy/registry.yaml
+++ b/pkgs/smithy-lang/smithy/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_owner: smithy-lang
     repo_name: smithy
     description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
+    windows_ext: .bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.47.0")

--- a/registry.yaml
+++ b/registry.yaml
@@ -85598,6 +85598,7 @@ packages:
     repo_owner: smithy-lang
     repo_name: smithy
     description: Smithy is a protocol-agnostic interface definition language and set of tools for generating clients, servers, and documentation for any programming language
+    windows_ext: .bat
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 1.47.0")


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

The Windows archive ships both `bin/smithy` (a POSIX sh script) and `bin/smithy.bat` (the real Windows launcher). Without `windows_ext`, aqua appends the default `.exe` to `bin/smithy`, so the installed `smithy.exe` is a `#!/usr/bin/env sh` script that Windows cannot execute.

Set `windows_ext: .bat` so the Windows launcher is selected instead.

Verified on a `windows-latest` GitHub runner:

- `bin\smithy.bat --version` → `1.72.1`
- `bin\smithy.bat validate model.smithy` → `SUCCESS: Validated 243 shapes`
- `bin\smithy` (the POSIX sh script) copied to `smithy.exe`, reproducing current
  behaviour → fails with "This version of ...\smithy.exe is not compatible with
  the version of Windows you're running."
