### PR TITLE
feat(mekedron/wolt-cli): add mekedron/wolt-cli

### DIFF
--- a/pkgs/mekedron/wolt-cli/pkg.yaml
+++ b/pkgs/mekedron/wolt-cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mekedron/wolt-cli@v2.3.1

--- a/pkgs/mekedron/wolt-cli/registry.yaml
+++ b/pkgs/mekedron/wolt-cli/registry.yaml
@@ -9,6 +9,9 @@ packages:
       - version_constraint: "true"
         asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: wolt
+          - name: wolt-mcp
         checksum:
           type: github_release
           asset: SHA256SUMS

--- a/pkgs/mekedron/wolt-cli/registry.yaml
+++ b/pkgs/mekedron/wolt-cli/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mekedron
+    repo_name: wolt-cli
+    description: "Free & Open Source CLI for Wolt: discover venues, inspect menus and options, manage carts, and preview checkout from the terminal"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -64726,6 +64726,22 @@ packages:
       asset: checksums.txt
       algorithm: sha256
   - type: github_release
+    repo_owner: mekedron
+    repo_name: wolt-cli
+    description: "Free & Open Source CLI for Wolt: discover venues, inspect menus and options, manage carts, and preview checkout from the terminal"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: mercari
     repo_name: hcledit
     asset: hcledit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -64734,6 +64734,9 @@ packages:
       - version_constraint: "true"
         asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: wolt
+          - name: wolt-mcp
         checksum:
           type: github_release
           asset: SHA256SUMS


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Add [mekedron/wolt-cli](https://github.com/mekedron/wolt-cli), an unofficial CLI for Wolt.

Scaffolded with `argd s mekedron/wolt-cli`. One manual fix was needed: the archive ships two executables, `wolt` and `wolt-mcp`, so the default single-file assumption (the repository name) resolves to a missing path and the install fails. Both are listed in `files` now.

Only darwin and linux assets are released, hence `supported_envs`. `argd t` passes, and both commands run from PATH:

```console
$ wolt --version
v2.3.1
$ wolt-mcp --help
wolt-mcp — Model Context Protocol server for wolt-cli.
```

`wolt-mcp` is a plain stdio MCP server executed from PATH, so it needs no special install location.

Claude Code was used to prepare this PR; I reviewed and tested the result.
