### PR TITLE
fix(squat/kilo): Windows assets gained a .exe suffix in 0.7.0

### DIFF
--- a/pkgs/squat/kilo/pkg.yaml
+++ b/pkgs/squat/kilo/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: squat/kilo@0.6.0
+  - name: squat/kilo@0.7.0
+  - name: squat/kilo
+    version: 0.6.0
   - name: squat/kilo
     version: 0.2.0

--- a/pkgs/squat/kilo/registry.yaml
+++ b/pkgs/squat/kilo/registry.yaml
@@ -14,8 +14,12 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: kgctl-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: kgctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -88338,11 +88338,15 @@ packages:
         rosetta2: true
         windows_arm_emulation: true
         complete_windows_ext: false
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: kgctl-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: kgctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - name: sr.ht/~charles/rq
     type: http
     description: |


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`squat/kilo` can't be installed on Windows from 0.7.0. #49708 has been failing on `windows-latest` and `windows-latest, arm64` since 2026-03.

Upstream renamed only the Windows asset:

```console
$ gh release view 0.6.0 --repo squat/kilo --json assets -q '.assets[].name'
kgctl-darwin-amd64
kgctl-darwin-arm64
kgctl-linux-amd64
kgctl-linux-arm
kgctl-linux-arm64
kgctl-windows-amd64

$ gh release view 0.7.0 --repo squat/kilo --json assets -q '.assets[].name'
kgctl-darwin-amd64
kgctl-darwin-arm64
kgctl-linux-amd64
kgctl-linux-arm
kgctl-linux-arm64
kgctl-windows-amd64.exe
```

macOS and Linux are unchanged, and 0.6.0's assets are still in place, so this is a change from 0.7.0 onwards rather than a retroactive one.

The package sets `complete_windows_ext: false`, which was right up to 0.6.0. With that, aqua keeps looking for the old name:

```console
0.6.0   windows/amd64  OK
0.6.0   windows/arm64  OK
0.7.0   windows/amd64  FAIL: error="the asset isn't found: kgctl-windows-amd64"
0.7.0   windows/arm64  FAIL: error="the asset isn't found: kgctl-windows-amd64"
```

`windows/arm64` fails for the same reason: there is no Windows ARM64 asset in either release, so `windows_arm_emulation` resolves it to the amd64 asset.

## Change

`format` is `raw`, so dropping `complete_windows_ext: false` lets aqua complete the suffix. The old setting moves to a bounded branch so versions below 0.7.0 keep resolving the old name.

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.7.0")
         asset: kgctl-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
         complete_windows_ext: false
+      - version_constraint: "true"
+        asset: kgctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
```

`pkg.yaml` pins 0.7.0 for the new branch and keeps 0.6.0 for the bounded one; 0.2.0 stays for the `Version == "0.2.0"` branch.

## Verification

aqua v2.62.3, macOS 26.6.2, local registry, `AQUA_GOOS`/`AQUA_GOARCH` per row. Installed with `aqua i`, then resolved with `aqua which` and checked that the resolved file exists — `aqua i` alone exits 0 without resolving the binary, so it does not prove much on its own.

```console
0.7.0   darwin/amd64   OK   asset=kgctl-darwin-amd64
0.7.0   darwin/arm64   OK   asset=kgctl-darwin-arm64
0.7.0   linux/amd64    OK   asset=kgctl-linux-amd64
0.7.0   linux/arm64    OK   asset=kgctl-linux-arm64
0.7.0   windows/amd64  OK   asset=kgctl-windows-amd64.exe
0.7.0   windows/arm64  OK   asset=kgctl-windows-amd64.exe
0.6.0   darwin/amd64   OK   asset=kgctl-darwin-amd64
0.6.0   darwin/arm64   OK   asset=kgctl-darwin-arm64
0.6.0   linux/amd64    OK   asset=kgctl-linux-amd64
0.6.0   linux/arm64    OK   asset=kgctl-linux-arm64
0.6.0   windows/amd64  OK   asset=kgctl-windows-amd64
0.6.0   windows/arm64  OK   asset=kgctl-windows-amd64
0.2.0   darwin/amd64   OK   asset=kgctl-darwin-amd64
0.2.0   darwin/arm64   OK   asset=kgctl-darwin-amd64
0.2.0   linux/amd64    OK   asset=kgctl-linux-amd64
0.2.0   linux/arm64    OK   asset=kgctl-linux-arm64
0.2.0   windows/amd64  OK   asset=kgctl-windows-amd64
0.2.0   windows/arm64  OK   asset=kgctl-windows-amd64
```

Each branch resolves the asset name it should, and 0.2.0's `rosetta2` behaviour is unchanged (darwin/arm64 → the amd64 asset).

```console
$ conftest test --combine pkgs/squat/kilo/registry.yaml pkgs/squat/kilo/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/squat/kilo/registry.yaml pkgs/squat/kilo/pkg.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. I could not run `argd t` — it requires Docker, which isn't running on this machine — so the matrix above is what I have instead; it covers more environments than CI does.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
