### PR TITLE
Add cloudsmith-io/cloudsmith-cli

### DIFF
--- a/pkgs/cloudsmith-io/cloudsmith-cli/pkg.yaml
+++ b/pkgs/cloudsmith-io/cloudsmith-cli/pkg.yaml
@@ -1,6 +1,2 @@
 packages:
   - name: cloudsmith-io/cloudsmith-cli@v1.23.0
-  - name: cloudsmith-io/cloudsmith-cli
-    version: v1.19.0
-  - name: cloudsmith-io/cloudsmith-cli
-    version: v1.8.7

--- a/pkgs/cloudsmith-io/cloudsmith-cli/pkg.yaml
+++ b/pkgs/cloudsmith-io/cloudsmith-cli/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: cloudsmith-io/cloudsmith-cli@v1.23.0
+  - name: cloudsmith-io/cloudsmith-cli
+    version: v1.19.0
+  - name: cloudsmith-io/cloudsmith-cli
+    version: v1.8.7

--- a/pkgs/cloudsmith-io/cloudsmith-cli/registry.yaml
+++ b/pkgs/cloudsmith-io/cloudsmith-cli/registry.yaml
@@ -6,14 +6,15 @@ packages:
     description: Cloudsmith Command Line Interface (CLI)
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.7")
-      - version_constraint: semver("<= 1.9.2")
-        no_asset: true
       - version_constraint: semver("<= 1.19.0")
+        no_asset: true
       - version_constraint: "true"
         asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: cloudsmith
+            src: cloudsmith/cloudsmith
         replacements:
           amd64: x86_64
           darwin: macos

--- a/pkgs/cloudsmith-io/cloudsmith-cli/registry.yaml
+++ b/pkgs/cloudsmith-io/cloudsmith-cli/registry.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: cloudsmith-io
+    repo_name: cloudsmith-cli
+    description: Cloudsmith Command Line Interface (CLI)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.8.7")
+      - version_constraint: semver("<= 1.9.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.19.0")
+      - version_constraint: "true"
+        asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -26963,14 +26963,15 @@ packages:
     description: Cloudsmith Command Line Interface (CLI)
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.8.7")
-      - version_constraint: semver("<= 1.9.2")
-        no_asset: true
       - version_constraint: semver("<= 1.19.0")
+        no_asset: true
       - version_constraint: "true"
         asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: cloudsmith
+            src: cloudsmith/cloudsmith
         replacements:
           amd64: x86_64
           darwin: macos

--- a/registry.yaml
+++ b/registry.yaml
@@ -26957,6 +26957,34 @@ packages:
           linux: Linux
           amd64: x86_64
           windows: Windows
+  - type: github_release
+    repo_owner: cloudsmith-io
+    repo_name: cloudsmith-cli
+    description: Cloudsmith Command Line Interface (CLI)
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 1.8.7")
+      - version_constraint: semver("<= 1.9.2")
+        no_asset: true
+      - version_constraint: semver("<= 1.19.0")
+      - version_constraint: "true"
+        asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            asset: cloudsmith-{{trimV .Version}}-{{.OS}}-{{.Arch}}-gnu.{{.Format}}
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
   - type: go_install
     repo_owner: cloudspannerecosystem
     repo_name: spanner-cli


### PR DESCRIPTION
## Summary

Adds `cloudsmith-io/cloudsmith-cli`, the official Cloudsmith CLI, using the standalone `github_release` binary assets (not the PyPI wheel/sdist).

- Releases before v1.20.0 shipped a Python zipapp (`.pyz`), not a standalone binary, so those are marked `no_asset` and unsupported.
- From v1.20.0 onward, the binary is a PyInstaller onedir bundle where the executable lives at `cloudsmith/cloudsmith` inside the archive (not the archive root), so an explicit `files` entry is required.
- Command name is `cloudsmith` (matches upstream, e.g. the Homebrew formula's `bin.write_exec_script libexec/"cloudsmith"`), not `cloudsmith-cli`.

## Test plan

Scaffolded with `argd s cloudsmith-io/cloudsmith-cli`, then manually fixed the `files` path and collapsed the stub `version_overrides` into a single `no_asset` branch for pre-1.20.0 releases.

```
$ argd t cloudsmith-io/cloudsmith-cli
...
testing os=linux arch=amd64 -> installed, command=cloudsmith
testing os=linux arch=arm64 -> installed
testing os=darwin arch=amd64 -> installed
testing os=darwin arch=arm64 -> installed
testing os=windows arch=amd64 -> installed, command=cloudsmith
testing os=windows arch=arm64 -> installed (via windows_arm_emulation)
```

```
$ conftest test --combine pkgs/cloudsmith-io/cloudsmith-cli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

- [x] Searched open/closed PRs for "cloudsmith" — no duplicates
- [x] Confirmed it installs as a single binary on `$PATH` (not the pip package)
- [x] `argd s` used for scaffolding
- [x] `argd t` passed on all supported platforms
- [x] `conftest test --combine` passed
- [x] `prettier -c` passed

## AI disclosure

Portions of this PR (scaffolding invocation, the `files`/`no_asset` fix, and this description) were drafted with Claude Code. Reviewed and verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)