### PR TITLE
fix(bahdotsh/wrkflw): assets use Rust target triples from v0.8.0

### DIFF
--- a/pkgs/bahdotsh/wrkflw/pkg.yaml
+++ b/pkgs/bahdotsh/wrkflw/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: bahdotsh/wrkflw@v0.7.3
+  - name: bahdotsh/wrkflw@v0.8.0
+  - name: bahdotsh/wrkflw
+    version: v0.7.3

--- a/pkgs/bahdotsh/wrkflw/registry.yaml
+++ b/pkgs/bahdotsh/wrkflw/registry.yaml
@@ -6,7 +6,7 @@ packages:
     description: Validate and execute GitHub Actions workflows locally
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.8.0")
         asset: wrkflw-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -15,3 +15,20 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: "true"
+        asset: wrkflw-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - windows

--- a/pkgs/bahdotsh/wrkflw/registry.yaml
+++ b/pkgs/bahdotsh/wrkflw/registry.yaml
@@ -28,7 +28,3 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - linux
-          - windows

--- a/registry.yaml
+++ b/registry.yaml
@@ -18758,7 +18758,7 @@ packages:
     description: Validate and execute GitHub Actions workflows locally
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.8.0")
         asset: wrkflw-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -18767,6 +18767,23 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
+      - version_constraint: "true"
+        asset: wrkflw-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - windows
   - type: github_release
     repo_owner: banzaicloud
     repo_name: banzai-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -18780,10 +18780,6 @@ packages:
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - linux
-          - windows
   - type: github_release
     repo_owner: banzaicloud
     repo_name: banzai-cli


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

`bahdotsh/wrkflw` can't be installed from v0.8.0. #52483 has been failing since 2026-04.

The asset names changed shape entirely — the version left the name and the OS/arch pair became a Rust target triple in the opposite order:

```console
$ gh release view v0.7.3 --repo bahdotsh/wrkflw --json assets -q '.assets[].name'
wrkflw-v0.7.3-linux-x86_64.tar.gz
wrkflw-v0.7.3-macos-arm64.tar.gz
wrkflw-v0.7.3-macos-x86_64.tar.gz

$ gh release view v0.8.0 --repo bahdotsh/wrkflw --json assets -q '.assets[].name'
wrkflw-aarch64-apple-darwin.tar.gz
wrkflw-aarch64-unknown-linux-gnu.tar.gz
wrkflw-x86_64-apple-darwin.tar.gz
wrkflw-x86_64-pc-windows-msvc.zip
wrkflw-x86_64-unknown-linux-gnu.tar.gz
wrkflw-x86_64-unknown-linux-musl.tar.gz
```

```console
v0.8.0  darwin/arm64  FAIL: error="the asset isn't found: wrkflw-v0.8.0-macos-arm64.tar.gz"
v0.8.0  linux/amd64   FAIL: error="the asset isn't found: wrkflw-v0.8.0-linux-x86_64.tar.gz"
```

v0.8.0 also added linux/arm64 and windows, which the old branch could not have reached.

## Change

```diff
-      - version_constraint: "true"
+      - version_constraint: semver("< 0.8.0")
         asset: wrkflw-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         ...
+      - version_constraint: "true"
+        asset: wrkflw-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - linux
+          - windows
```

Two notes on the choices:

- **Linux resolves the gnu build on both architectures.** musl exists for x86_64 only, so picking it there would leave the two architectures on different libc for no gain. Happy to switch to musl for amd64 if you'd rather have the static build.
- **Windows ships only `x86_64-pc-windows-msvc.zip`**, so that branch takes a `format: zip` override and `windows_arm_emulation` covers windows/arm64.

The archive is flat in both old and new releases — `wrkflw`, or `wrkflw.exe` on Windows — so no `files` block is needed.

## Verification

`argd t` with Docker — all six environments, exit 0, no errors:

```console
$ argd t bahdotsh/wrkflw
INF testing os=darwin  arch=amd64
INF testing os=darwin  arch=arm64
INF testing os=linux   arch=amd64
INF testing os=linux   arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Separately, against a local registry with `AQUA_GOOS`/`AQUA_GOARCH`, resolving each install with `aqua which` and checking the resolved file exists:

```console
v0.8.0   darwin/amd64   OK   wrkflw-x86_64-apple-darwin.tar.gz
v0.8.0   darwin/arm64   OK   wrkflw-aarch64-apple-darwin.tar.gz
v0.8.0   linux/amd64    OK   wrkflw-x86_64-unknown-linux-gnu.tar.gz
v0.8.0   linux/arm64    OK   wrkflw-aarch64-unknown-linux-gnu.tar.gz
v0.8.0   windows/amd64  OK   wrkflw-x86_64-pc-windows-msvc.zip
v0.8.0   windows/arm64  OK   wrkflw-x86_64-pc-windows-msvc.zip
v0.7.3   darwin/amd64   OK   wrkflw-v0.7.3-macos-x86_64.tar.gz
v0.7.3   darwin/arm64   OK   wrkflw-v0.7.3-macos-arm64.tar.gz
v0.7.3   linux/amd64    OK   wrkflw-v0.7.3-linux-x86_64.tar.gz
v0.7.3   linux/arm64    skipped, outside supported_envs — unchanged
v0.7.3   windows/*      skipped, outside supported_envs — unchanged
```

v0.7.3 behaves exactly as before.

```console
$ conftest test --combine pkgs/bahdotsh/wrkflw/registry.yaml pkgs/bahdotsh/wrkflw/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/bahdotsh/wrkflw/*.yaml
All matched files use Prettier code style!
```

`argd gr` was run; `registry.yaml` is updated accordingly. `pkg.yaml` pins v0.8.0 alongside v0.7.3.

## AI disclosure

Investigated and written with Claude (Claude Code); the agent is added as a commit co-author per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md). Every command above was executed and its real output pasted. I have reviewed the change and own it.
