### PR TITLE
fix(gurgeous/tennis): linux/arm64 and the checksum file are gone from v0.7.0

### DIFF
--- a/pkgs/gurgeous/tennis/pkg.yaml
+++ b/pkgs/gurgeous/tennis/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: gurgeous/tennis@v0.6.0
+  - name: gurgeous/tennis@v0.7.0
+  - name: gurgeous/tennis
+    version: v0.6.0

--- a/pkgs/gurgeous/tennis/registry.yaml
+++ b/pkgs/gurgeous/tennis/registry.yaml
@@ -8,7 +8,7 @@ packages:
       - csv
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -20,4 +20,13 @@ packages:
             src: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}/tennis
         supported_envs:
           - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: tennis
+            src: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}/tennis
+        supported_envs:
+          - linux/amd64
           - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -47803,7 +47803,7 @@ packages:
       - csv
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         checksum:
@@ -47815,6 +47815,15 @@ packages:
             src: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}/tennis
         supported_envs:
           - linux
+          - darwin/arm64
+      - version_constraint: "true"
+        asset: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: tennis
+            src: tennis_{{trimV .Version}}_{{.OS}}_{{.Arch}}/tennis
+        supported_envs:
+          - linux/amd64
           - darwin/arm64
   - type: github_release
     repo_owner: guumaster


### PR DESCRIPTION
## Problem

`gurgeous/tennis` has 2 stuck update PRs, #57161 (→ v0.7.0) and #57330 (→ v0.7.1). Both fail the same way:

```console
$ argd t gurgeous/tennis   # main's config, slot pinned to v0.7.0
error="the asset isn't found: tennis_0.7.0_linux_arm64.tar.gz"
```

| slot | `argd t` |
| --- | --- |
| v0.6.0 | exit 0 |
| v0.7.0 | exit 1 — `the asset isn't found: tennis_0.7.0_linux_arm64.tar.gz` |
| v0.7.1 | exit 1 — `the asset isn't found: tennis_0.7.1_linux_arm64.tar.gz` |

Two things changed at v0.7.0:

```console
$ gh release view v0.6.0 --repo gurgeous/tennis --json assets --jq '[.assets[].name]|join("\n")'
tennis_0.6.0_checksums.txt
tennis_0.6.0_darwin_amd64.tar.gz
tennis_0.6.0_darwin_arm64.tar.gz
tennis_0.6.0_linux_amd64.tar.gz
tennis_0.6.0_linux_arm64.tar.gz
tennis_0.6.0_windows_amd64.zip

$ gh release view v0.7.1 --repo gurgeous/tennis --json assets --jq '[.assets[].name]|join("\n")'
tennis_0.7.1_darwin_amd64.tar.gz
tennis_0.7.1_darwin_arm64.tar.gz
tennis_0.7.1_linux_amd64.tar.gz
tennis_0.7.1_windows_amd64.zip
```

Linux arm64 and the checksum file are both gone. This is deliberate rather than a broken release — upstream replaced GoReleaser with its own release workflow at v0.7.0, and its `RELEASE.md` lists exactly what a release is expected to carry:

```text
tennis_X.X.X_darwin_amd64.tar.gz
tennis_X.X.X_darwin_arm64.tar.gz
tennis_X.X.X_linux_amd64.tar.gz
tennis_X.X.X_windows_amd64.zip
```

No linux/arm64, and no checksums file. Both v0.7.0 and v0.7.1 match that list.

## Change

A new `version_constraint: "true"` branch for v0.7.0 onwards, with the previous branch renamed to `semver("< 0.7.0")` and otherwise untouched:

- `supported_envs` drops linux/arm64, becoming `[linux/amd64, darwin/arm64]`
- the `checksum` block is removed, since no checksum file is published any more

The asset template and `files[].src` are unchanged — the archive layout is the same.

`supported_envs` is otherwise left as it was. darwin/amd64 and windows/amd64 assets do exist, but they weren't covered before this PR either, so widening the platform list is a separate question I've deliberately kept out of here.

`pkg.yaml` pins one version per branch, with the updater slot in the branch this PR adds:

```yaml
packages:
  - name: gurgeous/tennis@v0.7.0
  - name: gurgeous/tennis
    version: v0.6.0
```

## Verification

`argd t gurgeous/tennis` — exit 0, six targets, no error lines.

Installing directly with checksums enabled, checked by `bin/` contents rather than the exit code:

| version | branch | target | result |
| --- | --- | --- | --- |
| v0.7.1, v0.7.0 | `"true"` | linux/amd64, darwin/arm64 | `bin/tennis` |
| v0.7.1 | `"true"` | linux/arm64, darwin/amd64 | skipped, `bin/` empty — not an error |
| v0.6.0 | `< 0.7.0` | linux/amd64, linux/arm64, darwin/arm64 | `bin/tennis` |

The linux/arm64 and darwin/amd64 rows matter because `aqua i` exits 0 for an unsupported platform without saying anything, so I checked that nothing was installed rather than trusting the exit code.

```console
$ conftest test --combine pkgs/gurgeous/tennis/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/gurgeous/tennis/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` regenerated with `argd gr`.

**Not verified:** the binaries were not executed on any platform — this change is about asset resolution and platform coverage.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
