### PR TITLE
feat(OpenRouterLabs/ori-releases): support Windows

### DIFF
--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -4,5 +4,3 @@ packages:
     version: cli-0.11.0-alpha-c8f51ad
   - name: OpenRouterLabs/ori-releases
     version: cli-0.10.2-d7b2684
-  - name: OpenRouterLabs/ori-releases
-    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/pkg.yaml
@@ -1,2 +1,8 @@
 packages:
-  - name: OpenRouterLabs/ori-releases@cli-0.10.2-d7b2684
+  - name: OpenRouterLabs/ori-releases@cli-0.12.0-68f9a36
+  - name: OpenRouterLabs/ori-releases
+    version: cli-0.11.0-alpha-c8f51ad
+  - name: OpenRouterLabs/ori-releases
+    version: cli-0.10.2-d7b2684
+  - name: OpenRouterLabs/ori-releases
+    version: cli-0.0.0-b98cd74

--- a/pkgs/OpenRouterLabs/ori-releases/registry.yaml
+++ b/pkgs/OpenRouterLabs/ori-releases/registry.yaml
@@ -11,7 +11,19 @@ packages:
     version_overrides:
       - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
         no_asset: true
-      - version_constraint: "true"
+      # ori-windows-x64.exe exists in this release but not in cli-0.11.0-fe98906,
+      # which sorts after it, so it can't be expressed as a range.
+      - version_constraint: Version == "cli-0.11.0-alpha-c8f51ad"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0-fe98906")
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw
         replacements:
@@ -23,3 +35,13 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -6537,7 +6537,19 @@ packages:
     version_overrides:
       - version_constraint: Version in ["cli-0.0.0-02e9757", "cli-0.0.0-1b829d5", "cli-0.0.0-1c71b5b", "cli-0.0.0-1f610f5", "cli-0.0.0-2f0a249", "cli-0.0.0-34641b1", "cli-0.0.0-3d9c01d", "cli-0.0.0-47f0103", "cli-0.0.0-50b0d25", "cli-0.0.0-5302a93", "cli-0.0.0-592965f", "cli-0.0.0-944fc7a", "cli-0.0.0-9645986", "cli-0.0.0-b5fd984", "cli-0.0.0-b98cd74", "cli-0.0.0-cebea8b", "cli-0.0.0-d68ced1", "cli-0.0.0-d9bbd76", "cli-0.0.0-e701796", "cli-0.0.0-faa36d3"]
         no_asset: true
-      - version_constraint: "true"
+      # ori-windows-x64.exe exists in this release but not in cli-0.11.0-fe98906,
+      # which sorts after it, so it can't be expressed as a range.
+      - version_constraint: Version == "cli-0.11.0-alpha-c8f51ad"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+      - version_constraint: semver("<= 0.11.0-fe98906")
         asset: ori-{{.OS}}-{{.Arch}}
         format: raw
         replacements:
@@ -6549,6 +6561,16 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: ori-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
   - type: github_release
     repo_owner: Orange-OpenSource
     repo_name: hurl


### PR DESCRIPTION
## Overview

The newest releases publish `ori-windows-x64.exe`, but `supported_envs` excludes Windows. Only x64 is published, so `windows_arm_emulation: true` is added.

## Why the alpha needs its own branch

Scanning all 223 releases, Windows assets exist only in the two newest ones, and not in the release that sorts between them:

```console
cli-0.12.0-68f9a36               assets=13  windows=ori-windows-x64.exe
cli-0.11.0-alpha-c8f51ad         assets=13  windows=ori-windows-x64.exe
cli-0.11.0-fe98906               assets=11  windows=(none)
cli-0.11.0-alpha-9f29296         assets=11  windows=(none)
...
```

`0.11.0-alpha-c8f51ad` sorts before `0.11.0-fe98906`, so a range can't include the alpha while excluding `fe98906`. It gets its own `Version ==` branch, the same shape the generator chose.

## About the generated code

`aqua gr OpenRouterLabs/ori-releases` was run for reference, but its output is not used as is:

- it dropped `files[].name: ori`, which is needed because the repository is named `ori-releases`
- for the `no_asset` branch it emitted a single version and no `no_asset: true` at all:

  ```yaml
        - version_constraint: Version == "cli-0.0.0-b98cd74"
        - version_constraint: Version == "cli-0.11.0-alpha-c8f51ad"
  ```

  where the current configuration lists 20 `cli-0.0.0-*` versions. With 223 releases in this repository the generator seems to have scanned only a part of them.

So the existing configuration is kept as the base and only the Windows branches are added, rather than replacing it with a partial generation.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/OpenRouterLabs/ori-releases/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| cli-0.12.0-68f9a36 | windows/amd64 | installed (`ori-windows-x64.exe`) |
| cli-0.12.0-68f9a36 | windows/arm64 | installed (through `windows_arm_emulation`) |
| cli-0.11.0-alpha-c8f51ad | windows/amd64 | installed |
| cli-0.11.0-fe98906 | windows/amd64 | skipped (unsupported env), as intended |
| cli-0.10.2-d7b2684 | windows/amd64 | skipped (unsupported env), as intended |
| cli-0.0.0-b98cd74 | windows/amd64 | `no asset is released for this version`, as intended |
| cli-0.12.0-68f9a36 | linux/amd64, linux/arm64 | installed |
| cli-0.11.0-alpha-c8f51ad, cli-0.10.2-d7b2684 | linux/amd64 | installed |

```console
$ aqua exec -- ori --version
{
  "ok": true,
  "command": "version",
  "data": {
    "name": "@ori-runtime/cli",
    "version": "0.12.0+68f9a36"
```

`pkg.yaml` pins one version per `version_overrides` branch.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/OpenRouterLabs/ori-releases/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.