### PR TITLE
Add Arata1202/ascdir

### DIFF
--- a/pkgs/Arata1202/ascdir/pkg.yaml
+++ b/pkgs/Arata1202/ascdir/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: Arata1202/ascdir@v1.0.0

--- a/pkgs/Arata1202/ascdir/registry.yaml
+++ b/pkgs/Arata1202/ascdir/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Arata1202
+    repo_name: ascdir
+    description: Manage App Store Connect text metadata as local files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ascdir_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -427,6 +427,22 @@ packages:
           linux: unknown-linux-gnu
           amd64: x86_64
   - type: github_release
+    repo_owner: Arata1202
+    repo_name: ascdir
+    description: Manage App Store Connect text metadata as local files
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: ascdir_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: Arriven
     repo_name: db1000n
     version_constraint: "false"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Summary

Add [Arata1202/ascdir](https://github.com/Arata1202/ascdir), a CLI tool that manages App Store Connect text metadata as local files.

The package configuration was generated with:

```sh
argd s Arata1202/ascdir
```

Linux and macOS releases use `tar.gz` archives, while Windows releases use `zip` archives. SHA-256 checksums are verified using the `checksums.txt` release asset.

## Verification

```sh
argd t Arata1202/ascdir
```

Installation succeeded on:

- Linux amd64
- Linux arm64
- macOS amd64
- macOS arm64
- Windows amd64
- Windows arm64

The registry configuration also passed Conftest and Prettier:

```text
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
All matched files use Prettier code style
```

The installed Linux amd64 binary was executed successfully:

```text
ascdir 1.0.0
```

## AI Disclosure

AI assistance was used to review the generated registry configuration and draft this pull request description. All generated output was reviewed and verified by the contributor.
