### PR TITLE
feat(metalbear-co/mirrord): support Windows

### DIFF
--- a/pkgs/metalbear-co/mirrord/pkg.yaml
+++ b/pkgs/metalbear-co/mirrord/pkg.yaml
@@ -5,24 +5,16 @@ packages:
   - name: metalbear-co/mirrord
     version: v3.174.0
   - name: metalbear-co/mirrord
-    version: 3.171.0
-  - name: metalbear-co/mirrord
     version: v3.171.0
   - name: metalbear-co/mirrord
     version: 3.170.0
   - name: metalbear-co/mirrord
     version: 3.27.1
   - name: metalbear-co/mirrord
-    version: 3.14.3
-  - name: metalbear-co/mirrord
     version: 3.4.0
   - name: metalbear-co/mirrord
     version: 3.0.11-alpha
   - name: metalbear-co/mirrord
-    version: 3.0.1-alpha
-  - name: metalbear-co/mirrord
     version: 2.8.1
-  - name: metalbear-co/mirrord
-    version: 2.7.0
   - name: metalbear-co/mirrord
     version: 2.2.1

--- a/pkgs/metalbear-co/mirrord/pkg.yaml
+++ b/pkgs/metalbear-co/mirrord/pkg.yaml
@@ -1,32 +1,28 @@
 packages:
   - name: metalbear-co/mirrord@3.251.0
   - name: metalbear-co/mirrord
-    version: 3.181.0
+    version: 3.177.0
   - name: metalbear-co/mirrord
     version: v3.174.0
   - name: metalbear-co/mirrord
-    version: 3.172.0
+    version: 3.171.0
+  - name: metalbear-co/mirrord
+    version: v3.171.0
   - name: metalbear-co/mirrord
     version: 3.170.0
   - name: metalbear-co/mirrord
-    version: 3.95.0
-  - name: metalbear-co/mirrord
-    version: 3.46.0
-  - name: metalbear-co/mirrord
     version: 3.27.1
-  - name: metalbear-co/mirrord
-    version: 3.22.0
   - name: metalbear-co/mirrord
     version: 3.14.3
   - name: metalbear-co/mirrord
-    version: 3.5.3
-  - name: metalbear-co/mirrord
     version: 3.4.0
   - name: metalbear-co/mirrord
-    version: 2.9.1
+    version: 3.0.11-alpha
+  - name: metalbear-co/mirrord
+    version: 3.0.1-alpha
+  - name: metalbear-co/mirrord
+    version: 2.8.1
   - name: metalbear-co/mirrord
     version: 2.7.0
   - name: metalbear-co/mirrord
     version: 2.2.1
-  - name: metalbear-co/mirrord
-    version: 2.2.0

--- a/pkgs/metalbear-co/mirrord/pkg.yaml
+++ b/pkgs/metalbear-co/mirrord/pkg.yaml
@@ -1,4 +1,34 @@
 packages:
   - name: metalbear-co/mirrord@3.251.0
   - name: metalbear-co/mirrord
+    version: 3.181.0
+  - name: metalbear-co/mirrord
+    version: 3.174.0
+  - name: metalbear-co/mirrord
+    version: 3.172.0
+  - name: metalbear-co/mirrord
+    version: 3.170.0
+  - name: metalbear-co/mirrord
+    version: 3.95.0
+  - name: metalbear-co/mirrord
+    version: 3.46.0
+  - name: metalbear-co/mirrord
+    version: 3.28.1
+  - name: metalbear-co/mirrord
+    version: 3.27.1
+  - name: metalbear-co/mirrord
+    version: 3.22.0
+  - name: metalbear-co/mirrord
+    version: 3.14.3
+  - name: metalbear-co/mirrord
+    version: 3.5.3
+  - name: metalbear-co/mirrord
+    version: 3.4.0
+  - name: metalbear-co/mirrord
+    version: 2.9.1
+  - name: metalbear-co/mirrord
+    version: 2.7.0
+  - name: metalbear-co/mirrord
+    version: 2.2.1
+  - name: metalbear-co/mirrord
     version: 2.2.0

