### PR TITLE
fix(aws/amazon-ec2-spot-interrupter): the asset name lost its version at v0.0.12

### DIFF
--- a/pkgs/aws/amazon-ec2-spot-interrupter/pkg.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: aws/amazon-ec2-spot-interrupter@v0.0.10
+  - name: aws/amazon-ec2-spot-interrupter@v0.0.16
+  - name: aws/amazon-ec2-spot-interrupter
+    version: v0.0.10
   - name: aws/amazon-ec2-spot-interrupter
     version: v0.0.7

--- a/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
+++ b/pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml
@@ -21,7 +21,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.0.10")
         asset: ec2-spot-interrupter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -34,3 +34,15 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: Version == "v0.0.11"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ec2-spot-interrupter_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ec2-spot-interrupter_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -17498,7 +17498,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.0.10")
         asset: ec2-spot-interrupter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -17511,6 +17511,18 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: Version == "v0.0.11"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ec2-spot-interrupter_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ec2-spot-interrupter_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
   - type: http
     repo_owner: aws
     repo_name: amazon-ecs-cli


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`aws/amazon-ec2-spot-interrupter` can't be installed from v0.0.12. #46999 has been failing since 2026-01.

v0.0.11 through v0.0.16 were all cut within a few hours on 2026-01-13, and the release layout changed partway through:

```console
$ for v in v0.0.10 v0.0.11 v0.0.12 v0.0.16; do
    echo "=== $v ==="
    gh release view $v --repo aws/amazon-ec2-spot-interrupter --json assets -q '.assets[].name'
  done
=== v0.0.10 ===
ec2-spot-interrupter_0.0.10_Darwin_amd64.tar.gz
ec2-spot-interrupter_0.0.10_Darwin_arm64.tar.gz
ec2-spot-interrupter_0.0.10_Linux_amd64.tar.gz
ec2-spot-interrupter_0.0.10_Linux_armv6.tar.gz
ec2-spot-interrupter_0.0.10_checksums.txt
=== v0.0.11 ===
=== v0.0.12 ===
ec2-spot-interrupter_0.0.12_checksums.txt
ec2-spot-interrupter_darwin_amd64.tar.gz
ec2-spot-interrupter_darwin_arm64.tar.gz
ec2-spot-interrupter_linux_amd64.tar.gz
ec2-spot-interrupter_linux_arm64.tar.gz
=== v0.0.16 ===
ec2-spot-interrupter_0.0.16_checksums.txt
ec2-spot-interrupter_darwin_amd64.tar.gz
ec2-spot-interrupter_darwin_arm64.tar.gz
ec2-spot-interrupter_linux_amd64.tar.gz
ec2-spot-interrupter_linux_arm64.tar.gz
```

Three changes: the version and the capitalised OS left the archive names, Linux `armv6` became `arm64`, and v0.0.11 shipped nothing at all. The checksum file kept its version, so that part of the config is still correct.

```console
v0.0.16  darwin/arm64  FAIL: error="the asset isn't found: ec2-spot-interrupter_0.0.16_Darwin_arm64.tar.gz"
v0.0.16  linux/amd64   FAIL: error="the asset isn't found: ec2-spot-interrupter_0.0.16_Linux_amd64.tar.gz"
```

## Change

```diff
       - version_constraint: semver("<= 0.0.7")
         ...
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.0.10")
         asset: ec2-spot-interrupter_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         replacements:
           darwin: Darwin
           linux: Linux
         ...
+      - version_constraint: Version == "v0.0.11"
+        no_asset: true
+      - version_constraint: "true"
+        asset: ec2-spot-interrupter_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: ec2-spot-interrupter_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
```

`replacements` is gone from the latest branch because the lowercase `GOOS` is now what the asset uses, and `supported_envs` takes the whole of `linux` because v0.0.12 replaced armv6 with arm64.

The branches stay in ascending order, so v0.0.11 reaches its own `no_asset` entry rather than the `<= 0.0.10` one.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors:

```console
$ argd t aws/amazon-ec2-spot-interrupter
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists:

```console
v0.0.16   darwin/amd64   OK   ec2-spot-interrupter_darwin_amd64.tar.gz
v0.0.16   darwin/arm64   OK   ec2-spot-interrupter_darwin_arm64.tar.gz
v0.0.16   linux/amd64    OK   ec2-spot-interrupter_linux_amd64.tar.gz
v0.0.16   linux/arm64    OK   ec2-spot-interrupter_linux_arm64.tar.gz
v0.0.12   darwin/amd64   OK   ec2-spot-interrupter_darwin_amd64.tar.gz
v0.0.12   darwin/arm64   OK   ec2-spot-interrupter_darwin_arm64.tar.gz
v0.0.12   linux/amd64    OK   ec2-spot-interrupter_linux_amd64.tar.gz
v0.0.12   linux/arm64    OK   ec2-spot-interrupter_linux_arm64.tar.gz
v0.0.10   darwin/amd64   OK   ec2-spot-interrupter_0.0.10_Darwin_amd64.tar.gz
v0.0.10   darwin/arm64   OK   ec2-spot-interrupter_0.0.10_Darwin_arm64.tar.gz
v0.0.10   linux/amd64    OK   ec2-spot-interrupter_0.0.10_Linux_amd64.tar.gz
v0.0.10   linux/arm64    skipped, outside supported_envs — unchanged
v0.0.7    darwin/amd64   OK   ec2-spot-interrupter_0.0.7_Darwin_amd64.tar.gz
v0.0.7    darwin/arm64   OK   ec2-spot-interrupter_0.0.7_Darwin_arm64.tar.gz
v0.0.7    linux/amd64    OK   ec2-spot-interrupter_0.0.7_Linux_amd64.tar.gz
v0.0.7    linux/arm64    skipped, outside supported_envs — unchanged
```

v0.0.12 is included to pin down the lower edge of the new branch, and the two older pins behave exactly as before.

v0.0.11 reaches its `no_asset` branch and reports the intended message rather than a missing asset:

```console
ERR install the package  package_version=v0.0.11
    error="no asset is released for this version"
```

```console
$ conftest test --combine pkgs/aws/amazon-ec2-spot-interrupter/registry.yaml pkgs/aws/amazon-ec2-spot-interrupter/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/aws/amazon-ec2-spot-interrupter/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` pins v0.0.16, v0.0.10 and v0.0.7 — one per asset-resolving branch. I left v0.0.11 unpinned, matching how `no_asset` branches are handled in `squat/kilo` and `cbroglie/mustache`.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
