### PR TITLE
fix(eza-community/eza): install the crate with --locked

### DIFF
--- a/pkgs/eza-community/eza/pkg.yaml
+++ b/pkgs/eza-community/eza/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: eza-community/eza@v0.23.4
+  - name: eza-community/eza@v0.23.5
+  - name: eza-community/eza
+    version: v0.23.4
   - name: eza-community/eza
     version: v0.14.1
   - name: eza-community/eza

--- a/pkgs/eza-community/eza/registry.yaml
+++ b/pkgs/eza-community/eza/registry.yaml
@@ -57,6 +57,8 @@ packages:
               - windows/arm64
             type: cargo
             crate: eza
+            cargo:
+              locked: true
           - goos: linux
             goarch: amd64
             replacements:

--- a/registry.yaml
+++ b/registry.yaml
@@ -37971,6 +37971,8 @@ packages:
               - windows/arm64
             type: cargo
             crate: eza
+            cargo:
+              locked: true
           - goos: linux
             goarch: amd64
             replacements:


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

On darwin and windows/arm64 this package builds from crates.io rather than downloading a binary, and v0.23.5 cannot be built there. #56708 has been failing on `macos-26`, `macos-26-intel` and `windows-latest, arm64` since 2026-07 — exactly the three environments that take the cargo path.

```console
error[E0433]: cannot find `lms` in `crate`
  --> palette-0.7.5/src/hsl.rs:46:28
   |
46 | #[derive(Debug, ArrayCast, FromColorUnclamped, WithAlpha)]
   |                            ^^^^^^^^^^^^^^^^^^ could not find `lms` in the crate root
   |
   = note: this error originates in the derive macro `FromColorUnclamped`

error: failed to compile `eza v0.23.5`
```

eza's `Cargo.toml` pins `palette = "=0.7.5"` on purpose, but palette 0.7.5 depends on `palette_derive` with a caret requirement, so pinning `palette` does not hold the derive crate back. A fresh resolution picks `palette_derive` 0.7.7, whose macros expand to `crate::lms` and `xyz::meta` — paths that don't exist in the 0.7.5 library.

Reproduced against the currently pinned version as a control, on the same machine and toolchain:

```console
$ cargo install --version 0.23.4 eza
   Installed package `eza v0.23.4` (executable `eza`)

$ cargo install --version 0.23.5 eza
error: failed to compile `eza v0.23.5`
```

The published crate ships a `Cargo.lock` that holds `palette_derive` at 0.7.6, which does compile against 0.7.5:

```console
$ cargo install --version 0.23.5 --locked eza
  Downloaded palette_derive v0.7.6
   Compiling palette v0.7.5
   Compiling palette_derive v0.7.6
   Installed package `eza v0.23.5` (executable `eza`)
```

Upstream tracks this as [eza-community/eza#1912](https://github.com/eza-community/eza/issues/1912), with a fix proposed in [eza-community/eza#1910](https://github.com/eza-community/eza/pull/1910). Neither has merged, and v0.23.5 is still the latest release.

## Change

Add [`cargo.locked`](https://aquaproj.github.io/docs/reference/registry-config/cargo-package) to the cargo override on the latest branch:

```diff
         overrides:
           - envs:
               - darwin
               - windows/arm64
             type: cargo
             crate: eza
+            cargo:
+              locked: true
```

The `Version == "v0.11.0"` and `Version == "v0.11.1"` branches have their own cargo overrides and still build, so I left them alone.

This is worth keeping even after upstream lands #1910 — building a crate against its published lockfile is the reproducible behaviour, and it insulates the package from the next transitive-dependency drift.

## Verification

aqua v2.62.3, macOS 26.6.2 (darwin/arm64), Rust 1.97.1, local registry. Cargo-path versions were installed natively and the resulting binary was executed:

```console
v0.23.5   darwin/arm64 (cargo)  OK   eza - A modern, maintained replacement for ls
v0.23.4   darwin/arm64 (cargo)  OK   eza - A modern, maintained replacement for ls
v0.14.1   darwin/arm64 (cargo)  OK   eza - A modern, maintained replacement for ls
v0.14.0   darwin/arm64 (cargo)  OK   eza - A modern, maintained replacement for ls
```

v0.23.4, v0.14.1 and v0.14.0 are the existing `pkg.yaml` pins that fall under the same branch, so `locked: true` causes no regression for them.

The binary-download platforms are outside the cargo override and are unchanged:

```console
v0.23.5   linux/amd64    OK   asset=eza_x86_64-unknown-linux-musl.tar.gz
v0.23.5   linux/arm64    OK   asset=eza_aarch64-unknown-linux-gnu.tar.gz
v0.23.5   windows/amd64  OK   asset=eza.exe_x86_64-pc-windows-gnu.tar.gz
v0.23.4   linux/amd64    OK   asset=eza_x86_64-unknown-linux-musl.tar.gz
v0.23.4   linux/arm64    OK   asset=eza_aarch64-unknown-linux-gnu.tar.gz
v0.23.4   windows/amd64  OK   asset=eza.exe_x86_64-pc-windows-gnu.tar.gz
```

**I could not verify windows/arm64 locally** — cross-building the crate for Windows from macOS isn't something I can reproduce. The `windows-latest, arm64` CI job does run `cargo install --locked` on Windows, so it covers whether the flag and the lockfile resolve there; note that the runner is x64 with `AQUA_GOARCH=arm64`, so it does not prove the produced binary is ARM64 — that is a pre-existing property of the matrix, not something this change affects.

`pkg.yaml` pins v0.23.5 so the fix is exercised, and keeps v0.23.4 alongside it.

```console
$ conftest test --combine pkgs/eza-community/eza/registry.yaml pkgs/eza-community/eza/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/eza-community/eza/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `argd t` needs Docker, which isn't running on this machine.

## Note

While looking into this I noticed `pkgs/crates.io/**` is excluded from the test matrix in [`wc-test.yaml`](https://github.com/aquaproj/aqua-registry/blob/main/.github/workflows/wc-test.yaml):

```sh
grep -E "^pkgs/.*\.yaml" < "$CI_INFO_TEMP_DIR/pr_files.txt" | grep -v -E "^pkgs/crates\.io/" > "$pkgs" || :
```

so #57310 merged `crates.io/eza@0.23.5` with `test / test / test` skipped — that pin currently cannot be built either. I assume the exclusion is deliberate given how slow cargo builds are, so I've left it alone; happy to open a separate issue if it's worth tracking.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
