### PR TITLE
feat(rustic-rs/rustic): support Windows

### DIFF
--- a/pkgs/rustic-rs/rustic/pkg.yaml
+++ b/pkgs/rustic-rs/rustic/pkg.yaml
@@ -7,8 +7,6 @@ packages:
   - name: rustic-rs/rustic
     version: v0.6.1
   - name: rustic-rs/rustic
-    version: v0.6.0
-  - name: rustic-rs/rustic
     version: v0.5.4
   - name: rustic-rs/rustic
     version: v0.4.4

--- a/pkgs/rustic-rs/rustic/pkg.yaml
+++ b/pkgs/rustic-rs/rustic/pkg.yaml
@@ -3,7 +3,11 @@ packages:
   - name: rustic-rs/rustic
     version: v0.10.2
   - name: rustic-rs/rustic
-    version: v0.10.2
+    version: v0.9.4
+  - name: rustic-rs/rustic
+    version: v0.6.1
+  - name: rustic-rs/rustic
+    version: v0.6.0
   - name: rustic-rs/rustic
     version: v0.5.4
   - name: rustic-rs/rustic

--- a/pkgs/rustic-rs/rustic/registry.yaml
+++ b/pkgs/rustic-rs/rustic/registry.yaml
@@ -3,27 +3,12 @@ packages:
   - type: github_release
     repo_owner: rustic-rs
     repo_name: rustic
-    description: rustic - fast, encrypted, and deduplicated backups powered by Rust
+    description: "rustic - fast, encrypted, and deduplicated backups powered by Rust"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.10.2"
-        asset: rustic-{{.Version}}-1-g189b17c-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: darwin
-            goarch: arm64
-            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-      - version_constraint: semver("<= 0.2.0-rc1")
+      - version_constraint: Version == "v0.6.0"
+        no_asset: true
+      - version_constraint: Version == "v0.2.0-rc1"
         asset: rustic_{{trimV .Version}}_{{.Arch}}_64-{{.OS}}.{{.Format}}
         format: bz2
         files:
@@ -34,6 +19,46 @@ packages:
           linux: unknown-linux-musl
         supported_envs:
           - linux/amd64
+      - version_constraint: Version == "v0.6.1"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.10.2"
+        asset: rustic-{{.Version}}-1-g189b17c-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
       - version_constraint: semver("<= 0.2.2")
         asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -41,6 +66,13 @@ packages:
         files:
           - name: rustic
             src: rustic-rs
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
         overrides:
           - goos: linux
             goarch: amd64
@@ -51,16 +83,9 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
-        checksum:
-          type: github_release
-          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
-          algorithm: sha256
       - version_constraint: semver("<= 0.3.0")
         asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -68,6 +93,9 @@ packages:
         files:
           - name: rustic
             src: rustic-rs
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
         overrides:
           - goos: linux
             goarch: amd64
@@ -78,15 +106,16 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
       - version_constraint: semver("<= 0.4.4")
         asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
         overrides:
           - goos: linux
             goarch: amd64
@@ -96,10 +125,6 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
@@ -107,25 +132,11 @@ packages:
         asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
-      - version_constraint: Version == "v0.6.0"
-        no_asset: true
-      - version_constraint: "true"
-        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
         overrides:
           - goos: linux
             goarch: amd64
@@ -135,10 +146,39 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.9.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-        supported_envs:
-          - linux
-          - darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -81647,27 +81647,12 @@ packages:
   - type: github_release
     repo_owner: rustic-rs
     repo_name: rustic
-    description: rustic - fast, encrypted, and deduplicated backups powered by Rust
+    description: "rustic - fast, encrypted, and deduplicated backups powered by Rust"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v0.10.2"
-        asset: rustic-{{.Version}}-1-g189b17c-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            goarch: arm64
-            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
-          - goos: darwin
-            goarch: arm64
-            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-      - version_constraint: semver("<= 0.2.0-rc1")
+      - version_constraint: Version == "v0.6.0"
+        no_asset: true
+      - version_constraint: Version == "v0.2.0-rc1"
         asset: rustic_{{trimV .Version}}_{{.Arch}}_64-{{.OS}}.{{.Format}}
         format: bz2
         files:
@@ -81678,6 +81663,46 @@ packages:
           linux: unknown-linux-musl
         supported_envs:
           - linux/amd64
+      - version_constraint: Version == "v0.6.1"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.10.2"
+        asset: rustic-{{.Version}}-1-g189b17c-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: arm64
+            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
+          - goos: darwin
+            goarch: arm64
+            asset: rustic-{{.Version}}-1-{{.Arch}}-{{.OS}}.{{.Format}}
       - version_constraint: semver("<= 0.2.2")
         asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -81685,6 +81710,13 @@ packages:
         files:
           - name: rustic
             src: rustic-rs
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+        checksum:
+          type: github_release
+          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
+          algorithm: sha256
         overrides:
           - goos: linux
             goarch: amd64
