### PR TITLE
fix: stop regex-escaping signer_workflow

### DIFF
--- a/pkgs/Byron/dua-cli/registry.yaml
+++ b/pkgs/Byron/dua-cli/registry.yaml
@@ -176,4 +176,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: Byron/dua-cli/\.github/workflows/release\.yml
+          signer_workflow: Byron/dua-cli/.github/workflows/release.yml

--- a/pkgs/GitGuardian/ggshield/registry.yaml
+++ b/pkgs/GitGuardian/ggshield/registry.yaml
@@ -110,4 +110,4 @@ packages:
           - windows/amd64
           - linux/amd64
         github_artifact_attestations:
-          signer_workflow: GitGuardian/ggshield/\.github/workflows/tag\.yml
+          signer_workflow: GitGuardian/ggshield/.github/workflows/tag.yml

--- a/pkgs/GitTools/GitVersion/registry.yaml
+++ b/pkgs/GitTools/GitVersion/registry.yaml
@@ -43,4 +43,4 @@ packages:
         checksum:
           enabled: false
         github_artifact_attestations:
-          signer_workflow: GitTools/GitVersion/\.github/workflows/ci\.yml
+          signer_workflow: GitTools/GitVersion/.github/workflows/ci.yml

--- a/pkgs/StanMarek/ghost-complete/registry.yaml
+++ b/pkgs/StanMarek/ghost-complete/registry.yaml
@@ -39,4 +39,4 @@ packages:
         supported_envs:
           - darwin
         github_artifact_attestations:
-          signer_workflow: StanMarek/ghost-complete/\.github/workflows/release\.yml
+          signer_workflow: StanMarek/ghost-complete/.github/workflows/release.yml

--- a/pkgs/cargo-bins/cargo-binstall/registry.yaml
+++ b/pkgs/cargo-bins/cargo-binstall/registry.yaml
@@ -95,4 +95,4 @@ packages:
           - goos: linux
             format: tgz
         github_artifact_attestations:
-          signer_workflow: cargo-bins/cargo-binstall/\.github/workflows/release-cli\.yml
+          signer_workflow: cargo-bins/cargo-binstall/.github/workflows/release-cli.yml

--- a/pkgs/coder/coder/registry.yaml
+++ b/pkgs/coder/coder/registry.yaml
@@ -54,4 +54,4 @@ packages:
           - goos: linux
             format: tar.gz
         github_artifact_attestations:
-          signer_workflow: coder/coder/\.github/workflows/release\.yaml
+          signer_workflow: coder/coder/.github/workflows/release.yaml

--- a/pkgs/colbymchenry/codegraph/registry.yaml
+++ b/pkgs/colbymchenry/codegraph/registry.yaml
@@ -56,7 +56,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: colbymchenry/codegraph/\.github/workflows/release\.yml
+          signer_workflow: colbymchenry/codegraph/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/controlplaneio-fluxcd/flux-operator/flux-operator-mcp/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/flux-operator-mcp/registry.yaml
@@ -30,4 +30,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: controlplaneio-fluxcd/flux-operator/\.github/workflows/release\.yaml
+          signer_workflow: controlplaneio-fluxcd/flux-operator/.github/workflows/release.yaml

--- a/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
+++ b/pkgs/controlplaneio-fluxcd/flux-operator/registry.yaml
@@ -43,4 +43,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: controlplaneio-fluxcd/flux-operator/\.github/workflows/release\.yaml
+          signer_workflow: controlplaneio-fluxcd/flux-operator/.github/workflows/release.yaml

--- a/pkgs/dex4er/tf/registry.yaml
+++ b/pkgs/dex4er/tf/registry.yaml
@@ -28,4 +28,4 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: dex4er/tf/\.github/workflows/release\.yaml
+          signer_workflow: dex4er/tf/.github/workflows/release.yaml

--- a/pkgs/foundry-rs/foundry/registry.yaml
+++ b/pkgs/foundry-rs/foundry/registry.yaml
@@ -40,7 +40,7 @@ packages:
             format: zip
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: foundry-rs/foundry/\.github/workflows/release\.yml
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml
         cosign:
           bundle:
             type: github_release

--- a/pkgs/gastownhall/beads/registry.yaml
+++ b/pkgs/gastownhall/beads/registry.yaml
@@ -60,4 +60,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: gastownhall/beads/\.github/workflows/release\.yml
+          signer_workflow: gastownhall/beads/.github/workflows/release.yml

