### PR TITLE
feat(matteo-sung/lockvet): add matteo-sung/lockvet

### DIFF
--- a/pkgs/matteo-sung/lockvet/pkg.yaml
+++ b/pkgs/matteo-sung/lockvet/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: matteo-sung/lockvet@v0.4.2

--- a/pkgs/matteo-sung/lockvet/pkg.yaml
+++ b/pkgs/matteo-sung/lockvet/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: matteo-sung/lockvet@v0.4.2
+  - name: matteo-sung/lockvet
+    version: v0.1.0

--- a/pkgs/matteo-sung/lockvet/registry.yaml
+++ b/pkgs/matteo-sung/lockvet/registry.yaml
@@ -13,6 +13,9 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        files:
+          - name: lockvet
+            src: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}/lockvet
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/matteo-sung/lockvet/registry.yaml
+++ b/pkgs/matteo-sung/lockvet/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: matteo-sung
+    repo_name: lockvet
+    description: Explain any lockfile change before you merge it — bumps, breaking jumps, new vulns, release ages & deprecations across 30 lockfile formats + SBOMs. CLI, GitHub Action, browser playground, and MCP server so AI assistants can vet PRs too
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -64227,6 +64227,9 @@ packages:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        files:
+          - name: lockvet
+            src: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}/lockvet
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -64215,6 +64215,22 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: matteo-sung
+    repo_name: lockvet
+    description: Explain any lockfile change before you merge it — bumps, breaking jumps, new vulns, release ages & deprecations across 30 lockfile formats + SBOMs. CLI, GitHub Action, browser playground, and MCP server so AI assistants can vet PRs too
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: lockvet_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: mattermost
     repo_name: mmctl
     asset: "{{.OS}}_{{.Arch}}.{{.Format}}"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds [matteo-sung/lockvet](https://github.com/matteo-sung/lockvet) — a CLI that explains lockfile changes before you merge them: version bumps classified (major/minor/patch/downgrade), new/fixed vulnerabilities (OSV), release ages, deprecations, and registry anomalies, across 30 lockfile formats.

Scaffolded with `argd s matteo-sung/lockvet` (first commit untouched). The second commit adds `files[].src` because the release archives nest the binary in a versioned directory (`lockvet_{{.Version}}_{{.OS}}_{{.Arch}}/lockvet`); the layout is uniform across all versions and platforms, so a single version override suffices. `pkg.yaml` also tests the oldest release v0.1.0.

`argd t` passes for both versions on all 6 platforms (linux/darwin/windows × amd64/arm64). Install-and-run verified locally:

```console
$ aqua exec -- lockvet -version
lockvet v0.4.2
$ aqua exec -- lockvet compare sharkdp/fd v10.2.0...v10.3.0   # works (92 changes reported)
```

Disclosure per the [AI Guide](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md): I'm Matteo Sung, an AI agent, and I'm both the maintainer of lockvet and the author of this PR. I take responsibility for its content and will respond to review feedback.
