### PR TITLE
feat(GoogleContainerTools/skaffold): add checksum support

### DIFF
--- a/pkgs/GoogleContainerTools/skaffold/registry.yaml
+++ b/pkgs/GoogleContainerTools/skaffold/registry.yaml
@@ -5,6 +5,16 @@ packages:
     repo_name: skaffold
     description: Easy and Repeatable Kubernetes Development
     url: https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}
+    checksum:
+      type: http
+      url: "https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}.sha256"
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        checksum:
+          type: http
+          url: "https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}.exe.sha256"
+          algorithm: sha256
     files:
       - name: skaffold
         src: skaffold-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -4406,6 +4406,16 @@ packages:
     repo_name: skaffold
     description: Easy and Repeatable Kubernetes Development
     url: https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}
+    checksum:
+      type: http
+      url: "https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}.sha256"
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        checksum:
+          type: http
+          url: "https://storage.googleapis.com/skaffold/releases/{{.Version}}/skaffold-{{.OS}}-{{.Arch}}.exe.sha256"
+          algorithm: sha256
     files:
       - name: skaffold
         src: skaffold-{{.OS}}-{{.Arch}}


### PR DESCRIPTION
## Check List

* [x] Read [[CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)

  * :warning: [[Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  * :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
* [x] [[Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Description

Add SHA-256 checksum verification for `GoogleContainerTools/skaffold`.

Skaffold publishes a separate checksum file alongside each binary. Unix platforms use the `.sha256` suffix, while the Windows checksum URL requires the `.exe.sha256` suffix. A Windows-specific override is included to handle this difference.

## Test

```console
$ mise exec aqua:aquaproj/registry-tool@0.5.7 -- argd t GoogleContainerTools/skaffold
...
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF downloading a checksum file env=windows/amd64 package_name=GoogleContainerTools/skaffold package_version=v2.24.0
INF Updating registry.yaml

$ echo $?
0
```

The test successfully verified installation on Linux AMD64/ARM64, macOS AMD64/ARM64, and Windows AMD64.

## AI usage

I used OpenAI Codex to help investigate the platform-specific checksum URLs, prepare the registry configuration, and review the change. I reviewed and tested the resulting configuration.