--- a/pkgs/gittuf/gittuf/registry.yaml
+++ b/pkgs/gittuf/gittuf/registry.yaml
@@ -54,4 +54,4 @@ packages:
               - --certificate-identity
               - "https://github.com/gittuf/gittuf/.github/workflows/release.yml@refs/tags/{{.Version}}"
         github_artifact_attestations:
-          signer_workflow: gittuf/gittuf/\.github/workflows/release\.yml
+          signer_workflow: gittuf/gittuf/.github/workflows/release.yml

--- a/pkgs/gleam-lang/gleam/registry.yaml
+++ b/pkgs/gleam-lang/gleam/registry.yaml
@@ -142,7 +142,7 @@ packages:
             format: zip
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml
       - version_constraint: semver("<= 1.10.0")
         asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -171,7 +171,7 @@ packages:
             - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml
       - version_constraint: "true"
         asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -199,4 +199,4 @@ packages:
             - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml

--- a/pkgs/goccy/bigquery-emulator/registry.yaml
+++ b/pkgs/goccy/bigquery-emulator/registry.yaml
@@ -27,4 +27,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: goccy/bigquery-emulator/\.github/workflows/release\.yml
+          signer_workflow: goccy/bigquery-emulator/.github/workflows/release.yml

--- a/pkgs/graelo/pumas/registry.yaml
+++ b/pkgs/graelo/pumas/registry.yaml
@@ -29,4 +29,4 @@ packages:
         supported_envs:
           - darwin/arm64
         github_artifact_attestations:
-          signer_workflow: graelo/pumas/\.github/workflows/release\.yml
+          signer_workflow: graelo/pumas/.github/workflows/release.yml

--- a/pkgs/grafana/flint/registry.yaml
+++ b/pkgs/grafana/flint/registry.yaml
@@ -36,4 +36,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: grafana/flint/\.github/workflows/release\.yml
+          signer_workflow: grafana/flint/.github/workflows/release.yml

--- a/pkgs/hadolint/hadolint/registry.yaml
+++ b/pkgs/hadolint/hadolint/registry.yaml
@@ -89,4 +89,4 @@ packages:
           asset: checksums.sha256
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml
+          signer_workflow: hadolint/hadolint/.github/workflows/release.yml

--- a/pkgs/jdx/aube/registry.yaml
+++ b/pkgs/jdx/aube/registry.yaml
@@ -121,4 +121,4 @@ packages:
           - darwin/arm64
           - windows
         github_artifact_attestations:
-          signer_workflow: jdx/aube/\.github/workflows/release\.yml
+          signer_workflow: jdx/aube/.github/workflows/release.yml

--- a/pkgs/lintnet/lintnet/registry.yaml
+++ b/pkgs/lintnet/lintnet/registry.yaml
@@ -55,7 +55,7 @@ packages:
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
         github_artifact_attestations:
-          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
       - version_constraint: "true"
         asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -79,4 +79,4 @@ packages:
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
         github_artifact_attestations:
-          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml

--- a/pkgs/lxc/incus/registry.yaml
+++ b/pkgs/lxc/incus/registry.yaml
@@ -32,4 +32,4 @@ packages:
           arm64: aarch64
           darwin: macos
         github_artifact_attestations:
-          signer_workflow: lxc/incus/\.github/workflows/release\.yml
+          signer_workflow: lxc/incus/.github/workflows/release.yml

--- a/pkgs/masutaka/github-nippou/registry.yaml
+++ b/pkgs/masutaka/github-nippou/registry.yaml
@@ -42,4 +42,4 @@ packages:
           asset: github-nippou_{{.Version}}_checksums.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: masutaka/github-nippou/\.github/workflows/release\.yml
+          signer_workflow: masutaka/github-nippou/.github/workflows/release.yml

--- a/pkgs/matteo-sung/lockvet/registry.yaml
+++ b/pkgs/matteo-sung/lockvet/registry.yaml
@@ -33,4 +33,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: matteo-sung/lockvet/\.github/workflows/release\.yml
+          signer_workflow: matteo-sung/lockvet/.github/workflows/release.yml

--- a/pkgs/mekedron/wolt-cli/registry.yaml
+++ b/pkgs/mekedron/wolt-cli/registry.yaml
@@ -33,4 +33,4 @@ packages:
           - linux
           - darwin
         github_artifact_attestations:
