### PR TITLE
fix(gravitational/teleport): provide tbot and teleport on darwin

### DIFF
--- a/pkgs/gravitational/teleport/registry.yaml
+++ b/pkgs/gravitational/teleport/registry.yaml
@@ -23,13 +23,17 @@ packages:
           - name: tsh
             src: teleport/tsh
       - goos: darwin
-        url: https://cdn.teleport.dev/teleport-tools-{{trimV .Version}}.{{.Format}}
-        format: pkg
+        url: https://cdn.teleport.dev/teleport-{{.Version}}-darwin-{{.Arch}}-bin.{{.Format}}
+        format: tar.gz
         files:
+          - name: tbot
+            src: teleport/tbot
           - name: tctl
-            src: tctl-{{trimV .Version}}.pkg/Payload/tctl.app/Contents/MacOS/tctl
+            src: teleport/tctl.app/Contents/MacOS/tctl
+          - name: teleport
+            src: teleport/teleport
           - name: tsh
-            src: tsh-{{trimV .Version}}.pkg/Payload/tsh.app/Contents/MacOS/tsh
+            src: teleport/tsh.app/Contents/MacOS/tsh
       - goos: windows
         url: https://cdn.teleport.dev/teleport-{{.Version}}-windows-amd64-bin.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -46938,13 +46938,17 @@ packages:
           - name: tsh
             src: teleport/tsh
       - goos: darwin
-        url: https://cdn.teleport.dev/teleport-tools-{{trimV .Version}}.{{.Format}}
-        format: pkg
+        url: https://cdn.teleport.dev/teleport-{{.Version}}-darwin-{{.Arch}}-bin.{{.Format}}
+        format: tar.gz
         files:
+          - name: tbot
+            src: teleport/tbot
           - name: tctl
-            src: tctl-{{trimV .Version}}.pkg/Payload/tctl.app/Contents/MacOS/tctl
+            src: teleport/tctl.app/Contents/MacOS/tctl
+          - name: teleport
+            src: teleport/teleport
           - name: tsh
-            src: tsh-{{trimV .Version}}.pkg/Payload/tsh.app/Contents/MacOS/tsh
+            src: teleport/tsh.app/Contents/MacOS/tsh
       - goos: windows
         url: https://cdn.teleport.dev/teleport-{{.Version}}-windows-amd64-bin.{{.Format}}
         format: zip


### PR DESCRIPTION
## Problem

On darwin, `gravitational/teleport` installs only 2 of the 4 commands the package declares.

The top-level `files:` declares `tbot` / `tctl` / `teleport` / `tsh`, but the darwin override
uses `teleport-tools-<version>.pkg` ("CLI Client Tools"), which only contains `tctl` and `tsh`.

| goos | asset | commands provided |
|---|---|---|
| linux | `teleport-{{.Version}}-linux-{{.Arch}}-bin.tar.gz` | 4 |
| **darwin** | `teleport-tools-{{trimV .Version}}.pkg` | **2 (`tctl`, `tsh`)** |
| windows | `teleport-{{.Version}}-windows-amd64-bin.zip` | 3 |

Reproduced with aqua directly (aqua v2.62.3, macOS 26.6.2, arm64), using the current registry:

```console
$ aqua i -a
INF create a symbolic link ... command=tctl
INF create a symbolic link ... command=tsh

$ ls $AQUA_ROOT_DIR/bin
tctl  tsh
```

`teleport` and `tbot` are simply absent on darwin.

## Change

Point the darwin override at the same full tarball that linux already uses, and provide all
four commands. `tctl` and `tsh` live inside `.app` bundles, so they need `src`.

```yaml
      - goos: darwin
        url: https://cdn.teleport.dev/teleport-{{.Version}}-darwin-{{.Arch}}-bin.{{.Format}}
        format: tar.gz
        files:
          - name: tbot
            src: teleport/tbot
          - name: tctl
            src: teleport/tctl.app/Contents/MacOS/tctl
          - name: teleport
            src: teleport/teleport
          - name: tsh
            src: teleport/tsh.app/Contents/MacOS/tsh
```

Only the darwin override changes. linux and windows are untouched.

