### PR TITLE
feat(blacknon/hwatch): support Windows

### DIFF
--- a/pkgs/blacknon/hwatch/pkg.yaml
+++ b/pkgs/blacknon/hwatch/pkg.yaml
@@ -1,9 +1,17 @@
 packages:
   - name: blacknon/hwatch@0.4.2
   - name: blacknon/hwatch
+    version: 0.4.1
+  - name: blacknon/hwatch
+    version: 0.3.18
+  - name: blacknon/hwatch
+    version: 0.3.13
+  - name: blacknon/hwatch
     version: 0.3.0
   - name: blacknon/hwatch
     version: 0.2.1
+  - name: blacknon/hwatch
+    version: 0.1.4
   - name: blacknon/hwatch
     version: 0.1.2
   - name: blacknon/hwatch

--- a/pkgs/blacknon/hwatch/pkg.yaml
+++ b/pkgs/blacknon/hwatch/pkg.yaml
@@ -9,8 +9,6 @@ packages:
   - name: blacknon/hwatch
     version: 0.3.0
   - name: blacknon/hwatch
-    version: 0.2.1
-  - name: blacknon/hwatch
     version: 0.1.4
   - name: blacknon/hwatch
     version: 0.1.2

--- a/pkgs/blacknon/hwatch/registry.yaml
+++ b/pkgs/blacknon/hwatch/registry.yaml
@@ -3,62 +3,124 @@ packages:
   - type: github_release
     repo_owner: blacknon
     repo_name: hwatch
-    description: A modern alternative to the watch command, records the differences in execution results and can check this differences at after
-    supported_envs:
-      - darwin
-      - linux/amd64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-    version_constraint: semver(">= 0.3.1")
-    asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.tar.gz
-    files:
-      - name: hwatch
-        src: bin/hwatch
+    description: "hwatch: alternative watch command with history, diff view, JSONL logging, and change hooks. since 2018"
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("= 0.3.0")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+      - version_constraint: Version in ["0.1.6", "0.2.1"]
+        no_asset: true
+      - version_constraint: Version in ["0.2.0", "0.3.0"]
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        supported_envs:
-          - darwin
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch/hwatch
-      - version_constraint: semver("= 0.2.1") || semver("= 0.1.6")
-        supported_envs: []
+        supported_envs:
+          - darwin
       - version_constraint: semver("= 0.1.0")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}/hwatch
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.1.2")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
-        files:
-          - name: hwatch
-            src: hwatch
-      - version_constraint: semver("< 0.3.1")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.4")
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch/hwatch
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.13")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.18")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.1")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch
+      - version_constraint: "true"
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch

--- a/registry.yaml
+++ b/registry.yaml
@@ -20763,65 +20763,127 @@ packages:
   - type: github_release
     repo_owner: blacknon
     repo_name: hwatch