-          signer_workflow: mekedron/wolt-cli/\.github/workflows/release\.yml
+          signer_workflow: mekedron/wolt-cli/.github/workflows/release.yml

--- a/pkgs/openziti/zrok/registry.yaml
+++ b/pkgs/openziti/zrok/registry.yaml
@@ -44,4 +44,4 @@ packages:
           asset: checksums.sha256.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: openziti/zrok/\.github/workflows/release\.yml
+          signer_workflow: openziti/zrok/.github/workflows/release.yml

--- a/pkgs/ouch-org/ouch/registry.yaml
+++ b/pkgs/ouch-org/ouch/registry.yaml
@@ -129,4 +129,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: ouch-org/ouch/\.github/workflows/draft-release-automatic-trigger\.yml
+          signer_workflow: ouch-org/ouch/.github/workflows/draft-release-automatic-trigger.yml

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -129,7 +129,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows
@@ -166,7 +166,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows

--- a/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
+++ b/pkgs/ricoberger/grafana-kubernetes-plugin/registry.yaml
@@ -26,4 +26,4 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         github_artifact_attestations:
-          signer_workflow: ricoberger/grafana-kubernetes-plugin/\.github/workflows/release\.yml
+          signer_workflow: ricoberger/grafana-kubernetes-plugin/.github/workflows/release.yml

--- a/pkgs/rvben/rumdl/registry.yaml
+++ b/pkgs/rvben/rumdl/registry.yaml
@@ -104,4 +104,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: rvben/rumdl/\.github/workflows/release\.yml
+          signer_workflow: rvben/rumdl/.github/workflows/release.yml

--- a/pkgs/santosr2/TerraTidy/registry.yaml
+++ b/pkgs/santosr2/TerraTidy/registry.yaml
@@ -35,7 +35,7 @@ packages:
               type: github_release
               asset: checksums.txt.bundle
           github_artifact_attestations:
-            signer_workflow: santosr2/TerraTidy/\.github/workflows/release\.yml
+            signer_workflow: santosr2/TerraTidy/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/skaji/relocatable-perl/registry.yaml
+++ b/pkgs/skaji/relocatable-perl/registry.yaml
@@ -52,4 +52,4 @@ packages:
           - linux
           - darwin
         github_artifact_attestations:
-          signer_workflow: skaji/relocatable-perl/\.github/workflows/ci\.yml
+          signer_workflow: skaji/relocatable-perl/.github/workflows/ci.yml

--- a/pkgs/stefanprodan/timoni/registry.yaml
+++ b/pkgs/stefanprodan/timoni/registry.yaml
@@ -72,4 +72,4 @@ packages:
           type: github_release
           asset: timoni_{{trimV .Version}}_provenance.intoto.jsonl
         github_artifact_attestations:
-          signer_workflow: stefanprodan/timoni/\.github/workflows/release\.yaml
+          signer_workflow: stefanprodan/timoni/.github/workflows/release.yaml

--- a/pkgs/supernovae-st/nika/registry.yaml
+++ b/pkgs/supernovae-st/nika/registry.yaml
@@ -32,7 +32,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+          signer_workflow: supernovae-st/nika/.github/workflows/release.yml
         supported_envs:
           - linux
           - darwin
@@ -47,7 +47,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+          signer_workflow: supernovae-st/nika/.github/workflows/release.yml
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl

--- a/pkgs/taiki-e/cargo-llvm-cov/registry.yaml
+++ b/pkgs/taiki-e/cargo-llvm-cov/registry.yaml
@@ -66,4 +66,4 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         github_artifact_attestations:
-          signer-workflow: taiki-e/github-actions/\.github/workflows/rust-release\.yml
+          signer-workflow: taiki-e/github-actions/.github/workflows/rust-release.yml

--- a/pkgs/terraprovider/statebridge/registry.yaml
+++ b/pkgs/terraprovider/statebridge/registry.yaml
@@ -28,7 +28,7 @@ packages:
           type: github_release
           asset: multiple.intoto.jsonl
         github_artifact_attestations:
-          signer_workflow: terraprovider/statebridge/\.github/workflows/release\.yml
+          signer_workflow: terraprovider/statebridge/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip

--- a/pkgs/updatecli/updatecli/registry.yaml
+++ b/pkgs/updatecli/updatecli/registry.yaml
@@ -137,4 +137,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: updatecli/updatecli/\.github/workflows/release\.yaml
+          signer_workflow: updatecli/updatecli/.github/workflows/release.yaml

