### PR TITLE
refactor(apstndb/execspansql): use GitHub release version source

### DIFF
--- a/pkgs/apstndb/execspansql/registry.yaml
+++ b/pkgs/apstndb/execspansql/registry.yaml
@@ -4,4 +4,3 @@ packages:
     repo_owner: apstndb
     repo_name: execspansql
     description: Yet another gcloud spanner databases execute-sql replacement for better composability
-    version_source: github_tag

--- a/registry.yaml
+++ b/registry.yaml
@@ -14523,7 +14523,6 @@ packages:
     repo_owner: apstndb
     repo_name: execspansql
     description: Yet another gcloud spanner databases execute-sql replacement for better composability
-    version_source: github_tag
   - name: apstndb/spannerplanviz/rendertree
     type: go_install
     repo_owner: apstndb


### PR DESCRIPTION
For better minimum release age detection in supporting tools.

Ref https://github.com/aquaproj/aqua-registry/pull/57240, https://github.com/apstndb/execspansql/releases

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
