### PR TITLE
feat(specstoryai/getspecstory): support Windows

### DIFF
--- a/pkgs/atlassian.com/acli/registry.yaml
+++ b/pkgs/atlassian.com/acli/registry.yaml
@@ -7,13 +7,11 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
+    overrides:
+      - goos: windows
+        format: zip

--- a/pkgs/getdbt.com/dbt-fusion/registry.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/registry.yaml
@@ -7,17 +7,17 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
+      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
     files:
       - name: dbt
+    overrides:
+      - goos: windows
+        format: zip

--- a/pkgs/specstoryai/getspecstory/pkg.yaml
+++ b/pkgs/specstoryai/getspecstory/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: specstoryai/getspecstory@v1.13.0
+  - name: specstoryai/getspecstory@v2.10.0
+  - name: specstoryai/getspecstory
+    version: v1.13.0

--- a/pkgs/specstoryai/getspecstory/registry.yaml
+++ b/pkgs/specstoryai/getspecstory/registry.yaml
@@ -3,12 +3,12 @@ packages:
   - type: github_release
     repo_owner: specstoryai
     repo_name: getspecstory
-    description: Install our extensions for GH Copilot, Cursor and Claude Code. Try BearClaude. File issues and requests
+    description: Install our local first extensions for your favorite AI IDE or Terminal Agent. Process your histories into reusable skills with Lore. Sync your conversations to the cloud. File issues and requests
     files:
       - name: specstory
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.8.0")
         asset: SpecStoryCLI_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -22,3 +22,18 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: SpecStoryCLI_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: SpecStoryCLI_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -41282,20 +41282,20 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
     format: tar.gz
-    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
-      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
     files:
       - name: dbt
-    overrides:
-      - goos: windows
-        format: zip
   - type: github_release
     repo_owner: getgauge
     repo_name: gauge
@@ -87228,12 +87228,12 @@ packages:
   - type: github_release
     repo_owner: specstoryai
     repo_name: getspecstory
-    description: Install our extensions for GH Copilot, Cursor and Claude Code. Try BearClaude. File issues and requests
+    description: Install our local first extensions for your favorite AI IDE or Terminal Agent. Process your histories into reusable skills with Lore. Sync your conversations to the cloud. File issues and requests
     files:
       - name: specstory
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("<= 2.8.0")
         asset: SpecStoryCLI_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -87247,6 +87247,21 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: SpecStoryCLI_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: SpecStoryCLI_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: go_install
     repo_owner: spf13
     repo_name: cobra-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -17322,16 +17322,14 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin

--- a/registry.yaml
+++ b/registry.yaml
@@ -17322,14 +17322,16 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    overrides:
-      - goos: windows
-        format: zip
+    supported_envs:
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin
@@ -41280,20 +41282,20 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
+      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
     files:
       - name: dbt
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: getgauge
     repo_name: gauge

--- a/registry.yaml
+++ b/registry.yaml
@@ -17322,16 +17322,14 @@ packages:
     description: Software to interact with Atlassian Cloud from the terminal
     link: https://developer.atlassian.com/cloud/acli/
     version_source: github_tag
-    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    url: https://acli.atlassian.com/{{.OS}}/{{.Version}}/acli_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
     format: tar.gz
     files:
       - name: acli
         src: acli_{{.Version}}_{{.OS}}_{{.Arch}}/acli
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: atuinsh
     repo_name: atuin
@@ -41282,20 +41280,20 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
+      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
     files:
       - name: dbt
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: getgauge
     repo_name: gauge


### PR DESCRIPTION
## Overview

`specstoryai/getspecstory` publishes Windows archives, but `supported_envs` excludes Windows.

```console
$ gh api repos/specstoryai/getspecstory/releases/tags/v2.10.0 --jq '.assets[].name' | grep -i windows
SpecStoryCLI_Windows_arm64.zip
SpecStoryCLI_Windows_x86_64.zip
```

The configuration is generated, not hand written:

```sh
aqua gr specstoryai/getspecstory
```

Windows assets are published since v2.9.0, which the generated code expresses as the `semver("<= 2.8.0")` branch (v2.8.1 doesn't exist):

```console
v2.10.0   2 windows assets
v2.9.0    2 windows assets
v2.8.0    0
v2.7.0    0
...
```

### Manual fix on top of the generated code

`files[].name: specstory` is restored. `aqua gr` doesn't look into archives, so it can't know that the binary is named `specstory` while the repository is `getspecstory`. Without it, aqua would look for `getspecstory` in the archive.

`pkg.yaml` gains v2.10.0 so that CI exercises the latest branch; v1.13.0 covers the older one.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/specstoryai/getspecstory/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v2.10.0 | windows/amd64 | installed (`specstory.exe`) |
| v2.10.0 | windows/arm64 | installed (`specstory.exe`) |
| v1.13.0 | windows/amd64 | skipped (unsupported env), as intended |
| v2.10.0 | linux/amd64, linux/arm64 | installed |
| v1.13.0 | linux/amd64 | installed |

```console
$ aqua exec -- specstory --version
2.10.0 (SpecStory)
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/specstoryai/getspecstory/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.