### PR TITLE
feat(abemedia/stagelint): scaffold abemedia/stagelint

### DIFF
--- a/pkgs/abemedia/stagelint/pkg.yaml
+++ b/pkgs/abemedia/stagelint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: abemedia/stagelint@v0.1.3

--- a/pkgs/abemedia/stagelint/registry.yaml
+++ b/pkgs/abemedia/stagelint/registry.yaml
@@ -4,9 +4,10 @@ packages:
     repo_owner: abemedia
     repo_name: stagelint
     description: Run commands like linters and formatters on staged git files
-    version_filter: semver(">= 0.1.3")
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 0.1.3")
+        error_message: Please update to v0.1.3 or later
       - version_constraint: "true"
         asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz

--- a/pkgs/abemedia/stagelint/registry.yaml
+++ b/pkgs/abemedia/stagelint/registry.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: abemedia
+    repo_name: stagelint
+    description: Run commands like linters and formatters on staged git files
+    version_filter: semver(">= 0.1.3")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/abemedia/stagelint/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+        overrides:
+          - goos: windows
+            goarch: amd64
+            format: zip
+          - goos: windows
+            goarch: arm64
+            format: zip
+            asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}llvm.{{.Format}}

--- a/pkgs/abemedia/stagelint/scaffold.yaml
+++ b/pkgs/abemedia/stagelint/scaffold.yaml
@@ -1,4 +1,3 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
 name: abemedia/stagelint
-version_filter: semver(">= 0.1.3")

--- a/pkgs/abemedia/stagelint/scaffold.yaml
+++ b/pkgs/abemedia/stagelint/scaffold.yaml
@@ -1,0 +1,4 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+name: abemedia/stagelint
+version_filter: semver(">= 0.1.3")

--- a/registry.yaml
+++ b/registry.yaml
@@ -10956,6 +10956,43 @@ packages:
           - goos: windows
             asset: tgpt-{{.Arch}}.exe
   - type: github_release
+    repo_owner: abemedia
+    repo_name: stagelint
+    description: Run commands like linters and formatters on staged git files
+    version_filter: semver(">= 0.1.3")
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "^https://github\\.com/abemedia/stagelint/\\.github/workflows/.+\\.ya?ml@refs/tags/\\Q{{.Version}}\\E$"
+              - --certificate-oidc-issuer
+              - https://token.actions.githubusercontent.com
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
+        overrides:
+          - goos: windows
+            goarch: amd64
+            format: zip
+          - goos: windows
+            goarch: arm64
+            format: zip
+            asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}llvm.{{.Format}}
+  - type: github_release
     repo_owner: abhimanyu003
     repo_name: sttr
     description: cross-platform, cli app to perform various operations on string

--- a/registry.yaml
+++ b/registry.yaml
@@ -10959,9 +10959,10 @@ packages:
     repo_owner: abemedia
     repo_name: stagelint
     description: Run commands like linters and formatters on staged git files
-    version_filter: semver(">= 0.1.3")
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 0.1.3")
+        error_message: Please update to v0.1.3 or later
       - version_constraint: "true"
         asset: stagelint-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

<!-- Please write the description here -->

This PR adds stagelint - a git pre-commit runner for running linters and formatters against staged files.

I set the version filter to `>= 0.1.3` - this is due to not having standardised release asset names in the previous versions. The project is brand new so they wont have any users anyway.