### PR TITLE
fix(terramate-io/terramate): expose terramate-ls

### DIFF
--- a/pkgs/terramate-io/terramate/pkg.yaml
+++ b/pkgs/terramate-io/terramate/pkg.yaml
@@ -3,6 +3,8 @@ packages:
   - name: terramate-io/terramate
     version: v0.9.0
   - name: terramate-io/terramate
+    version: v0.3.0
+  - name: terramate-io/terramate
     version: v0.2.7
   - name: terramate-io/terramate
     version: v0.1.33

--- a/pkgs/terramate-io/terramate/registry.yaml
+++ b/pkgs/terramate-io/terramate/registry.yaml
@@ -83,11 +83,26 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.3.0")
+        asset: terramate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 0.9.0")
         asset: terramate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
+        files:
+          - name: terramate
+          - name: terramate-ls
         checksum:
           type: github_release
           asset: checksums.txt
@@ -100,6 +115,9 @@ packages:
         format: tar.gz
         replacements:
           amd64: x86_64
+        files:
+          - name: terramate
+          - name: terramate-ls
         checksum:
           type: github_release
           asset: checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -94137,11 +94137,26 @@ packages:
         overrides:
           - goos: windows
             format: zip
+      - version_constraint: semver("<= 0.3.0")
+        asset: terramate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
       - version_constraint: semver("<= 0.9.0")
         asset: terramate_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
+        files:
+          - name: terramate
+          - name: terramate-ls
         checksum:
           type: github_release
           asset: checksums.txt
@@ -94154,6 +94169,9 @@ packages:
         format: tar.gz
         replacements:
           amd64: x86_64
+        files:
+          - name: terramate
+          - name: terramate-ls
         checksum:
           type: github_release
           asset: checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

## Summary

Terramate release archives since v0.3.1 contain both `terramate` and `terramate-ls`, but the aqua registry currently exposes only the default `terramate` command.

This PR adds `terramate-ls` to the `files` configuration.

`terramate-ls` was added to the release archive in Terramate v0.3.1. Therefore, this PR adds a version boundary to preserve the existing configuration for v0.3.0 and earlier.

- v0.3.0 and earlier: expose only `terramate`
  - https://github.com/terramate-io/terramate/releases/tag/v0.3.0
- v0.3.1 and later: expose `terramate` and `terramate-ls`
  - https://github.com/terramate-io/terramate/releases/tag/v0.3.1

A v0.3.0 entry was also added to `pkg.yaml` to test the version boundary.

## Reproduction

### Environment

- OS: macOS 26.6.2
- Architecture: arm64
- aqua: v2.62.3
- Terramate: v0.17.2

### aqua.yaml

```yaml
registries:
  - type: standard
    ref: v4.529.1

packages:
  - name: terramate-io/terramate@v0.17.2
```

### Actual behavior

```console
$ aqua install
$ aqua which terramate-ls
Aug 27 02:26:37.547 ERR aqua failed program=aqua version=2.62.3 env=darwin/arm64 exe_name=terramate-ls doc=https://aquaproj.github.io/docs/reference/codes/004 exe_name=terramate-ls error="command is not found"
```

### Expected behavior

```console
$ aqua install
$ terramate-ls --version
0.17.2
```

## Verification

### Package installation test

```console
$ argd t terramate-io/terramate
```

Installation succeeded for:

- linux/amd64
- linux/arm64
- darwin/amd64
- darwin/arm64
- windows/amd64
- windows/arm64

### Policy test

```console
$ conftest test --combine pkgs/terramate-io/terramate/*

14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

### Formatting

```console
$ prettier --check \
    pkgs/terramate-io/terramate/pkg.yaml \
    pkgs/terramate-io/terramate/registry.yaml \
    registry.yaml
Checking formatting...
All matched files use Prettier code style!
```

### Command execution

```console
$ argd con
Aug 27 02:04:20.085 INF + /usr/local/bin/docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=arm64 aqua-registry aqua i -l program=argd version=0.5.7
Aug 27 02:04:20.161 INF + /usr/local/bin/docker exec -i -t -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=arm64 aqua-registry bash program=argd version=0.5.7
root@5434a15ce38d:/workspace# terramate-ls --version
0.17.2
```

## AI disclosure

Codex was used to investigate the version boundary, review the changes, and prepare the verification steps. The changes and test results were reviewed by the contributor.