### PR TITLE
feat(getdbt.com/dbt-fusion): support Windows

### DIFF
--- a/pkgs/getdbt.com/dbt-fusion/registry.yaml
+++ b/pkgs/getdbt.com/dbt-fusion/registry.yaml
@@ -7,17 +7,17 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
+      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
     files:
       - name: dbt
+    overrides:
+      - goos: windows
+        format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -41316,20 +41316,20 @@ packages:
     description: The next-generation engine for dbt
     link: https://docs.getdbt.com/docs/local/install-dbt
     version_source: github_tag
-    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.tar.gz
+    url: https://public.cdn.getdbt.com/fs/cli/fs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
     format: tar.gz
+    windows_arm_emulation: true
     replacements:
       linux: unknown-linux-gnu
       darwin: apple-darwin
+      windows: pc-windows-msvc
       amd64: x86_64
       arm64: aarch64
-    supported_envs:
-      - linux/amd64
-      - linux/arm64
-      - darwin/amd64
-      - darwin/arm64
     files:
       - name: dbt
+    overrides:
+      - goos: windows
+        format: zip
   - type: github_release
     repo_owner: getgauge
     repo_name: gauge


### PR DESCRIPTION
## Overview

`public.cdn.getdbt.com` publishes a Windows build, but `supported_envs` excludes Windows.

Windows uses `.zip` while the other platforms use `.tar.gz`, and only x86_64 is published:

```console
$ B=https://public.cdn.getdbt.com/fs/cli
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L "$B/fs-v2.0.0-preview.212-x86_64-pc-windows-msvc.tar.gz"
404
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L "$B/fs-v2.0.0-preview.212-x86_64-pc-windows-msvc.zip"
200
$ curl -sS -o /dev/null -w "%{http_code}\n" -I -L "$B/fs-v2.0.0-preview.212-aarch64-pc-windows-msvc.zip"
404
```

So:

- the extension in `url` is replaced with `{{.Format}}` and a `goos: windows` override switches the format
- `windows: pc-windows-msvc` is added to `replacements`
- `windows_arm_emulation: true` covers `windows/arm64`

The archive contains a flat binary, so the existing `files` entry resolves it through `complete_windows_ext`:

```console
$ unzip -l fs-v2.0.0-preview.212-x86_64-pc-windows-msvc.zip
410990168  2026-08-19 01:27   dbt.exe

$ tar tzf fs-v2.0.0-preview.212-x86_64-unknown-linux-gnu.tar.gz
dbt
```

`supported_envs` is dropped because every environment is supported now.

## Why no `version_overrides`

The Windows build exists for every version in `pkg.yaml`, down to the oldest tag of `ryan-pip/dbt-fusion-versions` (`v2.0.0-beta.13`):

```console
v2.0.0-preview.212     x86_64-pc-windows-msvc=200 aarch64-pc-windows-msvc=404
v2.0.0-preview.100     x86_64-pc-windows-msvc=200 aarch64-pc-windows-msvc=404
v2.0.0-beta.24         x86_64-pc-windows-msvc=200 aarch64-pc-windows-msvc=404
v2.0.0-beta.13         x86_64-pc-windows-msvc=200 aarch64-pc-windows-msvc=404
```

`argd s` only generates a stub for `type: http`, so this is written by hand, following the style guide.

## Tests

aqua v2.62.3, using `pkgs/getdbt.com/dbt-fusion/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v2.0.0-preview.212 | windows/amd64 | installed (`dbt.exe`) |
| v2.0.0-preview.212 | windows/arm64 | installed (`dbt.exe`, through `windows_arm_emulation`) |
| v2.0.0-beta.13 | windows/amd64 | installed (`dbt.exe`) |
| v2.0.0-preview.212 | linux/amd64 | installed |
| v2.0.0-beta.13 | linux/amd64 | installed |

```console
$ aqua exec -- dbt --version
dbt-fusion 2.0.0-preview.212
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/getdbt.com/dbt-fusion/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