@@ -81695,16 +81727,9 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
-        checksum:
-          type: github_release
-          asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.sha256
-          algorithm: sha256
       - version_constraint: semver("<= 0.3.0")
         asset: rustic-rs-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -81712,6 +81737,9 @@ packages:
         files:
           - name: rustic
             src: rustic-rs
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
         overrides:
           - goos: linux
             goarch: amd64
@@ -81722,15 +81750,16 @@ packages:
             replacements:
               arm64: aarch64
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
       - version_constraint: semver("<= 0.4.4")
         asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
         overrides:
           - goos: linux
             goarch: amd64
@@ -81740,10 +81769,6 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
         supported_envs:
           - linux
           - darwin
@@ -81751,25 +81776,11 @@ packages:
         asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
-        overrides:
-          - goos: linux
-            goarch: amd64
-            replacements:
-              linux: unknown-linux-musl
-          - goos: linux
-            goarch: arm64
-            replacements:
-              linux: unknown-linux-gnu
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
           windows: pc-windows-msvc
-      - version_constraint: Version == "v0.6.0"
-        no_asset: true
-      - version_constraint: "true"
-        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
         overrides:
           - goos: linux
             goarch: amd64
@@ -81779,13 +81790,42 @@ packages:
             goarch: arm64
             replacements:
               linux: unknown-linux-gnu
+      - version_constraint: semver("<= 0.9.4")
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
         replacements:
           amd64: x86_64
           arm64: aarch64
           darwin: apple-darwin
-        supported_envs:
-          - linux
-          - darwin
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            replacements:
+              linux: unknown-linux-musl
+          - goos: linux
+            goarch: arm64
+            replacements:
+              linux: unknown-linux-gnu
+      - version_constraint: "true"
+        asset: rustic-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
   - name: rustsec/rustsec/cargo-audit
     type: github_release
     repo_owner: rustsec


### PR DESCRIPTION
## Overview

`rustic-rs/rustic` publishes Windows archives, but `supported_envs` excludes Windows.

```console
$ gh api repos/rustic-rs/rustic/releases/tags/v0.11.4 --jq '.assets[].name' | grep windows
rustic-v0.11.4-x86_64-pc-windows-gnu.tar.gz
rustic-v0.11.4-x86_64-pc-windows-msvc.tar.gz
```

Only x86_64 is published for Windows, which the generated code covers with `windows_arm_emulation: true`.

The configuration is generated, not hand written:

```sh
aqua gr rustic-rs/rustic
```

Besides Windows, the generated code also adds the checksum configuration for recent versions and distinguishes v0.6.1 and v0.9.4, which the previous configuration did not.

### Manual fix on top of the generated code

`files[].src` is restored in the `Version == "v0.2.0-rc1"`, `semver("<= 0.2.2")` and `semver("<= 0.3.0")` branches. Those archives don't contain a file named `rustic`, and `aqua gr` doesn't look into archives, so it dropped them. Without the fix:

```console
v0.3.0       linux/amd64  => ERROR: check file_src is correct: exe_path isn't found
v0.2.2       linux/amd64  => ERROR: check file_src is correct: exe_path isn't found
v0.2.0-rc1   linux/amd64  => ERROR: check file_src is correct: exe_path isn't found
```

After restoring them:

```console
v0.3.0       linux/amd64  => OK rustic-rs
v0.2.2       linux/amd64  => OK rustic-rs
v0.2.0-rc1   linux/amd64  => OK rustic_0.2.0-rc1_x64_64-unknown-linux-musl
```

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/rustic-rs/rustic/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.
Every `version_overrides` branch is covered.

| version | windows/amd64 | linux/amd64 |
| --- | --- | --- |
| v0.11.4 | installed | installed (arm64 too) |
| v0.10.2 | installed | installed |
| v0.9.4 | installed | installed |
| v0.6.1 | skipped (unsupported env) | installed |
| v0.5.4 | installed | installed |
| v0.4.4 | skipped (unsupported env) | installed |
| v0.3.0 | skipped (unsupported env) | installed |
| v0.2.2 | skipped (unsupported env) | installed |
| v0.2.0-rc1 | skipped (unsupported env) | installed |

`v0.11.4` on `windows/arm64` also installs, through `windows_arm_emulation`.

```console
$ aqua exec -- rustic --version
rustic v0.11.4
```

`pkg.yaml` pins one version per `version_overrides` branch, and the duplicated v0.10.2 entry is removed.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/rustic-rs/rustic/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.