### PR TITLE
fix(qarmin/czkawka): macOS Intel isn't built from 12.0.0

### DIFF
--- a/pkgs/qarmin/czkawka/pkg.yaml
+++ b/pkgs/qarmin/czkawka/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: qarmin/czkawka@11.0.1
+  - name: qarmin/czkawka@12.0.1
+  - name: qarmin/czkawka
+    version: 11.0.1
   - name: qarmin/czkawka
     version: 9.0.0
   - name: qarmin/czkawka

--- a/pkgs/qarmin/czkawka/registry.yaml
+++ b/pkgs/qarmin/czkawka/registry.yaml
@@ -61,6 +61,17 @@ packages:
               - darwin/arm64
               - linux/arm64
             asset: "{{.OS}}_czkawka_cli_arm"
+      - version_constraint: semver("<= 11.0.1")
+        asset: "{{.OS}}_czkawka_cli_{{.Arch}}"
+        format: raw
+        overrides:
+          - goos: windows
+            asset: "{{.OS}}_czkawka_cli"
+        replacements:
+          amd64: x86_64
+          darwin: mac
+      # https://github.com/qarmin/czkawka/blob/12.0.0/.github/workflows/mac.yml stopped
+      # building on the macos-15-intel runner, so macOS Intel binaries aren't released.
       - version_constraint: "true"
         asset: "{{.OS}}_czkawka_cli_{{.Arch}}"
         format: raw
@@ -70,3 +81,7 @@ packages:
         replacements:
           amd64: x86_64
           darwin: mac
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -78854,6 +78854,17 @@ packages:
               - darwin/arm64
               - linux/arm64
             asset: "{{.OS}}_czkawka_cli_arm"
+      - version_constraint: semver("<= 11.0.1")
+        asset: "{{.OS}}_czkawka_cli_{{.Arch}}"
+        format: raw
+        overrides:
+          - goos: windows
+            asset: "{{.OS}}_czkawka_cli"
+        replacements:
+          amd64: x86_64
+          darwin: mac
+      # https://github.com/qarmin/czkawka/blob/12.0.0/.github/workflows/mac.yml stopped
+      # building on the macos-15-intel runner, so macOS Intel binaries aren't released.
       - version_constraint: "true"
         asset: "{{.OS}}_czkawka_cli_{{.Arch}}"
         format: raw
@@ -78863,6 +78874,10 @@ packages:
         replacements:
           amd64: x86_64
           darwin: mac
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64
   - type: github_release
     repo_owner: qdrant
     repo_name: qdrant


### PR DESCRIPTION
## Problem

`qarmin/czkawka` has 2 stuck update PRs, #56163 (→ 12.0.0) and #57908 (→ 12.0.1). Reproducing each by pinning the updater slot:

| slot | `argd t` |
| --- | --- |
| 11.0.1 (current pin) | exit 0 |
| 12.0.0 | exit 1 — `the asset isn't found: mac_czkawka_cli_x86_64` |
| 12.0.1 | exit 1 — `the asset isn't found: mac_czkawka_cli_x86_64` |

The macOS Intel build disappeared at 12.0.0, while everything else stayed:

```console
11.0.1                          12.0.1
linux_czkawka_cli_arm64         linux_czkawka_cli_arm64
linux_czkawka_cli_musl          linux_czkawka_cli_musl
linux_czkawka_cli_x86_64        linux_czkawka_cli_x86_64
mac_czkawka_cli_arm64           mac_czkawka_cli_arm64
mac_czkawka_cli_x86_64          (gone)
windows_czkawka_cli.exe         windows_czkawka_cli.exe
```

The release notes don't mention it, but upstream's own release workflow does — the Intel runner was dropped from the build matrix:

```console
$ curl .../11.0.1/.github/workflows/mac.yml | grep -A2 'matrix:'
        matrix:
          os: [macos-latest, macos-15-intel]

$ curl .../12.0.0/.github/workflows/mac.yml | grep -A2 'matrix:'
        matrix:
          os: [macos-latest]
```

The step that names the artifact is unchanged and still derives the arch from `runner.arch`, so no Intel runner means no `_x86_64` asset. Older releases keep theirs — nothing was removed retroactively.

## Change

A new `version_constraint: "true"` branch for 12.0.0 onwards with `supported_envs` narrowed, and the previous branch renamed to `semver("<= 11.0.1")` and otherwise untouched:

```yaml
      # https://github.com/qarmin/czkawka/blob/12.0.0/.github/workflows/mac.yml stopped
      # building on the macos-15-intel runner, so macOS Intel binaries aren't released.
      - version_constraint: "true"
        ...
        supported_envs:
          - darwin/arm64
          - linux
          - windows/amd64
```

`darwin/arm64` and `windows/amd64` are spelled out rather than using a bare `amd64`, since `amd64` on its own also matches darwin/amd64 — the platform being dropped.

`pkg.yaml` pins one version per branch, with the updater slot in the branch this PR adds:

```yaml
packages:
  - name: qarmin/czkawka@12.0.1
  - name: qarmin/czkawka
    version: 11.0.1
```

## Verification

`argd t qarmin/czkawka` — exit 0, six targets, no error lines.

Installing across the boundary directly, checked by `bin/` contents rather than the exit code, because `aqua i` exits 0 silently on an unsupported platform:

| version | branch | target | `bin/` |
| --- | --- | --- | --- |
| 12.0.1 | `"true"` | linux/amd64, linux/arm64, darwin/arm64, windows/amd64 | `czkawka` |
| 12.0.1, 12.0.0 | `"true"` | darwin/amd64 | empty — skipped, not an error |
| 11.0.1 | `<= 11.0.1` | darwin/amd64, linux/amd64 | `czkawka` |
| 9.0.0 | `<= 9.0.0` | darwin/amd64 | `czkawka` |

```console
$ conftest test --combine pkgs/qarmin/czkawka/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/qarmin/czkawka/*.yaml
All matched files use Prettier code style!
```

`registry.yaml` regenerated with `argd gr`, and `argd fix` runs clean on this file.

**Not verified:** the binaries were not executed on any platform — this change is about asset resolution and platform coverage.

## AI disclosure

Written with Claude Code; disclosed as a commit co-author per [docs/ai.md](docs/ai.md). I reviewed and own the change.