-    description: A modern alternative to the watch command, records the differences in execution results and can check this differences at after
-    supported_envs:
-      - darwin
-      - linux/amd64
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
-      darwin: apple-darwin
-      linux: unknown-linux-musl
-    version_constraint: semver(">= 0.3.1")
-    asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.tar.gz
-    files:
-      - name: hwatch
-        src: bin/hwatch
+    description: "hwatch: alternative watch command with history, diff view, JSONL logging, and change hooks. since 2018"
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("= 0.3.0")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+      - version_constraint: Version in ["0.1.6", "0.2.1"]
+        no_asset: true
+      - version_constraint: Version in ["0.2.0", "0.3.0"]
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        supported_envs:
-          - darwin
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch/hwatch
-      - version_constraint: semver("= 0.2.1") || semver("= 0.1.6")
-        supported_envs: []
+        supported_envs:
+          - darwin
       - version_constraint: semver("= 0.1.0")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}/hwatch
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.1.2")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
-        files:
-          - name: hwatch
-            src: hwatch
-      - version_constraint: semver("< 0.3.1")
-        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.4")
+        asset: hwatch_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         rosetta2: true
-        replacements:
-          amd64: amd64
-          darwin: darwin
-          linux: linux
         files:
           - name: hwatch
             src: hwatch/hwatch
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.13")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.3.18")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.1")
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-gnu
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch
+      - version_constraint: "true"
+        asset: hwatch-{{.Version}}.{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: hwatch
+            src: bin/hwatch
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+            files:
+              - name: hwatch
+                src: target/{{.Arch}}-{{.OS}}/release/hwatch
   - type: http
     repo_owner: blender
     repo_name: blender


### PR DESCRIPTION
## Overview

`blacknon/hwatch` publishes Windows archives, but `supported_envs` excludes Windows.

```console
$ gh api repos/blacknon/hwatch/releases/tags/0.4.2 --jq '.assets[].name' | grep -i windows
hwatch-0.4.2.x86_64-pc-windows-msvc.zip
```

Only x86_64 is published for Windows, so `windows_arm_emulation: true` is used.

`aqua gr blacknon/hwatch` was used as the base. Besides Windows it also:

- resolves the two Conftest failures this file already had:

  ```console
  $ conftest test --combine pkgs/blacknon/hwatch/registry.yaml   # before
  FAIL - omit .files[].src if it's same with .files[].name
  FAIL - the top level version_constraint must be either empty or "false"
  ```

- distinguishes the `pc-windows-gnu` and `pc-windows-msvc` generations, which the previous configuration did not cover at all

## Manual fixes on top of the generated code

All of them are about `files[].src`, which `aqua gr` can't derive because it doesn't look into archives.

**1. Windows archives have a different layout.** The zips put the binary under `target/<triple>/release/`, while the tar.gz archives use `bin/`:

```console
$ unzip -l hwatch-0.4.2.x86_64-pc-windows-msvc.zip
  4739584  target/x86_64-pc-windows-msvc/release/hwatch.exe

$ tar tzf hwatch-0.4.2.x86_64-unknown-linux-musl.tar.gz
completion/bash/hwatch-completion.bash
completion/fish/hwatch.fish
completion/zsh/_hwatch
bin/hwatch
man/hwatch.1
```

So the `goos: windows` overrides carry their own `files`. Without it:

```console
0.4.2   windows/amd64  => ERROR: check file_src is correct: get file_src: GetFileAttributesEx ...
0.4.1   windows/amd64  => ERROR: check file_src is correct: get file_src: GetFileAttributesEx ...
0.3.18  windows/amd64  => ERROR: check file_src is correct: get file_src: GetFileAttributesEx ...
```

**2. The old generations have three different layouts**, which the generated `semver("<= 0.1.4")` branch merged into one:

```console
$ tar tzf hwatch_0.1.0_linux_amd64.tar.gz
hwatch_0.1.0_linux_amd64/hwatch

$ tar tzf hwatch_0.1.2_linux_amd64.tar.gz
./hwatch

$ tar tzf hwatch_0.1.4_linux_amd64.tar.gz
./hwatch/hwatch
```

0.1.0 and 0.1.2 therefore keep their own branches, as in the current configuration.

## Tests

aqua v2.62.3, using `pkgs/blacknon/hwatch/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | windows/amd64 | linux/amd64 |
| --- | --- | --- |
| 0.4.2 | installed | installed (arm64 too) |
| 0.4.1 | installed | installed |
| 0.3.18 | installed | installed |
| 0.3.13 | skipped (unsupported env) | installed |
| 0.3.0 | skipped (unsupported env) | skipped (darwin only) |
| 0.1.4 | skipped (unsupported env) | installed |
| 0.1.2 | — | installed |
| 0.1.0 | — | installed |

`0.4.2` on `windows/arm64` also installs, through `windows_arm_emulation`.

```console
$ aqua exec -- hwatch --version
hwatch 0.4.2
```

`pkg.yaml` pins one version per `version_overrides` branch.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/blacknon/hwatch/*` now passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.