### PR TITLE
feat(herdrdev/herdr): support Windows

### DIFF
--- a/pkgs/herdrdev/herdr/pkg.yaml
+++ b/pkgs/herdrdev/herdr/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: herdrdev/herdr@v0.8.2
   - name: herdrdev/herdr
+    version: v0.8.0
+  - name: herdrdev/herdr
     version: preview-2026-06-22-24c7377de01c
   - name: herdrdev/herdr
     version: preview-2026-06-05-1ce4213d9ebb

--- a/pkgs/herdrdev/herdr/registry.yaml
+++ b/pkgs/herdrdev/herdr/registry.yaml
@@ -5,7 +5,7 @@ packages:
     repo_name: herdr
     aliases:
       - name: ogulcancelik/herdr
-    description: agent multiplexer that lives in your terminal
+    description: the runtime your coding agents live on
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.4.0"
@@ -17,7 +17,8 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      # Windows assets of preview releases are irregular, so they are excluded.
+      - version_constraint: Version startsWith "preview-"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw
         replacements:
@@ -27,3 +28,25 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.8.0")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            asset: herdr-{{.OS}}-{{.Arch}}.{{.Format}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -49018,7 +49018,7 @@ packages:
     repo_name: herdr
     aliases:
       - name: ogulcancelik/herdr
-    description: agent multiplexer that lives in your terminal
+    description: the runtime your coding agents live on
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.4.0"
@@ -49030,7 +49030,8 @@ packages:
           darwin: macos
         supported_envs:
           - darwin
-      - version_constraint: "true"
+      # Windows assets of preview releases are irregular, so they are excluded.
+      - version_constraint: Version startsWith "preview-"
         asset: herdr-{{.OS}}-{{.Arch}}
         format: raw
         replacements:
@@ -49040,6 +49041,28 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 0.8.0")
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: herdr-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: windows
+            format: zip
+            asset: herdr-{{.OS}}-{{.Arch}}.{{.Format}}
   - type: github_release
     repo_owner: hetznercloud
     repo_name: cli


### PR DESCRIPTION
## Overview

`herdrdev/herdr` publishes a Windows archive, but `supported_envs` excludes Windows.

```console
$ gh api repos/herdrdev/herdr/releases/tags/v0.8.2 --jq '.assets[].name'
herdr-linux-aarch64
herdr-linux-x86_64
herdr-macos-aarch64
herdr-macos-x86_64
herdr-windows-x86_64.zip
```

Windows uses `.zip` while the other platforms ship a raw binary, so a `goos: windows` override switches `format` and `asset`. Only x86_64 is published, so `windows_arm_emulation: true` is added.

The archive carries the ConPTY sidecar next to the binary, and aqua extracts it all into the same directory, so the binary runs:

```console
$ find "$AQUA_ROOT_DIR/pkgs" -type f
.../herdr-windows-x86_64.zip/herdr.exe
.../herdr-windows-x86_64.zip/conpty/conpty.dll
.../herdr-windows-x86_64.zip/conpty/x64/OpenConsole.exe
.../herdr-windows-x86_64.zip/conpty/arm64/OpenConsole.exe
.../herdr-windows-x86_64.zip/conpty/herdr-conpty.json
.../herdr-windows-x86_64.zip/THIRD-PARTY-NOTICES/...

$ aqua exec -- herdr --version
herdr 0.8.2
```

## About the generated code

`aqua gr herdrdev/herdr` was used as the base, with three fixes:

1. **`aliases` is restored.** The generator drops it.
2. **Preview releases are matched by `Version startsWith "preview-"`.** The generated code put them into branches such as `semver("<= 2026.0.0-07-21-0f10e1453a7f")`, which never match, because `preview-2026-...` is not a semver. They fell through to the latest branch and failed:

   ```console
   preview-2026-06-22-24c7377de01c windows/amd64  => ERROR: the asset isn't found: herdr-windows-x86_64.zip
   preview-2026-06-05-1ce4213d9ebb windows/amd64  => ERROR: the asset isn't found: herdr-windows-x86_64.zip
   ```

3. **The empty `replacements: {}` blocks are dropped.** They are no-ops — the parent `replacements` still applies, which is what resolves `x86_64` — and the style guide asks to drop empty `replacements`.

### Why preview releases stay without Windows

Their Windows assets are irregular:

```console
v0.8.2                            herdr-windows-x86_64.zip
preview-2026-08-19-b5c4a0176e91   herdr-windows-x86_64.zip
v0.8.0                            (none)
preview-2026-07-21-0f10e1453a7f   herdr-windows-x86_64.exe
v0.7.5                            (none)
preview-2026-06-05-1ce4213d9ebb   (none)
```

`.zip` in the newest, `.exe` in the middle, missing in the oldest, and the stable releases between them have none at all. Rather than encode that, preview releases keep exactly the platforms they support today, and Windows is added only to the latest stable branch.

## Tests

aqua v2.62.3, using `pkgs/herdrdev/herdr/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v0.8.2 | windows/amd64 | installed |
| v0.8.2 | windows/arm64 | installed (through `windows_arm_emulation`) |
| v0.8.0 | windows/amd64 | skipped (unsupported env), as intended |
| preview-2026-06-22-24c7377de01c | windows/amd64 | skipped (unsupported env), as intended |
| preview-2026-06-05-1ce4213d9ebb | windows/amd64 | skipped (unsupported env), as intended |
| v0.4.0 | windows/amd64 | skipped (unsupported env), as intended |
| v0.8.2 | linux/amd64, linux/arm64 | installed |
| v0.8.0, both previews | linux/amd64 | installed |
| v0.4.0 | linux/amd64 | skipped (unsupported env), as intended |

`pkg.yaml` gains v0.8.0 so that CI exercises the stable branch without Windows; one version per `version_overrides` branch.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/herdrdev/herdr/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.