--- a/pkgs/metalbear-co/mirrord/pkg.yaml
+++ b/pkgs/metalbear-co/mirrord/pkg.yaml
@@ -3,7 +3,7 @@ packages:
   - name: metalbear-co/mirrord
     version: 3.181.0
   - name: metalbear-co/mirrord
-    version: 3.174.0
+    version: v3.174.0
   - name: metalbear-co/mirrord
     version: 3.172.0
   - name: metalbear-co/mirrord
@@ -12,8 +12,6 @@ packages:
     version: 3.95.0
   - name: metalbear-co/mirrord
     version: 3.46.0
-  - name: metalbear-co/mirrord
-    version: 3.28.1
   - name: metalbear-co/mirrord
     version: 3.27.1
   - name: metalbear-co/mirrord

--- a/pkgs/metalbear-co/mirrord/registry.yaml
+++ b/pkgs/metalbear-co/mirrord/registry.yaml
@@ -8,68 +8,6 @@ packages:
     version_overrides:
       - version_constraint: Version in ["2.4.0", "2.8.0", "2.9.0", "2.10.0", "3.0.0-alpha", "3.0.2-alpha", "3.0.18-alpha", "3.7.1", "3.10.1", "3.11.1", "3.14.2", "3.15.0", "3.19.0", "3.45.1", "3.95.1", "3.181.1"]
         no_asset: true
