### PR TITLE
feat: add skyhook-io/radar

### DIFF
--- a/pkgs/skyhook-io/radar/pkg.yaml
+++ b/pkgs/skyhook-io/radar/pkg.yaml
@@ -1,0 +1,22 @@
+packages:
+  - name: skyhook-io/radar@v1.11.0
+  - name: skyhook-io/radar
+    version: v1.4.6
+  - name: skyhook-io/radar
+    version: v1.4.4
+  - name: skyhook-io/radar
+    version: v1.3.2-rc.2
+  - name: skyhook-io/radar
+    version: v1.0.2-rc4
+  - name: skyhook-io/radar
+    version: v1.0.2-rc1
+  - name: skyhook-io/radar
+    version: v1.0.0
+  - name: skyhook-io/radar
+    version: v0.9.3
+  - name: skyhook-io/radar
+    version: v0.8.2
+  - name: skyhook-io/radar
+    version: v0.6.9
+  - name: skyhook-io/radar
+    version: v0.6.3

--- a/pkgs/skyhook-io/radar/pkg.yaml
+++ b/pkgs/skyhook-io/radar/pkg.yaml
@@ -1,21 +1,7 @@
 packages:
   - name: skyhook-io/radar@v1.11.0
   - name: skyhook-io/radar
-    version: v1.4.6
-  - name: skyhook-io/radar
-    version: v1.4.4
-  - name: skyhook-io/radar
-    version: v1.3.2-rc.2
-  - name: skyhook-io/radar
-    version: v1.0.2-rc4
-  - name: skyhook-io/radar
-    version: v1.0.2-rc1
-  - name: skyhook-io/radar
-    version: v1.0.0
-  - name: skyhook-io/radar
-    version: v0.9.3
-  - name: skyhook-io/radar
-    version: v0.8.2
+    version: v0.6.10
   - name: skyhook-io/radar
     version: v0.6.9
   - name: skyhook-io/radar

--- a/pkgs/skyhook-io/radar/registry.yaml
+++ b/pkgs/skyhook-io/radar/registry.yaml
@@ -1,0 +1,129 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: skyhook-io
+    repo_name: radar
+    description: "The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.9.3", "v1.0.1", "v1.0.2-rc6"]
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version in ["v1.0.2-rc1", "v1.0.2-rc5"]
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.3.2-rc.2"
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.3")
+        asset: explorer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.9")
+        asset: radar_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.8.2")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.0")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.2-rc4")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.4.4")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.4.6")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/skyhook-io/radar/registry.yaml
+++ b/pkgs/skyhook-io/radar/registry.yaml
@@ -4,6 +4,9 @@ packages:
     repo_owner: skyhook-io
     repo_name: radar
     description: The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary
+    files:
+      - name: kubectl-radar
+      - name: radar
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.3")
@@ -11,6 +14,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+            src: kubectl-explorer
+          - name: radar
             src: kubectl-explorer
         windows_arm_emulation: true
         checksum:
@@ -25,6 +30,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -38,6 +45,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release

--- a/pkgs/skyhook-io/radar/registry.yaml
+++ b/pkgs/skyhook-io/radar/registry.yaml
@@ -3,45 +3,15 @@ packages:
   - type: github_release
     repo_owner: skyhook-io
     repo_name: radar
-    description: "The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary"
+    description: The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.9.3", "v1.0.1", "v1.0.2-rc6"]
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version in ["v1.0.2-rc1", "v1.0.2-rc5"]
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.3.2-rc.2"
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 0.6.3")
         asset: explorer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubectl-radar
+            src: kubectl-explorer
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -53,61 +23,8 @@ packages:
       - version_constraint: semver("<= 0.6.9")
         asset: radar_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.8.2")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.0")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.2-rc4")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.4.4")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.4.6")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        files:
+          - name: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -119,10 +36,12 @@ packages:
       - version_constraint: "true"
         asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
