### PR TITLE
fix(GhostTroops/scan4all): macOS coverage changed twice after 2.8.7

### DIFF
--- a/pkgs/GhostTroops/scan4all/pkg.yaml
+++ b/pkgs/GhostTroops/scan4all/pkg.yaml
@@ -1,5 +1,9 @@
 packages:
-  - name: GhostTroops/scan4all@2.8.7
+  - name: GhostTroops/scan4all@2.9.1
+  - name: GhostTroops/scan4all
+    version: 2.8.9
+  - name: GhostTroops/scan4all
+    version: 2.8.7
   - name: GhostTroops/scan4all
     version: 2.8.6
   - name: GhostTroops/scan4all

--- a/pkgs/GhostTroops/scan4all/registry.yaml
+++ b/pkgs/GhostTroops/scan4all/registry.yaml
@@ -21,8 +21,21 @@ packages:
           type: github_release
           asset: scan4all-mac-checksums.txt
           algorithm: sha256
-    version_constraint: semver(">= 2.8.7")
+    version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 2.9.0")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 2.8.8")
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 2.8.7")
+        supported_envs:
+          - darwin
+          - amd64
       - version_constraint: semver(">= 2.8.6")
         supported_envs:
           - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -4036,8 +4036,21 @@ packages:
           type: github_release
           asset: scan4all-mac-checksums.txt
           algorithm: sha256
-    version_constraint: semver(">= 2.8.7")
+    version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 2.9.0")
+        rosetta2: true
+        supported_envs:
+          - darwin
+          - amd64
+      - version_constraint: semver(">= 2.8.8")
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 2.8.7")
+        supported_envs:
+          - darwin
+          - amd64
       - version_constraint: semver(">= 2.8.6")
         supported_envs:
           - linux/amd64


### PR DESCRIPTION
Closes #18427.

## Problem

`2.9.1` fails to install on macOS arm64:

```console
$ argd t GhostTroops/scan4all
ERR install the package env=darwin/arm64 package_name=GhostTroops/scan4all package_version=2.9.1 error="the asset isn't found: scan4all_2.9.1_darwin_arm64.zip"
ERR argd failed error="Linux/Darwin tests failed: test failed for darwin/arm64: exit status 1"
```

The macOS coverage changed twice after 2.8.7, and the single `>= 2.8.7` setting claims native arm64 support for all of it:

```console
$ for t in 2.8.7 2.8.8 2.8.9 2.9.0 2.9.1; do
    echo "-- $t"
    gh release view "$t" --repo GhostTroops/scan4all --json assets -q '[.assets[].name|select(endswith(".zip"))]|join(" ")'
  done
-- 2.8.7
scan4all_2.8.7_darwin_amd64.zip scan4all_2.8.7_darwin_arm64.zip scan4all_2.8.7_linux_amd64.zip scan4all_2.8.7_windows_amd64.zip
-- 2.8.8
scan4all_2.8.8_linux_amd64.zip scan4all_2.8.8_windows_amd64.zip
-- 2.8.9
scan4all_2.8.9_linux_amd64.zip scan4all_2.8.9_windows_amd64.zip
-- 2.9.0
scan4all_2.9.0_darwin_amd64.zip scan4all_2.9.0_linux_amd64.zip scan4all_2.9.0_windows_amd64.zip
-- 2.9.1
scan4all_2.9.1_darwin_amd64.zip scan4all_2.9.1_linux_amd64.zip scan4all_2.9.1_windows_amd64.zip
```

So darwin/arm64 breaks on 2.9.0 and 2.9.1, and darwin/amd64 breaks on 2.8.8 and 2.8.9. 2.8.8 and 2.8.9 also carry no `scan4all-mac-checksums.txt`.

## Change

Three branches instead of one:

- `>= 2.9.0` — darwin/amd64 plus `rosetta2: true`, so macOS arm64 keeps working through Rosetta 2 rather than losing support.
- `>= 2.8.8` — linux/amd64 and windows/amd64 only.
- `>= 2.8.7` — unchanged from what the top level used to say.

This also moves the top level `version_constraint` from `semver(">= 2.8.7")` to `"false"`, which the lint policy requires (`the top level version_constraint must be either empty or "false"`).

`2.9.1` becomes the pinned version and `2.8.9` is added so the new middle branch is covered too.

## Verification

```console
$ argd t GhostTroops/scan4all
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

With the download cache cleared first, each environment installs exactly the versions it should — 2.8.9 is skipped on darwin/amd64, and everything else is present:

```console
INF testing os=darwin arch=amd64
INF download ... package_version=2.4.5
INF download ... package_version=2.9.1
INF download ... package_version=2.8.6
INF download ... package_version=2.8.7
INF download ... package_version=2.6.9
```

And 2.9.1 does resolve through Rosetta 2 on macOS arm64:

```console
$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua which scan4all
/root/.local/share/aquaproj-aqua/pkgs/github_release/github.com/GhostTroops/scan4all/2.9.1/scan4all_2.9.1_darwin_amd64.zip/scan4all
```

```console
$ conftest test -p policy/pkg --combine pkgs/GhostTroops/scan4all/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/GhostTroops/scan4all/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/GhostTroops/scan4all/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
