### PR TITLE
feat(rafaelespinoza/godfish): Add rafaelespinoza/godfish

### DIFF
--- a/pkgs/rafaelespinoza/godfish/pkg.yaml
+++ b/pkgs/rafaelespinoza/godfish/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: rafaelespinoza/godfish@v0.18.0

--- a/pkgs/rafaelespinoza/godfish/registry.yaml
+++ b/pkgs/rafaelespinoza/godfish/registry.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: rafaelespinoza
+    repo_name: godfish
+    description: a db migration management CLI and library
+    version_filter: semver(">= 0.18.0")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: godfish_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/rafaelespinoza/godfish/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json

--- a/pkgs/rafaelespinoza/godfish/registry.yaml
+++ b/pkgs/rafaelespinoza/godfish/registry.yaml
@@ -3,13 +3,24 @@ packages:
   - type: github_release
     repo_owner: rafaelespinoza
     repo_name: godfish
-    description: a db migration management CLI and library
+    description: a db migration management CLI for cassandra, mysql, postgres, sqlite, sqlserver
     version_filter: semver(">= 0.18.0")
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: godfish_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+        files:
+          - name: godfish
+          - name: godfish-cassandra
+          - name: godfish-mysql
+          - name: godfish-postgres
+          - name: godfish-sqlite3
+          - name: godfish-sqlserver
         checksum:
           type: github_release
           asset: checksums.txt

--- a/pkgs/rafaelespinoza/godfish/scaffold.yaml
+++ b/pkgs/rafaelespinoza/godfish/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: rafaelespinoza/godfish
+version_filter: semver(">= 0.18.0")
+# version_prefix: cli-
+# all_assets_filter: not (Asset matches "-cli")

--- a/registry.yaml
+++ b/registry.yaml
@@ -78571,6 +78571,29 @@ packages:
           - name: raco
             src: racket/raco
   - type: github_release
+    repo_owner: rafaelespinoza
+    repo_name: godfish
+    description: a db migration management CLI and library
+    version_filter: semver(">= 0.18.0")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: godfish_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/rafaelespinoza/godfish/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+  - type: github_release
     repo_owner: rajatjindal
     repo_name: krew-release-bot
     description: bot to bump version of plugin in krew-index on new releases

--- a/registry.yaml
+++ b/registry.yaml
@@ -78573,13 +78573,24 @@ packages:
   - type: github_release
     repo_owner: rafaelespinoza
     repo_name: godfish
-    description: a db migration management CLI and library
+    description: a db migration management CLI for cassandra, mysql, postgres, sqlite, sqlserver
     version_filter: semver(">= 0.18.0")
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"
         asset: godfish_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+        files:
+          - name: godfish
+          - name: godfish-cassandra
+          - name: godfish-mysql
+          - name: godfish-postgres
+          - name: godfish-sqlite3
+          - name: godfish-sqlserver
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

- feat(rafaelespinoza/godfish): scaffold rafaelespinoza/godfish
- Update description, supported env, files

This is a DB migration manager, statically-linked, no language-specific features, SQL-based.
There are currently 5 different supported DBs: cassandra, mysql, postgres, sqlite3, sqlserver.

_A note for maintainer_

The upstream release archive bundles 1 unified binary (`godfish`) and 5 driver-specific binaries (`godfish-cassandra`, `godfish-mysql`, `godfish-postgres`, `godfish-sqlite3`, `godfish-sqlserver`).

Currently, all 6 binaries are defined under `files` in this single package (`rafaelespinoza/godfish`).
Please let me know if you would prefer this split into separate packages (e.g. `rafaelespinoza/godfish/godfish-postgres`, etc.) instead.

## Verifications

Registry test (`$ aqua exec -- argd t rafaelespinoza/godfish`):
```
Aug 21 22:26:39.902 INF checking if the container exists program=argd version=0.5.7 container_name=aqua-registry
Aug 21 22:26:39.966 INF checking if the container is running program=argd version=0.5.7 container_name=aqua-registry
Aug 21 22:26:40.156 INF Running Linux/Darwin tests program=argd version=0.5.7
...
Aug 21 22:26:41.162 INF checking if the container exists program=argd version=0.5.7 container_name=aqua-registry-windows
Aug 21 22:26:41.224 INF checking if the container is running program=argd version=0.5.7 container_name=aqua-registry-windows
Aug 21 22:26:41.422 INF Dockerfile isn't updated program=argd version=0.5.7
Aug 21 22:26:41.422 INF Running Windows tests program=argd version=0.5.7
...
Aug 21 22:26:41.982 INF Updating registry.yaml program=argd version=0.5.7
```

Example verification inside of interactive aqua-registry container:
```sh
root@207274c98eb3:/workspace# aqua install rafaelespinoza/godfish
root@207274c98eb3:/workspace# godfish version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		cassandra,mysql,postgres,sqlite3,sqlserver
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# godfish-cassandra version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		cassandra
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# godfish-mysql version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		mysql
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# godfish-postgres version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		postgres
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# godfish-sqlite3 version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		sqlite3
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# godfish-sqlserver version
BranchName:	HEAD
BuildTime:	2026-08-14T23:36:04+0000
Driver:		sqlserver
CommitHash:	6630643
GoVersion:	go1.25.13
Tag:		v0.18.0
root@207274c98eb3:/workspace# uname -sm
Linux aarch64
```