--- a/pkgs/wasilibs/go-yamllint/registry.yaml
+++ b/pkgs/wasilibs/go-yamllint/registry.yaml
@@ -32,4 +32,4 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer-workflow: wasilibs/actions/\.github/workflows/release\.yaml
+          signer-workflow: wasilibs/actions/.github/workflows/release.yaml

--- a/pkgs/wasmCloud/wasmCloud/wash/registry.yaml
+++ b/pkgs/wasmCloud/wasmCloud/wash/registry.yaml
@@ -30,7 +30,7 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/wash.yml
       - version_constraint: semver("<= 2.0.5")
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -46,7 +46,7 @@ packages:
             format: zip
             asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/wash.yml
       - version_constraint: semver("< 2.1.0")
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -62,7 +62,7 @@ packages:
             format: zip
             asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/release-tag.yml
       - version_constraint: "true"
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -87,4 +87,4 @@ packages:
             - --certificate-identity
             - https://github.com/wasmCloud/wasmCloud/.github/workflows/release-tag.yml@refs/heads/main
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/release-tag.yml

--- a/registry.yaml
+++ b/registry.yaml
@@ -1797,7 +1797,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: Byron/dua-cli/\.github/workflows/release\.yml
+          signer_workflow: Byron/dua-cli/.github/workflows/release.yml
   - type: github_release
     repo_owner: ByteNess
     repo_name: aws-vault
@@ -4145,7 +4145,7 @@ packages:
           - windows/amd64
           - linux/amd64
         github_artifact_attestations:
-          signer_workflow: GitGuardian/ggshield/\.github/workflows/tag\.yml
+          signer_workflow: GitGuardian/ggshield/.github/workflows/tag.yml
   - type: github_release
     repo_owner: GitTools
     repo_name: GitVersion
@@ -4189,7 +4189,7 @@ packages:
         checksum:
           enabled: false
         github_artifact_attestations:
-          signer_workflow: GitTools/GitVersion/\.github/workflows/ci\.yml
+          signer_workflow: GitTools/GitVersion/.github/workflows/ci.yml
   - type: github_release
     repo_owner: GoTestTools
     repo_name: gotestfmt
@@ -8279,7 +8279,7 @@ packages:
         supported_envs:
           - darwin
         github_artifact_attestations:
-          signer_workflow: StanMarek/ghost-complete/\.github/workflows/release\.yml
+          signer_workflow: StanMarek/ghost-complete/.github/workflows/release.yml
   - type: github_release
     repo_owner: Stranger6667
     repo_name: jsonschema
@@ -23691,7 +23691,7 @@ packages:
           - goos: linux
             format: tgz
         github_artifact_attestations:
-          signer_workflow: cargo-bins/cargo-binstall/\.github/workflows/release-cli\.yml
+          signer_workflow: cargo-bins/cargo-binstall/.github/workflows/release-cli.yml
   - type: github_release
     repo_owner: carthage-software
     repo_name: mago
@@ -27905,7 +27905,7 @@ packages:
           - goos: linux
             format: tar.gz
         github_artifact_attestations:
-          signer_workflow: coder/coder/\.github/workflows/release\.yaml
+          signer_workflow: coder/coder/.github/workflows/release.yaml
   - type: github_release
     repo_owner: coder3101
     repo_name: protols
@@ -28013,7 +28013,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: colbymchenry/codegraph/\.github/workflows/release\.yml
+          signer_workflow: colbymchenry/codegraph/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip
@@ -29518,7 +29518,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: controlplaneio-fluxcd/flux-operator/\.github/workflows/release\.yaml
+          signer_workflow: controlplaneio-fluxcd/flux-operator/.github/workflows/release.yaml
   - name: controlplaneio-fluxcd/flux-operator/flux-operator-mcp
     type: github_release
     repo_owner: controlplaneio-fluxcd
@@ -29549,7 +29549,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: controlplaneio-fluxcd/flux-operator/\.github/workflows/release\.yaml
+          signer_workflow: controlplaneio-fluxcd/flux-operator/.github/workflows/release.yaml
   - type: github_release
     repo_owner: controlplaneio
     repo_name: kubectl-kubesec
@@ -33683,7 +33683,7 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: dex4er/tf/\.github/workflows/release\.yaml
+          signer_workflow: dex4er/tf/.github/workflows/release.yaml
   - type: github_release
     repo_owner: dhall-lang
     repo_name: dhall-haskell