-      - version_constraint: Version in ["2.8.1", "2.9.1"]
-        asset: mirrord_{{.OS}}_{{.Arch}}
-        format: raw
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version in ["3.0.1-alpha", "3.0.17-alpha"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "3.14.3"
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version in ["3.171.0", "3.172.0"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-          - goos: windows
-            format: raw
-            asset: mirrord
       - version_constraint: Version in ["v3.171.0", "v3.172.0"]
         asset: mirrord
         format: raw
@@ -85,16 +23,17 @@ packages:
         supported_envs:
           - windows/amd64
       - version_constraint: Version in ["3.177.0", "3.181.0"]
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           darwin: mac
         overrides:
           - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux
           - darwin
@@ -111,7 +50,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 2.7.0")
+      - version_constraint: semver("<= 2.9.1")
         asset: mirrord_{{.OS}}_{{.Arch}}
         format: raw
         replacements:

--- a/pkgs/metalbear-co/mirrord/registry.yaml
+++ b/pkgs/metalbear-co/mirrord/registry.yaml
@@ -3,28 +3,307 @@ packages:
   - type: github_release
     repo_owner: metalbear-co
     repo_name: mirrord
-    description: By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment
-    replacements:
-      darwin: mac
-      amd64: x86_64
-      arm64: aarch64
-    version_constraint: semver(">= 2.2.1")
-    supported_envs:
-      - linux
-      - darwin
-    rosetta2: true
-    format: zip
-    asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-    overrides:
-      - goos: darwin
-        replacements:
-          amd64: universal
+    description: "Run any process, on your machine or in an AI agent's environment, as if it were a pod in your Kubernetes cluster: real env vars, DNS, network, traffic"
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 2.2.1")
-        rosetta2: false
+      - version_constraint: Version in ["2.4.0", "2.8.0", "2.9.0", "2.10.0", "3.0.0-alpha", "3.0.2-alpha", "3.0.18-alpha", "3.7.1", "3.10.1", "3.11.1", "3.14.2", "3.15.0", "3.19.0", "3.45.1", "3.95.1", "3.181.1"]
+        no_asset: true
+      - version_constraint: Version in ["2.8.1", "2.9.1"]
         asset: mirrord_{{.OS}}_{{.Arch}}
         format: raw
-        overrides: []
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: Version == "3.0.1-alpha"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version in ["3.0.17-alpha", "3.0.19-alpha"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "3.5.3"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "3.14.3"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version in ["3.171.0", "3.172.0"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: mirrord
+      - version_constraint: Version in ["v3.171.0", "v3.172.0"]
+        asset: mirrord
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v3.174.0"
+        asset: mirrord
+        format: raw
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version in ["3.177.0", "3.181.0"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.2.1")
+        asset: mirrord_{{.OS}}_{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.7.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}
+        format: raw
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.0.11-alpha")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.0.16-alpha")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.5.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.22.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.27.1")
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.28.1")
+        no_asset: true
+      - version_constraint: semver("<= 3.46.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.95.0")
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.170.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: mirrord

--- a/pkgs/metalbear-co/mirrord/registry.yaml
+++ b/pkgs/metalbear-co/mirrord/registry.yaml
@@ -22,7 +22,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "3.0.1-alpha"
+      - version_constraint: Version in ["3.0.1-alpha", "3.0.17-alpha"]
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         replacements:
@@ -35,58 +35,19 @@ packages:
             asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux/amd64
-          - darwin
-      - version_constraint: Version in ["3.0.17-alpha", "3.0.19-alpha"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            goarch: amd64
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "3.5.3"
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
           - darwin
       - version_constraint: Version == "3.14.3"
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
           - darwin
@@ -124,17 +85,16 @@ packages:
         supported_envs:
           - windows/amd64
       - version_constraint: Version in ["3.177.0", "3.181.0"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
         format: zip
         replacements:
           darwin: mac
         overrides:
           - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux
           - darwin
@@ -184,95 +144,36 @@ packages:
       - version_constraint: semver("<= 3.4.0")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 3.5.2")
         no_asset: true
-      - version_constraint: semver("<= 3.22.0")
+      - version_constraint: semver("<= 3.27.1")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 3.27.1")
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            goarch: amd64
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
           - darwin
       - version_constraint: semver("<= 3.28.1")
         no_asset: true
-      - version_constraint: semver("<= 3.46.0")
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 3.95.0")
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 3.170.0")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/pkgs/metalbear-co/mirrord/scaffold.yaml
+++ b/pkgs/metalbear-co/mirrord/scaffold.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Other than name is optional. All initial values are just examples.
+name: metalbear-co/mirrord
+# version_filter: not (Version matches "-rc")
+# version_prefix: cli-
+all_assets_filter: not (Asset matches "vscode")

--- a/registry.yaml
+++ b/registry.yaml
@@ -65441,7 +65441,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: Version == "3.0.1-alpha"
+      - version_constraint: Version in ["3.0.1-alpha", "3.0.17-alpha"]
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         replacements:
@@ -65454,58 +65454,19 @@ packages:
             asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux/amd64
-          - darwin
-      - version_constraint: Version in ["3.0.17-alpha", "3.0.19-alpha"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            goarch: amd64
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "3.5.3"
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
           - darwin
       - version_constraint: Version == "3.14.3"
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
           - darwin
@@ -65543,17 +65504,16 @@ packages:
         supported_envs:
           - windows/amd64
       - version_constraint: Version in ["3.177.0", "3.181.0"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
         format: zip
         replacements:
           darwin: mac
         overrides:
           - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux
           - darwin
@@ -65603,95 +65563,36 @@ packages:
       - version_constraint: semver("<= 3.4.0")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux/amd64
           - darwin
       - version_constraint: semver("<= 3.5.2")
         no_asset: true
-      - version_constraint: semver("<= 3.22.0")
+      - version_constraint: semver("<= 3.27.1")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
+        replacements:
+          darwin: mac
         overrides:
           - goos: linux
             replacements:
               amd64: x86_64
               arm64: aarch64
           - goos: darwin
-            goarch: amd64
             asset: mirrord_{{.OS}}_universal.{{.Format}}
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 3.27.1")
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
-        format: zip
-        overrides:
-          - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            goarch: amd64
-            replacements:
-              darwin: mac
-          - goos: darwin
-            goarch: arm64
-            format: raw
-            asset: vscode-ext-{{.OS}}-{{.Arch}}
         supported_envs:
           - linux
           - darwin
       - version_constraint: semver("<= 3.28.1")
         no_asset: true
-      - version_constraint: semver("<= 3.46.0")
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: semver("<= 3.95.0")
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-        supported_envs:
-          - linux
-          - darwin
       - version_constraint: semver("<= 3.170.0")
         asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -65427,68 +65427,6 @@ packages:
     version_overrides:
       - version_constraint: Version in ["2.4.0", "2.8.0", "2.9.0", "2.10.0", "3.0.0-alpha", "3.0.2-alpha", "3.0.18-alpha", "3.7.1", "3.10.1", "3.11.1", "3.14.2", "3.15.0", "3.19.0", "3.45.1", "3.95.1", "3.181.1"]
         no_asset: true
-      - version_constraint: Version in ["2.8.1", "2.9.1"]
-        asset: mirrord_{{.OS}}_{{.Arch}}
-        format: raw
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version in ["3.0.1-alpha", "3.0.17-alpha"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux/amd64
-          - darwin
-      - version_constraint: Version == "3.14.3"
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-        supported_envs:
-          - linux
-          - darwin
-      - version_constraint: Version in ["3.171.0", "3.172.0"]
-        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: zip
-        replacements:
-          darwin: mac
-        checksum:
-          type: github_release
-          asset: "{{.Asset}}.sha256"
-          algorithm: sha256
-        overrides:
-          - goos: linux
-            replacements:
-              amd64: x86_64
-              arm64: aarch64
-          - goos: darwin
-            asset: mirrord_{{.OS}}_universal.{{.Format}}
-          - goos: windows
-            format: raw
-            asset: mirrord
       - version_constraint: Version in ["v3.171.0", "v3.172.0"]
         asset: mirrord
         format: raw
@@ -65504,16 +65442,17 @@ packages:
         supported_envs:
           - windows/amd64
       - version_constraint: Version in ["3.177.0", "3.181.0"]
-        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
         format: zip
         replacements:
           darwin: mac
         overrides:
           - goos: linux
-            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
             replacements:
               amd64: x86_64
               arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
         supported_envs:
           - linux
           - darwin
@@ -65530,7 +65469,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: semver("<= 2.7.0")
+      - version_constraint: semver("<= 2.9.1")
         asset: mirrord_{{.OS}}_{{.Arch}}
         format: raw
         replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -65422,31 +65422,310 @@ packages:
   - type: github_release
     repo_owner: metalbear-co
     repo_name: mirrord
-    description: By mirroring traffic to and from your machine, mirrord surrounds your local service with a mirror image of its cloud environment
-    replacements:
-      darwin: mac
-      amd64: x86_64
-      arm64: aarch64
-    version_constraint: semver(">= 2.2.1")
-    supported_envs:
-      - linux
-      - darwin
-    rosetta2: true
-    format: zip
-    asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
-    overrides:
-      - goos: darwin
-        replacements:
-          amd64: universal
+    description: "Run any process, on your machine or in an AI agent's environment, as if it were a pod in your Kubernetes cluster: real env vars, DNS, network, traffic"
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("< 2.2.1")
-        rosetta2: false
+      - version_constraint: Version in ["2.4.0", "2.8.0", "2.9.0", "2.10.0", "3.0.0-alpha", "3.0.2-alpha", "3.0.18-alpha", "3.7.1", "3.10.1", "3.11.1", "3.14.2", "3.15.0", "3.19.0", "3.45.1", "3.95.1", "3.181.1"]
+        no_asset: true
+      - version_constraint: Version in ["2.8.1", "2.9.1"]
         asset: mirrord_{{.OS}}_{{.Arch}}
         format: raw
-        overrides: []
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: Version == "3.0.1-alpha"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version in ["3.0.17-alpha", "3.0.19-alpha"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: Version == "3.5.3"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "3.14.3"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version in ["3.171.0", "3.172.0"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: mirrord
+      - version_constraint: Version in ["v3.171.0", "v3.172.0"]
+        asset: mirrord
+        format: raw
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version == "v3.174.0"
+        asset: mirrord
+        format: raw
+        supported_envs:
+          - windows/amd64
+      - version_constraint: Version in ["3.177.0", "3.181.0"]
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 2.2.1")
+        asset: mirrord_{{.OS}}_{{.Arch}}
+        format: raw
+        replacements:
+          amd64: x86_64
+          darwin: mac
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 2.7.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}
+        format: raw
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.0.11-alpha")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.0.16-alpha")
+        no_asset: true
+      - version_constraint: semver("<= 3.4.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux/amd64
+          - darwin
+      - version_constraint: semver("<= 3.5.2")
+        no_asset: true
+      - version_constraint: semver("<= 3.22.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.27.1")
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        format: zip
+        overrides:
+          - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            goarch: amd64
+            replacements:
+              darwin: mac
+          - goos: darwin
+            goarch: arm64
+            format: raw
+            asset: vscode-ext-{{.OS}}-{{.Arch}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.28.1")
+        no_asset: true
+      - version_constraint: semver("<= 3.46.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.95.0")
+        asset: mirrord_{{.OS}}_universal.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 3.170.0")
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: mirrord_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          darwin: mac
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            replacements:
+              amd64: x86_64
+              arm64: aarch64
+          - goos: darwin
+            asset: mirrord_{{.OS}}_universal.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: mirrord
   - type: github_release
     repo_owner: mfontanini
     repo_name: presenterm


### PR DESCRIPTION
## Overview

`metalbear-co/mirrord` publishes `mirrord.exe`, but `supported_envs` excludes Windows.

```console
$ gh api repos/metalbear-co/mirrord/releases/latest --jq '.assets[].name'
libmirrord_layer_linux_aarch64.so
libmirrord_layer_linux_x86_64.so
libmirrord_layer_mac_universal.dylib
mirrord.exe
mirrord.exe.sha256
mirrord.msi
mirrord.msi.sha256
mirrord_layer_win.dll
mirrord_layer_win.dll.sha256
mirrord_linux_aarch64
...
```

The configuration is generated and used as is:

```sh
aqua gr metalbear-co/mirrord
```

Besides Windows it also:

- resolves the Conftest failure this file had:

  ```console
  $ conftest test --combine pkgs/metalbear-co/mirrord/registry.yaml   # before
  FAIL - the top level version_constraint must be either empty or "false"
  ```

- covers the whole release history, where the previous configuration had only two branches

## About `mirrord_layer_win.dll`

It is published as a separate asset and is not installed. That matches the existing behaviour on the other platforms: `libmirrord_layer_linux_*.so` and `libmirrord_layer_mac_universal.dylib` are separate assets too, and the archives contain only the CLI:

```console
$ unzip -l mirrord_linux_x86_64.zip
 76180424  mirrord
```

So Windows is not treated differently from Linux or macOS here.

## Tests

aqua v2.62.3 with `checksum.enabled: true`, using `pkgs/metalbear-co/mirrord/registry.yaml` as a local registry.
Windows results are from Windows 11 (26200) amd64, Linux results are from Ubuntu on WSL2 amd64.

| version | windows/amd64 | linux/amd64 |
| --- | --- | --- |
| 3.251.0 | installed (arm64 too) | installed (arm64 too) |
| 3.170.0, 3.46.0, 3.22.0 | skipped (unsupported env), as intended | installed |
| 3.4.0, 2.9.1, 2.2.1 | skipped (unsupported env), as intended | installed |

```console
$ aqua exec -- mirrord --version
mirrord 3.251.0
```

`pkg.yaml` pins one version per `version_overrides` branch.

`darwin` was not tested locally; it is left to CI.

`conftest test --combine pkgs/metalbear-co/mirrord/*` now passes 14/14. `prettier -c` and `argd fix` report no changes. `registry.yaml` is regenerated by `argd gr` in a separate commit.

## AI usage

This pull request was prepared with Claude Code. The agent is added as a commit co-author. I have reviewed the change and the test results myself.