### PR TITLE
fix(ipfs/kubo): address the package by its own name in pkg.yaml

### DIFF
--- a/pkgs/ipfs/kubo/pkg.yaml
+++ b/pkgs/ipfs/kubo/pkg.yaml
@@ -2,5 +2,5 @@ packages:
   - name: ipfs/kubo@v0.40.1
   - name: ipfs/kubo
     version: v0.13.1
-  - name: ipfs/go-ipfs
+  - name: ipfs/kubo
     version: v0.13.0


### PR DESCRIPTION
## Problem

`ipfs/kubo` has 3 open update PRs (#52XXX … #58151) and none of them can merge — but unlike the
other stuck packages, kubo installs fine. The failing check is `test / lint / lint`:

```console
FAIL pkgs/ipfs/kubo/pkg.yaml: package name mismatch:
  expected "ipfs/kubo" but got "ipfs/go-ipfs"
```

`pkg.yaml` addresses the package by `ipfs/go-ipfs`, which is a declared alias in `registry.yaml`.
The policy added in #50403 compares the entry name to the directory, so it rejects it.

Because lint runs on the files a PR changes, and the updater changes exactly
`pkgs/ipfs/kubo/pkg.yaml`, this fires on every update PR for this package.

## Change

One line in `pkgs/ipfs/kubo/pkg.yaml`:

```diff
-  - name: ipfs/go-ipfs
+  - name: ipfs/kubo
     version: v0.13.0
```

The version stays `v0.13.0`, so the same install is still exercised — only the name used to address
it changes. v0.13.0 and v0.13.1 both fall in the same `version_overrides` branch and both ship
`go-ipfs_<version>_<os>-<arch>.tar.gz`, so test coverage is unchanged.

### Why change the package rather than make the policy alias-aware

165 packages in the registry declare aliases, and kubo is the **only** one that uses an alias in
its `pkg.yaml`. So this looks like a one-off rather than a convention the policy should learn.

The trade-off, stated plainly: this does drop the one place where alias resolution is exercised
end-to-end. If you would rather keep that, the alternative is to teach the policy to accept a name
that matches any alias declared in the package's `registry.yaml` — happy to send that instead.

This is the companion to #59606, which fixes the same policy's genuine false positive on aqua's
`#` Go-sub-package syntax.

## Verification

The decisive check is lint on exactly what the updater changes — `pkg.yaml` alone:

```console
BEFORE  14 tests, 13 passed, 1 failure
        FAIL pkgs/ipfs/kubo/pkg.yaml: package name mismatch: expected "ipfs/kubo" but got "ipfs/go-ipfs"
AFTER   14 tests, 14 passed, 0 failures
```

The renamed entry and its neighbours still install (aqua v2.62.3, macOS 26.6.2; `bin/` checked
rather than the exit code, since `aqua i` can exit 0 with a wrong `files[].src`):

```console
ipfs/kubo@v0.13.0   errs=0  bin=[ipfs]     <- the renamed entry
ipfs/kubo@v0.13.1   errs=0  bin=[ipfs]
ipfs/kubo@v0.40.1   errs=0  bin=[ipfs]
```

```console
$ argd t ipfs/kubo          # exit 0, all six os/arch targets, no errors
$ prettier --check pkgs/ipfs/kubo/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` is unchanged, so `argd gr` produced no diff.

## Note on the other policy rule

`conftest test --combine pkgs/ipfs/kubo/*` still reports one failure —
`the top level version_constraint must be either empty or "false"` — because kubo's `registry.yaml`
uses `semver(">= 0.14.0")`. I have **not** touched that: 153 packages are in the same position, the
rule only applies to `registry.yaml`, and the updater never changes that file, so it blocks
nothing today. It felt like a separate conversation rather than something to slip into this PR.

## Effect

Unblocks the 3 stuck update PRs for this package.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per
[docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above
was actually executed and its real output pasted. I have reviewed the change and own it.