@@ -39830,7 +39830,7 @@ packages:
             format: zip
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: foundry-rs/foundry/\.github/workflows/release\.yml
+          signer_workflow: foundry-rs/foundry/.github/workflows/release.yml
         cosign:
           bundle:
             type: github_release
@@ -40991,7 +40991,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: gastownhall/beads/\.github/workflows/release\.yml
+          signer_workflow: gastownhall/beads/.github/workflows/release.yml
   - type: github_release
     repo_owner: gcla
     repo_name: termshark
@@ -42652,7 +42652,7 @@ packages:
               - --certificate-identity
               - "https://github.com/gittuf/gittuf/.github/workflows/release.yml@refs/tags/{{.Version}}"
         github_artifact_attestations:
-          signer_workflow: gittuf/gittuf/\.github/workflows/release\.yml
+          signer_workflow: gittuf/gittuf/.github/workflows/release.yml
   - type: github_release
     repo_owner: gitui-org
     repo_name: gitui
@@ -43028,7 +43028,7 @@ packages:
             format: zip
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml
       - version_constraint: semver("<= 1.10.0")
         asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -43057,7 +43057,7 @@ packages:
             - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml
       - version_constraint: "true"
         asset: gleam-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -43085,7 +43085,7 @@ packages:
             - https://token.actions.githubusercontent.com
         github_artifact_attestations:
           predicate_type: https://spdx.dev/Document/v2.3
-          signer_workflow: gleam-lang/gleam/\.github/workflows/release\.yaml
+          signer_workflow: gleam-lang/gleam/.github/workflows/release.yaml
   - type: http
     name: glossia.ai/cli
     aliases:
@@ -43901,7 +43901,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: goccy/bigquery-emulator/\.github/workflows/release\.yml
+          signer_workflow: goccy/bigquery-emulator/.github/workflows/release.yml
   - name: goccy/go-yaml/ycat
     type: go_build
     repo_owner: goccy
@@ -46538,7 +46538,7 @@ packages:
         supported_envs:
           - darwin/arm64
         github_artifact_attestations:
-          signer_workflow: graelo/pumas/\.github/workflows/release\.yml
+          signer_workflow: graelo/pumas/.github/workflows/release.yml
   - type: github_release
     repo_owner: grafana-cold-storage
     repo_name: grizzly
@@ -46618,7 +46618,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: grafana/flint/\.github/workflows/release\.yml
+          signer_workflow: grafana/flint/.github/workflows/release.yml
   - type: github_release
     repo_owner: grafana
     repo_name: gcx
@@ -47823,7 +47823,7 @@ packages:
           asset: checksums.sha256
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: hadolint/hadolint/\.github/workflows/release\.yml
+          signer_workflow: hadolint/hadolint/.github/workflows/release.yml
   - type: github_release
     repo_owner: hairyhenderson
     repo_name: gomplate
@@ -52600,7 +52600,7 @@ packages:
           - darwin/arm64
           - windows
         github_artifact_attestations:
-          signer_workflow: jdx/aube/\.github/workflows/release\.yml
+          signer_workflow: jdx/aube/.github/workflows/release.yml
   - type: github_release
     repo_owner: jdx
     repo_name: fnox
@@ -63057,7 +63057,7 @@ packages:
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
         github_artifact_attestations:
-          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
       - version_constraint: "true"
         asset: lintnet_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
@@ -63081,7 +63081,7 @@ packages:
               - --certificate-oidc-issuer
               - "https://token.actions.githubusercontent.com"
         github_artifact_attestations:
-          signer_workflow: suzuki-shunsuke/go-release-workflow/\.github/workflows/release\.yaml
+          signer_workflow: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
   - type: github_release
     repo_owner: linuxkit
     repo_name: linuxkit
@@ -63706,7 +63706,7 @@ packages:
           arm64: aarch64
           darwin: macos
         github_artifact_attestations:
-          signer_workflow: lxc/incus/\.github/workflows/release\.yml
+          signer_workflow: lxc/incus/.github/workflows/release.yml
   - type: github_release
     repo_owner: lycheeverse
     repo_name: lychee
@@ -64673,7 +64673,7 @@ packages:
           asset: github-nippou_{{.Version}}_checksums.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: masutaka/github-nippou/\.github/workflows/release\.yml
