### PR TITLE
feat(ariga/atlas/community): support Windows

### DIFF
--- a/pkgs/ariga/atlas/community/registry.yaml
+++ b/pkgs/ariga/atlas/community/registry.yaml
@@ -4,24 +4,34 @@ packages:
     type: http
     repo_owner: ariga
     repo_name: atlas
-    url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
     description: A modern tool for managing database schemas (Community Edition)
     link: https://atlasgo.io/community-edition
-    format: raw
-    supported_envs:
-      - darwin
-      - linux
-    files:
-      - name: atlas
-    checksum:
-      type: http
-      url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
-      file_format: raw
-      algorithm: sha256
-    version_constraint: semver(">= 0.22.0")
-    # https://github.com/ariga/atlas/issues/3296#issuecomment-2574924728
-    # > Old Versions of Atlas
-    # > As part of our Supported Version Policy mentioned above, binaries for versions that were published more than 6 months ago will be removed from the CDN and Docker Hub.
+    version_constraint: "false"
     version_overrides:
+      # https://github.com/ariga/atlas/issues/3296#issuecomment-2574924728
+      # > Old Versions of Atlas
+      # > As part of our Supported Version Policy mentioned above, binaries for versions that were published more than 6 months ago will be removed from the CDN and Docker Hub.
       - version_constraint: semver("< 0.21.0")
         no_asset: true
+      - version_constraint: "true"
+        url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+        files:
+          - name: atlas
+        checksum:
+          type: http
+          url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
+          file_format: raw
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            checksum:
+              type: http
+              url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
+              file_format: raw
+              algorithm: sha256

--- a/pkgs/ariga/atlas/community/registry.yaml
+++ b/pkgs/ariga/atlas/community/registry.yaml
@@ -17,10 +17,6 @@ packages:
         url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
         format: raw
         windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - linux
-          - windows
         files:
           - name: atlas
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16270,10 +16270,6 @@ packages:
         url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
         format: raw
         windows_arm_emulation: true
-        supported_envs:
-          - darwin
-          - linux
-          - windows
         files:
           - name: atlas
         checksum:

--- a/registry.yaml
+++ b/registry.yaml
@@ -16257,27 +16257,37 @@ packages:
     type: http
     repo_owner: ariga
     repo_name: atlas
-    url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
     description: A modern tool for managing database schemas (Community Edition)
     link: https://atlasgo.io/community-edition
-    format: raw
-    supported_envs:
-      - darwin
-      - linux
-    files:
-      - name: atlas
-    checksum:
-      type: http
-      url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
-      file_format: raw
-      algorithm: sha256
-    version_constraint: semver(">= 0.22.0")
-    # https://github.com/ariga/atlas/issues/3296#issuecomment-2574924728
-    # > Old Versions of Atlas
-    # > As part of our Supported Version Policy mentioned above, binaries for versions that were published more than 6 months ago will be removed from the CDN and Docker Hub.
+    version_constraint: "false"
     version_overrides:
+      # https://github.com/ariga/atlas/issues/3296#issuecomment-2574924728
+      # > Old Versions of Atlas
+      # > As part of our Supported Version Policy mentioned above, binaries for versions that were published more than 6 months ago will be removed from the CDN and Docker Hub.
       - version_constraint: semver("< 0.21.0")
         no_asset: true
+      - version_constraint: "true"
+        url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}
+        format: raw
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+        files:
+          - name: atlas
+        checksum:
+          type: http
+          url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.sha256
+          file_format: raw
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            checksum:
+              type: http
+              url: https://release.ariga.io/atlas/atlas-community-{{.OS}}-{{.Arch}}-{{.Version}}.exe.sha256
+              file_format: raw
+              algorithm: sha256
   - type: github_release
     repo_owner: aristocratos
     repo_name: btop


### PR DESCRIPTION
## Overview

`ariga/atlas` supports Windows, but `ariga/atlas/community` doesn't, although the CDN publishes Windows binaries at the same URL pattern.

```console
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://release.ariga.io/atlas/atlas-community-windows-amd64-v1.3.0.exe
200
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://release.ariga.io/atlas/atlas-community-windows-amd64-v1.3.0.exe.sha256
200
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://release.ariga.io/atlas/atlas-community-windows-arm64-v1.3.0.exe
403
```

