### PR TITLE
fix(wfxr/csview): the Intel macOS build is gone from v1.3.4

### DIFF
--- a/pkgs/wfxr/csview/pkg.yaml
+++ b/pkgs/wfxr/csview/pkg.yaml
@@ -1,2 +1,4 @@
 packages:
-  - name: wfxr/csview@v1.3.3
+  - name: wfxr/csview@v1.3.4
+  - name: wfxr/csview
+    version: v1.3.3

--- a/pkgs/wfxr/csview/registry.yaml
+++ b/pkgs/wfxr/csview/registry.yaml
@@ -23,10 +23,19 @@ packages:
         src: csview-{{.Version}}-{{.Arch}}-{{.OS}}/csview
     replacements:
       amd64: x86_64
+      arm64: aarch64
       darwin: apple-darwin
       windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 1.3.4")
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true

--- a/registry.yaml
+++ b/registry.yaml
@@ -102102,13 +102102,22 @@ packages:
         src: csview-{{.Version}}-{{.Arch}}-{{.OS}}/csview
     replacements:
       amd64: x86_64
+      arm64: aarch64
       darwin: apple-darwin
       windows: pc-windows-msvc
-    supported_envs:
-      - darwin
-      - linux
-      - amd64
-    rosetta2: true
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver(">= 1.3.4")
+        supported_envs:
+          - darwin/arm64
+          - linux
+          - windows/amd64
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - linux
+          - amd64
+        rosetta2: true
   - type: github_release
     repo_owner: whalebrew
     repo_name: whalebrew


### PR DESCRIPTION
Closes #30395.

## Problem

`v1.3.4` fails to install on macOS:

```console
$ argd t wfxr/csview
ERR install the package env=darwin/amd64 package_name=wfxr/csview package_version=v1.3.4 error="the asset isn't found: csview-v1.3.4-x86_64-apple-darwin.tar.gz"
ERR argd failed error="Linux/Darwin tests failed: test failed for darwin/amd64: exit status 1"
```

Upstream dropped the Intel macOS build in v1.3.4:

```console
$ gh release view v1.3.3 --repo wfxr/csview --json assets -q '.assets[].name' | grep darwin
csview-v1.3.3-aarch64-apple-darwin.tar.gz
csview-v1.3.3-x86_64-apple-darwin.tar.gz

$ gh release view v1.3.4 --repo wfxr/csview --json assets -q '.assets[].name' | grep darwin
csview-v1.3.4-aarch64-apple-darwin.tar.gz
```

`rosetta2: true` makes this worse rather than better: it sends darwin/arm64 to the same missing `x86_64-apple-darwin` asset, so both macOS architectures break on v1.3.4 even though the aarch64 build is right there.

## Change

Split the settings by version. From v1.3.4 on, darwin/arm64 uses the aarch64 build (`arm64: aarch64` added to `replacements`) and darwin/amd64 is unsupported. Versions up to v1.3.3 keep the previous behaviour including `rosetta2`.

`v1.3.4` becomes the pinned version and `v1.3.3` is kept so both branches are covered.

## Verification

```console
$ argd t wfxr/csview
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

With the download cache cleared first, the per-environment resolution is what the change intends — v1.3.4 is skipped on darwin/amd64 and installed on darwin/arm64:

```console
INF testing os=darwin arch=amd64
INF download and unarchive the package env=darwin/amd64 package_version=v1.3.3
INF testing os=darwin arch=arm64
INF download and unarchive the package env=darwin/arm64 package_version=v1.3.4
INF testing os=windows arch=amd64
INF download and unarchive the package env=windows/amd64 package_version=v1.3.3
INF download and unarchive the package env=windows/amd64 package_version=v1.3.4
```

(v1.3.3 on darwin/arm64 resolves through `rosetta2` to the x86_64 asset already fetched for darwin/amd64, so it produces no second download line.)

```console
$ conftest test -p policy/pkg --combine pkgs/wfxr/csview/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/wfxr/csview/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/wfxr/csview/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