+          signer_workflow: masutaka/github-nippou/.github/workflows/release.yml
   - type: github_release
     repo_owner: mathew-fleisch
     repo_name: bashbot
@@ -64808,7 +64808,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: matteo-sung/lockvet/\.github/workflows/release\.yml
+          signer_workflow: matteo-sung/lockvet/.github/workflows/release.yml
   - type: github_release
     repo_owner: mattermost
     repo_name: mmctl
@@ -65282,7 +65282,7 @@ packages:
           - linux
           - darwin
         github_artifact_attestations:
-          signer_workflow: mekedron/wolt-cli/\.github/workflows/release\.yml
+          signer_workflow: mekedron/wolt-cli/.github/workflows/release.yml
   - type: github_release
     repo_owner: mercari
     repo_name: hcledit
@@ -73358,7 +73358,7 @@ packages:
           asset: checksums.sha256.txt
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: openziti/zrok/\.github/workflows/release\.yml
+          signer_workflow: openziti/zrok/.github/workflows/release.yml
   - type: github_release
     repo_owner: operator-framework
     repo_name: operator-registry
@@ -74274,7 +74274,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: ouch-org/ouch/\.github/workflows/draft-release-automatic-trigger\.yml
+          signer_workflow: ouch-org/ouch/.github/workflows/draft-release-automatic-trigger.yml
   - type: github_release
     repo_owner: out-of-cheese-error
     repo_name: the-way
@@ -76742,7 +76742,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows
@@ -76779,7 +76779,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
         supported_envs:
           - linux
           - windows
@@ -80450,7 +80450,7 @@ packages:
         format: tar.gz
         windows_arm_emulation: true
         github_artifact_attestations:
-          signer_workflow: ricoberger/grafana-kubernetes-plugin/\.github/workflows/release\.yml
+          signer_workflow: ricoberger/grafana-kubernetes-plugin/.github/workflows/release.yml
   - type: github_release
     repo_owner: rlmcpherson
     repo_name: s3gof3r
@@ -81924,7 +81924,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: rvben/rumdl/\.github/workflows/release\.yml
+          signer_workflow: rvben/rumdl/.github/workflows/release.yml
   - type: github_release
     repo_owner: ryane
     repo_name: kfilt
@@ -82600,7 +82600,7 @@ packages:
               type: github_release
               asset: checksums.txt.bundle
           github_artifact_attestations:
-            signer_workflow: santosr2/TerraTidy/\.github/workflows/release\.yml
+            signer_workflow: santosr2/TerraTidy/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip
@@ -85549,7 +85549,7 @@ packages:
           - linux
           - darwin
         github_artifact_attestations:
-          signer_workflow: skaji/relocatable-perl/\.github/workflows/ci\.yml
+          signer_workflow: skaji/relocatable-perl/.github/workflows/ci.yml
   - type: github_release
     repo_owner: skanehira
     repo_name: ghost
@@ -88815,7 +88815,7 @@ packages:
           type: github_release
           asset: timoni_{{trimV .Version}}_provenance.intoto.jsonl
         github_artifact_attestations:
-          signer_workflow: stefanprodan/timoni/\.github/workflows/release\.yaml
+          signer_workflow: stefanprodan/timoni/.github/workflows/release.yaml
   - type: github_release
     repo_owner: stepchowfun
     repo_name: docuum
@@ -90117,7 +90117,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+          signer_workflow: supernovae-st/nika/.github/workflows/release.yml
         supported_envs:
           - linux
           - darwin
@@ -90132,7 +90132,7 @@ packages:
           asset: SHA256SUMS
           algorithm: sha256
         github_artifact_attestations:
-          signer_workflow: supernovae-st/nika/\.github/workflows/release\.yml
+          signer_workflow: supernovae-st/nika/.github/workflows/release.yml
         slsa_provenance:
           type: github_release
           asset: multiple.intoto.jsonl
@@ -92704,7 +92704,7 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         github_artifact_attestations:
-          signer-workflow: taiki-e/github-actions/\.github/workflows/rust-release\.yml
+          signer-workflow: taiki-e/github-actions/.github/workflows/rust-release.yml
   - type: github_release
     repo_owner: tailor-platform
     repo_name: patterner
@@ -94543,7 +94543,7 @@ packages:
           type: github_release
           asset: multiple.intoto.jsonl
         github_artifact_attestations:
