### PR TITLE
feat(vercel-labs/native): add vercel-labs/native

### DIFF
--- a/pkgs/vercel-labs/native/pkg.yaml
+++ b/pkgs/vercel-labs/native/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: vercel-labs/native@v0.8.4
+  - name: vercel-labs/native
+    version: v0.3.0
+  - name: vercel-labs/native
+    version: v0.1.1

--- a/pkgs/vercel-labs/native/registry.yaml
+++ b/pkgs/vercel-labs/native/registry.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: vercel-labs
+    repo_name: native
+    description: Toolkit for building native desktop apps
+    version_prefix: v
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: Version == "v0.1.1"
+        asset: zero-native-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin/arm64
+      - version_constraint: semver("<= 0.3.0")
+        asset: zero-native-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: zero-native-{{.OS}}-musl-{{.Arch}}
+      - version_constraint: "true"
+        asset: native-sdk-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: native-sdk-{{.OS}}-musl-{{.Arch}}

--- a/pkgs/vercel-labs/native/scaffold.yaml
+++ b/pkgs/vercel-labs/native/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+name: vercel-labs/native
+# The repo also publishes CEF/Chromium bundles in the same release stream, tagged
+# cef-<chromium version> (e.g. cef-144.0.6+g5f7e671+chromium-144.0.7559.59). Those
+# are not the CLI, so restrict scaffolding to the v-prefixed CLI releases.
+version_prefix: v

--- a/registry.yaml
+++ b/registry.yaml
@@ -98678,6 +98678,52 @@ packages:
             goarch: amd64
             asset: agent-browser-{{.OS}}-musl-{{.Arch}}
   - type: github_release
+    repo_owner: vercel-labs
+    repo_name: native
+    description: Toolkit for building native desktop apps
+    version_prefix: v
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: Version == "v0.1.1"
+        asset: zero-native-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin/arm64
+      - version_constraint: semver("<= 0.3.0")
+        asset: zero-native-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: zero-native-{{.OS}}-musl-{{.Arch}}
+      - version_constraint: "true"
+        asset: native-sdk-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x64
+          windows: win32
+        checksum:
+          type: github_release
+          asset: CHECKSUMS.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: native-sdk-{{.OS}}-musl-{{.Arch}}
+  - type: github_release
     repo_owner: version-fox
     repo_name: vfox
     description: A cross-platform and extendable version manager with support for Java, Node.js, Golang, Python, Flutter, .NET & more


### PR DESCRIPTION
Adds [vercel-labs/native](https://github.com/vercel-labs/native) (Native SDK), a toolkit for building native desktop apps. 7.4k stars, Apache-2.0, 34 releases, actively maintained.

Scaffolded with `argd s`, not hand-written.

## Scaffolding config

`argd s` on its own produced a package that failed tests. The repo publishes CEF/Chromium bundles in the same release stream, tagged `cef-<chromium version>` (e.g. `cef-144.0.6+g5f7e671+chromium-144.0.7559.59`). Those are not the CLI, and the generated config picked up an override for that tag, which then failed with `check file_src is correct`.

Per [docs/add_package.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md) I deleted the branch, generated a config with `aqua gr -init`, restricted scaffolding to the CLI releases, and regenerated:

```yaml
name: vercel-labs/native
version_prefix: v
```

That config is committed as `pkgs/vercel-labs/native/scaffold.yaml`.

Note that the CLI was renamed upstream — releases up to v0.3.0 ship a `zero-native-*` asset, later ones ship `native-sdk-*`. `argd s` discovered this on its own and generated the `version_overrides` for it; I did not write those by hand.

## Verification

```
$ argd t vercel-labs/native
```

Exit 0, no errors. Platforms exercised in containers:

```
AQUA_GOOS=darwin  AQUA_GOARCH=amd64
AQUA_GOOS=darwin  AQUA_GOARCH=arm64
AQUA_GOOS=linux   AQUA_GOARCH=amd64
AQUA_GOOS=linux   AQUA_GOARCH=arm64
AQUA_GOOS=windows AQUA_GOARCH=amd64
AQUA_GOOS=windows AQUA_GOARCH=arm64
```

Test versions in `pkg.yaml` cover one per `version_overrides` branch: `v0.8.4` (current `native-sdk-*` assets), `v0.3.0` (the `zero-native-*` branch with the musl override), and `v0.1.1` (darwin/arm64 only). `v0.1.0` is `no_asset: true` and has no test entry.

## AI disclosure

Per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md): this PR was prepared with Claude Code. All generated config came from `argd s`; the human contributor has reviewed the output and owns it.
