### PR TITLE
feat(Lifailon/lazyjournal): support Windows

### DIFF
--- a/pkgs/Lifailon/lazyjournal/pkg.yaml
+++ b/pkgs/Lifailon/lazyjournal/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
   - name: Lifailon/lazyjournal@0.8.6
   - name: Lifailon/lazyjournal
+    version: 0.6.0
+  - name: Lifailon/lazyjournal
     version: 0.4.0

--- a/pkgs/Lifailon/lazyjournal/registry.yaml
+++ b/pkgs/Lifailon/lazyjournal/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: Lifailon
     repo_name: lazyjournal
-    description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library
+    description: TUI for viewing logs from journald, auditd, file system, Docker and Podman containers, Compose stacks and Kubernetes pods with support for log highlighting and several filtering modes
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.0")
@@ -11,9 +11,12 @@ packages:
         format: raw
         supported_envs:
           - linux
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.6.0")
         asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
         format: raw
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -5629,7 +5629,7 @@ packages:
   - type: github_release
     repo_owner: Lifailon
     repo_name: lazyjournal
-    description: TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering with fuzzy find, regex support (like fzf and grep) and coloring the output, written in Go with the gocui library
+    description: TUI for viewing logs from journald, auditd, file system, Docker and Podman containers, Compose stacks and Kubernetes pods with support for log highlighting and several filtering modes
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.4.0")
@@ -5637,12 +5637,15 @@ packages:
         format: raw
         supported_envs:
           - linux
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.6.0")
         asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
         format: raw
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: lazyjournal-{{.Version}}-{{.OS}}-{{.Arch}}
+        format: raw
   - type: github_release
     repo_owner: LuaLS
     repo_name: lua-language-server


### PR DESCRIPTION
This replaces #59552, which mistakenly contained the commits of #59551 as well.

## Overview

`Lifailon/lazyjournal` publishes Windows binaries, but `supported_envs` doesn't include `windows`.

```console
$ gh api repos/Lifailon/lazyjournal/releases/tags/0.8.6 --jq '.assets[].name' | grep -i windows
lazyjournal-0.8.6-windows-amd64.exe
lazyjournal-0.8.6-windows-arm64.exe
```

Both `windows/amd64` and `windows/arm64` are published. The `asset` template already resolves to these names, because `complete_windows_ext` completes `.exe` for `format: raw`.

The configuration is generated, not hand written:

```sh
aqua gr Lifailon/lazyjournal
```

Windows assets are not available for every version. Scanning every release shows they are published since 0.7.0:

```console
0.8.6 .. 0.7.0   2 windows assets
0.6.0 .. 0.1.0   0 windows assets
```

The generated code expresses this as the `semver("<= 0.6.0")` branch, so only the latest branch gains Windows.

`pkg.yaml` pins one version per `version_overrides` branch: 0.8.6, 0.6.0 and 0.4.0.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/Lifailon/lazyjournal/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| 0.8.6 | windows/amd64 | installed (`lazyjournal-0.8.6-windows-amd64.exe`) |
| 0.8.6 | windows/arm64 | installed (`lazyjournal-0.8.6-windows-arm64.exe`) |
| 0.6.0 | windows/amd64 | skipped (unsupported env), as intended |
| 0.4.0 | windows/amd64 | skipped (unsupported env), as intended |
| 0.8.6 | linux/amd64, linux/arm64 | installed |
| 0.6.0 | linux/amd64 | installed |
| 0.4.0 | linux/amd64 | installed |

Windows:

```console
$ aqua i
$ aqua exec -- lazyjournal --version
0.8.6
```

Linux:

```console
0.8.6   linux/amd64  => OK lazyjournal-0.8.6-linux-amd64
0.8.6   linux/arm64  => OK lazyjournal-0.8.6-linux-arm64
0.6.0   linux/amd64  => OK lazyjournal-0.6.0-linux-amd64
0.4.0   linux/amd64  => OK lazyjournal-0.4.0-linux-amd64
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/Lifailon/lazyjournal/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
