### PR TITLE
feat(Gentleman-Programming/engram): add engram

### DIFF
--- a/pkgs/Gentleman-Programming/engram/pkg.yaml
+++ b/pkgs/Gentleman-Programming/engram/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: Gentleman-Programming/engram@v1.20.0
+  - name: Gentleman-Programming/engram
+    version: v0.1.7
+  - name: Gentleman-Programming/engram
+    version: v0.1.6

--- a/pkgs/Gentleman-Programming/engram/registry.yaml
+++ b/pkgs/Gentleman-Programming/engram/registry.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: Gentleman-Programming
+    repo_name: engram
+    description: Persistent memory system for AI coding agents. Agent-agnostic Go binary with SQLite + FTS5, MCP server, HTTP API, CLI, and TUI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["pi-v0.1.6", "pi-v0.1.7", "pi-v0.1.8"]
+        no_asset: true
+      - version_constraint: Version in ["v0.1.7", "v0.1.8", "v0.1.9"]
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.6")
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.10")
+        no_asset: true
+      - version_constraint: "true"
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -3780,6 +3780,46 @@ packages:
           algorithm: sha256
   - type: github_release
     repo_owner: Gentleman-Programming
+    repo_name: engram
+    description: Persistent memory system for AI coding agents. Agent-agnostic Go binary with SQLite + FTS5, MCP server, HTTP API, CLI, and TUI
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version in ["pi-v0.1.6", "pi-v0.1.7", "pi-v0.1.8"]
+        no_asset: true
+      - version_constraint: Version in ["v0.1.7", "v0.1.8", "v0.1.9"]
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.6")
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: semver("<= 0.1.10")
+        no_asset: true
+      - version_constraint: "true"
+        asset: engram_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
+    repo_owner: Gentleman-Programming
     repo_name: gentle-ai
     description: Ecosystem, frameworks, and workflows for AI coding agents
     version_filter: Version startsWith "v" and not (Version contains "-")


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds [Gentleman-Programming/engram](https://github.com/Gentleman-Programming/engram) — a persistent memory system for AI coding agents (Go binary, SQLite + FTS5, MCP server, HTTP API, CLI, and TUI) — generated with `argd s`.

The repository also publishes a second, unrelated product (`gentle-engram`, a Raspberry Pi companion package) under `pi-vX.Y.Z` tags with no downloadable release assets. `argd s` detected this automatically and scaffolded `no_asset: true` branches for those tags, so `version_overrides` has more branches than a typical single-product repo — this is expected, not a scaffolding error.

### Test evidence

```
$ argd t Gentleman-Programming/engram
# linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 — all installed successfully
# versions tested: v1.20.0, v0.1.7, v0.1.6 (from pkg.yaml)

$ docker exec -w /workspace aqua-registry aqua exec -- engram version
engram 1.20.0

$ conftest test --combine pkgs/Gentleman-Programming/engram/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier -c pkgs/Gentleman-Programming/engram/*.yaml
All matched files use Prettier code style!
```

---

AI disclosure: This contribution was prepared with AI assistance (Claude Code), reviewed and submitted by @AndryOre.
