### PR TITLE
Update Arata1202/ascdir to v1.2.1

### DIFF
--- a/pkgs/Arata1202/ascdir/pkg.yaml
+++ b/pkgs/Arata1202/ascdir/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: Arata1202/ascdir@v1.1.4
+  - name: Arata1202/ascdir@v1.2.0

--- a/pkgs/Arata1202/ascdir/pkg.yaml
+++ b/pkgs/Arata1202/ascdir/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: Arata1202/ascdir@v1.2.0
+  - name: Arata1202/ascdir@v1.2.1

--- a/pkgs/Arata1202/ascdir/registry.yaml
+++ b/pkgs/Arata1202/ascdir/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: Arata1202
     repo_name: ascdir
-    description: Manage App Store Connect metadata and product-page assets as reviewable files
+    description: Manage App Store Connect metadata, TestFlight distribution, and releases with safe CLI workflows
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/registry.yaml
+++ b/registry.yaml
@@ -429,7 +429,7 @@ packages:
   - type: github_release
     repo_owner: Arata1202
     repo_name: ascdir
-    description: Manage App Store Connect metadata and product-page assets as reviewable files
+    description: Manage App Store Connect metadata, TestFlight distribution, and releases with safe CLI workflows
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
Update `Arata1202/ascdir` to v1.2.1 and refresh its description for the new TestFlight and App Store release workflows.

Release: https://github.com/Arata1202/ascdir/releases/tag/v1.2.1