### PR TITLE
fix(gittower/git-flow-next): the archived binary is plain "git-flow" from v2.0.0

### DIFF
--- a/pkgs/gittower/git-flow-next/pkg.yaml
+++ b/pkgs/gittower/git-flow-next/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: gittower/git-flow-next@v1.2.0
+  - name: gittower/git-flow-next@v2.0.0
+  - name: gittower/git-flow-next
+    version: v1.2.0
   - name: gittower/git-flow-next
     version: v0.1.0

--- a/pkgs/gittower/git-flow-next/registry.yaml
+++ b/pkgs/gittower/git-flow-next/registry.yaml
@@ -10,13 +10,26 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.1.0-alpha.1"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         files:
           - name: git-flow
             src: git-flow-{{.Version}}-{{.OS}}-{{.Arch}}
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: git-flow
         checksum:
           type: github_release
           asset: git-flow-next-{{.Version}}-checksums.txt

--- a/registry.yaml
+++ b/registry.yaml
@@ -42473,13 +42473,26 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.1.0-alpha.1"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
         files:
           - name: git-flow
             src: git-flow-{{.Version}}-{{.OS}}-{{.Arch}}
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: git-flow
         checksum:
           type: github_release
           asset: git-flow-next-{{.Version}}-checksums.txt


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`gittower/git-flow-next` can't be installed from v2.0.0. #58497 has been failing on all six environments since 2026-08.

The asset names are identical between the two releases, so the download succeeds — it's the file *inside* the archive that changed:

```console
$ tar tzf git-flow-next-v1.2.0-linux-amd64.tar.gz
git-flow-v1.2.0-linux-amd64

$ tar tzf git-flow-next-v2.0.0-linux-amd64.tar.gz
git-flow
```

Same on every platform — `git-flow` on darwin and linux, `git-flow.exe` in the Windows zip.

`files[].src` is `git-flow-{{.Version}}-{{.OS}}-{{.Arch}}`, so aqua downloads the right asset and then fails to find the binary in it:

```console
v2.0.0  darwin/arm64  FAIL: error="check file_src is correct: exe_path isn't found: ..."
v2.0.0  linux/amd64   FAIL: error="check file_src is correct: exe_path isn't found: ..."
```

## Change

The old `src` moves to a bounded branch; the latest branch omits it, since the default — the file name, `git-flow` — is what the archive now contains, and `.exe` is completed automatically on Windows.

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 2.0.0")
         ...
         files:
           - name: git-flow
             src: git-flow-{{.Version}}-{{.OS}}-{{.Arch}}
         ...
+      - version_constraint: "true"
+        asset: git-flow-next-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        files:
+          - name: git-flow
+        checksum:
+          type: github_release
+          asset: git-flow-next-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
```

`pkg.yaml` pins v2.0.0 for the new branch and keeps v1.2.0 and v0.1.0 for the old one.

## Verification

`argd t`, with Docker running — all six environments, exit 0, no errors:

```console
$ argd t gittower/git-flow-next
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists — three versions across six environments, 18 combinations:

```console
v2.0.0   darwin/amd64   OK   git-flow
v2.0.0   darwin/arm64   OK   git-flow
v2.0.0   linux/amd64    OK   git-flow
v2.0.0   linux/arm64    OK   git-flow
v2.0.0   windows/amd64  OK   git-flow.exe
v2.0.0   windows/arm64  OK   git-flow.exe
v1.2.0   darwin/amd64   OK   git-flow-v1.2.0-darwin-amd64
v1.2.0   darwin/arm64   OK   git-flow-v1.2.0-darwin-arm64
v1.2.0   linux/amd64    OK   git-flow-v1.2.0-linux-amd64
v1.2.0   linux/arm64    OK   git-flow-v1.2.0-linux-arm64
v1.2.0   windows/amd64  OK   git-flow-v1.2.0-windows-amd64.exe
v1.2.0   windows/arm64  OK   git-flow-v1.2.0-windows-amd64.exe
v0.1.0   darwin/amd64   OK   git-flow-v0.1.0-darwin-amd64
v0.1.0   darwin/arm64   OK   git-flow-v0.1.0-darwin-arm64
v0.1.0   linux/amd64    OK   git-flow-v0.1.0-linux-amd64
v0.1.0   linux/arm64    OK   git-flow-v0.1.0-linux-arm64
v0.1.0   windows/amd64  OK   git-flow-v0.1.0-windows-amd64.exe
v0.1.0   windows/arm64  OK   git-flow-v0.1.0-windows-amd64.exe
```

Each branch resolves the name it should, and the two older pins are unchanged.

```console
$ conftest test --combine pkgs/gittower/git-flow-next/registry.yaml pkgs/gittower/git-flow-next/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/gittower/git-flow-next/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly.

## Note, not changed here

`windows_arm_emulation: true` is set, but upstream publishes `git-flow-next-<version>-windows-arm64.zip` in both v1.2.0 and v2.0.0, so Windows ARM64 resolves the amd64 asset and the native one goes unused. That isn't causing a failure, so I left it out of this change — happy to send it separately if you'd like it.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
