### PR TITLE
fix(bengadbois/pewpew): follow the goreleaser layout from v1.1.0

### DIFF
--- a/pkgs/bengadbois/pewpew/pkg.yaml
+++ b/pkgs/bengadbois/pewpew/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: bengadbois/pewpew@v1.0.0
+  - name: bengadbois/pewpew@v1.1.0
+  - name: bengadbois/pewpew
+    version: v1.0.0

--- a/pkgs/bengadbois/pewpew/registry.yaml
+++ b/pkgs/bengadbois/pewpew/registry.yaml
@@ -8,7 +8,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.3"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.1.0")
         asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
         format: tar.gz
         rosetta2: true
@@ -20,3 +20,12 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: pewpew_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pewpew
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -19622,7 +19622,7 @@ packages:
     version_overrides:
       - version_constraint: Version == "v0.3"
         no_asset: true
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.1.0")
         asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
         format: tar.gz
         rosetta2: true
@@ -19634,6 +19634,15 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: pewpew_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pewpew
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
   - type: github_release
     repo_owner: bensadeh
     repo_name: tailspin


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`bengadbois/pewpew` can't be installed from v1.1.0. #51176 has been failing on every environment since 2026-03.

v1.1.0 is the first release in five years (v1.0.0 is from 2021-01) and moved to goreleaser, which changed three things at once.

**Asset names**, and the target list:

```console
$ gh release view v1.0.0 --repo bengadbois/pewpew --json assets -q '.assets[].name'
darwin_amd64.tar.gz
freebsd_386.tar.gz … linux_mips64le.tar.gz … openbsd_amd64.tar.gz
linux_amd64.tar.gz
windows_amd64.tar.gz

$ gh release view v1.1.0 --repo bengadbois/pewpew --json assets -q '.assets[].name'
checksums.txt
pewpew_1.1.0_darwin_amd64.tar.gz
pewpew_1.1.0_darwin_arm64.tar.gz
pewpew_1.1.0_linux_386.tar.gz
pewpew_1.1.0_linux_amd64.tar.gz
pewpew_1.1.0_linux_arm64.tar.gz
pewpew_1.1.0_windows_386.tar.gz
pewpew_1.1.0_windows_amd64.tar.gz
pewpew_1.1.0_windows_arm64.tar.gz
```

**Archive layout**:

```console
$ tar tzf linux_amd64.tar.gz              # v1.0.0
./
./pewpew/
./pewpew/pewpew

$ tar tzf pewpew_1.1.0_linux_amd64.tar.gz # v1.1.0
LICENSE
README.md
pewpew
```

Windows carries `pewpew.exe` in the same flat shape.

So the download fails before anything else:

```console
v1.1.0  darwin/arm64  FAIL: error="the asset isn't found: darwin_amd64.tar.gz"
v1.1.0  linux/amd64   FAIL: error="the asset isn't found: linux_amd64.tar.gz"
```

## Change

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.1.0")
         asset: "{{.OS}}_{{.Arch}}.{{.Format}}"
         ...
+      - version_constraint: "true"
+        asset: pewpew_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pewpew
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
```

Three things fall away on the new branch:

- **`files[].src`** — the archive is flat, so the default (the file name) is correct, and `.exe` is completed on Windows.
- **`rosetta2` and `windows_arm_emulation`** — darwin, linux and windows all ship native arm64 now, so there is nothing to emulate.
- **`supported_envs`** — every environment aqua targets has an asset.

v1.1.0 also publishes `checksums.txt`, so checksum verification is enabled. It is a plain sha256sum file and the value matches:

```console
$ grep linux_amd64 checksums.txt
826c1458586c143c6b653edd6750ada1caabe623a5fc60af94cf858feefe7d64  pewpew_1.1.0_linux_amd64.tar.gz
$ shasum -a 256 pewpew_1.1.0_linux_amd64.tar.gz
826c1458586c143c6b653edd6750ada1caabe623a5fc60af94cf858feefe7d64  pewpew_1.1.0_linux_amd64.tar.gz
```

## Verification

`argd t` with Docker — all six environments, exit 0, no errors:

```console
$ argd t bengadbois/pewpew
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists:

```console
v1.1.0  darwin/amd64   OK   pewpew_1.1.0_darwin_amd64.tar.gz
v1.1.0  darwin/arm64   OK   pewpew_1.1.0_darwin_arm64.tar.gz
v1.1.0  linux/amd64    OK   pewpew_1.1.0_linux_amd64.tar.gz
v1.1.0  linux/arm64    OK   pewpew_1.1.0_linux_arm64.tar.gz
v1.1.0  windows/amd64  OK   pewpew_1.1.0_windows_amd64.tar.gz
v1.1.0  windows/arm64  OK   pewpew_1.1.0_windows_arm64.tar.gz
v1.0.0  darwin/amd64   OK   (unchanged)
v1.0.0  darwin/arm64   OK   (unchanged, via rosetta2)
v1.0.0  linux/amd64    OK   (unchanged)
v1.0.0  linux/arm64    skipped, outside supported_envs — unchanged
v1.0.0  windows/amd64  OK   (unchanged)
v1.0.0  windows/arm64  OK   (unchanged, via windows_arm_emulation)
```

v1.0.0 behaves exactly as before.

```console
$ conftest test --combine pkgs/bengadbois/pewpew/registry.yaml pkgs/bengadbois/pewpew/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/bengadbois/pewpew/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` pins v1.1.0 for the new branch and keeps v1.0.0 for the old one.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
