### PR TITLE
fix(temporalio/temporal): add no_asset rules

### DIFF
--- a/pkgs/temporalio/temporal/pkg.yaml
+++ b/pkgs/temporalio/temporal/pkg.yaml
@@ -1,6 +1,12 @@
 packages:
   - name: temporalio/temporal@v1.31.2
   - name: temporalio/temporal
-    version: v1.30.1
+    version: v1.14.6
   - name: temporalio/temporal
-    version: v1.29.6
+    version: v1.12.4
+  - name: temporalio/temporal
+    version: v1.8.2
+  - name: temporalio/temporal
+    version: v1.5.1
+  - name: temporalio/temporal
+    version: v1.4.2

--- a/pkgs/temporalio/temporal/pkg.yaml
+++ b/pkgs/temporalio/temporal/pkg.yaml
@@ -1,12 +1,6 @@
 packages:
   - name: temporalio/temporal@v1.31.2
   - name: temporalio/temporal
-    version: v1.14.6
+    version: v1.30.1
   - name: temporalio/temporal
-    version: v1.12.4
-  - name: temporalio/temporal
-    version: v1.8.2
-  - name: temporalio/temporal
-    version: v1.5.1
-  - name: temporalio/temporal
-    version: v1.4.2
+    version: v1.29.6

--- a/pkgs/temporalio/temporal/registry.yaml
+++ b/pkgs/temporalio/temporal/registry.yaml
@@ -3,41 +3,31 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal service
+    description: Temporal Server bundle (temporal-server + database tools)
+    files:
+      - name: temporal-server
+      - name: temporal-cassandra-tool
+      - name: temporal-sql-tool
+      - name: temporal-elasticsearch-tool
+      - name: tdbg
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version in ["v0.10.0", "v1.0.1", "v1.1.2", "v1.2.3", "v1.3.3", "v1.20.5", "v1.21.6", "v1.22.3", "v1.28.3.1", "v1.29.4.1", "v1.29.6.1", "v1.30.4.1"]
         no_asset: true
-      - version_constraint: semver("<= 1.4.2")
-      - version_constraint: semver("<= 1.4.4")
+      - version_constraint: semver("> 1.4.2, <= 1.4.4")
         no_asset: true
-      - version_constraint: semver("<= 1.5.1")
-      - version_constraint: semver("<= 1.7.3")
+      - version_constraint: semver("> 1.5.1, <= 1.7.3")
         no_asset: true
-      - version_constraint: semver("<= 1.8.2")
+      - version_constraint: semver("<= 1.30.1")
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.12.4")
-        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 1.14.6")
-        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: temporal-server
+          - name: temporal-cassandra-tool
+          - name: temporal-sql-tool
         checksum:
           type: github_release
           asset: checksums.txt
@@ -45,10 +35,10 @@ packages:
       - version_constraint: "true"
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip

--- a/pkgs/temporalio/temporal/registry.yaml
+++ b/pkgs/temporalio/temporal/registry.yaml
@@ -3,25 +3,41 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal Server bundle (temporal-server + database tools)
-    files:
-      - name: temporal-server
-      - name: temporal-cassandra-tool
-      - name: temporal-sql-tool
-      - name: temporal-elasticsearch-tool
-      - name: tdbg
+    description: Temporal service
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.30.1")
+      - version_constraint: Version in ["v0.10.0", "v1.0.1", "v1.1.2", "v1.2.3", "v1.3.3", "v1.20.5", "v1.21.6", "v1.22.3", "v1.28.3.1", "v1.29.4.1", "v1.29.6.1", "v1.30.4.1"]
+        no_asset: true
+      - version_constraint: semver("<= 1.4.2")
+      - version_constraint: semver("<= 1.4.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 1.7.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.8.2")
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
-        files:
-          - name: temporal-server
-          - name: temporal-cassandra-tool
-          - name: temporal-sql-tool
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.12.4")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.14.6")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt
@@ -29,10 +45,10 @@ packages:
       - version_constraint: "true"
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -93599,41 +93599,31 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal service
+    description: Temporal Server bundle (temporal-server + database tools)
+    files:
+      - name: temporal-server
+      - name: temporal-cassandra-tool
+      - name: temporal-sql-tool
+      - name: temporal-elasticsearch-tool
+      - name: tdbg
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version in ["v0.10.0", "v1.0.1", "v1.1.2", "v1.2.3", "v1.3.3", "v1.20.5", "v1.21.6", "v1.22.3", "v1.28.3.1", "v1.29.4.1", "v1.29.6.1", "v1.30.4.1"]
         no_asset: true