-          asset: checksums-desktop.txt
+          asset: checksums.txt
           algorithm: sha256
         overrides:
           - goos: windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -85468,6 +85468,9 @@ packages:
     repo_owner: skyhook-io
     repo_name: radar
     description: The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary
+    files:
+      - name: kubectl-radar
+      - name: radar
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.6.3")
@@ -85475,6 +85478,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+            src: kubectl-explorer
+          - name: radar
             src: kubectl-explorer
         windows_arm_emulation: true
         checksum:
@@ -85489,6 +85494,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -85502,6 +85509,8 @@ packages:
         format: tar.gz
         files:
           - name: kubectl-radar
+          - name: radar
+            src: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release

--- a/registry.yaml
+++ b/registry.yaml
@@ -85465,6 +85465,133 @@ packages:
             files:
               - name: sk
   - type: github_release
+    repo_owner: skyhook-io
+    repo_name: radar
+    description: "The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["v0.9.3", "v1.0.1", "v1.0.2-rc6"]
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version in ["v1.0.2-rc1", "v1.0.2-rc5"]
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: Version == "v1.3.2-rc.2"
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.3")
+        asset: explorer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.6.9")
+        asset: radar_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.8.2")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.0")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.0.2-rc4")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.4.4")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 1.4.6")
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums-desktop.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: sl1pm4t
     repo_name: k2tf
     description: Kubernetes YAML to Terraform HCL converter

--- a/registry.yaml
+++ b/registry.yaml
@@ -85467,45 +85467,15 @@ packages:
   - type: github_release
     repo_owner: skyhook-io
     repo_name: radar
-    description: "The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary"
+    description: The missing open-source Kubernetes UI with a built-in MCP server for AI agents. See what's broken, why, and what changed. Issues, Topology, event timeline, Helm, GitOps, live service traffic, and cluster audits - all in one Go binary
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["v0.9.3", "v1.0.1", "v1.0.2-rc6"]
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version in ["v1.0.2-rc1", "v1.0.2-rc5"]
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: Version == "v1.3.2-rc.2"
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
       - version_constraint: semver("<= 0.6.3")
         asset: explorer_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubectl-radar
+            src: kubectl-explorer
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -85517,61 +85487,8 @@ packages:
       - version_constraint: semver("<= 0.6.9")
         asset: radar_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 0.8.2")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.0")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.0.2-rc4")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.4.4")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums-desktop.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
-      - version_constraint: semver("<= 1.4.6")
-        asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        files:
+          - name: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
@@ -85583,10 +85500,12 @@ packages:
       - version_constraint: "true"
         asset: radar_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kubectl-radar
         windows_arm_emulation: true
         checksum:
           type: github_release
-          asset: checksums-desktop.txt
+          asset: checksums.txt
           algorithm: sha256
         overrides:
           - goos: windows


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Radar is a kubectl plugin, so `argd s` could not finish: archives hold `kubectl-radar` and it was looking for `radar`. Second commit fixes that and two more things generation could not guess.

The repo ships two products from one tag, and so two checksum files. `checksums-desktop.txt` is for the desktop app, only `checksums.txt` covers these assets, and it is there in all 131 releases. Generation picked one or the other per version, which is why scaffolded `version_overrides` looked so noisy.

Asset name changed twice: `explorer_` up to v0.6.3 (tool was renamed), then `radar_` without the `v` prefix through v0.6.9, then `radar_v` from v0.6.10 on. Old versions keep `kubectl-radar` as command name via `files[].src`, so the command does not change under user if you pin an old version.

`argd t` passes for linux, darwin and windows on both amd64 and arm64, with v1.11.0 and one version from each era. conftest is 14/14. Also installed it through local registry and ran the binary.

One thing I was not sure about: upstream install script and Homebrew formula also create a bare `radar` next to the plugin name. I left it out to match `elsesiy/kubectl-view-secret`, which exposes only the plugin command. Can add a second `files` entry if you prefer both.

AI was used to prepare this pull request and its description. I reviewed it and take responsibility for the content.
