### PR TITLE
fix(modem-dev/hunk): support windows/amd64 for >= v0.12.0-beta.2

### DIFF
--- a/pkgs/modem-dev/hunk/pkg.yaml
+++ b/pkgs/modem-dev/hunk/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: modem-dev/hunk@v0.18.0
   - name: modem-dev/hunk
+    version: v0.11.1
+  - name: modem-dev/hunk
     version: v0.6.1

--- a/pkgs/modem-dev/hunk/pkg.yaml
+++ b/pkgs/modem-dev/hunk/pkg.yaml
@@ -1,6 +1,10 @@
 packages:
   - name: modem-dev/hunk@v0.18.0
   - name: modem-dev/hunk
+    version: v0.12.0-beta.2
+  - name: modem-dev/hunk
+    version: v0.12.0-beta.1
+  - name: modem-dev/hunk
     version: v0.11.1
   - name: modem-dev/hunk
     version: v0.6.1

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -17,7 +17,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("< 0.12.0-beta.2")
+      - version_constraint: semver("<= 0.12.0-beta.1")
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:

--- a/pkgs/modem-dev/hunk/registry.yaml
+++ b/pkgs/modem-dev/hunk/registry.yaml
@@ -17,6 +17,17 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("< 0.12.0-beta.2")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -28,3 +39,4 @@ packages:
         supported_envs:
           - linux
           - darwin
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -66810,7 +66810,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("< 0.12.0-beta.2")
+      - version_constraint: semver("<= 0.12.0-beta.1")
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:

--- a/registry.yaml
+++ b/registry.yaml
@@ -66810,6 +66810,17 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: semver("< 0.12.0-beta.2")
+        asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: hunk
+            src: "{{.AssetWithoutExt}}/hunk"
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: hunkdiff-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -66821,6 +66832,7 @@ packages:
         supported_envs:
           - linux
           - darwin
+          - windows/amd64
   - type: github_release
     repo_owner: momaek
     repo_name: authy


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## The bug

On Windows, `aqua i` for `modem-dev/hunk` exits 0 and installs nothing. `supported_envs`
lists only `linux` and `darwin`, so aqua skips the package as unsupported — a skip rather
than an error, so there is no diagnostic and no `hunk` command afterwards. hunk has
published `hunkdiff-windows-x64.tar.gz` since v0.12.0-beta.2; this entry predates that.

## Fix

- Split the trailing `version_overrides` entry: `semver("<= 0.12.0-beta.1")` keeps the
  linux/darwin-only `supported_envs`, and the `"true"` entry adds `windows/amd64`. The
  split is required — appending `windows/amd64` to the existing `"true"` entry turns
  today's silent skip into a hard `the asset isn't found: hunkdiff-windows-x64.tar.gz`
  failure for every release from v0.6.2 to v0.12.0-beta.1.
- `windows/amd64` rather than bare `windows`, because hunk publishes no Windows arm64
  asset. `windows_arm_emulation` is not set — untested, so out of scope here.
- No `.exe` handling is needed: aqua's
  [`completeWindowsExtToFileSrc`](https://github.com/aquaproj/aqua/blob/main/pkg/config/windows_ext.go)
  appends the extension, so the existing `src: "{{.AssetWithoutExt}}/hunk"` resolves to
  `hunkdiff-windows-x64\hunk.exe`.
- `pkg.yaml`: added `v0.12.0-beta.2`, `v0.12.0-beta.1` and `v0.11.1` in long syntax, so CI
  covers the new branch and both sides of the boundary. No existing test version was
  removed and the updater-owned `modem-dev/hunk@v0.18.0` line is untouched.

## Verification

`argd t modem-dev/hunk` — exit 0. On `windows/amd64` it installs v0.12.0-beta.2 and
v0.18.0 and skips v0.12.0-beta.1 / v0.11.1 / v0.6.1; `windows/arm64` skips cleanly. Those
are the two `windows-latest` legs in `wc-test.yaml`. darwin and linux (amd64 + arm64)
resolve exactly as before this change.

`argd t` only simulates Windows via `AQUA_GOOS`, so I also reproduced it on real hardware:

<details>
<summary>Real Windows reproduction — environment, <code>aqua.yaml</code>, before/after</summary>

aqua `2.62.3`, Windows 11 Pro 25H2 build 26200, amd64 (`env=windows/amd64`), PowerShell
5.1. The registry is fetched over aqua's real `github_content` path pinned to this PR's
head commit, not a local file registry.

```yaml
---
registries:
  - name: hunk-pr
    type: github_content
    repo_owner: elucid
    repo_name: aqua-registry
    ref: 37434b7b5f86667eaca20ea4d7da8012fd25c7a0
    path: pkgs/modem-dev/hunk/registry.yaml
