### PR TITLE
fix(arxanas/git-branchless): macOS is aarch64-only from v0.11.0

### DIFF
--- a/pkgs/arxanas/git-branchless/pkg.yaml
+++ b/pkgs/arxanas/git-branchless/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: arxanas/git-branchless@v0.10.0
+  - name: arxanas/git-branchless@v0.11.1
+  - name: arxanas/git-branchless
+    version: v0.10.0
   - name: arxanas/git-branchless
     version: v0.9.0
   - name: arxanas/git-branchless

--- a/pkgs/arxanas/git-branchless/registry.yaml
+++ b/pkgs/arxanas/git-branchless/registry.yaml
@@ -22,7 +22,7 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.11.0")
         asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
@@ -39,3 +39,20 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -16387,7 +16387,7 @@ packages:
         supported_envs:
           - linux/amd64
           - windows
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.11.0")
         asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
@@ -16404,6 +16404,23 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows
   - type: github_release
     repo_owner: asciidoctor
     repo_name: asciidoctor-reveal.js


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`arxanas/git-branchless` can't be installed on macOS from v0.11.0. #54213 has been failing since 2026-05.

Upstream started publishing macOS binaries in v0.11.0, and only for Apple Silicon:

```console
$ gh release view v0.10.0 --repo arxanas/git-branchless --json assets -q '.assets[].name'
git-branchless-v0.10.0-x86_64-pc-windows-msvc.zip
git-branchless-v0.10.0-x86_64-unknown-linux-musl.tar.gz

$ gh release view v0.11.1 --repo arxanas/git-branchless --json assets -q '.assets[].name'
git-branchless-v0.11.1-aarch64-apple-darwin.tar.gz
git-branchless-v0.11.1-aarch64-unknown-linux-musl.tar.gz
git-branchless-v0.11.1-x86_64-pc-windows-msvc.zip
git-branchless-v0.11.1-x86_64-unknown-linux-musl.tar.gz
```

There is no `x86_64-apple-darwin` in any release. The latest branch sets `rosetta2: true`, so aqua resolves darwin to the x86_64 asset on both architectures — and it doesn't exist:

```console
v0.11.1  darwin/amd64   FAIL: error="the asset isn't found: git-branchless-v0.11.1-x86_64-apple-darwin.tar.gz"
v0.11.1  darwin/arm64   FAIL: error="the asset isn't found: git-branchless-v0.11.1-x86_64-apple-darwin.tar.gz"
v0.11.1  linux/amd64    OK
v0.11.1  windows/amd64  OK
v0.11.1  windows/arm64  OK
```

so the native `aarch64-apple-darwin` asset is never used. In CI only `macos-15-intel` shows as failed; `macos-14` was cancelled by the workflow's `cancel-in-progress` concurrency before it could report, but it fails for the same reason.

## Change

`rosetta2` moves to a bounded branch, and the latest branch resolves the native aarch64 asset:

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.11.0")
         asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         rosetta2: true
         ...
+      - version_constraint: "true"
+        asset: git-branchless-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows
```

macOS Intel is dropped on that branch because upstream ships no asset for it — that part is the fix, not a policy choice.

v0.11.0 also added `aarch64-unknown-linux-musl`, so `supported_envs` gains the whole of `linux` rather than `amd64` only. **That part is a support addition rather than a fix — say the word and I'll drop it.**

The `Version == "v0.10.0"` branch is untouched.

## Verification

aqua v2.62.3, macOS 26.6.2, local registry, `AQUA_GOOS`/`AQUA_GOARCH` per row. Installed with `aqua i`, then resolved with `aqua which` and checked the resolved file exists. Six versions across all six environments — 36 combinations, no failures:

```console
v0.11.1  darwin/amd64   skipped, outside supported_envs
v0.11.1  darwin/arm64   OK   git-branchless-v0.11.1-aarch64-apple-darwin.tar.gz
v0.11.1  linux/amd64    OK   git-branchless-v0.11.1-x86_64-unknown-linux-musl.tar.gz
v0.11.1  linux/arm64    OK   git-branchless-v0.11.1-aarch64-unknown-linux-musl.tar.gz
v0.11.1  windows/amd64  OK   git-branchless-v0.11.1-x86_64-pc-windows-msvc.zip
v0.11.1  windows/arm64  OK   git-branchless-v0.11.1-x86_64-pc-windows-msvc.zip

v0.11.0  same as v0.11.1

v0.10.0  darwin/*       skipped, unchanged (its own branch)
v0.10.0  linux/amd64    OK   git-branchless-v0.10.0-x86_64-unknown-linux-musl.tar.gz
v0.10.0  windows/amd64  OK   git-branchless-v0.10.0-x86_64-pc-windows-msvc.zip
v0.10.0  windows/arm64  OK   git-branchless-v0.10.0-x86_64-pc-windows-msvc.zip

v0.9.0   darwin/amd64   OK   git-branchless-v0.9.0-x86_64-apple-darwin.tar.gz
v0.9.0   darwin/arm64   OK   git-branchless-v0.9.0-x86_64-apple-darwin.tar.gz   (rosetta2, unchanged)
v0.9.0   linux/amd64    OK   git-branchless-v0.9.0-x86_64-unknown-linux-musl.tar.gz
v0.9.0   windows/amd64  OK   git-branchless-v0.9.0-x86_64-pc-windows-msvc.zip
v0.9.0   windows/arm64  OK   git-branchless-v0.9.0-x86_64-pc-windows-msvc.zip

v0.5.1   same shape as v0.9.0
v0.3.12  same shape as v0.9.0
```

Every branch resolves the asset it should, and the three older pins keep their previous behaviour including `rosetta2`.

```console
$ conftest test --combine pkgs/arxanas/git-branchless/registry.yaml pkgs/arxanas/git-branchless/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/arxanas/git-branchless/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `argd t` needs Docker, which isn't running on this machine.

`pkg.yaml` pins v0.11.1 for the new branch and keeps v0.10.0, v0.9.0, v0.5.1 and v0.3.12.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
