### PR TITLE
fix(anthropics/claude-code): install from GitHub Releases and verify

### DIFF
--- a/pkgs/anthropics/claude-code/pkg.yaml
+++ b/pkgs/anthropics/claude-code/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: anthropics/claude-code@v2.1.223
+  - name: anthropics/claude-code
+    version: v2.1.126

--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -10,7 +10,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v2.1.88"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.1.117") or Version == "v2.1.126"
         format: raw
         url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude
         files:
@@ -32,14 +32,20 @@ packages:
           - linux
       - version_constraint: "true"
         type: github_release
-        asset: claude-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         overrides:
-          - goos: darwin
-            asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: claude-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
-            asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
         files:
           - name: claude
         replacements:

--- a/pkgs/anthropics/claude-code/registry.yaml
+++ b/pkgs/anthropics/claude-code/registry.yaml
@@ -30,3 +30,22 @@ packages:
         supported_envs:
           - darwin
           - linux
+      - version_constraint: "true"
+        type: github_release
+        asset: claude-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: darwin
+            asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: zip
+            asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
+        files:
+          - name: claude
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -13804,7 +13804,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v2.1.88"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.1.117") or Version == "v2.1.126"
         format: raw
         url: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{trimV .Version}}/{{.OS}}-{{.Arch}}/claude
         files:
@@ -13824,6 +13824,31 @@ packages:
         supported_envs:
           - darwin
           - linux
+      - version_constraint: "true"
+        type: github_release
+        asset: claude-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: claude-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        files:
+          - name: claude
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: SHASUMS256.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: antonmedv
     repo_name: fx


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [X] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [X] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## What

`anthropics/claude-code` downloads a raw binary from a Google Cloud Storage bucket with no checksum verification. Since v2.1.118 Anthropic publishes per-platform archives and a `SHASUMS256.txt` on GitHub Releases, so this switches the latest version branch to `github_release` and configures `checksum`.

This also adds Windows support, which the GCS source never had. Every release in range ships `claude-win32-x64.zip` and `claude-win32-arm64.zip`; both contain `claude.exe` at the archive root and are listed in `SHASUMS256.txt`.

## AI disclosure

Claude Code helped me understand what changes needed to be made, but I made the actual changes myself.