### PR TITLE
refactor(kunobi-ninja/kunobi): use GitHub release as version source

### DIFF
--- a/pkgs/kunobi-ninja/kunobi/registry.yaml
+++ b/pkgs/kunobi-ninja/kunobi/registry.yaml
@@ -7,7 +7,6 @@ packages:
       - name: kunobi-ninja/kunobi-releases
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
-    version_source: github_tag
     url: https://r2.kunobi.ninja/v{{.Version}}/Kunobi_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     format: tar.gz
     replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -61254,7 +61254,6 @@ packages:
       - name: kunobi-ninja/kunobi-releases
     description: Kubernetes IDE for managing clusters, resources, and workloads
     link: https://kunobi.ninja
-    version_source: github_tag
     url: https://r2.kunobi.ninja/v{{.Version}}/Kunobi_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     format: tar.gz
     replacements:


### PR DESCRIPTION
To improve minimum release age detection in supporting tools.

Ref https://github.com/aquaproj/aqua-registry/pull/57240, https://github.com/kunobi-ninja/kunobi/releases

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
