### PR TITLE
fix(wasmerio/wasmer): macOS Intel isn't supported from v7.2.0-alpha.2

### DIFF
--- a/pkgs/wasmerio/wasmer/pkg.yaml
+++ b/pkgs/wasmerio/wasmer/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: wasmerio/wasmer@v7.1.0
+  - name: wasmerio/wasmer@v7.3.0
+  - name: wasmerio/wasmer
+    version: v7.1.0
   - name: wasmerio/wasmer
     version: 2.2.1
   - name: wasmerio/wasmer

--- a/pkgs/wasmerio/wasmer/registry.yaml
+++ b/pkgs/wasmerio/wasmer/registry.yaml
@@ -26,8 +26,15 @@ packages:
         src: bin/wasmer
       - name: wasmer-headless
         src: bin/wasmer-headless
-    version_constraint: semver(">= 3.0.0-beta")
+    version_constraint: "false"
     version_overrides:
+      # https://github.com/wasmerio/wasmer/pull/6506 dropped the x86_64-darwin target.
+      - version_constraint: semver(">= 7.2.0-alpha.2")
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64
+      - version_constraint: semver(">= 3.0.0-beta")
       - version_constraint: semver(">= 3.0.0-alpha")
         overrides:
           - goos: linux
@@ -56,11 +63,11 @@ packages:
           - goos: windows
             files:
               - name: wapm
-                src: bin/wapm.exe
+                src: bin/wapm
               - name: wasmer-headless
-                src: bin/wasmer-headless.exe
+                src: bin/wasmer-headless
               - name: wasmer
-                src: bin/wasmer.exe
+                src: bin/wasmer
       - version_constraint: semver(">= 2.0.0-rc1")
         replacements: {}
         supported_envs:

--- a/pkgs/wasmerio/wasmer/registry.yaml
+++ b/pkgs/wasmerio/wasmer/registry.yaml
@@ -96,7 +96,7 @@ packages:
         replacements: {}
         rosetta2: true
       - version_constraint: semver(">= 0.16.0")
-        files: &wasmerio_wasmer_files_1
+        files:
           - name: wapm
             src: bin/wapm
           - name: wasmer
@@ -107,7 +107,11 @@ packages:
           - darwin
           - linux/amd64
       - version_constraint: semver(">= 0.14.0")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             asset: wasmer-c-api-{{.OS}}.{{.Format}}
@@ -117,7 +121,11 @@ packages:
           - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 0.10.2")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             format: raw
@@ -125,7 +133,11 @@ packages:
         replacements: {}
         rosetta2: true
       - version_constraint: semver(">= 0.10.0")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -101433,8 +101433,15 @@ packages:
         src: bin/wasmer
       - name: wasmer-headless
         src: bin/wasmer-headless
-    version_constraint: semver(">= 3.0.0-beta")
+    version_constraint: "false"
     version_overrides:
+      # https://github.com/wasmerio/wasmer/pull/6506 dropped the x86_64-darwin target.
+      - version_constraint: semver(">= 7.2.0-alpha.2")
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64
+      - version_constraint: semver(">= 3.0.0-beta")
       - version_constraint: semver(">= 3.0.0-alpha")
         overrides:
           - goos: linux
@@ -101463,11 +101470,11 @@ packages:
           - goos: windows
             files:
               - name: wapm
-                src: bin/wapm.exe
+                src: bin/wapm
               - name: wasmer-headless
-                src: bin/wasmer-headless.exe
+                src: bin/wasmer-headless
               - name: wasmer
-                src: bin/wasmer.exe
+                src: bin/wasmer
       - version_constraint: semver(">= 2.0.0-rc1")
         replacements: {}
         supported_envs:

--- a/registry.yaml
+++ b/registry.yaml
@@ -101503,7 +101503,7 @@ packages:
         replacements: {}
         rosetta2: true
       - version_constraint: semver(">= 0.16.0")
-        files: &wasmerio_wasmer_files_1
+        files:
           - name: wapm
             src: bin/wapm
           - name: wasmer
@@ -101514,7 +101514,11 @@ packages:
           - darwin
           - linux/amd64
       - version_constraint: semver(">= 0.14.0")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             asset: wasmer-c-api-{{.OS}}.{{.Format}}
@@ -101524,7 +101528,11 @@ packages:
           - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 0.10.2")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             format: raw
@@ -101532,7 +101540,11 @@ packages:
         replacements: {}
         rosetta2: true
       - version_constraint: semver(">= 0.10.0")
