### PR TITLE
fix(apple/pkl-go/pkl-gen-go): binaries aren't released since v0.13.0

### DIFF
--- a/aqua-registry-updater.yaml
+++ b/aqua-registry-updater.yaml
@@ -12,6 +12,7 @@ templates:
 ignore_packages:
   # asset isn't released anymore
   # keep-sorted start
+  - apple/pkl-go/pkl-gen-go # https://github.com/apple/pkl-go/releases - binaries aren't released anymore
   - github/licensed
   - golang/tools/godoc # https://github.com/golang/go/issues/59056#issuecomment-3254809429
   - google/jsonnet

--- a/pkgs/apple/pkl-go/pkl-gen-go/registry.yaml
+++ b/pkgs/apple/pkl-go/pkl-gen-go/registry.yaml
@@ -8,6 +8,11 @@ packages:
     version_filter: 'Version startsWith "v"'
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 0.13.0")
+        error_message: |
+          Releases since v0.13.0 don't include pkl-gen-go binaries.
+
+          https://github.com/apple/pkl-go/releases
       - version_constraint: "true"
         asset: pkl-gen-go-{{.OS}}-{{.Arch}}.bin
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -14760,6 +14760,11 @@ packages:
     version_filter: 'Version startsWith "v"'
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 0.13.0")
+        error_message: |
+          Releases since v0.13.0 don't include pkl-gen-go binaries.
+
+          https://github.com/apple/pkl-go/releases
       - version_constraint: "true"
         asset: pkl-gen-go-{{.OS}}-{{.Arch}}.bin
         format: raw


### PR DESCRIPTION
## Problem

`apple/pkl-go/pkl-gen-go` has 4 open update PRs (#49528 … #56732) and none of them can merge. The
package has been pinned at `v0.12.1` since 2026-02 and the "from" version never advances.

Upstream **stopped attaching the `pkl-gen-go` binaries to releases**:

```console
v0.11.0   pkl-gen-go-linux-aarch64.bin  pkl-gen-go-linux-amd64.bin  pkl-gen-go-macos.bin
v0.12.0   pkl-gen-go-linux-aarch64.bin  pkl-gen-go-linux-amd64.bin  pkl-gen-go-macos.bin
v0.12.1   pkl-gen-go-linux-aarch64.bin  pkl-gen-go-linux-amd64.bin  pkl-gen-go-macos.bin
v0.13.0   NO ASSETS
v0.13.1   NO ASSETS
v0.13.2   NO ASSETS
v0.14.0   NO ASSETS
```

Those four releases with no assets are exactly the four the updater has been trying to bump to.
They span 2026-02-27 to 2026-07-09, and `.github/workflows/release.yml` at v0.14.0 has no step
that builds or uploads a `pkl-gen-go` binary — it only uploads test-result artifacts.

I could not find an upstream issue or release note explaining the change, so I'm reporting the
observation rather than the intent.

## Change

Following the pattern already used for `github/licensed`, `grafana/xk6` and `nmstate/nmstate`:

1. **`pkgs/apple/pkl-go/pkl-gen-go/registry.yaml`** — a new `semver(">= 0.13.0")` branch with an
   `error_message`, so users get a clear explanation instead of `the asset isn't found`:

   ```yaml
         - version_constraint: semver(">= 0.13.0")
           error_message: |
             Releases since v0.13.0 don't include pkl-gen-go binaries.

             https://github.com/apple/pkl-go/releases
   ```

2. **`aqua-registry-updater.yaml`** — add the package to `ignore_packages`, so the updater stops
   opening PRs that cannot pass.

The existing `"true"` branch is untouched.

The constraint is open-ended (`>= 0.13.0`) rather than bounded at v0.14.0, because nothing
upstream suggests the next release will differ. If the binaries come back this becomes a bounded
range and the `ignore_packages` entry gets removed — happy to do it the bounded way instead if
you'd prefer.

## `pkg.yaml` is unchanged

It already pins `apple/pkl-go/pkl-gen-go@v0.12.1` — the last release that works — plus five older
versions. That is where the `github/licensed` (`@3.9.1`), `grafana/xk6` (`@v0.8.1`) and
`nmstate/nmstate` (`@v2.2.55`) precedents leave their pins.

## Verification

aqua v2.62.3, macOS 26.6.2, local `aqua.yaml` with a `type: local` registry pointing at this PR's
file:

```console
### new error_message branch
v0.14.0   linux/amd64   Releases since v0.13.0 don't include pkl-gen-go binaries.
v0.13.0   darwin/arm64  Releases since v0.13.0 don't include pkl-gen-go binaries.

### working range - unchanged
v0.12.1   linux/amd64   OK (installed)
v0.12.1   darwin/arm64  OK (installed)
v0.7.0    linux/amd64   OK (installed)
```

### Repository test procedure

```console
$ argd t apple/pkl-go/pkl-gen-go
$ echo $?
0
```

Exit 0 on all six os/arch targets, no errors in the log.

```console
$ conftest test --combine pkgs/apple/pkl-go/pkl-gen-go/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier --check pkgs/apple/pkl-go/pkl-gen-go/*.yaml aqua-registry-updater.yaml
All matched files use Prettier code style!
```

The new `ignore_packages` entry sorts to the top of the block, before `github/licensed`; I verified
the block is still in order.

`argd gr` was run; `registry.yaml` is updated accordingly.

## Effect

This unblocks the 4 stuck update PRs — not by making them installable, which upstream currently
makes impossible, but by making the failure explicit and stopping the updater from retrying.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per
[docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above
was actually executed and its real output pasted. I have reviewed the change and own it.