## Why not the `.pkg`? Was it intentional?

I checked before changing anything. The `.pkg` choice does **not** appear to be a deliberate
Gatekeeper/notarization decision:

- Only one commit touches this file: aquaproj/aqua-registry#47183 (the original add). No
  discussion of `.pkg` vs. tarball, no review comments.
- In aquaproj/aqua-registry#47164 the maintainer listed the assets straight off the Teleport
  downloads page and picked the row labelled `CLI Client Tools` for macOS
  (`teleport-tools-<v>.pkg`) and for windows. That row is client-tools-only by design, which is
  exactly why the server binary `teleport` and `tbot` are missing.
- The issue only asked for `tsh` / `tctl` / `teleport`, so the gap was not noticed.

## Gatekeeper / notarization: verified, not assumed

This was the main risk, so I tested it on macOS rather than reasoning about it.

**The binaries in the full tarball are signed and notarized:**

```console
$ codesign -dv --verbose=2 teleport/tsh.app
Identifier=QH8AA5B8UP.com.gravitational.teleport.tsh
CodeDirectory v=20500 ... flags=0x10300(hard,kill,runtime)
Authority=Developer ID Application: Gravitational Inc. (QH8AA5B8UP)
Authority=Developer ID Certification Authority
Authority=Apple Root CA

$ codesign --verify --deep --strict teleport/tsh.app   # rc=0, no output
$ spctl -a -t exec -vv teleport/tsh.app
teleport/tsh.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Gravitational Inc. (QH8AA5B8UP)
```

`tctl.app` is likewise `accepted / source=Notarized Developer ID`. `tbot` and `teleport` are
bare Mach-O executables signed with the same Developer ID (hardened runtime,
`codesign --verify` rc=0); `spctl -a -t exec` reports `rejected (the code is valid but does not
seem to be an app)`, which is the expected answer for a non-bundle CLI, not a signature problem.

**The important detail: the `.app` bundle must stay intact.**

`tctl.app` / `tsh.app` are signed with `hard,kill`. If the executable is copied *out* of the
bundle it is killed by the kernel:

```console
$ cp teleport/tsh.app/Contents/MacOS/tsh ./tsh && ./tsh version
$ echo $?
137                     # SIGKILL

$ ./teleport/tsh.app/Contents/MacOS/tsh version    # in place
Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
```

aqua does not copy the file out — it unarchives the whole tarball and resolves `files[].src`
inside it, so the bundle is preserved:

```console
$ find $AQUA_ROOT_DIR/pkgs/http/cdn.teleport.dev -maxdepth 4
.../teleport-v18.10.0-darwin-arm64-bin.tar.gz/teleport/tbot
.../teleport-v18.10.0-darwin-arm64-bin.tar.gz/teleport/tctl.app
.../teleport-v18.10.0-darwin-arm64-bin.tar.gz/teleport/teleport
.../teleport-v18.10.0-darwin-arm64-bin.tar.gz/teleport/tsh.app
```

This is the same mechanism the current `.pkg` config already relies on
(`.../Payload/tsh.app/Contents/MacOS/tsh`), so this PR does not change the Gatekeeper situation
for `tctl` / `tsh` at all — it only adds two more binaries alongside them.

Nothing downloaded by aqua carries a `com.apple.quarantine` xattr, so no Gatekeeper prompt is
involved either way.

## Assets exist (HTTP status)

```console
$ curl -sSI -o /dev/null -w '%{http_code} %header{content-length}\n' \
    https://cdn.teleport.dev/teleport-v18.10.0-darwin-arm64-bin.tar.gz
200 181797407
$ curl -sSI -o /dev/null -w '%{http_code} %header{content-length}\n' \
    https://cdn.teleport.dev/teleport-v18.10.0-darwin-amd64-bin.tar.gz
200 203226736
```

## Archive contents

```console
$ tar tzf teleport-v18.10.0-darwin-arm64-bin.tar.gz | grep -E 'MacOS|^teleport/(tbot|teleport)$'
teleport/tbot
teleport/teleport
teleport/tctl.app/Contents/MacOS/tctl
teleport/tsh.app/Contents/MacOS/tsh
```

