### PR TITLE
feat(mikevalstar/okq): scaffold mikevalstar/okq

### DIFF
--- a/pkgs/mikevalstar/okq/pkg.yaml
+++ b/pkgs/mikevalstar/okq/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: mikevalstar/okq@v0.8.0

--- a/pkgs/mikevalstar/okq/registry.yaml
+++ b/pkgs/mikevalstar/okq/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: mikevalstar
+    repo_name: okq
+    description: Fast, deterministic CLI to search and navigate Open Knowledge Format (OKF), or Obsidian style doc bundles — for humans and AI agents. Find by frontmatter, traverse the link graph, surface orphans/deadlinks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: okq-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: okq-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -65767,6 +65767,29 @@ packages:
               - --certificate-oidc-issuer
               - https://token.actions.githubusercontent.com
   - type: github_release
+    repo_owner: mikevalstar
+    repo_name: okq
+    description: Fast, deterministic CLI to search and navigate Open Knowledge Format (OKF), or Obsidian style doc bundles — for humans and AI agents. Find by frontmatter, traverse the link graph, surface orphans/deadlinks
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: okq-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: okq-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: miku
     repo_name: zek
     description: Generate a Go struct from XML


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

okq is a CLI for querying Google's OKF standard / Markdown-with-frontmatter doc bundles — search, frontmatter filters, link graph. I'm the tool's author.

Scaffolded with `argd s`; all platform tests pass locally. Windows arm64 uses emulation since okq only publishes an x86_64 Windows binary.

Claude Code orchestrated this PR, but was reviewed by hand by me (mike)
