### PR TITLE
feat(zwasm/zwasm): add zwasm/zwasm

### DIFF
--- a/pkgs/zwasm/zwasm/pkg.yaml
+++ b/pkgs/zwasm/zwasm/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: zwasm/zwasm@v2.5.0
+  - name: zwasm/zwasm
+    version: v1.5.0

--- a/pkgs/zwasm/zwasm/registry.yaml
+++ b/pkgs/zwasm/zwasm/registry.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: zwasm
+    repo_name: zwasm
+    description: A fast, spec-compliant WebAssembly runtime written in Zig
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.11.1"
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+            replacements: {}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -103855,6 +103855,54 @@ packages:
           - windows
           - amd64
   - type: github_release
+    repo_owner: zwasm
+    repo_name: zwasm
+    description: A fast, spec-compliant WebAssembly runtime written in Zig
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.11.1"
+        no_asset: true
+      - version_constraint: semver("<= 1.5.0")
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+        supported_envs:
+          - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: zwasm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+            replacements: {}
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
+  - type: github_release
     repo_owner: zyedidia
     repo_name: eget
     description: Easily install prebuilt binaries from GitHub


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

This PR adds [zwasm](https://github.com/zwasm/zwasm), a WebAssembly runtime written in Zig.

Scaffolded with `argd s zwasm/zwasm`; the container tests passed for all six environments (linux, darwin and windows on both amd64 and arm64). The tool was then installed and executed against the generated registry:

- `v2.5.0` -> `zwasm v2.5.0 (wasm: v3_0, wasi: p2, engine: both)`
- `v1.5.0` -> `zwasm 1.5.0`

Two notes on the generated config, both matching the releases as published:

- `v1.11.1` is `no_asset: true`. It is a freeze tag for the v1 line and carries no binaries.
- `supported_envs` omits `darwin/amd64` for every version. The project publishes `macos-aarch64` only, so there is no Intel macOS asset to resolve.
