### PR TITLE
feat(masutaka/github-nippou): update to 4.3.2, add GH artifact attestations config

### DIFF
--- a/pkgs/masutaka/github-nippou/pkg.yaml
+++ b/pkgs/masutaka/github-nippou/pkg.yaml
@@ -1,5 +1,5 @@
 packages:
-  - name: masutaka/github-nippou@v4.3.0
+  - name: masutaka/github-nippou@v4.3.2
   - name: masutaka/github-nippou
     version: v4.2.9
   - name: masutaka/github-nippou

--- a/pkgs/masutaka/github-nippou/pkg.yaml
+++ b/pkgs/masutaka/github-nippou/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: masutaka/github-nippou@v4.3.2
   - name: masutaka/github-nippou
+    version: v4.3.0
+  - name: masutaka/github-nippou
     version: v4.2.9
   - name: masutaka/github-nippou
     version: v4.1.11

--- a/pkgs/masutaka/github-nippou/registry.yaml
+++ b/pkgs/masutaka/github-nippou/registry.yaml
@@ -25,6 +25,14 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: Version == "v4.3.0"
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: github-nippou_{{.Version}}_checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -33,3 +41,5 @@ packages:
           type: github_release
           asset: github-nippou_{{.Version}}_checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: masutaka/github-nippou/\.github/workflows/release\.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -64172,6 +64172,14 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: Version == "v4.3.0"
+        asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: github-nippou_{{.Version}}_checksums.txt
+          algorithm: sha256
       - version_constraint: "true"
         asset: github-nippou_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
@@ -64180,6 +64188,8 @@ packages:
           type: github_release
           asset: github-nippou_{{.Version}}_checksums.txt
           algorithm: sha256
+        github_artifact_attestations:
+          signer_workflow: masutaka/github-nippou/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: mathew-fleisch
     repo_name: bashbot


### PR DESCRIPTION
https://github.com/masutaka/github-nippou/attestations?q=sort%3Acreated-asc

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [ ] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->
