### PR TITLE
fix(ryane/kfilt): the asset name lost its version at v1.0.0

### DIFF
--- a/pkgs/ryane/kfilt/pkg.yaml
+++ b/pkgs/ryane/kfilt/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: ryane/kfilt@v0.0.8
+  - name: ryane/kfilt@v1.0.0
+  - name: ryane/kfilt
+    version: v0.0.8
   - name: ryane/kfilt
     version: v0.0.5

--- a/pkgs/ryane/kfilt/registry.yaml
+++ b/pkgs/ryane/kfilt/registry.yaml
@@ -19,7 +19,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.0.0")
         asset: kfilt_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         checksum:
@@ -29,3 +29,13 @@ packages:
         overrides:
           - goos: darwin
             asset: kfilt_{{trimV .Version}}_{{.OS}}_all
+      - version_constraint: "true"
+        asset: kfilt_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: kfilt_{{.OS}}_all

--- a/registry.yaml
+++ b/registry.yaml
@@ -82260,7 +82260,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.0.0")
         asset: kfilt_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         format: raw
         checksum:
@@ -82270,6 +82270,16 @@ packages:
         overrides:
           - goos: darwin
             asset: kfilt_{{trimV .Version}}_{{.OS}}_all
+      - version_constraint: "true"
+        asset: kfilt_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: kfilt_{{.OS}}_all
   - type: github_release
     repo_owner: ryodocx
     repo_name: kube-credential-cache


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`ryane/kfilt` can't be installed from v1.0.0. #44959 has been failing since 2025-12.

The asset names dropped the version:

```console
$ gh release view v0.0.8 --repo ryane/kfilt --json assets -q '.assets[].name'
checksums.txt
kfilt_0.0.8_darwin_all
kfilt_0.0.8_linux_amd64
kfilt_0.0.8_linux_arm64
kfilt_0.0.8_windows_amd64.exe
kfilt_0.0.8_windows_arm64.exe

$ gh release view v1.0.0 --repo ryane/kfilt --json assets -q '.assets[].name'
checksums.txt
kfilt_darwin_all
kfilt_linux_amd64
kfilt_linux_arm64
kfilt_windows_amd64.exe
kfilt_windows_arm64.exe
kubectl-kfilt_darwin_all.tar.gz
… (kubectl-kfilt_* in .tar.gz and .zip for every platform)
```

so the download fails:

```console
v1.0.0  darwin/arm64  FAIL: error="the asset isn't found: kfilt_1.0.0_darwin_all"
v1.0.0  linux/amd64   FAIL: error="the asset isn't found: kfilt_1.0.0_linux_amd64"
```

## Change

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 1.0.0")
         asset: kfilt_{{trimV .Version}}_{{.OS}}_{{.Arch}}
         ...
         overrides:
           - goos: darwin
             asset: kfilt_{{trimV .Version}}_{{.OS}}_all
+      - version_constraint: "true"
+        asset: kfilt_{{.OS}}_{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: kfilt_{{.OS}}_all
```

The darwin `_all` override and the `checksums.txt` reference carry over unchanged — only `{{trimV .Version}}_` goes away. `.exe` is still completed automatically on Windows, matching `kfilt_windows_amd64.exe`.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors:

```console
$ argd t ryane/kfilt
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists — three versions across six environments:

```console
v1.0.0   darwin/amd64   OK   kfilt_darwin_all
v1.0.0   darwin/arm64   OK   kfilt_darwin_all
v1.0.0   linux/amd64    OK   kfilt_linux_amd64
v1.0.0   linux/arm64    OK   kfilt_linux_arm64
v1.0.0   windows/amd64  OK   kfilt_windows_amd64.exe
v1.0.0   windows/arm64  OK   kfilt_windows_arm64.exe
v0.0.8   darwin/amd64   OK   kfilt_0.0.8_darwin_all
v0.0.8   darwin/arm64   OK   kfilt_0.0.8_darwin_all
v0.0.8   linux/amd64    OK   kfilt_0.0.8_linux_amd64
v0.0.8   linux/arm64    OK   kfilt_0.0.8_linux_arm64
v0.0.8   windows/amd64  OK   kfilt_0.0.8_windows_amd64.exe
v0.0.8   windows/arm64  OK   kfilt_0.0.8_windows_arm64.exe
v0.0.5   darwin/amd64   OK   kfilt_0.0.5_darwin_amd64
v0.0.5   darwin/arm64   OK   kfilt_0.0.5_darwin_amd64   (rosetta2, unchanged)
v0.0.5   linux/amd64    OK   kfilt_0.0.5_linux_amd64
v0.0.5   linux/arm64    skipped, outside supported_envs — unchanged
v0.0.5   windows/amd64  OK   kfilt_0.0.5_windows_amd64.exe
v0.0.5   windows/arm64  OK   kfilt_0.0.5_windows_amd64.exe
```

Both older pins are unaffected.

```console
$ conftest test --combine pkgs/ryane/kfilt/registry.yaml pkgs/ryane/kfilt/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/ryane/kfilt/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` pins v1.0.0 alongside v0.0.8 and v0.0.5.

## Note, not part of this change

v1.0.0 also started publishing `kubectl-kfilt_<os>_<arch>.tar.gz` / `.zip` — kfilt as a kubectl plugin, which would be in scope as its own package per [docs/support_policy.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/support_policy.md) since kubectl just looks for `kubectl-*` on `$PATH`. I left it out to keep this a fix; happy to scaffold `ryane/kfilt/kubectl-kfilt` separately if you'd like it.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
