### PR TITLE
feat(re-taro/tsmcp): scaffold re-taro/tsmcp

### DIFF
--- a/pkgs/re-taro/tsmcp/pkg.yaml
+++ b/pkgs/re-taro/tsmcp/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: re-taro/tsmcp@v0.1.0

--- a/pkgs/re-taro/tsmcp/registry.yaml
+++ b/pkgs/re-taro/tsmcp/registry.yaml
@@ -3,6 +3,7 @@ packages:
   - type: github_release
     repo_owner: re-taro
     repo_name: tsmcp
+    description: MCP server specialized for the TypeScript 7 native language server (tsc --lsp)
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"

--- a/pkgs/re-taro/tsmcp/registry.yaml
+++ b/pkgs/re-taro/tsmcp/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: re-taro
+    repo_name: tsmcp
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tsmcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -78998,6 +78998,21 @@ packages:
           - linux/amd64
           - darwin
   - type: github_release
+    repo_owner: re-taro
+    repo_name: tsmcp
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: tsmcp_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: realm
     repo_name: SwiftLint
     description: A tool to enforce Swift style and conventions

--- a/registry.yaml
+++ b/registry.yaml
@@ -79000,6 +79000,7 @@ packages:
   - type: github_release
     repo_owner: re-taro
     repo_name: tsmcp
+    description: MCP server specialized for the TypeScript 7 native language server (tsc --lsp)
     version_constraint: "false"
     version_overrides:
       - version_constraint: "true"


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

[tsmcp](https://github.com/re-taro/tsmcp) is an MCP server specialized for the TypeScript 7 native language server (`tsc --lsp`). It exposes the read-only LSP capabilities (hover, definition, references, symbols, diagnostics, call hierarchy, etc.) as MCP tools for coding agents. I'm the author of the tool.

Scaffolded with `argd s`. `argd t` and `conftest` pass locally, and I installed the package via aqua with the local registry and confirmed `tsmcp --version` works (linux/darwin, amd64/arm64; no windows assets are published).

The second commit adds `description` (the GitHub repository description was set after scaffolding).

This PR was prepared with the assistance of Claude Code and reviewed by me.