### PR TITLE
feat: add PSU3D0/agent-spreadsheet

### DIFF
--- a/pkgs/PSU3D0/agent-spreadsheet/pkg.yaml
+++ b/pkgs/PSU3D0/agent-spreadsheet/pkg.yaml
@@ -1,0 +1,12 @@
+packages:
+  - name: PSU3D0/agent-spreadsheet@v0.13.0
+  - name: PSU3D0/agent-spreadsheet
+    version: v0.12.0
+  - name: PSU3D0/agent-spreadsheet
+    version: v0.11.1
+  - name: PSU3D0/agent-spreadsheet
+    version: v0.10.1
+  - name: PSU3D0/agent-spreadsheet
+    version: v0.10.0
+  - name: PSU3D0/agent-spreadsheet
+    version: v0.4.0

--- a/pkgs/PSU3D0/agent-spreadsheet/registry.yaml
+++ b/pkgs/PSU3D0/agent-spreadsheet/registry.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: PSU3D0
+    repo_name: agent-spreadsheet
+    description: MCP server for spreadsheet analysis and editing. Slim, token-efficient tool surface designed for LLM agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.10.1"
+        asset: spreadsheet-cli-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.11.1"
+        asset: spreadsheet-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.12.0"
+        asset: agent-spreadsheet-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: spreadsheet-read-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.0")
+        asset: spreadsheet-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: agent-spreadsheet-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}

--- a/pkgs/PSU3D0/agent-spreadsheet/registry.yaml
+++ b/pkgs/PSU3D0/agent-spreadsheet/registry.yaml
@@ -85,6 +85,9 @@ packages:
         asset: agent-spreadsheet-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: agent-spreadsheet
+          - name: asp
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6851,6 +6851,9 @@ packages:
         asset: agent-spreadsheet-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
+        files:
+          - name: agent-spreadsheet
+          - name: asp
         replacements:
           amd64: x86_64
           arm64: aarch64

--- a/registry.yaml
+++ b/registry.yaml
@@ -6767,6 +6767,103 @@ packages:
           asset: checksums.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: PSU3D0
+    repo_name: agent-spreadsheet
+    description: MCP server for spreadsheet analysis and editing. Slim, token-efficient tool surface designed for LLM agents
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.10.1"
+        asset: spreadsheet-cli-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.11.1"
+        asset: spreadsheet-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: Version == "v0.12.0"
+        asset: agent-spreadsheet-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.4.0")
+        asset: spreadsheet-read-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.10.0")
+        asset: spreadsheet-mcp-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: macos
+        overrides:
+          - goos: darwin
+            replacements:
+              arm64: aarch64
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: agent-spreadsheet-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+            replacements: {}
+  - type: github_release
     repo_owner: PaddiM8
     repo_name: kalker
     description: Kalker is a calculator program that supports user-defined variables, functions, differentiation, and integration


### PR DESCRIPTION
Adds [PSU3D0/agent-spreadsheet](https://github.com/PSU3D0/agent-spreadsheet) — a CLI (`agent-spreadsheet` / `asp`) for AI-agent spreadsheet work on .xlsx workbooks: read, profile, edit, recalculate (native Rust engine), and verify. Apache-2.0.

Scaffolded with `argd s "PSU3D0/agent-spreadsheet"`; a follow-up commit adds `files` for the two commands (`agent-spreadsheet` and the `asp` alias) shipped in the release archives since v0.13.0. Earlier releases published raw binaries under the project's previous names, which the generated version_overrides cover.

`argd t "PSU3D0/agent-spreadsheet"` passes locally (all container platforms). Latest versions verify against the release `SHA256SUMS` via the github_release checksum config.

Disclosure per docs/ai.md: this PR was prepared with AI assistance (Claude); the maintainer of the packaged tool reviewed the result and is the PR author.