### PR TITLE
fix(astral-sh/ruff): use glibc binary by default on Linux, fall back to musl

### DIFF
--- a/pkgs/astral-sh/ruff/registry.yaml
+++ b/pkgs/astral-sh/ruff/registry.yaml
@@ -11,15 +11,25 @@ packages:
       - version_constraint: semver("<= 0.1.7")
         asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -27,15 +37,25 @@ packages:
       - version_constraint: semver("<= 0.4.10")
         asset: ruff-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -46,17 +66,27 @@ packages:
         files:
           - name: ruff
             src: "{{.AssetWithoutExt}}/ruff"
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+            files:
+              - name: ruff
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -67,17 +97,27 @@ packages:
         files:
           - name: ruff
             src: "{{.AssetWithoutExt}}/ruff"
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+            files:
+              - name: ruff
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"

--- a/registry.yaml
+++ b/registry.yaml
@@ -16877,15 +16877,25 @@ packages:
       - version_constraint: semver("<= 0.1.7")
         asset: ruff-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -16893,15 +16903,25 @@ packages:
       - version_constraint: semver("<= 0.4.10")
         asset: ruff-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -16912,17 +16932,27 @@ packages:
         files:
           - name: ruff
             src: "{{.AssetWithoutExt}}/ruff"
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+            files:
+              - name: ruff
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
@@ -16933,17 +16963,27 @@ packages:
         files:
           - name: ruff
             src: "{{.AssetWithoutExt}}/ruff"
-        overrides:
-          - goos: windows
-            format: zip
-            files:
-              - name: ruff
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+            files:
+              - name: ruff
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"


### PR DESCRIPTION

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

Ruff publishes both `glibc` and `musl` for Linux (see [releases](https://github.com/astral-sh/ruff/releases/tag/0.16.3)).
I installed Ruff with `mise`, via Aqua Registry, but it always pick `musl` build though my machine is glibc-based Ubuntu, because the `musl` is hardcoded in Aqua Registry.

This PR is to help `mise` pick the correct `glibc` / `musl` variant.

Assisted-by: Crush:kimi-k3
