### PR TITLE
fix(muquit/mailsend-go): the archive is flat from v1.0.12

### DIFF
--- a/pkgs/muquit/mailsend-go/pkg.yaml
+++ b/pkgs/muquit/mailsend-go/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: muquit/mailsend-go@v1.0.11
+  - name: muquit/mailsend-go@v1.0.12
+  - name: muquit/mailsend-go
+    version: v1.0.11
   - name: muquit/mailsend-go
     version: v1.0.10
   - name: muquit/mailsend-go

--- a/pkgs/muquit/mailsend-go/registry.yaml
+++ b/pkgs/muquit/mailsend-go/registry.yaml
@@ -49,7 +49,7 @@ packages:
         files:
           - name: mailsend-go
             src: mailsend-go-dir/mailsend-go
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.0.11")
         asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -63,3 +63,17 @@ packages:
         files:
           - name: mailsend-go
             src: "{{.AssetWithoutExt}}/mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}"
+      - version_constraint: "true"
+        asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: mailsend-go-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: mailsend-go
+            src: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}

--- a/registry.yaml
+++ b/registry.yaml
@@ -68969,7 +68969,7 @@ packages:
         files:
           - name: mailsend-go
             src: mailsend-go-dir/mailsend-go
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.0.11")
         asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
         format: tar.gz
         windows_arm_emulation: true
@@ -68983,6 +68983,20 @@ packages:
         files:
           - name: mailsend-go
             src: "{{.AssetWithoutExt}}/mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}"
+      - version_constraint: "true"
+        asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: mailsend-go-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: mailsend-go
+            src: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}
   - type: github_release
     repo_owner: mutagen-io
     repo_name: mutagen


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`muquit/mailsend-go` can't be installed from v1.0.12. #53982 has been failing on every environment since 2026-05.

The asset names are unchanged, so the download succeeds — the wrapper directory inside the archive is what went away:

```console
$ tar tzf mailsend-go-v1.0.11-linux-amd64.d.tar.gz
mailsend-go-v1.0.11-linux-amd64.d/LICENSE.txt
mailsend-go-v1.0.11-linux-amd64.d/README.md
mailsend-go-v1.0.11-linux-amd64.d/mailsend-go-v1.0.11-linux-amd64
mailsend-go-v1.0.11-linux-amd64.d/mailsend-go.1
mailsend-go-v1.0.11-linux-amd64.d/platforms.txt

$ tar tzf mailsend-go-v1.0.12-linux-amd64.d.tar.gz
.
LICENSE.txt
README.md
mailsend-go-v1.0.12-linux-amd64
platforms.txt
```

Windows is the same shape — `mailsend-go-v1.0.12-windows-amd64.exe` sits at the root of the zip.

`files[].src` is `{{.AssetWithoutExt}}/mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}`, so aqua fetches the right asset and then can't find the binary in it:

```console
v1.0.12  darwin/arm64  FAIL: error="check file_src is correct: exe_path isn't found: ..."
v1.0.12  linux/amd64   FAIL: error="check file_src is correct: exe_path isn't found: ..."
```

## Change

The nested `src` moves to a bounded branch, and the latest branch drops the directory prefix:

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("<= 1.0.11")
         asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
         ...
         files:
           - name: mailsend-go
             src: "{{.AssetWithoutExt}}/mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}"
+      - version_constraint: "true"
+        asset: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}.d.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: mailsend-go-{{.Version}}-checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        files:
+          - name: mailsend-go
+            src: mailsend-go-{{.Version}}-{{.OS}}-{{.Arch}}
```

Everything else — the asset template, the checksum file, the Windows zip override — carries over unchanged, and `.exe` is still completed automatically on Windows.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors:

```console
$ argd t muquit/mailsend-go
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists — four versions across six environments, 24 combinations:

```console
v1.0.12   darwin/amd64   OK   mailsend-go-v1.0.12-darwin-amd64
v1.0.12   darwin/arm64   OK   mailsend-go-v1.0.12-darwin-arm64
v1.0.12   linux/amd64    OK   mailsend-go-v1.0.12-linux-amd64
v1.0.12   linux/arm64    OK   mailsend-go-v1.0.12-linux-arm64
v1.0.12   windows/amd64  OK   mailsend-go-v1.0.12-windows-amd64.exe
v1.0.12   windows/arm64  OK   mailsend-go-v1.0.12-windows-amd64.exe
v1.0.11   darwin/amd64   OK   mailsend-go-v1.0.11-darwin-amd64
v1.0.11   darwin/arm64   OK   mailsend-go-v1.0.11-darwin-arm64
v1.0.11   linux/amd64    OK   mailsend-go-v1.0.11-linux-amd64
v1.0.11   linux/arm64    OK   mailsend-go-v1.0.11-linux-arm64
v1.0.11   windows/amd64  OK   mailsend-go-v1.0.11-windows-amd64.exe
v1.0.11   windows/arm64  OK   mailsend-go-v1.0.11-windows-amd64.exe
v1.0.10   all six        OK   mailsend-go / mailsend-go.exe
v1.0.3    five, linux/arm64 skipped (outside supported_envs) — unchanged
```

v1.0.11 is pinned to hold the upper edge of the bounded branch, and the two older pins behave exactly as before.

```console
$ conftest test --combine pkgs/muquit/mailsend-go/registry.yaml pkgs/muquit/mailsend-go/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/muquit/mailsend-go/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
