### PR TITLE
feat(mekedron/wolt-cli): GitHub artifact attestations config

### DIFF
--- a/pkgs/mekedron/wolt-cli/pkg.yaml
+++ b/pkgs/mekedron/wolt-cli/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: mekedron/wolt-cli@v2.4.1
+  - name: mekedron/wolt-cli
+    version: v2.4.0

--- a/pkgs/mekedron/wolt-cli/registry.yaml
+++ b/pkgs/mekedron/wolt-cli/registry.yaml
@@ -6,6 +6,19 @@ packages:
     description: "Free & Open Source CLI for Wolt: discover venues, inspect menus and options, manage carts, and preview checkout from the terminal"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 2.4.0")
+        asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: wolt
+          - name: wolt-mcp
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -19,3 +32,5 @@ packages:
         supported_envs:
           - linux
           - darwin
+        github_artifact_attestations:
+          signer_workflow: mekedron/wolt-cli/\.github/workflows/release\.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -64771,6 +64771,19 @@ packages:
     description: "Free & Open Source CLI for Wolt: discover venues, inspect menus and options, manage carts, and preview checkout from the terminal"
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("<= 2.4.0")
+        asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: wolt
+          - name: wolt-mcp
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
       - version_constraint: "true"
         asset: wolt_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -64784,6 +64797,8 @@ packages:
         supported_envs:
           - linux
           - darwin
+        github_artifact_attestations:
+          signer_workflow: mekedron/wolt-cli/\.github/workflows/release\.yml
   - type: github_release
     repo_owner: mercari
     repo_name: hcledit


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Follow-up to @scop's review on #58468: add GitHub artifact attestations config for `mekedron/wolt-cli`.

https://github.com/mekedron/wolt-cli/attestations?q=sort%3Acreated-asc

v2.4.1 is the first release that publishes attestations, so the config is gated behind a `version_override` and the pre-2.4.1 branch keeps installing with `SHA256SUMS` alone. `pkg.yaml` pins v2.4.0 so that branch stays covered by the test.

`argd t mekedron/wolt-cli` passes; the log shows the split — the verification step runs for v2.4.1 only:

```console
$ argd t mekedron/wolt-cli
INF download and unarchive the package env=linux/arm64 package_name=mekedron/wolt-cli package_version=v2.4.1
INF download and unarchive the package env=linux/arm64 package_name=mekedron/wolt-cli package_version=v2.4.0
INF verify GitHub Artifact Attestations env=linux/arm64 package_name=mekedron/wolt-cli package_version=v2.4.1
```

As a negative control, installing v2.4.1 with the `signer_workflow` pointed at a workflow that does not exist fails, so the check is not a no-op:

```console
WRN execute gh attestation verify args="attestation verify /tmp/714419273 -R mekedron/wolt-cli --signer-workflow mekedron/wolt-cli/\\.github/workflows/bogus\\.yml"
ERR install the package error="verify the asset: verify a package with gh attestation: verify GitHub Artifact Attestations"
```

Claude Code was used to prepare this PR; I reviewed and tested the result.
