### PR TITLE
feat(apache/ant): support 1.8.0 - 1.10.0

### DIFF
--- a/pkgs/apache/ant/pkg.yaml
+++ b/pkgs/apache/ant/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
   - name: apache/ant@rel/1.10.17
+  - name: apache/ant
+    version: rel/1.10.0
+  - name: apache/ant
+    version: rel/1.9.16

--- a/pkgs/apache/ant/registry.yaml
+++ b/pkgs/apache/ant/registry.yaml
@@ -8,8 +8,26 @@ packages:
     version_prefix: rel/
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 1.8.0")
+        error_message: Please use 1.8.0 or later
       - version_constraint: semver("<= 1.10.0")
-        error_message: Please use 1.10.1 or later
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: http
+          url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}.sha512
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{128}\b)
+        files:
+          - name: ant
+            src: apache-ant-{{.SemVer}}/bin/ant
+        overrides:
+          - goos: windows
+            files:
+              - name: ant
+                src: apache-ant-{{.SemVer}}/bin/ant.bat
       - version_constraint: "true"
         url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
         format: tar.xz

--- a/registry.yaml
+++ b/registry.yaml
@@ -14156,8 +14156,26 @@ packages:
     version_prefix: rel/
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver("< 1.8.0")
+        error_message: Please use 1.8.0 or later
       - version_constraint: semver("<= 1.10.0")
-        error_message: Please use 1.10.1 or later
+        url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: http
+          url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}.sha512
+          file_format: regexp
+          algorithm: sha512
+          pattern:
+            checksum: ^(\b[A-Fa-f0-9]{128}\b)
+        files:
+          - name: ant
+            src: apache-ant-{{.SemVer}}/bin/ant
+        overrides:
+          - goos: windows
+            files:
+              - name: ant
+                src: apache-ant-{{.SemVer}}/bin/ant.bat
       - version_constraint: "true"
         url: https://archive.apache.org/dist/ant/binaries/apache-ant-{{.SemVer}}-bin.{{.Format}}
         format: tar.xz


### PR DESCRIPTION
## What

Extend `apache/ant` down to **1.8.0**. Versions 1.8.0–1.10.0 now install from the `.tar.gz`
archives; only `< 1.8.0` still errors.

## Why this is a follow-up, not a policy change

The exclusion was explicitly left open by the author of the PR that added the package,
aquaproj/aqua-registry#49947:

