### PR TITLE
feat(rui314/mold): support Windows

### DIFF
--- a/pkgs/rui314/mold/pkg.yaml
+++ b/pkgs/rui314/mold/pkg.yaml
@@ -4,5 +4,3 @@ packages:
     version: v2.40.2
   - name: rui314/mold
     version: v1.5.1
-  - name: rui314/mold
-    version: v1.0.3

--- a/pkgs/rui314/mold/pkg.yaml
+++ b/pkgs/rui314/mold/pkg.yaml
@@ -1,4 +1,8 @@
 packages:
   - name: rui314/mold@v2.42.0
   - name: rui314/mold
+    version: v2.40.2
+  - name: rui314/mold
     version: v1.5.1
+  - name: rui314/mold
+    version: v1.0.3

--- a/pkgs/rui314/mold/registry.yaml
+++ b/pkgs/rui314/mold/registry.yaml
@@ -3,19 +3,19 @@ packages:
   - type: github_release
     repo_owner: rui314
     repo_name: mold
-    description: "Mold: A Modern Linker"
+    description: "mold: A Modern Linker"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0.3") || Version == "v1.6.0-pre.1"
+      - version_constraint: Version == "v1.6.0-pre.1"
         no_asset: true
-      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 2.40.2")
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
           arm64: aarch64
-        supported_envs:
-          - linux
         files:
           - name: mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
@@ -23,16 +23,33 @@ packages:
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
           - name: ld64.mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
-      - version_constraint: "true"
-        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         supported_envs:
           - linux
+      - version_constraint: "true"
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
         files:
           - name: mold
-            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+            src: bin/mold
           - name: ld.mold
-            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+            src: bin/mold
+          - name: ld64.mold
+            src: bin/mold
+        overrides:
+          - goos: linux
+            format: tar.gz
+            replacements:
+              arm64: aarch64
+            files:
+              - name: mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+              - name: ld.mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+              - name: ld64.mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+        supported_envs:
+          - linux
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -81029,19 +81029,19 @@ packages:
   - type: github_release
     repo_owner: rui314
     repo_name: mold
-    description: "Mold: A Modern Linker"
+    description: "mold: A Modern Linker"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 1.0.3") || Version == "v1.6.0-pre.1"
+      - version_constraint: Version == "v1.6.0-pre.1"
         no_asset: true
-      - version_constraint: semver("<= 1.5.1")
+      - version_constraint: semver("<= 1.0.3")
+        no_asset: true
+      - version_constraint: semver("<= 2.40.2")
         asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
           amd64: x86_64
           arm64: aarch64
-        supported_envs:
-          - linux
         files:
           - name: mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
@@ -81049,19 +81049,36 @@ packages:
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
           - name: ld64.mold
             src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
-      - version_constraint: "true"
-        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         supported_envs:
           - linux
+      - version_constraint: "true"
+        asset: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: zip
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
         files:
           - name: mold
-            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+            src: bin/mold
           - name: ld.mold
-            src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+            src: bin/mold
+          - name: ld64.mold
+            src: bin/mold
+        overrides:
+          - goos: linux
+            format: tar.gz
+            replacements:
+              arm64: aarch64
+            files:
+              - name: mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+              - name: ld.mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+              - name: ld64.mold
+                src: mold-{{trimV .Version}}-{{.Arch}}-{{.OS}}/bin/mold
+        supported_envs:
+          - linux
+          - windows/amd64
   - type: github_release
     repo_owner: runatlantis
     repo_name: atlantis


### PR DESCRIPTION
## Overview

`rui314/mold` publishes a Windows archive, but `supported_envs` is `linux` only.

```console
$ gh api repos/rui314/mold/releases/tags/v2.42.0 --jq '.assets[].name' | grep -i windows
mold-2.42.0-x86_64-windows.zip
```

Only x86_64 is published for Windows, which the generated code covers with `windows_arm_emulation` and `supported_envs: [linux, windows/amd64]`.

The configuration is generated:

```sh
aqua gr rui314/mold
```

## Manual fix on top of the generated code

`files` is restored, with a `goos: linux` override, because the archives use different layouts:

```console
$ unzip -l mold-2.42.0-x86_64-windows.zip
 23140352  bin/mold.exe
     1088  share/doc/mold/LICENSE
    46520  share/man/man1/mold.1

$ tar tzf mold-2.42.0-x86_64-linux.tar.gz | grep bin/
mold-2.42.0-x86_64-linux/bin/mold
```

`aqua gr` doesn't look into archives, so it dropped `files` entirely, which would also have lost the `ld.mold` and `ld64.mold` commands. With the fix all three are installed on Windows too:

```console
$ ls "$AQUA_ROOT_DIR/bin"
ld.mold.exe ld64.mold.exe mold.exe

$ aqua exec -- mold --version
mold 2.42.0 (441dc1d1fd3c72f41bc9d30f440431d34738def3; compatible with GNU ld)
```

## Tests

aqua v2.62.3, using `pkgs/rui314/mold/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | windows/amd64 | linux/amd64 |
| --- | --- | --- |
| v2.42.0 | installed (arm64 too, through `windows_arm_emulation`) | installed (arm64 too) |
| v2.40.2 | skipped (unsupported env), as intended | installed |
| v1.5.1 | skipped (unsupported env), as intended | installed |
| v1.0.3 | `no asset is released for this version`, as intended | — |

`pkg.yaml` pins one version per `version_overrides` branch.

`conftest test --combine pkgs/rui314/mold/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.