### PR TITLE
feat(yaml/yamlscript): support Windows

### DIFF
--- a/pkgs/yaml/yamlscript/registry.yaml
+++ b/pkgs/yaml/yamlscript/registry.yaml
@@ -5,36 +5,324 @@ packages:
     repo_name: yamlscript
     description: Programming in YAML
     version_constraint: "false"
-    asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.xz
-    files:
-      - name: ys
-        src: "{{.AssetWithoutExt}}/ys"
-    replacements:
-      amd64: x64
-      arm64: aarch64
-      darwin: macos
     version_overrides:
-      - version_constraint: Version in ["0.1.29", "0.1.44", "0.1.50"]
+      - version_constraint: Version == "0.1.29"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
         supported_envs:
           - linux/amd64
-      - version_constraint: Version in ["0.1.36", "0.1.63", "0.1.64", "0.1.66"] or semver(">= 0.1.69, <= 0.1.71")
+      - version_constraint: Version == "0.1.36"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version in ["0.1.40", "0.1.60", "0.1.61"]
+      - version_constraint: Version == "0.1.40"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
         supported_envs:
           - linux
           - darwin/arm64
-      - version_constraint: semver("<= 0.1.33") or semver(">= 0.1.36, <=0.1.39") or Version == "0.1.45"
+      - version_constraint: Version in ["0.1.44", "0.1.50"]
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.1.45"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin/arm64
+      - version_constraint: Version == "0.1.61"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: libyamlscript-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version in ["0.1.62", "0.1.65"]
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "0.1.66"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.2.3"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.33")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.35")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.39")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.60")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.64")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.68")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.71")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.2.8")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
         supported_envs:
           - linux
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.21")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin/arm64
+      - version_constraint: semver("<= 0.2.26")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: ys
+                src: "{{.AssetWithoutExt}}/ys-{{.Version}}"
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+            files:
+              - name: ys
+                src: "{{.AssetWithoutExt}}/ys-{{.Version}}"
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64

--- a/pkgs/yaml/yamlscript/registry.yaml
+++ b/pkgs/yaml/yamlscript/registry.yaml
@@ -86,13 +86,9 @@ packages:
           amd64: x64
           arm64: aarch64
           darwin: macos
-        overrides:
-          - goos: darwin
-            goarch: amd64
-            asset: libyamlscript-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         supported_envs:
           - linux
-          - darwin
+          - darwin/arm64
       - version_constraint: Version in ["0.1.62", "0.1.65"]
         asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.xz

--- a/registry.yaml
+++ b/registry.yaml
@@ -102747,13 +102747,9 @@ packages:
           amd64: x64
           arm64: aarch64
           darwin: macos
-        overrides:
-          - goos: darwin
-            goarch: amd64
-            asset: libyamlscript-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         supported_envs:
           - linux
-          - darwin
+          - darwin/arm64
       - version_constraint: Version in ["0.1.62", "0.1.65"]
         asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.xz

--- a/registry.yaml
+++ b/registry.yaml
@@ -102666,39 +102666,327 @@ packages:
     repo_name: yamlscript
     description: Programming in YAML
     version_constraint: "false"
-    asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
-    format: tar.xz
-    files:
-      - name: ys
-        src: "{{.AssetWithoutExt}}/ys"
-    replacements:
-      amd64: x64
-      arm64: aarch64
-      darwin: macos
     version_overrides:
-      - version_constraint: Version in ["0.1.29", "0.1.44", "0.1.50"]
+      - version_constraint: Version == "0.1.29"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
         supported_envs:
           - linux/amd64
-      - version_constraint: Version in ["0.1.36", "0.1.63", "0.1.64", "0.1.66"] or semver(">= 0.1.69, <= 0.1.71")
+      - version_constraint: Version == "0.1.36"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version in ["0.1.40", "0.1.60", "0.1.61"]
+      - version_constraint: Version == "0.1.40"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
         supported_envs:
           - linux
           - darwin/arm64
