### PR TITLE
feat: add `OpenRouterLabs/ori-releases`

### DIFF
--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: OpenRouterLabs/ori-releases@cli-0.6.0-4a77da2
+  - name: OpenRouterLabs/ori-releases
+    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: OpenRouterLabs/ori-releases@cli-0.6.0-alpha-f38294b
-  - name: OpenRouterLabs/ori-releases
-    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -1,4 +1,2 @@
 packages:
   - name: OpenRouterLabs/ori-releases@cli-0.6.0-4a77da2
-  - name: OpenRouterLabs/ori-releases
-    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: OpenRouterLabs/ori-releases@cli-0.6.0-4a77da2
+  - name: OpenRouterLabs/ori-releases@cli-0.6.0-alpha-f38294b
+  - name: OpenRouterLabs/ori-releases
+    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: OpenRouterLabs
+    repo_name: ori-releases
+    description: Ori CLI release repo
+    version_filter: not (Version matches "-alpha")
+    version_prefix: cli-
+    files:
+      - name: ori
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "cli-0.0.0-b98cd74"
+      - version_constraint: "true"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -10,7 +10,7 @@ packages:
       - name: ori
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "cli-0.0.0-b98cd74"
+      - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
         no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -9,7 +9,8 @@ packages:
       - name: ori
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "cli-0.0.0-b98cd74"
+      - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
+        no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -4,14 +4,12 @@ packages:
     repo_owner: OpenRouterLabs
     repo_name: ori-releases
     description: Ori CLI release repo
-    version_filter: not (Version matches "-alpha")
     version_prefix: cli-
     files:
       - name: ori
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
-        no_asset: true
+      - version_constraint: Version == "cli-0.0.0-b98cd74"
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -11,6 +11,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "cli-0.0.0-b98cd74"
+        no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/pkgs/OpenRouterLabs/ori-releases/scaffold.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/scaffold.yaml
@@ -4,6 +4,6 @@
 # https://aquaproj.github.io/
 # Other than name is optional. All initial values are just examples.
 name: OpenRouterLabs/ori-releases
-version_filter: not (Version matches "-alpha")
+# version_filter: not (Version matches "-alpha")
 version_prefix: cli-
 # all_assets_filter: not (Asset matches "-cli")

--- a/pkgs/OpenRouterLabs/ori-releases/scaffold.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: OpenRouterLabs/ori-releases
+version_filter: not (Version matches "-alpha")
+version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -6343,6 +6343,7 @@ packages:
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "cli-0.0.0-b98cd74"
+        no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -6336,14 +6336,12 @@ packages:
     repo_owner: OpenRouterLabs
     repo_name: ori-releases
     description: Ori CLI release repo
-    version_filter: not (Version matches "-alpha")
     version_prefix: cli-
     files:
       - name: ori
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "cli-0.0.0-b98cd74"
-        no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -6341,7 +6341,8 @@ packages:
       - name: ori
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "cli-0.0.0-b98cd74"
+      - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
+        no_asset: true
       - version_constraint: "true"
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -6333,6 +6333,29 @@ packages:
         format: raw
         complete_windows_ext: false
   - type: github_release
+    repo_owner: OpenRouterLabs
+    repo_name: ori-releases
+    description: Ori CLI release repo
+    version_filter: not (Version matches "-alpha")
+    version_prefix: cli-
+    files:
+      - name: ori
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "cli-0.0.0-b98cd74"
+      - version_constraint: "true"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl
     description: Hurl, run and test HTTP requests with plain text


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

This pull request adds support for managing the Ori CLI from OpenRouter (OpenRouterLabs Organization on GitHub) in the package registry. The main changes introduce configuration files for the new package, including its registry entry, scaffold, and version pinning.

Refer: https://openrouter.ai/blog/announcements/ori-harness/

---

Installation Tested on a Fresh VM:

<img width="1666" height="573" alt="image" src="https://github.com/user-attachments/assets/e59b42ec-585d-4ece-828f-62d415d378dc" />


---

Summary of Changes:

- Added a new entry for `OpenRouterLabs/ori-releases` in the main registry file (`registry.yaml`), specifying how to fetch and verify Ori CLI releases, including asset naming, checksum verification, and supported environments. [[1]](diffhunk://#diff-f76ed8dd27e8719d0875cf0811376cd4346db1d9114076c0c710a4677e802428R6335-R6358) [[2]](diffhunk://#diff-6ec9331e45a5e9d2af813a500fa85f44df27017e02ebcc6915576eb94d271ac4R1-R26)
- Introduced a scaffold configuration file (`scaffold.yaml`) for `OpenRouterLabs/ori-releases` to provide metadata and initial settings for the package.
- Pinned the Ori CLI package version in `pkg.yaml` to `cli-0.6.0-4a77da2` to ensure a specific version is used.