### PR TITLE
feat(mercari/tfnotify): support Windows

### DIFF
--- a/pkgs/mercari/tfnotify/pkg.yaml
+++ b/pkgs/mercari/tfnotify/pkg.yaml
@@ -1,2 +1,12 @@
 packages:
   - name: mercari/tfnotify@v1.1.12
+  - name: mercari/tfnotify
+    version: v0.8.0
+  - name: mercari/tfnotify
+    version: v0.7.5
+  - name: mercari/tfnotify
+    version: v0.7.0
+  - name: mercari/tfnotify
+    version: v0.5.0
+  - name: mercari/tfnotify
+    version: v0.3.1

--- a/pkgs/mercari/tfnotify/registry.yaml
+++ b/pkgs/mercari/tfnotify/registry.yaml
@@ -4,12 +4,71 @@ packages:
     repo_owner: mercari
     repo_name: tfnotify
     description: A CLI command to parse Terraform execution result and notify it to GitHub
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux/amd64
-    asset: tfnotify_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: tfnotify_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.0"
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: tfnotify_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        files:
+          - name: tfnotify
+            src: tfnotify_{{.Version}}_{{.OS}}_{{.Arch}}/tfnotify
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: tfnotify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.0")
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.5")
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -65309,15 +65309,74 @@ packages:
     repo_owner: mercari
     repo_name: tfnotify
     description: A CLI command to parse Terraform execution result and notify it to GitHub
-    rosetta2: true
-    supported_envs:
-      - darwin
-      - linux/amd64
-    asset: tfnotify_{{.OS}}_{{.Arch}}.tar.gz
-    checksum:
-      type: github_release
-      asset: tfnotify_{{trimV .Version}}_checksums.txt
-      algorithm: sha256
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.8.0"
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.1")
+        asset: tfnotify_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        rosetta2: true
+        files:
+          - name: tfnotify
+            src: tfnotify_{{.Version}}_{{.OS}}_{{.Arch}}/tfnotify
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.5.0")
+        asset: tfnotify_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.0")
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.7.5")
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: tfnotify_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfnotify_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: mergestat
     repo_name: mergestat-lite


### PR DESCRIPTION
## Overview

`mercari/tfnotify` publishes Windows archives, but `supported_envs` excludes Windows.

```console
$ gh api repos/mercari/tfnotify/releases/tags/v1.1.12 --jq '.assets[].name' | grep windows
tfnotify_windows_386.zip
tfnotify_windows_amd64.zip
tfnotify_windows_arm64.zip
```

The configuration is generated, not hand written:

```sh
aqua gr mercari/tfnotify
```

The generated code covers every historical asset naming scheme of this repository, where the current configuration had a single flat setting that only worked for recent versions.

### Manual fix on top of the generated code

The `semver("<= 0.3.1")` branch needs `files[].src`. Those archives nest the binary in a directory, which `aqua gr` cannot know because it doesn't look into archives:

```console
$ tar tzf tfnotify_v0.3.1_linux_amd64.tar.gz
tfnotify_v0.3.1_linux_amd64/
tfnotify_v0.3.1_linux_amd64/CHANGELOG.md
tfnotify_v0.3.1_linux_amd64/LICENSE
tfnotify_v0.3.1_linux_amd64/README.md
tfnotify_v0.3.1_linux_amd64/tfnotify

$ tar tzf tfnotify_0.5.0_linux_amd64.tar.gz
CHANGELOG.md
LICENSE
README.md
tfnotify
```

Without the fix, v0.3.1 fails with `check file_src is correct: exe_path isn't found`.

`pkg.yaml` pins one version per `version_overrides` branch: v1.1.12, v0.8.0, v0.7.5, v0.7.0, v0.5.0 and v0.3.1.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/mercari/tfnotify/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v1.1.12 | windows/amd64, windows/arm64 | installed (`tfnotify.exe`) |
| v0.8.0, v0.7.5, v0.3.1 | windows/amd64 | skipped (unsupported env), as intended |
| v1.1.12 | linux/amd64, linux/arm64 | installed |
| v0.8.0, v0.7.5, v0.7.0, v0.5.0, v0.3.1 | linux/amd64 | installed |

```console
$ aqua exec -- tfnotify --version   # windows/amd64
tfnotify version 1.1.12

$ aqua exec -- tfnotify --version   # linux/amd64, v0.3.1
tfnotify version 0.3.1
```

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/mercari/tfnotify/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.
