### PR TITLE
Update Arata1202/ascdir to v1.2.2

### DIFF
--- a/pkgs/Arata1202/ascdir/pkg.yaml
+++ b/pkgs/Arata1202/ascdir/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: Arata1202/ascdir@v1.2.1
+  - name: Arata1202/ascdir@v1.2.2


### PR DESCRIPTION
Update `Arata1202/ascdir` to v1.2.2.

Release: https://github.com/Arata1202/ascdir/releases/tag/v1.2.2

## Verification

- Confirmed the v1.2.2 GitHub Release completed successfully.
- Verified all release asset checksums.
- Executed the Linux AMD64 binary and confirmed `ascdir 1.2.2`.
