### PR TITLE
feat: add gohugoio/hugo/hugo-extended-withdeploy

### DIFF
--- a/pkgs/gohugoio/hugo/hugo-extended-withdeploy/pkg.yaml
+++ b/pkgs/gohugoio/hugo/hugo-extended-withdeploy/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: gohugoio/hugo/hugo-extended-withdeploy@v0.165.0
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    version: v0.152.2
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    version: v0.138.0
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    version: v0.137.0

--- a/pkgs/gohugoio/hugo/hugo-extended-withdeploy/registry.yaml
+++ b/pkgs/gohugoio/hugo/hugo-extended-withdeploy/registry.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    type: github_release
+    repo_owner: gohugoio
+    repo_name: hugo
+    description: The world’s fastest framework for building websites
+    files:
+      - name: hugo
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.139.5"
+        no_asset: true
+      - version_constraint: semver("< 0.137.0")
+        no_asset: true
+      - version_constraint: Version == "v0.137.0"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+      - version_constraint: semver("<= 0.138.0")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+      - version_constraint: semver("<= 0.152.2")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: pkg
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+            files:
+              - name: hugo
+                src: Payload/hugo
+          - goos: windows
+            format: zip

--- a/pkgs/gohugoio/hugo/hugo-extended-withdeploy/scaffold.yaml
+++ b/pkgs/gohugoio/hugo/hugo-extended-withdeploy/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: gohugoio/hugo/hugo-extended-withdeploy
+# version_filter: not (Version matches "-rc$")
+# version_prefix: cli-
+all_assets_filter: (Asset matches "extended_withdeploy") or (Asset matches "checksum")

--- a/registry.yaml
+++ b/registry.yaml
@@ -44762,6 +44762,79 @@ packages:
                 src: Payload/hugo
           - goos: windows
             format: zip
+  - name: gohugoio/hugo/hugo-extended-withdeploy
+    type: github_release
+    repo_owner: gohugoio
+    repo_name: hugo
+    description: The world’s fastest framework for building websites
+    files:
+      - name: hugo
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.139.5"
+        no_asset: true
+      - version_constraint: semver("< 0.137.0")
+        no_asset: true
+      - version_constraint: Version == "v0.137.0"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+        supported_envs:
+          - darwin
+          - linux/amd64
+      - version_constraint: semver("<= 0.138.0")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux/amd64
+          - windows
+      - version_constraint: semver("<= 0.152.2")
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: hugo_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            format: pkg
+            asset: hugo_extended_withdeploy_{{trimV .Version}}_{{.OS}}-universal.{{.Format}}
+            files:
+              - name: hugo
+                src: Payload/hugo
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: gojuno
     repo_name: minimock


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

---

This PR adds the `gohugoio/hugo/hugo-extended-withdeploy` package. The `+withdeploy` variant was first introduced in Hugo v0.137.0, released on Nov 4, 2024.

The version breakpoints are as follows:

- [v0.137.0](https://github.com/gohugoio/hugo/releases/tag/v0.137.0): First release; Darwin and Linux AMD64 added
- [v0.137.1](https://github.com/gohugoio/hugo/releases/tag/v0.137.1): Windows AMD64 added
- [v0.139.0](https://github.com/gohugoio/hugo/releases/tag/v0.139.0): Linux ARM64 added
- [v0.139.5](https://github.com/gohugoio/hugo/releases/tag/v0.139.5): Omitted, technical release
- [v0.153.0](https://github.com/gohugoio/hugo/releases/tag/v0.133.0): Darwin changed from .tar.gz to .pkg

### Testing

```
❱ cat /tmp/aqua-hugo-test.yaml
registries:
  - name: local
    type: local
    path: /Users/sviatoslav/Workspace/aqua-registry/pkgs/gohugoio/hugo/hugo-extended-withdeploy/registry.yaml
packages:
  - name: gohugoio/hugo/hugo-extended-withdeploy@v0.137.0
    registry: local

❱ aqua -c /tmp/aqua-hugo-test.yaml install
Aug 19 00:11:27.537 INF download and unarchive the package program=aqua version=2.62.3 env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.13 registry=""
Aug 19 00:11:28.190 INF create a symbolic link program=aqua version=2.62.3 env=darwin/arm64 package_name=aqua-proxy package_version=v1.2.13 registry=""
Aug 19 00:11:28.196 INF create a symbolic link program=aqua version=2.62.3 env=darwin/arm64 package_name=gohugoio/hugo/hugo-extended-withdeploy package_version=v0.137.0 command=hugo
Aug 19 00:11:28.197 INF download and unarchive the package program=aqua version=2.62.3 env=darwin/arm64 package_name=gohugoio/hugo/hugo-extended-withdeploy package_version=v0.137.0 registry=local

❱ aqua -c /tmp/aqua-hugo-test.yaml exec -- hugo version
hugo v0.137.0-59c115813595cba1b1c0e70b867e734992648d1b+extended darwin/arm64 BuildDate=2024-11-04T16:04:06Z VendorInfo=gohugoio

❱ aqua -c /tmp/aqua-hugo-test.yaml install
Aug 19 00:12:51.465 INF download and unarchive the package program=aqua version=2.62.3 env=darwin/arm64 package_name=gohugoio/hugo/hugo-extended-withdeploy package_version=v0.138.0 registry=local

❱ aqua -c /tmp/aqua-hugo-test.yaml exec -- hugo version
hugo v0.138.0-ad82998d54b3f9f8c2741b67356813b55b3134b9+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=gohugoio

❱ aqua -c /tmp/aqua-hugo-test.yaml install
Aug 19 00:13:52.297 INF download and unarchive the package program=aqua version=2.62.3 env=darwin/arm64 package_name=gohugoio/hugo/hugo-extended-withdeploy package_version=v0.152.2 registry=local

❱ aqua -c /tmp/aqua-hugo-test.yaml exec -- hugo version
hugo v0.152.2-6abdacad3f3fe944ea42177844469139e81feda6+extended+withdeploy darwin/arm64 BuildDate=2025-10-24T15:31:49Z VendorInfo=gohugoio

❱ aqua -c /tmp/aqua-hugo-test.yaml install
Aug 19 00:16:18.097 INF download and unarchive the package program=aqua version=2.62.3 env=darwin/arm64 package_name=gohugoio/hugo/hugo-extended-withdeploy package_version=v0.165.0 registry=local

❱ aqua -c /tmp/aqua-hugo-test.yaml exec -- hugo version
hugo v0.165.0-76a5e1880ab46688155b02e99bab9be2a6134492+extended+withdeploy darwin/arm64 BuildDate=2026-08-12T14:26:28Z VendorInfo=gohugoio
```