### PR TITLE
fix(hashicorp/vagrant/vagrant-go): binaries aren't released since v2.4.4

### DIFF
--- a/pkgs/hashicorp/vagrant/vagrant-go/pkg.yaml
+++ b/pkgs/hashicorp/vagrant/vagrant-go/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: hashicorp/vagrant/vagrant-go@v2.4.5
+  - name: hashicorp/vagrant/vagrant-go@v2.4.3

--- a/pkgs/hashicorp/vagrant/vagrant-go/registry.yaml
+++ b/pkgs/hashicorp/vagrant/vagrant-go/registry.yaml
@@ -9,6 +9,11 @@ packages:
       - name: vagrant
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 2.4.4")
+        error_message: |
+          The Go implementation of Vagrant was removed from the main branch and isn't released since v2.4.4.
+
+          https://github.com/hashicorp/vagrant/issues/12819#issuecomment-2738619021
       - version_constraint: "true"
         asset: vagrant-go_{{.OS}}_{{.Arch}}
         format: raw

--- a/registry.yaml
+++ b/registry.yaml
@@ -48106,6 +48106,11 @@ packages:
       - name: vagrant
     version_constraint: "false"
     version_overrides:
+      - version_constraint: semver(">= 2.4.4")
+        error_message: |
+          The Go implementation of Vagrant was removed from the main branch and isn't released since v2.4.4.
+
+          https://github.com/hashicorp/vagrant/issues/12819#issuecomment-2738619021
       - version_constraint: "true"
         asset: vagrant-go_{{.OS}}_{{.Arch}}
         format: raw


### PR DESCRIPTION
Closes #36755.

## Problem

This package is already broken on `main`. `v2.4.5` is the version pinned in `pkg.yaml`, and it does not install:

```console
$ argd t hashicorp/vagrant/vagrant-go
ERR install the package env=linux/amd64 package_name=hashicorp/vagrant/vagrant-go package_version=v2.4.5 error="the asset isn't found: vagrant-go_linux_amd64"
ERR argd failed error="Linux/Darwin tests failed: test failed for linux/amd64: exit status 1"
```

CI did not catch it because the test matrix only runs the packages a pull request changes, and the assets disappeared after the bump to v2.4.5 was merged in #35763.

v2.4.3 is the last release that carries them:

```console
$ gh release view v2.4.3 --repo hashicorp/vagrant --json assets -q '.assets[].name'
vagrant-2.4.3.gem
vagrant-go_darwin_amd64
vagrant-go_darwin_arm64
vagrant-go_darwin_universal
vagrant-go_linux_386
vagrant-go_linux_amd64
vagrant_2.4.3_SHA256SUMS
vagrant_2.4.3_SHA256SUMS.sig

$ gh release view v2.4.4 --repo hashicorp/vagrant --json assets -q '.assets[].name'
vagrant-2.4.4.gem
vagrant_2.4.4_SHA256SUMS
vagrant_2.4.4_SHA256SUMS.sig
```

No later release has them either — the twenty most recent releases are all `2.4.10.dev+*` prereleases with 12 packaging assets each and no `vagrant-go_*`.

This is deliberate upstream. From https://github.com/hashicorp/vagrant/issues/12819#issuecomment-2738619021 (chrisroberts, 2025-03-20): the project was paused, the implementation was removed from the main Vagrant branch, and it is retained only in the `vagrant-go` branch.

The updater already stopped proposing versions for this package in #37928. What is left is the registry side, which still fails with a bare "the asset isn't found".

## Change

Add an `error_message` for v2.4.4 and later, and move the pinned test version back to v2.4.3.

Dropping v2.4.5 from `pkg.yaml` is not a coverage loss: that version cannot be installed at all, so it tests nothing. v2.4.3 exercises the same branch and does install.

## Verification

```console
$ argd t hashicorp/vagrant/vagrant-go
INF testing os=linux arch=amd64
INF download and unarchive the package env=linux/amd64 package_version=v2.4.3
INF downloading a checksum file env=linux/amd64 package_version=v2.4.3
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF download and unarchive the package env=darwin/amd64 package_version=v2.4.3
INF testing os=darwin arch=arm64
INF download and unarchive the package env=darwin/arm64 package_version=v2.4.3
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

And what someone asking for a newer version now sees:

```console
$ aqua i   # hashicorp/vagrant/vagrant-go@v2.4.6
ERR The Go implementation of Vagrant was removed from the main branch and isn't released since v2.4.4.

https://github.com/hashicorp/vagrant/issues/12819#issuecomment-2738619021
 package_name=hashicorp/vagrant/vagrant-go package_version=v2.4.6
ERR install the package error="the package has a field `error_message`"
```

```console
$ conftest test -p policy/pkg --combine pkgs/hashicorp/vagrant/vagrant-go/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/hashicorp/vagrant/vagrant-go/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/hashicorp/vagrant/vagrant-go/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
