### PR TITLE
fix(ci): resolve AQUA_CONFIG from the workspace so go_build works

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -155,7 +155,7 @@ jobs:
         env:
           AQUA_GOOS: ${{ matrix.env.goos }}
           AQUA_GOARCH: ${{ matrix.env.goarch }}
-          AQUA_CONFIG: ${{ github.workspace }}/aqua/test.yaml
+          AQUA_CONFIG: aqua/test.yaml
           AQUA_GITHUB_TOKEN: ${{github.token}}
 
   test-alpine:

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -143,7 +143,9 @@ jobs:
         env:
           AQUA_GOOS: ${{ matrix.env.goos }}
           AQUA_GOARCH: ${{ matrix.env.goarch }}
-          AQUA_CONFIG: aqua/test.yaml
+          # `go_build` runs `go` from the extracted source directory. If `go` is an aqua proxy,
+          # it resolves AQUA_CONFIG from that directory, so the path must be absolute.
+          AQUA_CONFIG: ${{ github.workspace }}/aqua/test.yaml
           AQUA_GITHUB_TOKEN: ${{github.token}}
 
       - name: Install packages for testing
@@ -153,7 +155,7 @@ jobs:
         env:
           AQUA_GOOS: ${{ matrix.env.goos }}
           AQUA_GOARCH: ${{ matrix.env.goarch }}
-          AQUA_CONFIG: aqua/test.yaml
+          AQUA_CONFIG: ${{ github.workspace }}/aqua/test.yaml
           AQUA_GITHUB_TOKEN: ${{github.token}}
 
   test-alpine:


### PR DESCRIPTION
## Problem

`go_build` packages fail on the macOS test jobs. It broke #59673 and #59674, but the cause is in the workflow rather than in either package.

```
ERR aqua failed exe_name=go
  error="open a file: open /Users/runner/.local/share/aquaproj-aqua/pkgs/go_build/
  github.com/segmentio/topicctl/v2.0.2/src/topicctl-2.0.2/aqua/test.yaml: no such file or directory"
ERR check file_src is correct
  error="check file_src is correct: build Go tool: build a go package: exit status 1"
```

Three things line up to produce it:

1. On macOS the job installs Go through aqua (`aqua g -i golang/go`), so `go` on `PATH` is an aqua proxy. Linux runners use the preinstalled Go, which is why only macOS fails.
2. `go_build` runs `go` with the working directory set to the extracted source tree.
3. `AQUA_CONFIG` is the relative path `aqua/test.yaml`, so the proxy resolves it against that source tree instead of the workspace, and finds nothing.

This is the same shape as #57525, where an aqua proxy in the test job had to be worked around — there for `pwsh` on Windows.

## Change

Point `AQUA_CONFIG` at the workspace in the two "Install packages for testing" steps:

```diff
-          AQUA_CONFIG: aqua/test.yaml
+          AQUA_CONFIG: ${{ github.workspace }}/aqua/test.yaml
```

[`update.yaml`](.github/workflows/update.yaml) already does this — `AQUA_CONFIG: ${{ github.workspace }}/aqua/update.yaml` — so the pattern is established in this repository. The job-level default and the other jobs are left alone, since only these steps run installs that can change the working directory.

## Verification

Reproduced locally with `go` deliberately made an aqua proxy, installing `segmentio/topicctl@v2.0.2` through `go_build` and changing nothing but `AQUA_CONFIG`:

```console
$ AQUA_CONFIG=aqua/test.yaml aqua i
ERR aqua failed exe_name=go
  error="open a file: open .../src/topicctl-2.0.2/aqua/test.yaml: no such file or directory"
ERR check file_src is correct: build Go tool: build a go package: exit status 1

$ AQUA_CONFIG=/abs/path/aqua/test.yaml aqua i
built: .../pkgs/go_build/github.com/segmentio/topicctl/v2.0.2/bin/topicctl
```

Same registry, same package, same aqua — the relative path is the only difference.

```console
$ actionlint .github/workflows/wc-test.yaml   # with shellcheck on PATH
exit 0

$ npx prettier@3 --check .github/workflows/wc-test.yaml
All matched files use Prettier code style!
```

**Not verified:** the macOS jobs only exercise this once the change is on a branch CI actually runs, so the proof above is the local reproduction rather than a green macOS run of a `go_build` package. #59673 and #59674 should go green once this merges, and I'll confirm and report.

Existing `go_build` packages — `goccy/go-yaml/ycat`, `Checkmarx/kics`, `alpkeskin/mosint`, `kubernetes/cloud-provider-gcp/gke-gcloud-auth-plugin` — are affected the same way, but their last CI runs predate the current macOS images, so nothing has surfaced it until now.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
