### PR TITLE
fix(openvex/vexctl): follow the Sigstore bundle from v0.4.4

### DIFF
--- a/pkgs/openvex/vexctl/pkg.yaml
+++ b/pkgs/openvex/vexctl/pkg.yaml
@@ -1,4 +1,6 @@
 packages:
-  - name: openvex/vexctl@v0.4.1
+  - name: openvex/vexctl@v0.4.4
+  - name: openvex/vexctl
+    version: v0.4.1
   - name: openvex/vexctl
     version: v0.2.5

--- a/pkgs/openvex/vexctl/registry.yaml
+++ b/pkgs/openvex/vexctl/registry.yaml
@@ -34,7 +34,7 @@ packages:
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.pem
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.1")
         asset: vexctl-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -62,3 +62,29 @@ packages:
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.pem
+      - version_constraint: "true"
+        asset: vexctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: vexctl_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/openvex/vexctl/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+            bundle:
+              type: github_release
+              asset: vexctl_checksums.txt.sigstore.json
+        cosign:
+          opts:
+            - --certificate-identity-regexp
+            - "https://github\\.com/openvex/vexctl/\\.github/workflows/release\\.yaml@.*"
+            - --certificate-oidc-issuer
+            - "https://token.actions.githubusercontent.com"
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.sigstore.json"

--- a/registry.yaml
+++ b/registry.yaml
@@ -73431,7 +73431,7 @@ packages:
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.pem
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.1")
         asset: vexctl-{{.OS}}-{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -73459,6 +73459,32 @@ packages:
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.sig
             - --certificate
             - https://github.com/openvex/vexctl/releases/download/{{.Version}}/{{.Asset}}.pem
+      - version_constraint: "true"
+        asset: vexctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: vexctl_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/openvex/vexctl/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+            bundle:
+              type: github_release
+              asset: vexctl_checksums.txt.sigstore.json
+        cosign:
+          opts:
+            - --certificate-identity-regexp
+            - "https://github\\.com/openvex/vexctl/\\.github/workflows/release\\.yaml@.*"
+            - --certificate-oidc-issuer
+            - "https://token.actions.githubusercontent.com"
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.sigstore.json"
   - type: github_release
     repo_owner: openziti
     repo_name: zrok


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`openvex/vexctl` can't be installed from v0.4.4. #55478 has been failing on every environment since 2026-06.

v0.4.4 replaced the detached signature and certificate with a Sigstore bundle. The binaries are named exactly as before — only the signature files changed:

```console
$ gh release view v0.4.1 --repo openvex/vexctl --json assets -q '.assets[].name' | grep -E 'darwin-arm64|checksums'
vexctl-darwin-arm64
vexctl-darwin-arm64.pem
vexctl-darwin-arm64.sig
vexctl_checksums.txt
vexctl_checksums.txt.pem
vexctl_checksums.txt.sig

$ gh release view v0.4.4 --repo openvex/vexctl --json assets -q '.assets[].name' | grep -E 'darwin-arm64|checksums'
vexctl-darwin-arm64
vexctl-darwin-arm64.sigstore.json
vexctl_checksums.txt
vexctl_checksums.txt.sigstore.json
```

The package points `--signature` and `--certificate` at the `.sig`/`.pem` URLs, which now 404, so verification fails with `error="verify with Cosign"`.

v0.4.2 and v0.4.3 were never released, so the boundary is exactly between v0.4.1 and v0.4.4:

```console
v0.4.4    detached .sig=0   bundle=1
v0.4.1    detached .sig=1   bundle=0
v0.4.0    detached .sig=1   bundle=0
v0.3.0    detached .sig=1   bundle=0
v0.2.5    detached .sig=1   bundle=0
```

## Change

The identity regexp and OIDC issuer are unchanged — this is still keyless signing from the same workflow, and I verified by hand that the existing pair validates the new bundle:

```console
$ cosign verify-blob vexctl_checksums.txt \
    --bundle=vexctl_checksums.txt.sigstore.json \
    --certificate-identity-regexp 'https://github\.com/openvex/vexctl/\.github/workflows/release\.yaml@.*' \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
Verified OK
```

So the detached form is bounded to v0.4.1 and below, and the latest branch swaps in [`cosign.bundle`](https://aquaproj.github.io/docs/reference/registry-config/cosign) for both the checksum file and each asset:

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.4.1")
         …unchanged detached configuration…
+      - version_constraint: "true"
+        asset: vexctl-{{.OS}}-{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: vexctl_checksums.txt
+          algorithm: sha256
+          cosign:
+            opts:
+              - --certificate-identity-regexp
+              - "https://github\\.com/openvex/vexctl/\\.github/workflows/release\\.yaml@.*"
+              - --certificate-oidc-issuer
+              - "https://token.actions.githubusercontent.com"
+            bundle:
+              type: github_release
+              asset: vexctl_checksums.txt.sigstore.json
+        cosign:
+          opts:
+            …same identity and issuer…
+          bundle:
+            type: github_release
+            asset: "{{.Asset}}.sigstore.json"
```

`bundle` is used rather than another `opts` entry because aqua downloads that file and passes `--bundle <path>`; cosign only accepts a local path there, so a URL cannot work. `{{.Asset}}` already resolves to `vexctl-windows-amd64.exe` on Windows, so the per-asset bundle name comes out right there too.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors, and **30 `Verified OK` lines**: the checksum file and every asset are verified, on both the new and the old branch.

```console
$ argd t openvex/vexctl
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
$ grep -c 'Verified OK' argd_t.log
30
```

```console
$ conftest test --combine pkgs/openvex/vexctl/registry.yaml pkgs/openvex/vexctl/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/openvex/vexctl/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` pins v0.4.4 for the new branch, v0.4.1 to hold the upper edge of the detached one, and keeps v0.2.5.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