-          signer_workflow: terraprovider/statebridge/\.github/workflows/release\.yml
+          signer_workflow: terraprovider/statebridge/.github/workflows/release.yml
         overrides:
           - goos: windows
             format: zip
@@ -98196,7 +98196,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer_workflow: updatecli/updatecli/\.github/workflows/release\.yaml
+          signer_workflow: updatecli/updatecli/.github/workflows/release.yaml
   - type: github_release
     repo_owner: uptrace
     repo_name: uptrace
@@ -100769,7 +100769,7 @@ packages:
           - goos: windows
             format: zip
         github_artifact_attestations:
-          signer-workflow: wasilibs/actions/\.github/workflows/release\.yaml
+          signer-workflow: wasilibs/actions/.github/workflows/release.yaml
   - type: github_release
     repo_owner: wasm-bindgen
     repo_name: wasm-pack
@@ -100863,7 +100863,7 @@ packages:
           linux: unknown-linux-musl
           windows: pc-windows-msvc
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/wash.yml
       - version_constraint: semver("<= 2.0.5")
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -100879,7 +100879,7 @@ packages:
             format: zip
             asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/wash\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/wash.yml
       - version_constraint: semver("< 2.1.0")
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -100895,7 +100895,7 @@ packages:
             format: zip
             asset: wash-{{.Arch}}-{{.OS}}.{{.Format}}
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/release-tag.yml
       - version_constraint: "true"
         asset: wash-{{.Arch}}-{{.OS}}
         format: raw
@@ -100920,7 +100920,7 @@ packages:
             - --certificate-identity
             - https://github.com/wasmCloud/wasmCloud/.github/workflows/release-tag.yml@refs/heads/main
         github_artifact_attestations:
-          signer_workflow: wasmCloud/wasmCloud/\.github/workflows/release-tag\.yml
+          signer_workflow: wasmCloud/wasmCloud/.github/workflows/release-tag.yml
   - type: github_release
     repo_owner: wasmerio
     repo_name: wapm-cli


### PR DESCRIPTION
`gh` v2.97.0 changed how `--signer-workflow` is interpreted, which breaks attestation verification for 38 packages in this registry.

## What changed upstream

From the cli/cli v2.97.0 release notes:

> `gh attestation verify` built the certificate matcher from `--signer-repo` and `--signer-workflow` without escaping regex metacharacters, so a lookalike repository or workflow name could satisfy a matcher intended for a trusted signer and bypass attestation verification.

`pkg/cmd/attestation/verify/policy.go`:

```go
// v2.96.0 — the value is used as a regex verbatim
return fmt.Sprintf("^https://%s/%s", hostname, signerWorkflow), nil

// v2.97.0 — the value is treated as a literal
return "^" + regexp.QuoteMeta(fmt.Sprintf("https://%s/%s", hostname, signerWorkflow)), nil
```

## Why these entries break

They were written for the old regex behaviour and are pre-escaped:

```yaml
signer_workflow: pnpm/pnpm/\.github/workflows/release\.yml
```

`QuoteMeta` escapes that `\.` again, producing a matcher that requires a literal backslash in the certificate SAN. It can never match `https://github.com/pnpm/pnpm/.github/workflows/release.yml`, so verification fails and aqua refuses to install the package:

```
Error: verifying with issuer "sigstore.dev"
ERR install the package  package_name=pnpm/pnpm package_version=v11.5.2
    error="verify the asset: verify a package with gh attestation: verify GitHub Artifact Attestations"
```

## This change

Removes the escaping from all 38 affected packages — 92 occurrences, all of them `\.`, nothing else. Every changed line is a `signer_workflow` line and the diff is `\.` to `.` only.

The registry was already inconsistent here: 116 packages set `signer_workflow`, and the other 78 are already plain paths. This brings the outliers in line with the majority rather than introducing a new convention.

## On older gh

The two versions read the field differently, so no single value is strict under both. With the escaping removed, `gh` < 2.97.0 treats the dots as regex wildcards and the match is looser than intended — though still anchored to the exact `owner/repo`, so a lookalike repository is rejected either way.

That is the same behaviour the other 78 entries have always had, and it only applies until a user updates `gh`. Since the escaped form does not merely match loosely on current `gh` but fails outright, this seems the right way round.

## Note

This is independent of aquaproj/aqua#5096, which is where the failure surfaced. Any user on gh >= 2.97.0 already fails to install these 38 packages today.
