### PR TITLE
fix(containers/conmon): v2.2.0 has no assets

### DIFF
--- a/pkgs/containers/conmon/registry.yaml
+++ b/pkgs/containers/conmon/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: An OCI container runtime monitor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 2.0.9") || Version in ["v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
+      - version_constraint: semver("<= 2.0.9") || Version in ["v2.2.0", "v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
         no_asset: true
       - version_constraint: semver("<= 2.0.17") || Version in ["v2.0.20", "v2.0.24"]
         asset: conmon

--- a/registry.yaml
+++ b/registry.yaml
@@ -29255,7 +29255,7 @@ packages:
     description: An OCI container runtime monitor
     version_constraint: "false"
     version_overrides:
-      - version_constraint: semver("<= 2.0.9") || Version in ["v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
+      - version_constraint: semver("<= 2.0.9") || Version in ["v2.2.0", "v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
         no_asset: true
       - version_constraint: semver("<= 2.0.17") || Version in ["v2.0.20", "v2.0.24"]
         asset: conmon


### PR DESCRIPTION
## Problem

`containers/conmon` has 2 stuck update PRs, #46920 (→ v2.2.0) and #48608 (→ v2.2.1). Only the first one is a real failure.

I reproduced each by pinning the updater slot to its target version against `main`'s config:

| slot | `argd t containers/conmon` |
| --- | --- |
| v2.2.0 | exit 1 — `the asset isn't found: conmon.amd64` |
| v2.2.1 | exit 0 |

v2.2.0 shipped with no release assets at all, while every release around it has the usual five:

```console
$ for v in v2.1.10 v2.1.11 v2.1.12 v2.1.13 v2.2.0 v2.2.1; do
    gh release view $v --repo containers/conmon --json assets --jq '[.assets[].name]|length'
  done
5
5
5
5
0
5
```

It is not a draft or a prerelease — it was published on 2026-01-12 with full release notes, and v2.2.1 followed with assets restored. I could not find an upstream issue about it. So this looks like an isolated gap rather than a change in how conmon publishes binaries, which is the same shape as the gaps the package already records.

## Change

v2.2.0 joins the existing `no_asset` list, next to the other isolated gaps:

```diff
-      - version_constraint: semver("<= 2.0.9") || Version in ["v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
+      - version_constraint: semver("<= 2.0.9") || Version in ["v2.2.0", "v2.1.1", "v2.0.29", "v2.0.28", "v2.0.21"]
         no_asset: true
```

Anyone who asks for v2.2.0 now gets a statement of fact instead of a confusing lookup failure:

```console
# before
error="the asset isn't found: conmon.amd64"
# after
error="no asset is released for this version"
```

`pkg.yaml` is unchanged. The `version_constraint: "true"` branch isn't touched, and a `no_asset` version can't be pinned as test data because installing it fails by design.

## On the two stuck PRs

To be explicit, because this doesn't turn either of them green by itself:

- **#48608 (v2.2.1)** passes today — its red checks are stale. [auto-rerun.yaml](.github/workflows/auto-rerun.yaml) only re-runs bot PRs created within the last 4 days, and this one is from February, so nothing has re-run it. It should go green on a re-run.
- **#46920 (v2.2.0)** will stay red even with this change, since the version genuinely has nothing to install. Once v2.2.1 lands it becomes conflicting and [close-conflicting-pr.yaml](.github/workflows/close-conflicting-pr.yaml) will close it.

## Verification

```console
$ argd t containers/conmon
exit 0, six targets, no error lines

$ conftest test --combine pkgs/containers/conmon/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/containers/conmon/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` regenerated with `argd gr`.

**Not verified:** the binary was not executed — this change only records that a version has no assets.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
