### PR TITLE
fix(hadolint/hadolint): download checksums.sha256 for >= v2.15.0

### DIFF
--- a/pkgs/hadolint/hadolint/registry.yaml
+++ b/pkgs/hadolint/hadolint/registry.yaml
@@ -86,7 +86,7 @@ packages:
           darwin: macos
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
+          asset: checksums.sha256
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -47578,7 +47578,7 @@ packages:
           darwin: macos
         checksum:
           type: github_release
-          asset: "{{.Asset}}.sha256"
+          asset: checksums.sha256
           algorithm: sha256
         github_artifact_attestations:
           signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml


### PR DESCRIPTION
## What

`hadolint/hadolint` v2.15.0 and later no longer publish per-asset `<asset>.sha256` files.
They publish a single `checksums.sha256` instead, so the latest `version_overrides`
branch points at release assets that don't exist.

- v2.14.0 assets: `hadolint-linux-x86_64`, `hadolint-linux-x86_64.sha256`, ... (per-asset checksum files)
- v2.15.1 assets: `hadolint-linux-x86_64`, ..., `checksums.sha256` (single checksum file)

```console
$ gh release view v2.15.1 --repo hadolint/hadolint --json assets --jq '[.assets[].name]'
["checksums.sha256","hadolint-linux-arm64","hadolint-linux-x86_64","hadolint-macos-arm64","hadolint-macos-x86_64","hadolint-windows-x86_64.exe"]
```

The checksum file format is unchanged (`<sha256>  *<file name>`), so only `checksum.asset` needs
to change. This matches what the scaffolder generates for the latest version:

```console
$ aqua gr -l 1 hadolint/hadolint
packages:
  - type: github_release
    repo_owner: hadolint
    repo_name: hadolint
    description: Dockerfile linter, validate inline bash, written in Haskell
    asset: hadolint-{{.OS}}-{{.Arch}}
    format: raw
    windows_arm_emulation: true
    replacements:
      amd64: x86_64
      darwin: macos
    checksum:
      type: github_release
      asset: checksums.sha256
      algorithm: sha256
```

The `<= 2.14.0` branch already covers the old layout, so no other branch needs a change.

## Why CI didn't catch this

Recent aqua versions resolve asset digests from the GitHub API, so the broken `checksum.asset`
is never requested. The failure only surfaces on aqua versions that download the checksum file.
Reproduced with aqua v2.55.3:

```console
# before (current main)
$ aqua update-checksum -deep
level=error msg=update checksums env=darwin/arm64 error=download a checksum file: the asset isn't found: hadolint-macos-x86_64.sha256 package_name=hadolint/hadolint package_version=v2.15.1 program_version=2.55.3
level=fatal msg=aqua failed error=it failed to update some packages' checksums
$ echo $?
1

# after (this PR)
$ aqua update-checksum -deep
level=info msg=updating a package checksum env=darwin/arm64 package_name=hadolint/hadolint package_version=v2.15.1 program_version=2.55.3
$ echo $?
0
```

The generated `aqua-checksums.json` contains all 5 published assets and the values match
`checksums.sha256` in the release.

## Test

```console
$ argd t hadolint/hadolint
...
INF verify GitHub Artifact Attestations env=linux/arm64 package_name=hadolint/hadolint package_version=v2.15.1 registry=standard
INF verify GitHub Artifact Attestations env=darwin/amd64 package_name=hadolint/hadolint package_version=v2.15.1 registry=standard
INF verify GitHub Artifact Attestations env=darwin/arm64 package_name=hadolint/hadolint package_version=v2.15.1 registry=standard
INF verify GitHub Artifact Attestations env=windows/amd64 package_name=hadolint/hadolint package_version=v2.15.1 registry=standard
INF Updating registry.yaml program=argd version=0.5.7
$ echo $?
0

$ conftest test pkgs/hadolint/hadolint/*.yaml
28 tests, 28 passed, 0 warnings, 0 failures, 0 exceptions
```

All `pkg.yaml` test versions (v1.2.2 / v2.7.0 / v2.9.3 / v2.10.0 / v2.12.1-beta / v2.14.0 / v2.15.1)
install successfully on linux, darwin and windows for both amd64 and arm64.

## Note

AI (Claude Code) was used to investigate and prepare this change; it is added as a commit co-author.
I reviewed the change and take responsibility for it.