-        files: *wasmerio_wasmer_files_1
+        files:
+          - name: wapm
+            src: bin/wapm
+          - name: wasmer
+            src: bin/wasmer
         overrides:
           - goos: windows
             format: raw


### PR DESCRIPTION
## Problem

`wasmerio/wasmer` has 3 stuck update PRs — #56244 (→ v7.2.0), #57519 (→ v7.2.1) and #59223 (→ v7.3.0). Reproducing each by pinning the updater slot:

| slot | `argd t` |
| --- | --- |
| v7.1.0 (current pin) | exit 0 |
| v7.2.0 | exit 1 — `the asset isn't found: wasmer-darwin-amd64.tar.gz` |
| v7.3.0 | exit 1 — `the asset isn't found: wasmer-darwin-amd64.tar.gz` |

macOS Intel disappeared at v7.2.0-alpha.2:

```console
v7.1.0          wasmer-darwin-amd64.tar.gz wasmer-darwin-arm64.tar.gz
v7.2.0-alpha.1  wasmer-darwin-amd64.tar.gz wasmer-darwin-arm64.tar.gz
v7.2.0-alpha.2  wasmer-darwin-arm64.tar.gz
v7.2.0          wasmer-darwin-arm64.tar.gz
v7.3.0          wasmer-darwin-arm64.tar.gz
```

Upstream says so in the v7.2.0 release notes, so it's deliberate and permanent:

> Dropped x86_64-darwin target (#6506) - Apple Silicon-only on macOS going forward.

Older releases keep their macOS Intel assets — nothing was removed retroactively.

## Change

A new first `version_override` for v7.2.0-alpha.2 onwards, narrowing `supported_envs`:

```yaml
      # https://github.com/wasmerio/wasmer/pull/6506 dropped the x86_64-darwin target.
      - version_constraint: semver(">= 7.2.0-alpha.2")
        supported_envs:
          - darwin/arm64
          - linux
          - windows/amd64
```

`darwin/arm64` and `windows/amd64` are written out rather than reusing the previous bare `amd64`, since `amd64` on its own also matches darwin/amd64 — the platform being dropped.

The old base range moves into its own branch so nothing else changes for it:

```diff
-    version_constraint: semver(">= 3.0.0-beta")
+    version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 7.2.0-alpha.2")
+        ...
+      - version_constraint: semver(">= 3.0.0-beta")
       - version_constraint: semver(">= 3.0.0-alpha")
```

### Two Conftest failures fixed along the way

`main` fails lint on this file today, and since lint runs on the files a PR touches, both had to be dealt with here:

```console
$ conftest test --combine pkgs/wasmerio/wasmer/registry.yaml   # on main
FAIL - pkgs/wasmerio/wasmer/registry.yaml: .files[].src must not end with .exe. Remove .exe from src
FAIL - pkgs/wasmerio/wasmer/registry.yaml: the top level version_constraint must be either empty or "false"
14 tests, 12 passed, 0 warnings, 2 failures, 0 exceptions
```

The first is the `>= 2.2.1` branch's Windows override spelling out `bin/wapm.exe` and friends; aqua completes `.exe` on Windows by itself, per [complete_windows_ext](https://aquaproj.github.io/docs/reference/registry-config/complete-windows-ext), so the suffixes are removed. The second is the `version_constraint: "false"` change above.

## Verification

`argd t wasmerio/wasmer` — exit 0, six targets, no error lines, and all 15 pinned versions install.

Installing across the boundary directly, checked by `bin/` contents rather than the exit code, because `aqua i` exits 0 silently on an unsupported platform:

| version | branch | target | `bin/` |
| --- | --- | --- | --- |
| v7.3.0 | `>= 7.2.0-alpha.2` | linux/amd64, darwin/arm64, windows/amd64 | `wasmer`, `wasmer-headless` |
| v7.3.0 | `>= 7.2.0-alpha.2` | linux/arm64 | `wasmer` |
| v7.3.0, v7.2.0 | `>= 7.2.0-alpha.2` | darwin/amd64 | empty — skipped, not an error |
| v7.2.0-alpha.1, v7.1.0 | `>= 3.0.0-beta` | darwin/amd64 | `wasmer`, `wasmer-headless` |
| 2.2.1 | `>= 2.2.1` | darwin/amd64 | `wapm`, `wasmer-headless`, `wax` |

```console
$ conftest test --combine pkgs/wasmerio/wasmer/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/wasmerio/wasmer/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` regenerated with `argd gr`.

**Not verified:** the binaries were not executed on any platform — this change is about asset resolution and platform coverage.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
