### PR TITLE
fix(FairwindsOps/gonogo): follow the Sigstore bundle and new key at v0.4.0

### DIFF
--- a/pkgs/FairwindsOps/gonogo/pkg.yaml
+++ b/pkgs/FairwindsOps/gonogo/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: FairwindsOps/gonogo@v0.3.1
+  - name: FairwindsOps/gonogo@v0.4.0
+  - name: FairwindsOps/gonogo
+    version: v0.3.1

--- a/pkgs/FairwindsOps/gonogo/registry.yaml
+++ b/pkgs/FairwindsOps/gonogo/registry.yaml
@@ -30,6 +30,7 @@ packages:
           cosign:
             opts:
               - --key
-              - https://artifacts.fairwinds.com/cosign.pub
-              - --signature
-              - https://github.com/FairwindsOps/gonogo/releases/download/{{.Version}}/checksums.txt.sig
+              - https://artifacts.fairwinds.com/cosign-p256.pub
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json

--- a/registry.yaml
+++ b/registry.yaml
@@ -3295,9 +3295,10 @@ packages:
           cosign:
             opts:
               - --key
-              - https://artifacts.fairwinds.com/cosign.pub
-              - --signature
-              - https://github.com/FairwindsOps/gonogo/releases/download/{{.Version}}/checksums.txt.sig
+              - https://artifacts.fairwinds.com/cosign-p256.pub
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
   - type: github_release
     repo_owner: FairwindsOps
     repo_name: nova


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`FairwindsOps/gonogo` can't be installed from v0.4.0. #52778 has been failing on every environment since 2026-04, with `error="verify with Cosign"`.

Two things changed at once.

**The signature format.** The detached signature is gone, replaced by a Sigstore bundle:

```console
$ gh release view v0.3.1 --repo FairwindsOps/gonogo --json assets -q '.assets[].name' | grep checksums
checksums.txt
checksums.txt.sig

$ gh release view v0.4.0 --repo FairwindsOps/gonogo --json assets -q '.assets[].name' | grep checksums
checksums.txt
checksums.txt.sigstore.json
```

**The signing key.** Pulling the public key out of the bundle's Rekor entry and comparing it with the one the package references:

```console
# https://artifacts.fairwinds.com/cosign.pub — what the package uses (P-521)
MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBWcVxY7hX22GB5VP3fT1MFXrWHo0l …

# the key that actually signed v0.4.0, from verificationMaterial.tlogEntries (P-256)
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVMNfUvTvewgGh5cctPlDg5upuCfX …
```

Different keys, so even given the bundle the old key cannot verify it:

```console
$ cosign verify-blob --key https://artifacts.fairwinds.com/cosign.pub \
    --bundle checksums.txt.sigstore.json checksums.txt
Error: failed to verify signature: invalid signature when validating ASN.1 encoded signature
```

Upstream's `.goreleaser.yml` now signs with a Vault key and documents the new command in its release-notes template:

```yaml
signs:
  - cmd: cosign
    signature: "${artifact}.sigstore.json"
    args:
      - "sign-blob"
      - "--key=hashivault://cosign-p256"
      - "--bundle=${signature}"
```

```bash
cosign verify-blob checksums.txt --bundle=checksums.txt.sigstore.json --key https://artifacts.fairwinds.com/cosign-p256.pub
```

That key is published, and it matches the one from the Rekor entry byte for byte:

```console
$ cosign verify-blob checksums.txt --bundle=checksums.txt.sigstore.json \
    --key https://artifacts.fairwinds.com/cosign-p256.pub
Verified OK
```

## Change

The existing `"true"` branch already covers only v0.4.0 and later — everything below is handled by `semver("<= 0.3.1")` — so no new branch is needed, just the right key and source:

```diff
           cosign:
             opts:
               - --key
-              - https://artifacts.fairwinds.com/cosign.pub
-              - --signature
-              - https://github.com/FairwindsOps/gonogo/releases/download/{{.Version}}/checksums.txt.sig
+              - https://artifacts.fairwinds.com/cosign-p256.pub
+            bundle:
+              type: github_release
+              asset: checksums.txt.sigstore.json
```

[`cosign.bundle`](https://aquaproj.github.io/docs/reference/registry-config/cosign) (aqua >= v2.47.0) is used rather than another `opts` entry because aqua downloads that file and passes `--bundle <path>`, and cosign only accepts a local path there — a URL in `opts` cannot work.

I did not add `--insecure-ignore-tlog`: transparency log verification passes on v0.4.0, so this branch verifies slightly more than the v0.3.1 one, which keeps that flag.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors, and the Cosign step actually runs and succeeds for both versions:

```console
$ argd t FairwindsOps/gonogo
INF verifying a file with Cosign  package_name=FairwindsOps/gonogo package_version=v0.4.0
Verified OK
INF verifying a file with Cosign  package_name=FairwindsOps/gonogo package_version=v0.3.1
Verified OK
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

v0.3.1 keeps using the old key and detached signature, unchanged.

```console
$ conftest test --combine pkgs/FairwindsOps/gonogo/registry.yaml pkgs/FairwindsOps/gonogo/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/FairwindsOps/gonogo/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` gains v0.4.0 alongside v0.3.1 so both branches are exercised.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