> For simplicity, ignores versions `1.10.0` and earlier ([before smaller `.xz` archives were
> being published](https://archive.apache.org/dist/ant/binaries/)). Ant is very old, and 1.10.x
> series is [from 2017](https://ant.apache.org/antnews.html) so nearly 9 years old. There's
> little value in supporting older versions IMHO, **but someone can add support later if they
> like.**

That is the only commit that has ever touched `pkgs/apache/ant/registry.yaml`, so no later
decision supersedes it. `docs/support_policy.md` says nothing about old versions.

## Why the cutoff was at 1.10.0: `.tar.xz` starts at 1.10.1

The existing constraint sits exactly at the format boundary — the cutoff was format-driven,
not a support decision:

```console
$ B=https://archive.apache.org/dist/ant/binaries
$ for v in 1.10.0 1.10.1; do
    printf "%-8s xz=%s gz=%s\n" "$v" \
      "$(curl -sSI -o /dev/null -w '%{http_code}' $B/apache-ant-$v-bin.tar.xz)" \
      "$(curl -sSI -o /dev/null -w '%{http_code}' $B/apache-ant-$v-bin.tar.gz)"
  done
1.10.0   xz=404 gz=200
1.10.1   xz=200 gz=200
```

`.tar.gz` is published for every version, so the older range only needs `format: tar.gz`.

## Why the floor is 1.8.0 and not 1.6.0: `.tar.gz.sha512` starts at 1.8.0

```console
$ curl -sSI -o /dev/null -w '%{http_code}\n' $B/apache-ant-1.7.1-bin.tar.gz.sha512
404
$ curl -sSI -o /dev/null -w '%{http_code}\n' $B/apache-ant-1.8.0-bin.tar.gz.sha512
200
```

1.7.1 and older publish only sha1/md5. Proposing weak checksums is not worth doing, so
1.6.0–1.7.1 (8 versions, 2003–2008) keep erroring — with the message updated to
`Please use 1.8.0 or later`.

## All 23 versions in range verified

Every version in 1.8.0–1.10.0 has `.tar.gz` = 200, `.tar.gz.sha512` = 200, and a checksum file
that is a bare 128-hex string — the same shape as the 1.10.1+ `.tar.xz.sha512` files, so the
existing `pattern.checksum: ^(\b[A-Fa-f0-9]{128}\b)` matches unchanged:

```console
1.8.0    gz=200 sha512=200 bare128
1.8.1    gz=200 sha512=200 bare128
... (1.8.2 1.8.3 1.8.4 1.9.0 … 1.9.15) ...
1.9.16   gz=200 sha512=200 bare128
1.10.0   gz=200 sha512=200 bare128
=== ALL 23 gz=200, sha512=200, bare-128-hex: YES ===
```

`rel/` tags exist for all of them (5 for 1.8.x, 17 for 1.9.x, 1 for 1.10.0), so
`version_source: github_tag` lists them without change.

Archive layout is unchanged, checked at the floor, the middle and the boundary — so the
existing `files[].src` and the windows `overrides` block apply as-is:

```console
### 1.8.0
apache-ant-1.8.0/bin/ant apache-ant-1.8.0/bin/ant.bat
### 1.9.16
apache-ant-1.9.16/bin/ant apache-ant-1.9.16/bin/ant.bat
### 1.10.0
apache-ant-1.10.0/bin/ant apache-ant-1.10.0/bin/ant.bat
```

## Shape of the change

`version_overrides` is evaluated in order, first match wins:

1. `semver("< 1.8.0")` → `error_message`
2. `semver("<= 1.10.0")` → same download, `format: tar.gz`
3. `version_constraint: "true"` → the existing `tar.xz` branch, **untouched**

Only `format` actually differs between branches 2 and 3, because both `url` and `checksum.url`
interpolate `{{.Format}}`. aqua's `version_overrides` do merge onto the base package
(`overrideVersion` starts from a copy of the base and only replaces fields the override sets),
so branch 2 could have been a two-line override with the download fields hoisted to the base.
I did not do that, because
[docs/registry_yaml.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/registry_yaml.md)
says the opposite is the house style:

> We decided not to rely on base settings as much as possible. ... Merge with base settings
> makes code DRY, but it's difficult to update settings when settings of new versions are
> changed.

So branch 2 repeats the settings in full and the existing branch is left alone. Happy to switch
to the hoisted form if you would rather have the smaller file.

## Verification

Reproduced with `aqua` directly (not via mise).

- aqua v2.62.3
- macOS 26.6.2, darwin/arm64
- Java: Temurin JDK 17.0.20.1+1 (needed to run `ant` at all; no JDK ships with the package)

`aqua.yaml` used:

```yaml
checksum:
  enabled: true
registries:
  - name: local
    type: local
    path: registry.yaml   # this PR's pkgs/apache/ant/registry.yaml
packages:
  - name: apache/ant
    version: rel/1.9.16
    registry: local
```

**Before** — 1.9.16 refused:

```console
$ aqua i -a
ERR Please use 1.10.1 or later  package_name=apache/ant package_version=rel/1.9.16
ERR install the package ... error="the package has a field `error_message`"
```

**After** — each version installed into its own `AQUA_ROOT_DIR`, checksum verification on,
then executed:

```console
rel/1.7.1   -> ERR Please use 1.8.0 or later            (still refused, new floor)
rel/1.8.0   -> Apache Ant version 1.8.0 compiled on February 1 2010
rel/1.9.16  -> Apache Ant(TM) version 1.9.16 compiled on July 10 2021
rel/1.10.0  -> Apache Ant(TM) version 1.10.0 compiled on December 27 2016
rel/1.10.17 -> Apache Ant(TM) version 1.10.17 compiled on April 6 2026
```

1.8.0 (floor), 1.10.0 (upper boundary of the new branch) and 1.10.17 (existing `tar.xz` branch,
regression check) all run. `ant -version` exits 0 for all four installable versions.

sha512 verification really happens on the new branch — aqua fetched the `.tar.gz.sha512` URL and
recorded it, and the value matches upstream:

```console
$ cat aqua-checksums.json
{
  "checksums": [
    {
      "id": "http/archive.apache.org/dist/ant/binaries/apache-ant-1.9.16-bin.tar.gz",
      "checksum": "8D542A7A...EC4A366",
      "algorithm": "sha512"
    }
  ]
}

$ curl -sS $B/apache-ant-1.9.16-bin.tar.gz.sha512
8d542a7a636a491e76170148881b6f413f4564aad1ab034f426bd946be93382001862bd6c60865aa2b57b39b9633e0181fe8997dd6323123aaf76b410ec4a366
```

(The `{{.Format}}` interpolation resolves to `-bin.tar.gz.sha512` on branch 2 and
`-bin.tar.xz.sha512` on branch 3; both were exercised.)

### Repository test procedure

```console
$ argd t apache/ant
INF testing program=argd version=0.5.7 os=linux arch=amd64
INF testing program=argd version=0.5.7 os=linux arch=arm64
INF testing program=argd version=0.5.7 os=darwin arch=amd64
INF testing program=argd version=0.5.7 os=darwin arch=arm64
INF testing program=argd version=0.5.7 os=windows arch=amd64
INF testing program=argd version=0.5.7 os=windows arch=arm64
INF Updating registry.yaml
$ echo $?
0
```

Exit 0 for all six targets, no errors in the log. All three pinned versions are exercised on
each target, e.g.:

```console
INF download and unarchive the package env=linux/amd64 package_name=apache/ant package_version=rel/1.9.16
INF download and unarchive the package env=linux/amd64 package_name=apache/ant package_version=rel/1.10.0
INF download and unarchive the package env=linux/amd64 package_name=apache/ant package_version=rel/1.10.17
```

```console
$ conftest test --combine pkgs/apache/ant/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/apache/ant/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly.

## `pkg.yaml`

Added one pinned version inside the new branch per the "pin one test version per
`version_overrides` branch" rule, plus the branch's upper boundary:

- `rel/1.9.16` — inside the new `<= 1.10.0` branch
- `rel/1.10.0` — the exact boundary between the two download branches

`rel/1.10.17` is left exactly as it is — this is not a version bump, and Renovate still owns it.
The `< 1.8.0` branch has no pinned version because it cannot install by design.

## Out of scope

Ant 1.6.0–1.7.1. Their archives exist but publish only sha1/md5, so they keep erroring.

## Not verified

- I executed `ant` only on darwin/arm64. The linux and windows targets were covered by
  `argd t` (install only — `argd t` does not run the binary).
- Ant 1.8.0 was run under JDK 17; I did not test it against the JDKs of its own era.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author
per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command
above was actually executed and its real output pasted. I have reviewed the change and own it.
