### PR TITLE
fix(go-simpler/sloglint): the Windows archive is tar.gz from v0.12.0

### DIFF
--- a/pkgs/go-simpler/sloglint/pkg.yaml
+++ b/pkgs/go-simpler/sloglint/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: go-simpler/sloglint@v0.11.1
+  - name: go-simpler/sloglint@v0.12.0
+  - name: go-simpler/sloglint
+    version: v0.11.1

--- a/pkgs/go-simpler/sloglint/registry.yaml
+++ b/pkgs/go-simpler/sloglint/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Ensure consistent code style when using log/slog
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.12.0")
         asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -21,3 +21,15 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sloglint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -43338,7 +43338,7 @@ packages:
     description: Ensure consistent code style when using log/slog
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.12.0")
         asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -43353,6 +43353,18 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: sloglint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: sloglint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
+          - windows
   - type: github_release
     repo_owner: go-swagger
     repo_name: go-swagger


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`go-simpler/sloglint` can't be installed on Windows from v0.12.0. #52320 has been failing on `windows-latest` and `windows-latest, arm64` since 2026-04.

Upstream changed the Windows archive format and added several targets:

```console
$ gh release view v0.11.1 --repo go-simpler/sloglint --json assets -q '.assets[].name'
sloglint_0.11.1_checksums.txt
sloglint_0.11.1_darwin_amd64.tar.gz
sloglint_0.11.1_darwin_arm64.tar.gz
sloglint_0.11.1_linux_amd64.tar.gz
sloglint_0.11.1_windows_amd64.zip

$ gh release view v0.12.0 --repo go-simpler/sloglint --json assets -q '.assets[].name'
sloglint_0.12.0_checksums.txt
sloglint_0.12.0_darwin_amd64.tar.gz
sloglint_0.12.0_darwin_arm64.tar.gz
sloglint_0.12.0_linux_386.tar.gz
sloglint_0.12.0_linux_amd64.tar.gz
sloglint_0.12.0_linux_arm64.tar.gz
sloglint_0.12.0_linux_armv6.tar.gz
sloglint_0.12.0_windows_386.tar.gz
sloglint_0.12.0_windows_amd64.tar.gz
```

The package overrides `format` to `zip` on Windows, which was right up to v0.11.1. With that, aqua keeps looking for an asset that no longer exists:

```console
v0.11.1   windows/amd64  OK
v0.11.1   windows/arm64  OK
v0.12.0   windows/amd64  FAIL: error="the asset isn't found: sloglint_0.12.0_windows_amd64.zip"
v0.12.0   windows/arm64  FAIL: error="the asset isn't found: sloglint_0.12.0_windows_amd64.zip"
```

`windows/arm64` fails for the same reason: there is no Windows ARM64 asset, so `windows_arm_emulation` resolves it to the amd64 one.

## Change

The `overrides` block moves to a bounded branch so versions below v0.12.0 keep resolving the zip, and the latest branch drops it.

I also widened `supported_envs` from `amd64` to `linux` on the new branch, because v0.12.0 started publishing `linux_arm64`. **Say the word and I'll drop that part** — it is a support addition rather than a fix, so it does not have to ride along with this. The other new targets (`linux_386`, `linux_armv6`, `windows_386`) are 32-bit and out of scope per [docs/support_policy.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/support_policy.md).

`pkg.yaml` pins v0.12.0 for the new branch and keeps v0.11.1 for the bounded one.

## Verification

aqua v2.62.3, macOS 26.6.2, local registry, `AQUA_GOOS`/`AQUA_GOARCH` per row. Installed with `aqua i`, then resolved with `aqua which` and checked that the resolved file exists — `aqua i` alone exits 0 without resolving the binary.

```console
v0.12.0   darwin/amd64   OK   asset=sloglint_0.12.0_darwin_amd64.tar.gz
v0.12.0   darwin/arm64   OK   asset=sloglint_0.12.0_darwin_arm64.tar.gz
v0.12.0   linux/amd64    OK   asset=sloglint_0.12.0_linux_amd64.tar.gz
v0.12.0   linux/arm64    OK   asset=sloglint_0.12.0_linux_arm64.tar.gz
v0.12.0   windows/amd64  OK   asset=sloglint_0.12.0_windows_amd64.tar.gz
v0.12.0   windows/arm64  OK   asset=sloglint_0.12.0_windows_amd64.tar.gz
v0.11.1   darwin/amd64   OK   asset=sloglint_0.11.1_darwin_amd64.tar.gz
v0.11.1   darwin/arm64   OK   asset=sloglint_0.11.1_darwin_arm64.tar.gz
v0.11.1   linux/amd64    OK   asset=sloglint_0.11.1_linux_amd64.tar.gz
v0.11.1   linux/arm64    skipped, outside supported_envs — unchanged
v0.11.1   windows/amd64  OK   asset=sloglint_0.11.1_windows_amd64.zip
v0.11.1   windows/arm64  OK   asset=sloglint_0.11.1_windows_amd64.zip
```

Each branch resolves the archive it should, and v0.11.1 is untouched.

```console
$ conftest test --combine pkgs/go-simpler/sloglint/registry.yaml pkgs/go-simpler/sloglint/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/go-simpler/sloglint/registry.yaml pkgs/go-simpler/sloglint/pkg.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. I could not run `argd t` — it needs Docker, which isn't running on this machine — so the matrix above stands in for it; it covers more environments than CI does.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
