### PR TITLE
fix(truffleruby/truffleruby/community-native): macOS Intel isn't supported from graal-34.0.0

### DIFF
--- a/pkgs/truffleruby/truffleruby/community-native/pkg.yaml
+++ b/pkgs/truffleruby/truffleruby/community-native/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: truffleruby/truffleruby/community-native@graal-25.0.0
+  - name: truffleruby/truffleruby/community-native@graal-34.0.1
+  - name: truffleruby/truffleruby/community-native
+    version: graal-33.0.1

--- a/pkgs/truffleruby/truffleruby/community-native/registry.yaml
+++ b/pkgs/truffleruby/truffleruby/community-native/registry.yaml
@@ -63,7 +63,7 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 23.0.1")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 34.0.0")
         asset: truffleruby-community-{{.SemVer}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -76,3 +76,16 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: truffleruby-community-{{.SemVer}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64

--- a/registry.yaml
+++ b/registry.yaml
@@ -97006,7 +97006,7 @@ packages:
     version_overrides:
       - version_constraint: semver("<= 23.0.1")
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 34.0.0")
         asset: truffleruby-community-{{.SemVer}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -97019,6 +97019,19 @@ packages:
         supported_envs:
           - linux
           - darwin
+      - version_constraint: "true"
+        asset: truffleruby-community-{{.SemVer}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          arm64: aarch64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin/arm64
   - name: truffleruby/truffleruby/oracle-native
     aliases:
       - name: oracle/truffleruby/oracle-native


### PR DESCRIPTION
## Problem

`truffleruby/truffleruby/community-native` has 4 stuck update PRs. Reproducing each by pinning the updater slot to its target version shows only half of them are real failures:

| slot | `argd t` |
| --- | --- |
| graal-25.0.0 (current pin) | exit 0 |
| graal-33.0.1 | exit 0 |
| graal-34.0.0 | exit 1 — `the asset isn't found: truffleruby-community-34.0.0-macos-amd64.tar.gz` |
| graal-34.0.1 | exit 1 — `the asset isn't found: truffleruby-community-34.0.1-macos-amd64.tar.gz` |

The two PRs targeting graal-33.x pass today — their red checks are stale, since [auto-rerun.yaml](.github/workflows/auto-rerun.yaml) only re-runs bot PRs created within the last 4 days.

macOS Intel was dropped at graal-34.0.0:

```console
$ gh release view graal-33.0.1 --repo truffleruby/truffleruby --json assets --jq '...'
truffleruby-community-33.0.1-linux-aarch64.tar.gz
truffleruby-community-33.0.1-linux-amd64.tar.gz
truffleruby-community-33.0.1-macos-aarch64.tar.gz
truffleruby-community-33.0.1-macos-amd64.tar.gz

$ gh release view graal-34.0.1 --repo truffleruby/truffleruby --json assets --jq '...'
truffleruby-community-34.0.1-linux-aarch64.tar.gz
truffleruby-community-34.0.1-linux-amd64.tar.gz
truffleruby-community-34.0.1-macos-aarch64.tar.gz
```

Upstream states it in the graal-34.0.0 release notes, so this is deliberate and permanent rather than a broken release:

> Remove support for `darwin-amd64` (aka `x86_64-darwin`, macOS Intel) since both Apple and GraalVM no longer support it (#4011, @eregon).

Older releases keep their macOS Intel assets — nothing was removed retroactively.

## Change

A new `version_constraint: "true"` branch for graal-34.0.0 onwards with `supported_envs` narrowed to `[linux, darwin/arm64]`. The previous branch is renamed to `semver("< 34.0.0")` and is otherwise unchanged, so every release that still ships a macOS Intel build keeps it.

`pkg.yaml` pins one version per branch, with the updater slot in the branch this PR adds:

```yaml
packages:
  - name: truffleruby/truffleruby/community-native@graal-34.0.1
  - name: truffleruby/truffleruby/community-native
    version: graal-33.0.1
```

## Verification

`argd t truffleruby/truffleruby/community-native` — exit 0, six targets, no error lines.

Installing directly with checksums enabled, counting the commands actually linked into `bin/` rather than trusting the exit code, because `aqua i` exits 0 silently on an unsupported platform:

| version | branch | target | commands in `bin/` |
| --- | --- | --- | --- |
| graal-34.0.1 | `"true"` | linux, darwin/arm64 | 15 |
| graal-34.0.1 | `"true"` | darwin/amd64 | 0 — skipped, not an error |
| graal-33.0.1 | `< 34.0.0` | darwin/amd64 | 15 |
| graal-25.0.0 | `< 34.0.0` | darwin/amd64 | 15 |

```console
$ conftest test --combine pkgs/truffleruby/truffleruby/community-native/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/truffleruby/truffleruby/community-native/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` regenerated with `argd gr`.

**Not verified:** the binaries were not executed on any platform — this change is about asset resolution and platform coverage.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
