### PR TITLE
fix(s0undt3ch/ToolR): split linux release asset by libc

### DIFF
--- a/pkgs/s0undt3ch/ToolR/registry.yaml
+++ b/pkgs/s0undt3ch/ToolR/registry.yaml
@@ -21,12 +21,22 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -81596,13 +81596,23 @@ packages:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-          linux: unknown-linux-musl
+          linux: unknown-linux-gnu
           windows: pc-windows-msvc
         checksum:
           type: github_release
           asset: "{{.Asset}}.sha256"
           algorithm: sha256
         overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
           - goos: windows
             format: zip
   - type: github_release


### PR DESCRIPTION
## Summary

ToolR ships both `gnu` and `musl` linux release assets from v0.20.0 (the
earliest version this registry supports) onward, but the registry only
pointed every linux platform key (both `linux-amd64`/`linux-arm64` and
their `-musl` counterparts) at the musl asset.

Renovate's mise-lockfile updater infers `gnu` for the plain `linux-x64`
key by filename convention, so it disagreed with what `mise
lock`/`aqua` actually resolve (musl for every linux key), producing
merge conflicts in downstream consumers' `mise.lock` on every run.

Fix: flip the default `linux` replacement to `gnu`, and add the
libc-keyed `variants` override pair (same shape as the most recent
`version_overrides` entry in `pkgs/jdx/aube/registry.yaml`) so glibc
hosts resolve to the gnu asset and musl hosts opt in explicitly.

No `version_overrides` cutoff was needed: every ToolR release from
v0.20.0 onward ships both `gnu` and `musl` linux assets (checked via
`gh api repos/s0undt3ch/ToolR/releases/tags/<tag>`), and versions
before v0.20.0 already `error_message` out.

## Verification

`argd s "s0undt3ch/ToolR"` regenerated a broken scaffold for this
already-merged package (it dropped the `files:` src mapping, the
`< 0.20.0` `error_message`, and `github_artifact_attestations`,
breaking install), so the libc split was applied by hand to the
existing, working `registry.yaml`, mirroring `pkgs/jdx/aube`'s
established pattern, then verified with `argd t`:

    $ argd t s0undt3ch/ToolR
    ...
    key: libc detected, running tests on Alpine
    ...
    (exit 0, all platforms pass: linux/amd64+arm64 (gnu, via glibc
    containers), linux/amd64+arm64 (musl, auto-triggered Alpine run),
    darwin/amd64+arm64, windows/amd64+arm64)

`conftest test pkgs/s0undt3ch/ToolR/*.yaml` — 28 tests, 28 passed.

## AI disclosure

This PR was drafted with Claude Code (Anthropic), per docs/ai.md.