### PR TITLE
fix(linebender/resvg): Windows binaries aren't built from v0.48.0

### DIFF
--- a/pkgs/linebender/resvg/pkg.yaml
+++ b/pkgs/linebender/resvg/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: linebender/resvg@v0.47.0
+  - name: linebender/resvg@v0.48.1
+  - name: linebender/resvg
+    version: v0.47.0
   - name: linebender/resvg
     version: 0.45.0
   - name: linebender/resvg

--- a/pkgs/linebender/resvg/registry.yaml
+++ b/pkgs/linebender/resvg/registry.yaml
@@ -46,6 +46,19 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
+      - version_constraint: semver(">= 0.48.0")
+        asset: resvg-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: "true"
         asset: resvg-{{.OS}}.{{.Format}}
         format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -62985,6 +62985,19 @@ packages:
         supported_envs:
           - linux/amd64
           - windows/amd64
+      - version_constraint: semver(">= 0.48.0")
+        asset: resvg-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: macos
+        overrides:
+          - goos: linux
+            format: tar.gz
+        supported_envs:
+          - darwin
+          - linux/amd64
       - version_constraint: "true"
         asset: resvg-{{.OS}}.{{.Format}}
         format: zip


### PR DESCRIPTION
Closes #58143.

## Problem

`v0.48.1` fails to install on Windows:

```console
$ argd t linebender/resvg
ERR install the package env=windows/amd64 package_name=linebender/resvg package_version=v0.48.1 error="the asset isn't found: resvg-win64.zip"
ERR argd failed error="windows tests failed: test failed for windows/amd64: exit status 1"
```

Neither v0.48.0 nor v0.48.1 has a Windows asset, while v0.47.0 does:

```console
$ gh api repos/linebender/resvg/releases -q '.[]|select(.tag_name|test("v0.4[78]"))|"\(.tag_name) win assets: " + ([.assets[]|select(.name|test("win"))|.name]|join(",") // "none")'
v0.48.1 win assets:
v0.48.0 win assets:
v0.47.0 win assets: resvg-win64.zip,usvg-win64.zip
```

This isn't a release that was still uploading — every v0.48.1 asset landed within four minutes of the release being published. The Windows job simply produced nothing:

```console
$ gh api repos/linebender/resvg/actions/runs/30751657113/jobs -q '.jobs[]|"  \(.name): \(.conclusion)  runner=\(.runner_name // "-")"'
  Create Release: success  runner=GitHub Actions 1000248605
  Release Windows: cancelled  runner=-
  Release macOS (aarch64): success  runner=GitHub Actions 1000248606
  Release macOS (intel): success  runner=GitHub Actions 1000248608
  Release Linux: success  runner=GitHub Actions 1000248607
```

`Release Windows` was cancelled without ever being assigned a runner, in both the v0.48.0 and v0.48.1 runs, while every other job succeeded. The v0.47.0 run succeeded in full. The job is still defined in `tagged-release.yml` at the v0.48.1 tag and runs on `windows-2019`.

Upstream tracks this in [linebender/resvg#1117](https://github.com/linebender/resvg/issues/1117), which names the same cause and has been open since 2026-08-04 with no reply. I have not opened a duplicate.

## Change

A `semver(">= 0.48.0")` branch limited to macOS and linux/amd64.

On Windows this means aqua no longer fails with `the asset isn't found`; it skips the package instead, so v0.48.0 and later simply install nothing there and a Windows user has to pin v0.47.0 explicitly to keep the command. aqua does **not** fall back to an older version on its own. This is the same shape as the `wfxr/csview`, `GhostTroops/scan4all` and `timvisee/ffsend` fixes, where upstream also dropped a platform for newer releases.

The new branch also leaves out `rosetta2`. These releases ship `resvg-macos-aarch64.zip`, so Apple Silicon can use the native build instead of the Intel one the current branch forces it to.

If upstream attaches Windows binaries to these releases later, this branch is one line to widen again.

## Verification

```console
$ argd t linebender/resvg
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
```

With the download cache cleared first, v0.48.1 installs where it should and is skipped where it shouldn't:

```console
INF testing os=darwin arch=amd64
INF download ... package_version=v0.48.1
INF testing os=darwin arch=arm64
INF download ... package_version=v0.48.1
INF testing os=windows arch=amd64
INF download ... package_version=v0.41.0
INF download ... package_version=v0.47.0
INF download ... package_version=v0.44.0
```

macOS arm64 now gets the native build instead of the Intel one `rosetta2` forced it to:

```console
$ AQUA_GOOS=darwin AQUA_GOARCH=arm64 aqua which resvg
.../linebender/resvg/v0.48.1/resvg-macos-aarch64.zip/resvg
```

On Windows, with only v0.48.1 pinned — what a user actually writes — the package is skipped:

```console
$ cat aqua.yaml
packages:
  - name: linebender/resvg@v0.48.1

$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua i
$ AQUA_GOOS=windows AQUA_GOARCH=amd64 aqua which resvg
ERR aqua failed env=windows/amd64 exe_name=resvg error="command is not found"
```

The `argd t` run above resolves `resvg` to v0.47.0 on Windows only because `pkg.yaml` lists both versions; that is the test config, not aqua falling back.

```console
$ conftest test -p policy/pkg --combine pkgs/linebender/resvg/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/linebender/resvg/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/linebender/resvg/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
