### PR TITLE
refactor(apstndb/spannerplanviz/rendertree): use GitHub release ver src

### DIFF
--- a/pkgs/apstndb/spannerplanviz/rendertree/registry.yaml
+++ b/pkgs/apstndb/spannerplanviz/rendertree/registry.yaml
@@ -6,4 +6,3 @@ packages:
     repo_name: spannerplanviz
     path: github.com/apstndb/spannerplanviz/cmd/rendertree
     description: This tool render YAML or JSON representation of Cloud Spanner query plan as ascii format
-    version_source: github_tag

--- a/registry.yaml
+++ b/registry.yaml
@@ -14530,7 +14530,6 @@ packages:
     repo_name: spannerplanviz
     path: github.com/apstndb/spannerplanviz/cmd/rendertree
     description: This tool render YAML or JSON representation of Cloud Spanner query plan as ascii format
-    version_source: github_tag
   - type: github_release
     repo_owner: aptly-dev
     repo_name: aptly


### PR DESCRIPTION
For better minimum release age detection in supporting tools.

Ref https://github.com/aquaproj/aqua-registry/pull/57240, https://github.com/apstndb/spannerplanviz/releases

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
