### PR TITLE
fix(sharkdp/fd): resolve 32-bit ARM assets

### DIFF
--- a/pkgs/sharkdp/fd/registry.yaml
+++ b/pkgs/sharkdp/fd/registry.yaml
@@ -44,6 +44,10 @@ packages:
           windows: pc-windows-msvc
         overrides:
           - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
+          - goos: linux
             replacements:
               arm64: aarch64
           - goos: windows
@@ -58,6 +62,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: semver("<= 3.1.0")
@@ -100,6 +108,10 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: semver("<= 10.2.0")
@@ -113,6 +125,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: "true"
@@ -125,6 +141,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: darwin
             replacements:
               amd64: amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -83719,6 +83719,10 @@ packages:
           windows: pc-windows-msvc
         overrides:
           - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
+          - goos: linux
             replacements:
               arm64: aarch64
           - goos: windows
@@ -83733,6 +83737,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: semver("<= 3.1.0")
@@ -83775,6 +83783,10 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: semver("<= 10.2.0")
@@ -83788,6 +83800,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: windows
             format: zip
       - version_constraint: "true"
@@ -83800,6 +83816,10 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         overrides:
+          - goos: linux
+            goarch: arm
+            replacements:
+              linux: unknown-linux-musleabihf
           - goos: darwin
             replacements:
               amd64: amd64


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

`sharkdp/fd` cannot be installed on 32-bit ARM (`linux/arm`).

## Reproduction with aqua

- aqua version: `2.62.3`
- Host: `linux/amd64`, using the documented [`AQUA_GOOS` / `AQUA_GOARCH` override](https://aquaproj.github.io/docs/develop-registry/change-os-arch-for-test) for `linux/arm`. I don't have 32-bit ARM hardware, so as that page notes the binary itself is not executed; the check is that the asset resolves and exists.

`aqua.yaml`:

```yaml
---
registries:
  - name: standard
    type: local
    path: /path/to/aqua-registry/registry.yaml
packages:
  - name: sharkdp/fd@v10.4.2
```

Before this change:

```console
$ AQUA_GOOS=linux AQUA_GOARCH=arm aqua which fd
.../sharkdp/fd/v10.4.2/fd-v10.4.2-arm-unknown-linux-musl.tar.gz/fd-v10.4.2-arm-unknown-linux-musl/fd
```

`fd-v10.4.2-arm-unknown-linux-musl.tar.gz` is not published, so an install fails with `the asset isn't found`. Expected: one of the archives fd does publish for 32-bit ARM, `fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz` or `fd-v10.4.2-arm-unknown-linux-gnueabihf.tar.gz`.

## Cause

The package maps `linux` to `unknown-linux-musl` for every architecture. fd's 32-bit ARM archives carry the `eabihf` suffix (`arm-unknown-linux-musleabihf`), which no branch accounts for. 64-bit ARM is unaffected because `aarch64-unknown-linux-musl` has no such suffix.

## Fix

A `goos: linux` / `goarch: arm` override mapping `linux` to `unknown-linux-musleabihf`, in each version branch that `linux/arm` can reach and that has the assets: `Version == "v10.0.0"`, `Version == "v10.3.0"`, `semver("<= 9.0.0")`, `semver("<= 10.2.0")`, and the current `"true"` branch.

`semver("<= 8.2.1")` and `Version == "v4.0.0"` are left alone — their `supported_envs` already exclude 32-bit ARM and those releases publish no ARM archives.

## Verification

Every version pinned in `pkg.yaml` that can reach a patched branch, resolved for `linux/arm` and checked against the published release assets:

| version | resolved asset | published |
|---|---|---|
| v10.4.2 | `fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz` | yes |
| v10.3.0 | `fd-v10.3.0-arm-unknown-linux-musleabihf.tar.gz` | yes |
| v10.2.0 | `fd-v10.2.0-arm-unknown-linux-musleabihf.tar.gz` | yes |
| v10.0.0 | `fd-v10.0.0-arm-unknown-linux-musleabihf.tar.gz` | yes |
| v9.0.0  | `fd-v9.0.0-arm-unknown-linux-musleabihf.tar.gz`  | yes |

No change on other platforms for v10.4.2:

| platform | resolved asset |
|---|---|
| linux/amd64 | `fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz` |
| linux/arm64 | `fd-v10.4.2-aarch64-unknown-linux-musl.tar.gz` |
| linux/arm | `fd-v10.4.2-arm-unknown-linux-musleabihf.tar.gz` |
| darwin/arm64 | `fd-v10.4.2-aarch64-apple-darwin.tar.gz` |
| windows/amd64 | `fd-v10.4.2-x86_64-pc-windows-msvc.zip` |

`argd t sharkdp/fd` passes (exit 0). Worth noting that it covers darwin, linux and windows on amd64/arm64 only — **not** `linux/arm`, which is why this went unnoticed. The table above is the evidence for the 32-bit case.

`registry.yaml` was regenerated with `argd gr`; its diff is the same five additions and nothing else.

## Relation to #59016

[#59016](https://github.com/aquaproj/aqua-registry/pull/59016) targets the same symptom. I opened this separately rather than pushing to it because the approach differs on three points, and I may well have misread it — happy to close this if the maintainer prefers that one:

- It edits the generated `registry.yaml` rather than `pkgs/sharkdp/fd/registry.yaml`, and that file says it is generated by `aqua-registry gr`.
- Its fd hunk sits in the `Version == "v10.3.0"` branch, which the reported v10.4.2 install does not reach.
- It adds a replacement keyed on `armv7l`. aqua passes Go's `GOARCH`, which is `arm` for 32-bit ARM, so that key would not fire for aqua itself. It also maps to `arm` while leaving `linux: unknown-linux-musl`, which still yields `fd-...-arm-unknown-linux-musl.tar.gz`.

For context, this was reported through mise ([jdx/mise#12113](https://github.com/jdx/mise/pull/12113)), but it is reproducible with aqua alone as shown above.

---

*AI-assisted: investigated and authored with Claude Code (claude-opus-5). I have reviewed the change and the verification output and take responsibility for it.*
