### PR TITLE
arm fixes

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -83565,6 +83565,7 @@ packages:
         replacements:
           amd64: x86_64
           arm64: aarch64
+          armv7l: arm
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -83477,6 +83477,7 @@ packages:
         replacements:
           amd64: x86_64
           arm64: aarch64
+          armv7l: arm
           darwin: apple-darwin
           linux: unknown-linux-musl
           windows: pc-windows-msvc

--- a/registry.yaml
+++ b/registry.yaml
@@ -1562,6 +1562,7 @@ packages:
         replacements:
           amd64: x86_64
           arm64: aarch64
+          armv7l: armv7
           darwin: apple-darwin
           windows: pc-windows-msvc
         checksum:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
- [ x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

fix arm and armv7l mappings.

example:

```
~$ mise i fd
fd@10.4.2       install                                                                                                                                                         ◟
mise ERROR Failed to install aqua:sharkdp/fd@latest: no asset found: fd-v10.4.2-armv6l-unknown-linux-musl.tar.gz
Available assets:
fd-musl_10.4.2_amd64.deb
fd-musl_10.4.2_arm64.deb
fd-musl_10.4.2_armhf.deb
fd-musl_10.4.2_i686.deb
fd-v10.4.2-aarch64-apple-darwin.tar.gz
fd-v10.4.2-aarch64-pc-windows-msvc.zip
fd-v10.4.2-aarch64-unknown-linux-gnu.tar.gz
fd-v10.4.2-aarch64-unknown-linux-musl.tar.gz
fd-v10.4.2-arm-unknown-linux-gnueabihf.tar.gz
fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz
fd-v10.4.2-i686-pc-windows-msvc.zip
fd-v10.4.2-i686-unknown-linux-gnu.tar.gz
fd-v10.4.2-i686-unknown-linux-musl.tar.gz
fd-v10.4.2-x86_64-pc-windows-gnu.zip
fd-v10.4.2-x86_64-pc-windows-msvc.zip
fd-v10.4.2-x86_64-unknown-linux-gnu.tar.gz
fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz
fd_10.4.2_amd64.deb
fd_10.4.2_arm64.deb
fd_10.4.2_armhf.deb
fd_10.4.2_i686.deb
mise ERROR Version: 2026.8.8 linux-arm (2026-08-17)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
~$ mise i ripgrep
ripgrep@15.2.0  install                                                                                                                                                         ◜
mise ERROR Failed to install aqua:BurntSushi/ripgrep@latest: no asset found: ripgrep-15.2.0-armv6l-linux.tar.gz
Available assets:
ripgrep-15.2.0-aarch64-apple-darwin.tar.gz
ripgrep-15.2.0-aarch64-apple-darwin.tar.gz.sha256
ripgrep-15.2.0-aarch64-pc-windows-msvc.zip
ripgrep-15.2.0-aarch64-pc-windows-msvc.zip.sha256
ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz
ripgrep-15.2.0-aarch64-unknown-linux-gnu.tar.gz.sha256
ripgrep-15.2.0-aarch64-unknown-linux-musl.tar.gz
ripgrep-15.2.0-aarch64-unknown-linux-musl.tar.gz.sha256
ripgrep-15.2.0-armv7-unknown-linux-gnueabihf.tar.gz
ripgrep-15.2.0-armv7-unknown-linux-gnueabihf.tar.gz.sha256
ripgrep-15.2.0-armv7-unknown-linux-musleabi.tar.gz
ripgrep-15.2.0-armv7-unknown-linux-musleabi.tar.gz.sha256
ripgrep-15.2.0-armv7-unknown-linux-musleabihf.tar.gz
ripgrep-15.2.0-armv7-unknown-linux-musleabihf.tar.gz.sha256
ripgrep-15.2.0-i686-pc-windows-msvc.zip
ripgrep-15.2.0-i686-pc-windows-msvc.zip.sha256
ripgrep-15.2.0-s390x-unknown-linux-gnu.tar.gz
ripgrep-15.2.0-s390x-unknown-linux-gnu.tar.gz.sha256
ripgrep-15.2.0-x86_64-apple-darwin.tar.gz
ripgrep-15.2.0-x86_64-apple-darwin.tar.gz.sha256
ripgrep-15.2.0-x86_64-pc-windows-gnu.zip
ripgrep-15.2.0-x86_64-pc-windows-gnu.zip.sha256
ripgrep-15.2.0-x86_64-pc-windows-msvc.zip
ripgrep-15.2.0-x86_64-pc-windows-msvc.zip.sha256
ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz
ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz.sha256
ripgrep_15.2.0-1_amd64.deb
ripgrep_15.2.0-1_amd64.deb.sha256
mise ERROR Version: 2026.8.8 linux-arm (2026-08-17)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
~$ mise i bat
bat@0.26.1      install                                                                                                                                                         ◜
mise ERROR Failed to install aqua:sharkdp/bat@latest: no asset found: bat-v0.26.1-armv6l-unknown-linux-musl.tar.gz
Available assets:
bat-musl_0.26.1_arm64.deb
bat-musl_0.26.1_musl-linux-amd64.deb
bat-musl_0.26.1_musl-linux-i686.deb
bat-v0.26.1-aarch64-apple-darwin.tar.gz
bat-v0.26.1-aarch64-pc-windows-msvc.zip
bat-v0.26.1-aarch64-unknown-linux-gnu.tar.gz
bat-v0.26.1-aarch64-unknown-linux-musl.tar.gz
bat-v0.26.1-arm-unknown-linux-gnueabihf.tar.gz
bat-v0.26.1-arm-unknown-linux-musleabihf.tar.gz
bat-v0.26.1-i686-pc-windows-msvc.zip
bat-v0.26.1-i686-unknown-linux-gnu.tar.gz
bat-v0.26.1-i686-unknown-linux-musl.tar.gz
bat-v0.26.1-x86_64-apple-darwin.tar.gz
bat-v0.26.1-x86_64-pc-windows-msvc.zip
bat-v0.26.1-x86_64-unknown-linux-gnu.tar.gz
bat-v0.26.1-x86_64-unknown-linux-musl.tar.gz
bat_0.26.1_amd64.deb
bat_0.26.1_arm64.deb
bat_0.26.1_armhf.deb
bat_0.26.1_i686.deb
bat_0.26.1_musl-linux-armhf.deb
mise ERROR Version: 2026.8.8 linux-arm (2026-08-17)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```