### PR TITLE
fix(projectdiscovery/naabu): follow the checksum and platform changes since v2.3.6

### DIFF
--- a/pkgs/projectdiscovery/naabu/pkg.yaml
+++ b/pkgs/projectdiscovery/naabu/pkg.yaml
@@ -1,5 +1,11 @@
 packages:
-  - name: projectdiscovery/naabu@v2.3.5
+  - name: projectdiscovery/naabu@v2.6.1
+  - name: projectdiscovery/naabu
+    version: v2.5.0
+  - name: projectdiscovery/naabu
+    version: v2.3.6
+  - name: projectdiscovery/naabu
+    version: v2.3.5
   - name: projectdiscovery/naabu
     version: v2.0.8
   - name: projectdiscovery/naabu

--- a/pkgs/projectdiscovery/naabu/registry.yaml
+++ b/pkgs/projectdiscovery/naabu/registry.yaml
@@ -4,27 +4,94 @@ packages:
     repo_owner: projectdiscovery
     repo_name: naabu
     description: A fast port scanner written in go with a focus on reliability and simplicity. Designed to be used in combination with other tools for attack surface discovery in bug bounties and pentests
-    rosetta2: true
-    asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
-    replacements:
-      darwin: macOS
-    version_constraint: semver(">= 2.0.9")
-    supported_envs:
-      - darwin
-      - amd64
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("= 2.0.8")
+      - version_constraint: Version == "v2.0.8"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
         supported_envs:
           - darwin
           - linux/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.9")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
         supported_envs:
           - windows
           - darwin
           - linux/amd64
-    checksum:
-      type: github_release
-      asset: naabu-{{.OS}}-checksums.txt
-      algorithm: sha256
-      replacements:
-        darwin: mac
+      - version_constraint: semver("<= 2.3.5")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: Version == "v2.3.6"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.5.0")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        overrides:
+          - goos: linux
+            checksum:
+              type: github_release
+              asset: naabu-{{.OS}}-{{.Arch}}-checksums.txt
+              algorithm: sha256
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -77395,30 +77395,97 @@ packages:
     repo_owner: projectdiscovery
     repo_name: naabu
     description: A fast port scanner written in go with a focus on reliability and simplicity. Designed to be used in combination with other tools for attack surface discovery in bug bounties and pentests
-    rosetta2: true
-    asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
-    replacements:
-      darwin: macOS
-    version_constraint: semver(">= 2.0.9")
-    supported_envs:
-      - darwin
-      - amd64
+    version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("= 2.0.8")
+      - version_constraint: Version == "v2.0.8"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
         supported_envs:
           - darwin
           - linux/amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.9")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
         supported_envs:
           - windows
           - darwin
           - linux/amd64
-    checksum:
-      type: github_release
-      asset: naabu-{{.OS}}-checksums.txt
-      algorithm: sha256
-      replacements:
-        darwin: mac
+      - version_constraint: semver("<= 2.3.5")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: Version == "v2.3.6"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        supported_envs:
+          - darwin
+          - windows/amd64
+      - version_constraint: semver("<= 2.5.0")
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-{{.OS}}-checksums.txt
+          algorithm: sha256
+          replacements:
+            darwin: mac
+        overrides:
+          - goos: linux
+            checksum:
+              type: github_release
+              asset: naabu-{{.OS}}-{{.Arch}}-checksums.txt
+              algorithm: sha256
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: "true"
+        rosetta2: true
+        asset: naabu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+        replacements:
+          darwin: macOS
+        checksum:
+          type: github_release
+          asset: naabu-checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - amd64
   - type: github_release
     repo_owner: projectdiscovery
     repo_name: nuclei


### PR DESCRIPTION
## Problem