packages:
  - name: modem-dev/hunk@<VERSION>
    registry: hunk-pr
```

```powershell
$env:AQUA_DISABLE_POLICY = "true"   # only because this is not the standard registry
$env:AQUA_ROOT_DIR = "C:\aquapr\<case>\root"
$env:AQUA_CONFIG   = "C:\aquapr\<case>\aqua.yaml"
aqua i; aqua which hunk; hunk --version
```

**Before** — current `main` (`ref: 608d3508d9`). Expected hunk installed; actual exit 0,
nothing installed:

```console
> aqua i
# (only aqua-proxy) EXIT=0
> aqua which hunk
ERR aqua failed env=windows/amd64 exe_name=hunk error="command is not found"
# EXIT=1
```

**After** — this PR:

```console
> aqua i
INF download and unarchive the package env=windows/amd64 package_name=modem-dev/hunk package_version=v0.18.0 registry=hunk-pr
# EXIT=0
> aqua which hunk
C:\aquapr\PR-v0.18.0\root\pkgs\github_release\github.com\modem-dev\hunk\v0.18.0\hunkdiff-windows-x64.tar.gz\hunkdiff-windows-x64\hunk.exe
> hunk --version
0.18.0
```

`aqua which` is the interesting line: the entry never mentions `.exe`, and aqua still
resolved `hunk.exe`.

Full matrix on `windows/amd64` — both sides of the boundary behave as intended:

| pinned version | `aqua i` | installed | `hunk --version` |
|---|---|---|---|
| v0.18.0 | 0 | `hunk.exe` | `0.18.0` |
| v0.12.0 | 0 | `hunk.exe` | `0.12.0` |
| v0.12.0-beta.2 | 0 | `hunk.exe` | `0.12.0-beta.2` |
| v0.12.0-beta.1 | 0 | *(skipped, no error)* | — |
| v0.11.1 | 0 | *(skipped, no error)* | — |
| v0.6.1 | 0 | *(skipped, no error)* | — |

Without the version split, the same run against v0.11.1 fails hard:

```console
ERR install the package env=windows/amd64 package_name=modem-dev/hunk package_version=v0.11.1 error="the asset isn't found: hunkdiff-windows-x64.tar.gz"
# EXIT=1
```

</details>

## On `argd s`

I ran `argd s modem-dev/hunk` rather than hand-editing blind. The generated config omits
`files[].src` from all three `version_overrides` branches. hunk's binary is nested inside
a directory in the archive (`hunkdiff-linux-x64/hunk`), so without `files[].src` nothing
installs on any platform, and `argd t` fails on `linux/amd64`:

```
ERR check file_src is correct ... package_version=v0.18.1 file_name=hunk
    exe_path=.../hunkdiff-linux-x64.tar.gz/hunk error="check file_src is correct: exe_path isn't found"
ERR argd failed error="Linux/Darwin tests failed: test failed for linux/amd64: exit status 1"
```

This matches the note in `docs/guide.md` that `files` cannot be auto-generated. I
therefore followed `docs/guide.md` → "Modifying Existing Packages": starting from the
generated output and restoring `files[].src` yields a config identical to this PR, which
passes `argd t` cleanly. Two things from the generated output I did not adopt:
`windows_arm_emulation: true` (hunk ships no Windows arm64 asset, and I have not tested
emulation) and the `v0.18.0` → `v0.18.1` bump in `pkg.yaml` (that pin is owned by
`aqua-registry-updater`).

AI disclosure per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md):
prepared with Claude Code, credited as a commit co-author. I reviewed the configuration
and reproduced every result above myself.
