### PR TITLE
fix(SonarSource/sonarqube-cli): install Windows binary as sonar.exe

### DIFF
--- a/pkgs/SonarSource/sonarqube-cli/registry.yaml
+++ b/pkgs/SonarSource/sonarqube-cli/registry.yaml
@@ -34,7 +34,6 @@ packages:
       - version_constraint: "true"
         url: https://binaries.sonarsource.com/Distribution/sonarqube-cli/{{.Version}}/{{.OS}}/sonarqube-cli-{{.Version}}-{{.OS}}-{{.Arch}}.bin
         format: raw
-        complete_windows_ext: false
         replacements:
           darwin: macos
           amd64: x86-64

--- a/registry.yaml
+++ b/registry.yaml
@@ -7807,7 +7807,6 @@ packages:
       - version_constraint: "true"
         url: https://binaries.sonarsource.com/Distribution/sonarqube-cli/{{.Version}}/{{.OS}}/sonarqube-cli-{{.Version}}-{{.OS}}-{{.Arch}}.bin
         format: raw
-        complete_windows_ext: false
         replacements:
           darwin: macos
           amd64: x86-64


### PR DESCRIPTION
## Summary

- Restore default Windows executable extension completion for SonarQube CLI.
- Keep the Unix .bin artifacts and explicit Windows .exe download URL.

## Root Cause

The latest SonarQube CLI registry entry set complete_windows_ext: false.
Because files.name is sonar, mise installed the Windows executable without the
default .exe suffix.

This caused Windows to install sonar instead of sonar.exe, so invoking sonar
did not execute the CLI correctly.

## Reproduction

The issue was originally reported on Windows 11 amd64 with SonarQube CLI
1.6.0.4255, where the installation contained an extensionless sonar file
instead of sonar.exe.

The fix was verified using the changed registry from the local branch:

```text
file:///C:/work/aqua-registry/registry.yaml
```

```text
mise 2026.8.14 windows-x64 (2026-08-25)
sonarqube-cli@1.6.0.4255 extract sonarqube-cli-1.6.0.4255-windows-x86-64.exe
```

Native Windows verification:

```text
sonar.exe
Test-Path sonar.exe: True
Test-Path extensionless sonar: False
```

```powershell
mise exec sonarqube-cli@1.6.0.4255 --command 'sonar --version'
```

Output:

```text
1.6.0
```

## Verification

```text
argd t SonarSource/sonarqube-cli
```

Passed with Windows/amd64 coverage and exit status 0.

```text
conftest test --combine pkgs/SonarSource/sonarqube-cli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

Direct aqua target-mode verification was also performed using a local registry
and AQUA_GOOS=windows AQUA_GOARCH=amd64. The Windows .exe asset was selected
and downloaded successfully.

The native Windows verification used the changed local registry before it was
merged upstream.

## AI Disclosure

This change was investigated and prepared with assistance from OpenAI Codex.
The registry change and verification results were reviewed manually.