-      - version_constraint: semver("<= 0.1.33") or semver(">= 0.1.36, <=0.1.39") or Version == "0.1.45"
+      - version_constraint: Version in ["0.1.44", "0.1.50"]
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: Version == "0.1.45"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin/arm64
+      - version_constraint: Version == "0.1.61"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            goarch: amd64
+            asset: libyamlscript-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version in ["0.1.62", "0.1.65"]
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "0.1.66"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "0.2.3"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.33")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.35")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.39")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+      - version_constraint: semver("<= 0.1.60")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.64")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 0.1.68")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.1.71")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
       - version_constraint: semver("<= 0.2.8")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
         supported_envs:
           - linux
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.21")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        replacements:
+          darwin: macos
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x64
+          - goos: darwin
+            replacements:
+              arm64: aarch64
         supported_envs:
           - linux/amd64
           - darwin/arm64
+      - version_constraint: semver("<= 0.2.26")
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+              arm64: aarch64
+          - goos: windows
+            format: zip
+            files:
+              - name: ys
+                src: "{{.AssetWithoutExt}}/ys-{{.Version}}"
+        supported_envs:
+          - linux/amd64
+          - darwin/arm64
+          - windows/amd64
+      - version_constraint: "true"
+        asset: ys-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.xz
+        files:
+          - name: ys
+            src: "{{.AssetWithoutExt}}/ys"
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+            files:
+              - name: ys
+                src: "{{.AssetWithoutExt}}/ys-{{.Version}}"
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows/amd64
   - type: github_release
     repo_owner: yannh
     repo_name: kubeconform


### PR DESCRIPTION
## Overview

`yaml/yamlscript` publishes a Windows archive, but `supported_envs` excludes Windows.

```console
$ gh api repos/yaml/yamlscript/releases/tags/0.2.32 --jq '.assets[].name' | grep -i windows
libys-0.2.32-windows-x64.zip
ys-0.2.32-windows-x64.zip
```

The configuration is generated, not hand written:

```sh
aqua gr yaml/yamlscript
```

The generated code also stops relying on the base settings, as the [version_overrides style guide](https://github.com/aquaproj/aqua-registry/blob/main/docs/registry_yaml.md#version_overrides-style-guide) asks. The current file keeps `asset`, `format`, `files` and `replacements` in the base and only overrides `supported_envs` per version.

## Manual fixes on top of the generated code

**1. `files` is restored** — `aqua gr` doesn't look into archives.

**2. The Windows archive names the binary differently.** It ships only `ys-<version>.exe`, while the tar.xz archives contain both `ys` and `ys-<version>`:

```console
$ unzip -l ys-0.2.32-windows-x64.zip
     1728  ys-0.2.32-windows-x64/Makefile
 55160596  ys-0.2.32-windows-x64/ys-0.2.32-build-report.html
 62681088  ys-0.2.32-windows-x64/ys-0.2.32.exe
     8913  ys-0.2.32-windows-x64/ys-sh-0.2.32

$ tar tJf ys-0.2.32-linux-x64.tar.xz | head -5
ys-0.2.32-linux-x64/
ys-0.2.32-linux-x64/ys-0.2.32-build-report.html
ys-0.2.32-linux-x64/ys-0.2.32
ys-0.2.32-linux-x64/ys
ys-0.2.32-linux-x64/ys-sh-0.2.32
```

So the `goos: windows` override carries `src: "{{.AssetWithoutExt}}/ys-{{.Version}}"`, and `complete_windows_ext` adds `.exe`.

**3. The empty `replacements: {}` in the `goos: windows` override is dropped.** It is a no-op — the parent `amd64: x64` is what resolves `ys-0.2.32-windows-x64.zip` — and the style guide asks to drop empty `replacements`.

## Tests

aqua v2.62.3, using `pkgs/yaml/yamlscript/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | windows/amd64 | linux/amd64 |
| --- | --- | --- |
| 0.2.32 | installed (arm64 too, through `windows_arm_emulation`) | installed |
| 0.2.8 | skipped (unsupported env), as intended | installed |
| 0.1.71, 0.1.66, 0.1.45, 0.1.29 | skipped (unsupported env), as intended | installed |

```console
$ aqua exec -- ys --version
YS (YAMLScript) 0.2.32
```

`pkg.yaml` is unchanged; it already pins 17 versions covering the branches.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/yaml/yamlscript/*` passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.