### PR TITLE
fix(cyberark/kubeletctl): the Windows asset name went back to amd64 in v1.13

### DIFF
--- a/pkgs/cyberark/kubeletctl/pkg.yaml
+++ b/pkgs/cyberark/kubeletctl/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: cyberark/kubeletctl@v1.12
+  - name: cyberark/kubeletctl@v1.13
+  - name: cyberark/kubeletctl
+    version: v1.12
   - name: cyberark/kubeletctl
     version: v1.11
   - name: cyberark/kubeletctl

--- a/pkgs/cyberark/kubeletctl/registry.yaml
+++ b/pkgs/cyberark/kubeletctl/registry.yaml
@@ -38,7 +38,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: Version == "v1.12"
         asset: kubeletctl_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -46,3 +46,7 @@ packages:
           - goos: windows
             replacements:
               amd64: x64
+      - version_constraint: "true"
+        asset: kubeletctl_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -30870,7 +30870,7 @@ packages:
           - darwin
           - windows
           - amd64
-      - version_constraint: "true"
+      - version_constraint: Version == "v1.12"
         asset: kubeletctl_{{.OS}}_{{.Arch}}
         format: raw
         windows_arm_emulation: true
@@ -30878,6 +30878,10 @@ packages:
           - goos: windows
             replacements:
               amd64: x64
+      - version_constraint: "true"
+        asset: kubeletctl_{{.OS}}_{{.Arch}}
+        format: raw
+        windows_arm_emulation: true
   - type: github_release
     repo_owner: cybozu
     repo_name: assam


### PR DESCRIPTION
Closes #30842.

## Problem

`v1.13` fails to install on Windows:

```console
$ argd t cyberark/kubeletctl
ERR install the package env=windows/amd64 package_name=cyberark/kubeletctl package_version=v1.13 error="the asset isn't found: kubeletctl_windows_x64.exe"
ERR argd failed error="windows tests failed: test failed for windows/amd64: exit status 1"
```

The fallback branch replaces `amd64` with `x64` on Windows. That was right for v1.12 and only v1.12 — v1.13 went back to the `amd64` name:

```console
$ gh release view v1.12 --repo cyberark/kubeletctl --json assets -q '.assets[].name' | grep windows
kubeletctl_windows_x64.exe
kubeletctl_windows_x86.exe

$ gh release view v1.13 --repo cyberark/kubeletctl --json assets -q '.assets[].name' | grep windows
kubeletctl_windows_386.exe
kubeletctl_windows_amd64.exe
```

## Change

Pin the replacement to `Version == "v1.12"` and leave the fallback branch without it. `v1.13` is added to `pkg.yaml` as the pinned version and `v1.12` is kept so the new branch stays covered.

## Verification

```console
$ argd t cyberark/kubeletctl
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

All six environments pass for every pinned version (v1.13, v1.12, v1.11, v1.10, v1.9, v1.3).

```console
$ conftest test -p policy/pkg --combine pkgs/cyberark/kubeletctl/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/cyberark/kubeletctl/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/cyberark/kubeletctl/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