This PR aligns `ariga/atlas/community` with `ariga/atlas`:

- add `windows` to `supported_envs`
- `windows_arm_emulation: true`, because there is no `windows/arm64` binary (403 above), which is the same situation as `ariga/atlas`
- an override for `goos: windows` that appends `.exe` to the checksum URL. `complete_windows_ext` completes `.exe` for `url` but not for `checksum.url`, so `ariga/atlas` already has the same override

## Why the top level `version_constraint` is moved

This is not part of the Windows support itself, but the CI lint fails without it.

`pkgs/ariga/atlas/community/registry.yaml` had a top level `version_constraint`, which violates the Conftest policy, so `conftest` fails as soon as the file is touched:

```console
$ conftest test --combine pkgs/ariga/atlas/community/registry.yaml
FAIL - Combined - main - pkgs/ariga/atlas/community/registry.yaml: the top level version_constraint must be either empty or "false"

14 tests, 13 passed, 0 warnings, 1 failure, 0 exceptions
```

Simply deleting the line is not equivalent. aqua evaluates the top level `version_constraint` first, and when it matches, `version_overrides` are ignored, so deleting it breaks the `no_asset: true` override for old versions:

```console
# top level version_constraint deleted
$ aqua i   # ariga/atlas/community@v0.20.0
ERR install the package ... download_url=https://release.ariga.io/atlas/atlas-community-windows-amd64-v0.20.0.exe error="download a package: status code >= 400"
```

So the configuration is moved into `version_overrides` with a `version_constraint: "true"` branch, which keeps the existing behaviour (see the test results below: `v0.20.0` still reports `no asset is released for this version`).

After the change:

```console
$ conftest test --combine pkgs/ariga/atlas/community/registry.yaml

14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/ariga/atlas/community/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result | same as before this PR? |
| --- | --- | --- | --- |
| v1.3.0 | windows/amd64 | installed | newly supported |
| v0.32.0 | windows/amd64 | installed | newly supported |
| v1.3.0 | windows/arm64 | installed (resolved to the amd64 binary) | newly supported |
| v1.3.0 | linux/amd64 | installed | yes |
| v1.3.0 | linux/arm64 | installed | yes |
| v0.20.0 | windows/amd64, linux/amd64 | `no asset is released for this version` | yes |
| v0.21.0 | windows/amd64, linux/amd64 | `download a package: status code >= 400` | yes |

`windows/amd64`:

```console
$ aqua i
INF download and unarchive the package ... env=windows/amd64 package_name=ariga/atlas/community package_version=v1.3.0 registry=standard
INF download and unarchive the package ... env=windows/amd64 package_name=ariga/atlas/community package_version=v0.32.0 registry=standard
INF downloading a checksum file ... env=windows/amd64 package_name=ariga/atlas/community package_version=v1.3.0 registry=standard
INF downloading a checksum file ... env=windows/amd64 package_name=ariga/atlas/community package_version=v0.32.0 registry=standard

$ aqua exec -- atlas version
atlas community version v1.3.0
https://github.com/ariga/atlas/releases/tag/v1.3.0
To download an official version, visit: https://atlasgo.io/getting-started#installation
```

`windows/arm64` (`AQUA_GOARCH=arm64`, clean `AQUA_ROOT_DIR`) resolves to the amd64 binary through `windows_arm_emulation`:

```console
$ AQUA_GOARCH=arm64 aqua i
INF download and unarchive the package ... env=windows/arm64 package_name=ariga/atlas/community package_version=v1.3.0 registry=standard

$ find "$AQUA_ROOT_DIR/pkgs/http" -type f
.../pkgs/http/release.ariga.io/atlas/atlas-community-windows-amd64-v1.3.0.exe/atlas-community-windows-amd64-v1.3.0.exe
```

`linux/amd64` and `linux/arm64`:

```console
v1.3.0     linux/amd64  => OK atlas-community-linux-amd64-v1.3.0
v0.32.0    linux/amd64  => OK atlas-community-linux-amd64-v0.32.0
v0.20.0    linux/amd64  => no_asset (skip)
v0.21.0    linux/amd64  => ERROR: error="download a package: status code >= 400"
v1.3.0     linux/arm64  => OK atlas-community-linux-arm64-v1.3.0
```

`darwin` was not tested locally; it is left to CI.

`prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