`projectdiscovery/naabu` has 6 stuck update PRs (#44227, #44616, #50111, #47382, #52586, #53297). Upstream changed the release layout three times since v2.3.5, and the package config still describes the v2.3.5 shape.

| tag | checksum files | archives |
| --- | --- | --- |
| ≤ v2.3.5 | `naabu-linux-checksums.txt`, `naabu-mac-checksums.txt`, `naabu-windows-checksums.txt` | linux/amd64, macOS, windows |
| **v2.3.6** | mac + windows only | **no linux assets at all** |
| v2.3.7 – v2.5.0 | linux became per-arch: `naabu-linux-amd64-checksums.txt`, `naabu-linux-arm64-checksums.txt` (mac / windows unchanged) | linux amd64 + arm64, macOS, windows |
| ≥ v2.6.0 | a single `naabu-checksums.txt` | windows/arm64 dropped |

### 1. v2.3.6 cannot be installed on Linux

This is the hard failure behind #44227:

```console
$ argd t projectdiscovery/naabu   # with main's config, slot pinned to v2.3.6
ERR install the package package_version=v2.3.6
  error="the asset isn't found: naabu_2.3.6_linux_amd64.zip"
```

### 2. Checksum verification silently stopped happening from v2.3.7

The configured `naabu-{{.OS}}-checksums.txt` stopped resolving, but `docker/aqua-test.yaml` sets `require_checksum: false`, so this fails open rather than failing loudly:

```console
$ curl -o /dev/null -w '%{http_code}\n' .../v2.3.5/naabu-linux-checksums.txt
302
$ curl -o /dev/null -w '%{http_code}\n' .../v2.3.7/naabu-linux-checksums.txt
404
$ curl -o /dev/null -w '%{http_code}\n' .../v2.6.1/naabu-linux-checksums.txt
404
```

So for every version from v2.3.7 on, Linux installs have been running without upstream checksum verification.

### 3. Only one of the six PRs actually fails today

I reproduced each stuck PR by pinning the slot to its target version against main's config:

| slot | `argd t` |
| --- | --- |
| v2.3.6 | exit 1 — `the asset isn't found: naabu_2.3.6_linux_amd64.zip` |
| v2.3.7 / v2.4.0 / v2.5.0 / v2.6.0 / v2.6.1 | exit 0 |

The other five are stale red checks, not current failures — [auto-rerun.yaml](.github/workflows/auto-rerun.yaml) only re-runs bot PRs created within the last 4 days, and these are months old. They should go green on a re-run once this merges, but they were also passing *without* checksum verification, which this PR fixes.

## Change

`version_overrides` now has one self-contained branch per release layout. The top-level `version_constraint` becomes `"false"`, which also clears an existing Conftest failure:

```console
$ conftest test --combine pkgs/projectdiscovery/naabu/registry.yaml   # on main
FAIL - pkgs/projectdiscovery/naabu/registry.yaml: the top level version_constraint must be either empty or "false"
14 tests, 13 passed, 0 warnings, 1 failure, 0 exceptions
```

`v2.3.6` gets `supported_envs: [darwin, windows/amd64]` since it ships no Linux build, the v2.3.7–v2.5.0 branch overrides the checksum asset for `goos: linux` only, and the `"true"` branch uses the single `naabu-checksums.txt`.

`supported_envs` is otherwise left as it was (`[darwin, amd64]`). Linux arm64 assets do exist from v2.3.7 — adding that is a separate change and I'd rather not fold it in here.

## Verification

Every branch installed directly, checksums enabled, checked by the extracted file rather than the exit code:

| version | branch | targets | result |
| --- | --- | --- | --- |
| v2.6.1 | `"true"` | linux/amd64, darwin/amd64, darwin/arm64, windows/amd64 | ok |
| v2.5.0 | `<= 2.5.0` | linux/amd64, darwin/arm64, windows/amd64 | ok |
| v2.3.7 | `<= 2.5.0` | linux/amd64 | ok |
| v2.3.6 | `== v2.3.6` | darwin/arm64, windows/amd64 | ok |
| v2.3.5 | `<= 2.3.5` | linux/amd64, darwin/arm64 | ok |
| v2.0.8 | `== v2.0.8` | linux/amd64 | ok |
| v2.0.7 | `< 2.0.9` | windows/amd64 | ok |

And the checksum URLs this PR builds all resolve:

```console
v2.3.7  naabu-linux-amd64-checksums.txt  302
v2.5.0  naabu-linux-amd64-checksums.txt  302
v2.6.0  naabu-checksums.txt              302
v2.6.1  naabu-checksums.txt              302
```

```console
$ argd t projectdiscovery/naabu
exit 0, six targets, no error lines

$ conftest test --combine pkgs/projectdiscovery/naabu/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/projectdiscovery/naabu/*.yaml
All matched files use Prettier code style!
```

`pkg.yaml` pins one version per branch, with the updater slot in the branch this PR adds. `registry.yaml` regenerated with `argd gr`.

**Not verified:** the binary was not executed on any platform — this change is about asset and checksum resolution. Linux arm64 is not covered because it stays outside `supported_envs`.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
