### PR TITLE
feat(atlassian.com/acli): support Windows

### DIFF
--- a/pkgs/atlassian.com/acli/registry.yaml
+++ b/pkgs/atlassian.com/acli/registry.yaml
@@ -7,13 +7,11 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -17322,16 +17322,14 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin


### PR DESCRIPTION
## Overview

`acli.atlassian.com` publishes Windows archives, but `supported_envs` excludes Windows.

Windows uses `.zip` while the other platforms use `.tar.gz`:

```console
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://acli.atlassian.com/windows/1.3.30-stable/acli_1.3.30-stable_windows_amd64.tar.gz
403
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://acli.atlassian.com/windows/1.3.30-stable/acli_1.3.30-stable_windows_amd64.zip
200
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L https://acli.atlassian.com/windows/1.3.30-stable/acli_1.3.30-stable_windows_arm64.zip
200
```

So the extension in `url` is replaced with `{{.Format}}` and a `goos: windows` override switches the format.

The archive layout matches the existing `files[].src` template, because `complete_windows_ext` completes `.exe`:

```console
$ unzip -l acli_1.3.30-stable_windows_amd64.zip
 17692160  2026-08-26 14:38   acli_1.3.30-stable_windows_amd64/acli.exe

$ tar tzf acli_1.3.30-stable_linux_amd64.tar.gz
acli_1.3.30-stable_linux_amd64/acli
```

`supported_envs` is dropped because every environment is supported now.

## Why no `version_overrides`

Windows amd64 and arm64 archives exist for all 47 tags of `ryan-pip/acli-versions`, down to the oldest one (`1.1.0-stable`), so no version split is needed:

```console
1.3.30-stable    win-amd64=200 win-arm64=200 linux-amd64=200
1.3.0-stable     win-amd64=200 win-arm64=200 linux-amd64=200
1.2.0-stable     win-amd64=200 win-arm64=200 linux-amd64=200
1.1.0-stable     win-amd64=200 win-arm64=200 linux-amd64=200
```

`argd s` only generates a stub for `type: http`, so this is written by hand, following the style guide.

## Tests

aqua v2.62.3, using `pkgs/atlassian.com/acli/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| 1.3.30-stable | windows/amd64 | installed (`acli.exe`) |
| 1.3.30-stable | windows/arm64 | installed (`acli.exe`) |
| 1.2.0-stable | windows/amd64 | installed (`acli.exe`) |
| 1.3.30-stable | linux/amd64, linux/arm64 | installed |
| 1.2.0-stable | linux/amd64 | installed |

```console
$ aqua exec -- acli --version
acli version 1.3.30-stable
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/atlassian.com/acli/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
