### PR TITLE
feat(yorukot/superfile): support Windows

### DIFF
--- a/pkgs/yorukot/superfile/pkg.yaml
+++ b/pkgs/yorukot/superfile/pkg.yaml
@@ -1,4 +1,10 @@
 packages:
   - name: yorukot/superfile@v1.6.0
   - name: yorukot/superfile
+    version: v1.5.0
+  - name: yorukot/superfile
+    version: v1.1.7
+  - name: yorukot/superfile
+    version: v1.1.1
+  - name: yorukot/superfile
     version: v1.0.0

--- a/pkgs/yorukot/superfile/registry.yaml
+++ b/pkgs/yorukot/superfile/registry.yaml
@@ -6,16 +6,17 @@ packages:
     aliases:
       - name: MHNightCat/superfile
     description: Pretty fancy and modern terminal file manager
-    files:
-      - name: spf
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0"
         asset: spf
         format: raw
+        files:
+          - name: spf
         supported_envs:
           - linux/amd64
-      - version_constraint: "true"
+      # Windows assets are missing only in this release. v1.1.7.1 has them.
+      - version_constraint: Version == "v1.1.7"
         asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -24,3 +25,34 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 1.1.1")
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.6.0-rc1")
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        checksum:
+          type: github_release
+          asset: superfile-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -103361,16 +103361,17 @@ packages:
     aliases:
       - name: MHNightCat/superfile
     description: Pretty fancy and modern terminal file manager
-    files:
-      - name: spf
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v1.0.0"
         asset: spf
         format: raw
+        files:
+          - name: spf
         supported_envs:
           - linux/amd64
-      - version_constraint: "true"
+      # Windows assets are missing only in this release. v1.1.7.1 has them.
+      - version_constraint: Version == "v1.1.7"
         asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -103379,6 +103380,37 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: semver("<= 1.1.1")
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 1.6.0-rc1")
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: superfile-{{.OS}}-{{.Version}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: spf
+            src: dist/{{.AssetWithoutExt}}/spf
+        checksum:
+          type: github_release
+          asset: superfile-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: ysugimoto
     repo_name: falco


### PR DESCRIPTION
## Overview

`yorukot/superfile` publishes Windows archives, but `supported_envs` excludes Windows.

```console
$ gh api repos/yorukot/superfile/releases/tags/v1.6.0 --jq '.assets[].name' | grep -i windows
superfile-windows-v1.6.0-amd64.zip
superfile-windows-v1.6.0-arm64.zip
```

Windows uses `.zip` while the other platforms use `.tar.gz`, so a `goos: windows` override switches the format. The archive layout matches the existing `files[].src`, because `complete_windows_ext` completes `.exe`:

```console
$ unzip -l superfile-windows-v1.6.0-amd64.zip
        0  dist/superfile-windows-v1.6.0-amd64/
 28179456  dist/superfile-windows-v1.6.0-amd64/spf.exe
```

## About the generated code

`aqua gr yorukot/superfile` was used as the base, with these fixes:

1. **`aliases` and `files` are restored.** The generator drops both. `files` is required, because the binary is `spf` while the repository is `superfile`, and it lives under `dist/<asset>/` in the archives.
2. **The generated `semver("<= 1.0.0")` branch was empty:**

   ```yaml
         - version_constraint: semver("<= 1.0.0")
         - version_constraint: semver("<= 1.1.1")
   ```

   v1.0.0 ships an asset named `spf` and v0.1.0-beta one named `superfile`, with no OS or arch for the generator to build a template from. v1.0.0 keeps its existing dedicated branch.

## Version boundaries

```console
v1.6.0     windows=amd64,arm64  checksum=superfile-v1.6.0-checksums.txt
v1.6.0-rc1 windows=amd64,arm64  checksum=(none)
...
v1.1.7.1   windows=amd64,arm64
v1.1.7     windows=(none)        <-- gap
v1.1.6     windows=amd64,arm64
...
v1.1.1     windows=(none)
v1.0.1     windows=(none)
v1.0.0     asset is `spf`
```

Windows assets are missing only in v1.1.7 while v1.1.7.1 has them, so it needs its own `Version ==` branch. Checksums are published since v1.6.0.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/yorukot/superfile/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | env | result |
| --- | --- | --- |
| v1.6.0 | windows/amd64, windows/arm64 | installed (`spf.exe`) |
| v1.5.0 | windows/amd64 | installed |
| v1.1.7.1 | windows/amd64 | installed |
| v1.1.7 | windows/amd64 | skipped (unsupported env), as intended |
| v1.1.1, v1.0.0 | windows/amd64 | skipped (unsupported env), as intended |
| v1.6.0 | linux/amd64, linux/arm64 | installed |
| v1.5.0, v1.1.7, v1.1.1, v1.0.0 | linux/amd64 | installed |

```console
$ aqua exec -- spf --version
superfile version v1.6.0
```

`pkg.yaml` pins one version per `version_overrides` branch.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/yorukot/superfile/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.