-      - version_constraint: semver("<= 1.4.2")
-      - version_constraint: semver("<= 1.4.4")
+      - version_constraint: semver("> 1.4.2, <= 1.4.4")
         no_asset: true
-      - version_constraint: semver("<= 1.5.1")
-      - version_constraint: semver("<= 1.7.3")
+      - version_constraint: semver("> 1.5.1, <= 1.7.3")
         no_asset: true
-      - version_constraint: semver("<= 1.8.2")
+      - version_constraint: semver("<= 1.30.1")
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        rosetta2: true
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-        supported_envs:
-          - darwin
-          - windows
-          - amd64
-      - version_constraint: semver("<= 1.12.4")
-        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        checksum:
-          type: github_release
-          asset: checksums.txt
-          algorithm: sha256
-      - version_constraint: semver("<= 1.14.6")
-        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: temporal-server
+          - name: temporal-cassandra-tool
+          - name: temporal-sql-tool
         checksum:
           type: github_release
           asset: checksums.txt
@@ -93641,13 +93631,13 @@ packages:
       - version_constraint: "true"
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        overrides:
+          - goos: windows
+            format: zip
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
   - type: github_release
     repo_owner: tenable
     repo_name: terrascan

--- a/registry.yaml
+++ b/registry.yaml
@@ -93599,25 +93599,41 @@ packages:
   - type: github_release
     repo_owner: temporalio
     repo_name: temporal
-    description: Temporal Server bundle (temporal-server + database tools)
-    files:
-      - name: temporal-server
-      - name: temporal-cassandra-tool
-      - name: temporal-sql-tool
-      - name: temporal-elasticsearch-tool
-      - name: tdbg
+    description: Temporal service
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.30.1")
+      - version_constraint: Version in ["v0.10.0", "v1.0.1", "v1.1.2", "v1.2.3", "v1.3.3", "v1.20.5", "v1.21.6", "v1.22.3", "v1.28.3.1", "v1.29.4.1", "v1.29.6.1", "v1.30.4.1"]
+        no_asset: true
+      - version_constraint: semver("<= 1.4.2")
+      - version_constraint: semver("<= 1.4.4")
+        no_asset: true
+      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 1.7.3")
+        no_asset: true
+      - version_constraint: semver("<= 1.8.2")
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
-        files:
-          - name: temporal-server
-          - name: temporal-cassandra-tool
-          - name: temporal-sql-tool
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.12.4")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 1.14.6")
+        asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         checksum:
           type: github_release
           asset: checksums.txt
@@ -93625,13 +93641,13 @@ packages:
       - version_constraint: "true"
         asset: temporal_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
-        overrides:
-          - goos: windows
-            format: zip
         checksum:
           type: github_release
           asset: checksums.txt
           algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: tenable
     repo_name: terrascan


### PR DESCRIPTION
## Summary

- re-scaffold `temporalio/temporal` from the complete GitHub Release history
- mark all 33 releases with zero assets as `no_asset`, including `v1.28.3.1`, `v1.29.4.1`, `v1.29.6.1`, and `v1.30.4.1`
- preserve the curated Temporal Server bundle binaries and existing regression versions
- regenerate the repository-level `registry.yaml`

## Verification

Re-scaffolded first as required:

```console
$ argd s temporalio/temporal
[feat/temporalio/temporal 5b388d3daa] feat(temporalio/temporal): scaffold temporalio/temporal
...
ERR install the package package_name=temporalio/temporal package_version=v1.5.1 error="invalid package: github_release package requires asset"
ERR install the package package_name=temporalio/temporal package_version=v1.4.2 error="invalid package: github_release package requires asset"
```

The generated test failure came from the generic scaffold dropping the package's curated multi-binary `files` configuration. The follow-up commit restores it while retaining the generated `no_asset` detections.

```console
$ argd t temporalio/temporal
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

Verified an affected version directly with aqua against the local registry:

```console
$ AQUA_POLICY_CONFIG=aqua-policy.yaml aqua -c aqua-noasset-test.yaml i
ERR install the package package_name=temporalio/temporal package_version=v1.30.4.1 registry=local error="no asset is released for this version"
```

```console
$ conftest test --combine pkgs/temporalio/temporal/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

AI assistance: Codex was used to investigate releases, update the registry, and verify the change.
