### PR TITLE
feat(concourse/concourse/fly): checksum config

### DIFF
--- a/pkgs/concourse/concourse/fly/registry.yaml
+++ b/pkgs/concourse/concourse/fly/registry.yaml
@@ -14,7 +14,9 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      algorithm: sha1
     files:
       - name: fly

--- a/registry.yaml
+++ b/registry.yaml
@@ -28658,8 +28658,10 @@ packages:
       - darwin
       - amd64
     rosetta2: true
-    # TODO checksum: support sha1
-    # https://github.com/aquaproj/aqua/issues/1216
+    checksum:
+      type: github_release
+      asset: "{{.Asset}}.sha1"
+      algorithm: sha1
     files:
       - name: fly
   - name: connectrpc/connect-go/protoc-gen-connect-go


### PR DESCRIPTION
Checksums are available actually starting from 3.12.0, but it appears the registry entry started at 7.9.0 time and has never supported versions anywhere near that old.

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