## Result after the change

darwin/arm64 (native, this machine):

```console
$ aqua i -a
INF create a symbolic link ... command=tbot
INF create a symbolic link ... command=tctl
INF create a symbolic link ... command=teleport
INF create a symbolic link ... command=tsh

$ tbot version     # Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
$ tctl version     # Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
$ teleport version # Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
$ tsh version      # Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
```

All four exit 0. Beyond `version`, each command was exercised once more to be sure it is a
working binary and not just a version string:

```console
$ tsh status                 # "ERROR: Not logged in."          (runs)
$ tctl status                # "ERROR: Could not load Teleport host UUID file ..." (runs)
$ teleport configure --help  # "usage: teleport configure [<flags>]"
$ tbot --help                # "Usage: tbot [<flags>] <command> [<args> ...]"
```

darwin/amd64 (`AQUA_GOARCH=amd64`, all four installed and executed, exit 0):

```console
$ file .../teleport-v18.10.0-darwin-amd64-bin.tar.gz/teleport/teleport
Mach-O 64-bit executable x86_64
$ teleport version
Teleport v18.10.0 git:v18.10.0-0-gddaa46b8 go1.25.11
```

**Caveat:** the amd64 binaries were *executed* through **Rosetta 2 on an arm64 Mac**, not on
native Intel hardware. Signature/notarization state and archive layout are identical to arm64.
CI's `macos-26-intel` job runs `aqua i`, so it confirms the amd64 tarball downloads and all four
`files[].src` paths resolve on native Intel, but it does not execute the binaries — so native
Intel *execution* remains unverified.

## Repository test procedure

```console
$ argd t gravitational/teleport
... os=linux arch=amd64
... os=linux arch=arm64
... os=darwin arch=amd64
... os=darwin arch=arm64
... os=windows arch=amd64
... os=windows arch=arm64
INF Updating registry.yaml
$ echo $?
0
```

Exit 0 for all six targets, no errors in the log.

```console
$ conftest test --combine pkgs/gravitational/teleport/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/gravitational/teleport/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly.

`pkg.yaml` is unchanged (no manual version bump).

CI on this PR is green: all 20 checks pass, including `test (macos-26)`, `test (macos-26-intel)`,
`test (ubuntu-24.04)`, `test (ubuntu-24.04-arm)`, `test (windows-latest)` and
`test (windows-latest, arm64)`.

## Not changed / not verified

Things I measured but deliberately left out of this PR, so they are recorded rather than
silently fixed:

- **darwin below v17.0.1 uses a different layout.** `tctl` / `tsh` are plain files
  (`teleport/tctl`, `teleport/tsh`), not `.app` bundles — the `.app` layout starts at v17.0.1
  (checked: v16.5.18 flat, v17.0.1 bundled). Those versions are *already* broken on darwin today,
  because `teleport-tools-<v>.pkg` 404s for them (v18.0.0, v16.x, v15.x, v14.x, v13.x all 404).
  So this PR neither fixes nor regresses them. A `version_overrides` branch for `< 17.0.0` would
  work for darwin (verified: v16.5.18 installs and all four run), but since
  `version_overrides[].overrides` replaces the whole `overrides` list, a correct old-version
  branch also has to describe windows, and old windows archives diverge a lot
  (v16: no `tbot.exe`; v15: no `tctl.exe`; v13: nested under `teleport/`). That is a bigger,
  separate change — happy to open it if you want it.
- **windows declares `tbot` for versions that do not ship it.** `tbot.exe` is absent from the
  windows zip before ~v17.5 (checked: v17.4.0 has only `tctl.exe`/`tsh.exe`; v17.5.1 has
  `tbot.exe`). Pre-existing, untouched here.
- Some versions are missing from the CDN entirely for every OS (v17.0.0, v17.0.6 → 404), so
  those are not installable regardless of this change.
- I did **not** execute the binaries on native Intel macOS (only install is covered there, by
  CI), nor on a real Windows or Linux host outside the `argd t` containers.

## AI usage

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author.
All commands above were actually executed and their real output pasted; results were reviewed
before submitting.
