### PR TITLE
fix(CircleCI-Public/circleci-cli): unset files[].src for >= v1.0.39747-pre

### DIFF
--- a/pkgs/CircleCI-Public/circleci-cli/pkg.yaml
+++ b/pkgs/CircleCI-Public/circleci-cli/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: CircleCI-Public/circleci-cli@v0.1.38646
+  - name: CircleCI-Public/circleci-cli@v1.0.47091
+  - name: CircleCI-Public/circleci-cli
+    version: v0.1.38646
   - name: CircleCI-Public/circleci-cli
     version: v0.1.28434
   - name: CircleCI-Public/circleci-cli

--- a/pkgs/CircleCI-Public/circleci-cli/registry.yaml
+++ b/pkgs/CircleCI-Public/circleci-cli/registry.yaml
@@ -47,9 +47,21 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 1.0.39747-pre")
+        asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: circleci-cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: circleci
         checksum:
           type: github_release
           asset: circleci-cli_{{trimV .Version}}_checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -2067,9 +2067,21 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("< 1.0.39747-pre")
+        asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: circleci-cli_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: "true"
         asset: circleci-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: circleci
         checksum:
           type: github_release
           asset: circleci-cli_{{trimV .Version}}_checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`CircleCI-Public/circleci-cli` fails to install on recent versions:

```
$ aqua i
ERR check file_src is correct package_name=CircleCI-Public/circleci-cli package_version=v1.0.47027 env=darwin/arm64 error="check file_src is correct: exe_path isn't found: stat .../circleci-cli_1.0.47027_darwin_arm64.tar.gz/circleci-cli_1.0.47027_darwin_arm64/circleci: no such file or directory"
ERR executable files aren't found
Files in the unarchived package:
circleci
share/bash-completion/completions/circleci
share/fish/vendor_completions.d/circleci.fish
share/man/man1/circleci.1
share/zsh/site-functions/_circleci
```

aqua v2.62.3, darwin/arm64.

## Cause

Upstream changed the archive layout. The binary used to be nested in a
version-named directory, but newer releases put it at the archive root:

```console
# circleci-cli_0.1.38646_darwin_arm64.tar.gz
circleci-cli_0.1.38646_darwin_arm64/api/graphql/LICENSE
circleci-cli_0.1.38646_darwin_arm64/md_docs/LICENSE
circleci-cli_0.1.38646_darwin_arm64/circleci

# circleci-cli_1.0.47091_darwin_arm64.tar.gz
LICENSE
share/bash-completion/completions/circleci
share/fish/vendor_completions.d/circleci.fish
share/man/man1/circleci.1
share/zsh/site-functions/_circleci
circleci
```

So the package-level `files[].src: "{{.AssetWithoutExt}}/circleci"` no longer
resolves.

I bisected every `v1.0*` tag (320 releases) by listing the archive contents to
find the exact boundary:

| tag | layout |
| --- | --- |
| `v1.0.39739-pre` | old (nested) |
| `v1.0.39747-pre` | new (root) |

## Fix

Split the trailing `version_overrides` entry:

- `version_constraint: semver("< 1.0.39747-pre")` — unchanged behaviour, keeps
  the inherited `files[].src`.
- `version_constraint: "true"` — adds a `files` block with only `name`, so the
  binary is picked up from the archive root.

`pkg.yaml`: promoted `@v1.0.47091` to the latest entry and pinned
`v0.1.38646` in the long form so the older branch keeps a test version. No
existing test versions were dropped.

I followed [docs/guide.md § Modifying Existing Packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/guide.md#modifying-existing-packages)
method 3 — `aqua gr -l 1 CircleCI-Public/circleci-cli` produced exactly the
existing latest-version config, and since `files` can't be auto-generated it is
the only hand-written part.

## Verification

`argd t CircleCI-Public/circleci-cli` — passes on all platforms, no errors:

```
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF download and unarchive the package env=darwin/amd64 package_name=CircleCI-Public/circleci-cli package_version=v1.0.47091 registry=standard
INF download and unarchive the package env=darwin/amd64 package_name=CircleCI-Public/circleci-cli package_version=v0.1.38646 registry=standard
INF download and unarchive the package env=darwin/amd64 package_name=CircleCI-Public/circleci-cli package_version=v0.1.28434 registry=standard
INF download and unarchive the package env=darwin/amd64 package_name=CircleCI-Public/circleci-cli package_version=v0.1.28363 registry=standard
INF download and unarchive the package env=darwin/amd64 package_name=CircleCI-Public/circleci-cli package_version=v0.1.17522 registry=standard
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

`conftest test --combine pkgs/CircleCI-Public/circleci-cli/*`:

```
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

Executed the tool from the local registry per docs/run_tool.md
(`AQUA_GLOBAL_CONFIG=$PWD/aqua-all.yaml`):

```console
$ aqua exec -- circleci version
circleci 1.0.47091 (66186e495abd)
```

## AI disclosure

This change was investigated and drafted with Claude Code, per
[docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md).
I reviewed the diff, ran the verification above myself, and take responsibility
for the content.
