### PR TITLE
fix(timvisee/ffsend): v0.2.77 only ships the Linux amd64 build

### DIFF
--- a/pkgs/timvisee/ffsend/pkg.yaml
+++ b/pkgs/timvisee/ffsend/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: timvisee/ffsend@v0.2.76
+  - name: timvisee/ffsend@v0.2.77
+  - name: timvisee/ffsend
+    version: v0.2.76
   - name: timvisee/ffsend
     version: v0.2.75
   - name: timvisee/ffsend

--- a/pkgs/timvisee/ffsend/registry.yaml
+++ b/pkgs/timvisee/ffsend/registry.yaml
@@ -143,7 +143,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.76")
         asset: ffsend-{{.Version}}-{{.OS}}-{{.Arch}}-static
         format: raw
         windows_arm_emulation: true
@@ -157,3 +157,10 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: ffsend-{{.Version}}-{{.OS}}-{{.Arch}}-static
+        format: raw
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -95604,7 +95604,7 @@ packages:
         supported_envs:
           - linux/amd64
           - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("<= 0.2.76")
         asset: ffsend-{{.Version}}-{{.OS}}-{{.Arch}}-static
         format: raw
         windows_arm_emulation: true
@@ -95618,6 +95618,13 @@ packages:
           - darwin
           - windows
           - amd64
+      - version_constraint: "true"
+        asset: ffsend-{{.Version}}-{{.OS}}-{{.Arch}}-static
+        format: raw
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
   - type: github_release
     repo_owner: tinygo-org
     repo_name: tinygo


### PR DESCRIPTION
Closes #31717.

## Problem

`v0.2.77` fails to install on macOS:

```console
$ argd t timvisee/ffsend
ERR install the package env=darwin/amd64 package_name=timvisee/ffsend package_version=v0.2.77 error="the asset isn't found: ffsend-v0.2.77-macos"
ERR argd failed error="Linux/Darwin tests failed: test failed for darwin/amd64: exit status 1"
```

v0.2.77 ships only the two Linux binaries:

```console
$ gh release view v0.2.76 --repo timvisee/ffsend --json assets -q '.assets[].name'
ffsend-v0.2.76-linux-x64
ffsend-v0.2.76-linux-x64-static
ffsend-v0.2.76-macos
ffsend-v0.2.76-windows-x64-static.exe
ffsend-v0.2.76-windows-x64.exe

$ gh release view v0.2.77 --repo timvisee/ffsend --json assets -q '.assets[].name'
ffsend-v0.2.77-linux-x64
ffsend-v0.2.77-linux-x64-static
```

## Change

Move the current settings to a `<= 0.2.76` branch and restrict the fallback branch to `linux/amd64`. The asset template already produces `ffsend-v0.2.77-linux-x64-static`, so only `supported_envs` needed narrowing; `windows_arm_emulation` and the darwin override go away with the platforms they served.

`v0.2.77` becomes the pinned version and `v0.2.76` is kept.

## Verification

```console
$ argd t timvisee/ffsend
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

On macOS and Windows, `aqua` now falls back to the newest version that still has a binary there, instead of failing:

```console
$ AQUA_GOOS=linux   AQUA_GOARCH=amd64 aqua which ffsend
.../timvisee/ffsend/v0.2.77/ffsend-v0.2.77-linux-x64-static/ffsend-v0.2.77-linux-x64-static
$ AQUA_GOOS=darwin  AQUA_GOARCH=amd64 aqua which ffsend
.../timvisee/ffsend/v0.2.76/ffsend-v0.2.76-macos/ffsend-v0.2.76-macos
$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua which ffsend
.../timvisee/ffsend/v0.2.76/ffsend-v0.2.76-windows-x64-static.exe/ffsend-v0.2.76-windows-x64-static.exe
```

```console
$ conftest test -p policy/pkg --combine pkgs/timvisee/ffsend/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/timvisee/ffsend/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/timvisee/ffsend/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
