### PR TITLE
feat(homeport/dyff): support Windows

### DIFF
--- a/pkgs/homeport/dyff/pkg.yaml
+++ b/pkgs/homeport/dyff/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
   - name: homeport/dyff@v1.12.0
+  - name: homeport/dyff
+    version: v1.5.6

--- a/pkgs/homeport/dyff/pkg.yaml
+++ b/pkgs/homeport/dyff/pkg.yaml
@@ -2,3 +2,15 @@ packages:
   - name: homeport/dyff@v1.12.0
   - name: homeport/dyff
     version: v1.5.6
+  - name: homeport/dyff
+    version: v1.4.0
+  - name: homeport/dyff
+    version: v1.2.1
+  - name: homeport/dyff
+    version: v1.2.0
+  - name: homeport/dyff
+    version: v0.9.0
+  - name: homeport/dyff
+    version: v0.5-beta.2
+  - name: homeport/dyff
+    version: v0.4-alpha

--- a/pkgs/homeport/dyff/registry.yaml
+++ b/pkgs/homeport/dyff/registry.yaml
@@ -3,21 +3,77 @@ packages:
   - type: github_release
     repo_owner: homeport
     repo_name: dyff
-    description: A diff tool for YAML files, and sometimes JSON
-    asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: "/ˈdʏf/ - diff tool for YAML files, and sometimes JSON"
     version_constraint: "false"
     version_overrides:
-      # Windows assets are published since v1.5.7
-      - version_constraint: semver("< 1.5.7")
+      - version_constraint: Version == "v0.5-beta.20"
+        no_asset: true
+      - version_constraint: Version in ["v1.2.1", "v1.4.1"]
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.0-alpha")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
-          - linux
-      - version_constraint: "true"
-        supported_envs:
-          - darwin
-          - linux
           - windows
+          - amd64
+      - version_constraint: semver("<= 0.5.0-beta.2")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.9.0")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.2.0")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.4.0")
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.5.6")
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/pkgs/homeport/dyff/registry.yaml
+++ b/pkgs/homeport/dyff/registry.yaml
@@ -4,11 +4,20 @@ packages:
     repo_owner: homeport
     repo_name: dyff
     description: A diff tool for YAML files, and sometimes JSON
-    supported_envs:
-      - darwin
-      - linux
     asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     checksum:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      # Windows assets are published since v1.5.7
+      - version_constraint: semver("< 1.5.7")
+        supported_envs:
+          - darwin
+          - linux
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -49496,14 +49496,23 @@ packages:
     repo_owner: homeport
     repo_name: dyff
     description: A diff tool for YAML files, and sometimes JSON
-    supported_envs:
-      - darwin
-      - linux
     asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
     checksum:
       type: github_release
       asset: checksums.txt
       algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      # Windows assets are published since v1.5.7
+      - version_constraint: semver("< 1.5.7")
+        supported_envs:
+          - darwin
+          - linux
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - windows
   - type: github_release
     repo_owner: homeport
     repo_name: havener

--- a/registry.yaml
+++ b/registry.yaml
@@ -49495,24 +49495,80 @@ packages:
   - type: github_release
     repo_owner: homeport
     repo_name: dyff
-    description: A diff tool for YAML files, and sometimes JSON
-    asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: checksums.txt
-      algorithm: sha256
+    description: "/ˈdʏf/ - diff tool for YAML files, and sometimes JSON"
     version_constraint: "false"
     version_overrides:
-      # Windows assets are published since v1.5.7
-      - version_constraint: semver("< 1.5.7")
+      - version_constraint: Version == "v0.5-beta.20"
+        no_asset: true
+      - version_constraint: Version in ["v1.2.1", "v1.4.1"]
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.4.0-alpha")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
         supported_envs:
           - darwin
-          - linux
-      - version_constraint: "true"
-        supported_envs:
-          - darwin
-          - linux
           - windows
+          - amd64
+      - version_constraint: semver("<= 0.5.0-beta.2")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+      - version_constraint: semver("<= 0.9.0")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 1.2.0")
+        asset: dyff-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.4.0")
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 1.5.6")
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: dyff_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: homeport
     repo_name: havener


### PR DESCRIPTION
## Overview

`homeport/dyff` publishes Windows binaries, but `supported_envs` doesn't include `windows`.

```console
$ gh api repos/homeport/dyff/releases/tags/v1.12.0 --jq '.assets[].name'
checksums.txt
dyff_1.12.0_darwin_amd64.tar.gz
dyff_1.12.0_darwin_arm64.tar.gz
dyff_1.12.0_linux_amd64.tar.gz
dyff_1.12.0_linux_arm64.tar.gz
dyff_1.12.0_windows_amd64.tar.gz
dyff_1.12.0_windows_arm64.tar.gz
```

Both `windows/amd64` and `windows/arm64` are published, and the archive contains `dyff.exe`, which `complete_windows_ext` resolves without a `files` block.

## Why `version_overrides` is added

Windows assets are not available for every version. They are published since **v1.5.7**:

```console
$ for t in v1.5.5 v1.5.6 v1.5.7 v1.5.8; do
    printf '%-8s %s\n' "$t" "$(gh api repos/homeport/dyff/releases/tags/$t --jq '.assets[].name' | grep -c windows)"
  done
v1.5.5   0
v1.5.6   0
v1.5.7   2
v1.5.8   2
```

So instead of adding `windows` to every version, the configuration is split at v1.5.7.

`version_constraint: "false"` is added together with `version_overrides`. Without it the top level configuration always matches and `version_overrides` are never evaluated, because aqua checks the top level `version_constraint` first and uses the top level configuration when it matches.

`pkg.yaml` gains `v1.5.6` so that CI exercises the older branch as well, one test version per `version_overrides` branch.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/homeport/dyff/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v1.12.0 | windows/amd64 | installed (`dyff.exe`) |
| v1.12.0 | windows/arm64 | installed (`dyff.exe`) |
| v1.5.6 | windows/amd64 | skipped (unsupported env), as intended |
| v1.12.0 | linux/amd64, linux/arm64 | installed |
| v1.5.6 | linux/amd64, linux/arm64 | installed |

Windows:

```console
$ aqua i
$ aqua exec -- dyff version
dyff.exe version 1.12.0
```

Linux:

```console
$ aqua i
$ find root/pkgs -type f -printf '%f\n' | sort | tr '\n' ' '
LICENSE README.md dyff
$ aqua exec -- dyff version
dyff version 1.12.0
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/homeport/dyff/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
