### PR TITLE
fix(keilerkonzept/terraform-module-versions): support the v3.3 tag and asset layout

### DIFF
--- a/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
@@ -3,4 +3,6 @@ packages:
   - name: keilerkonzept/terraform-module-versions
     version: 3.2.1
   - name: keilerkonzept/terraform-module-versions
-    version: 3.0.29
+    version: 3.1.0
+  - name: keilerkonzept/terraform-module-versions
+    version: 0.11.0

--- a/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
@@ -3,8 +3,4 @@ packages:
   - name: keilerkonzept/terraform-module-versions
     version: 3.2.1
   - name: keilerkonzept/terraform-module-versions
-    version: 3.1.13
-  - name: keilerkonzept/terraform-module-versions
-    version: 3.1.0
-  - name: keilerkonzept/terraform-module-versions
-    version: 0.11.0
+    version: 3.0.29

--- a/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
@@ -1,5 +1,9 @@
 packages:
-  - name: keilerkonzept/terraform-module-versions@3.1.13
+  - name: keilerkonzept/terraform-module-versions@v3.3.13
+  - name: keilerkonzept/terraform-module-versions
+    version: 3.2.1
+  - name: keilerkonzept/terraform-module-versions
+    version: 3.1.13
   - name: keilerkonzept/terraform-module-versions
     version: 3.1.0
   - name: keilerkonzept/terraform-module-versions

--- a/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
@@ -4,41 +4,42 @@ packages:
     repo_owner: keilerkonzept
     repo_name: terraform-module-versions
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
-    asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: osx
-    supported_envs:
-      - darwin
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["3.0.29", "3.1.14", "v3.2.1"]
+      - version_constraint: Version == "v3.2.1"
         no_asset: true
-      - version_constraint: semver(">= 3.3.0")
+      - version_constraint: Version in ["3.0.29", "3.1.14"]
+        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 3.2.1")
+        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
         asset: terraform-module-versions_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        overrides:
-          - goos: windows
-            format: zip
         checksum:
           type: github_release
           asset: terraform-module-versions_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        supported_envs:
-          - darwin
-          - linux
-          - windows
-      - version_constraint: semver("< 3.3.0")
-        rosetta2: true
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - linux
-          - amd64

--- a/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
@@ -6,17 +6,8 @@ packages:
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v3.2.1"
+      - version_constraint: Version in ["v3.2.1", "3.1.14", "3.0.29"]
         no_asset: true
-      - version_constraint: Version in ["3.0.29", "3.1.14"]
-        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: osx
-        supported_envs:
-          - darwin
       - version_constraint: semver("<= 3.2.1")
         asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
+++ b/pkgs/keilerkonzept/terraform-module-versions/registry.yaml
@@ -11,12 +11,30 @@ packages:
       darwin: osx
     supported_envs:
       - darwin
-    rosetta2: true
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["3.0.29", "3.1.14"]
+      - version_constraint: Version in ["3.0.29", "3.1.14", "v3.2.1"]
         no_asset: true
-      - version_constraint: semver("< 3.1.14")
+      - version_constraint: semver(">= 3.3.0")
+        asset: terraform-module-versions_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: terraform-module-versions_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+      - version_constraint: semver("< 3.3.0")
+        rosetta2: true
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -57388,17 +57388,8 @@ packages:
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version == "v3.2.1"
+      - version_constraint: Version in ["v3.2.1", "3.1.14", "3.0.29"]
         no_asset: true
-      - version_constraint: Version in ["3.0.29", "3.1.14"]
-        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        rosetta2: true
-        replacements:
-          amd64: x86_64
-          darwin: osx
-        supported_envs:
-          - darwin
       - version_constraint: semver("<= 3.2.1")
         asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -57393,12 +57393,30 @@ packages:
       darwin: osx
     supported_envs:
       - darwin
-    rosetta2: true
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["3.0.29", "3.1.14"]
+      - version_constraint: Version in ["3.0.29", "3.1.14", "v3.2.1"]
         no_asset: true
-      - version_constraint: semver("< 3.1.14")
+      - version_constraint: semver(">= 3.3.0")
+        asset: terraform-module-versions_{{.OS}}_{{.Arch}}.{{.Format}}
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        overrides:
+          - goos: windows
+            format: zip
+        checksum:
+          type: github_release
+          asset: terraform-module-versions_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - darwin
+          - linux
+          - windows
+      - version_constraint: semver("< 3.3.0")
+        rosetta2: true
         overrides:
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -57386,44 +57386,45 @@ packages:
     repo_owner: keilerkonzept
     repo_name: terraform-module-versions
     description: "CLI tool that checks Terraform code for module updates. Single binary, no dependencies. linux, osx, windows. #golang #cli #terraform"
-    asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-    format: tar.gz
-    replacements:
-      amd64: x86_64
-      darwin: osx
-    supported_envs:
-      - darwin
     version_constraint: "false"
     version_overrides:
-      - version_constraint: Version in ["3.0.29", "3.1.14", "v3.2.1"]
+      - version_constraint: Version == "v3.2.1"
         no_asset: true
-      - version_constraint: semver(">= 3.3.0")
+      - version_constraint: Version in ["3.0.29", "3.1.14"]
+        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        supported_envs:
+          - darwin
+      - version_constraint: semver("<= 3.2.1")
+        asset: terraform-module-versions_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          darwin: osx
+        overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
         asset: terraform-module-versions_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
         replacements:
           amd64: x86_64
           darwin: Darwin
           linux: Linux
           windows: Windows
-        overrides:
-          - goos: windows
-            format: zip
         checksum:
           type: github_release
           asset: terraform-module-versions_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        supported_envs:
-          - darwin
-          - linux
-          - windows
-      - version_constraint: semver("< 3.3.0")
-        rosetta2: true
         overrides:
           - goos: windows
             format: zip
-        supported_envs:
-          - darwin
-          - linux
-          - amd64
   - type: github_release
     repo_owner: keisku
     repo_name: kubectl-explore


### PR DESCRIPTION
Closes #12439.

## Problem

Every release after `3.1.13` — seventeen of them, from 2025-02-05 to 2025-07-18 — is unusable, and it fails quietly. `version_constraint` is `"false"` and no `version_overrides` branch matches these versions, so aqua installs nothing and only reports it at lookup time:

```console
$ aqua i    # keilerkonzept/terraform-module-versions@v3.3.13
$ aqua which terraform-module-versions
ERR aqua failed ... error="command is not found"

$ aqua i    # @3.2.0
$ aqua which terraform-module-versions
ERR aqua failed ... error="command is not found"

$ aqua i    # @3.1.13
INF download and unarchive the package package_version=3.1.13
$ aqua which terraform-module-versions
.../3.1.13/terraform-module-versions_3.1.13_linux_x86_64.tar.gz/terraform-module-versions
```

Upstream changed two things:

```console
$ gh release view 3.1.13 --repo keilerkonzept/terraform-module-versions --json assets -q '.assets[].name'
terraform-module-versions_3.1.13_linux_arm64.tar.gz
terraform-module-versions_3.1.13_linux_x86_32.tar.gz
terraform-module-versions_3.1.13_linux_x86_64.tar.gz
terraform-module-versions_3.1.13_osx_x86_64.tar.gz
terraform-module-versions_3.1.13_windows_x86_32.zip
terraform-module-versions_3.1.13_windows_x86_64.zip

$ gh release view v3.3.13 --repo keilerkonzept/terraform-module-versions --json assets -q '.assets[].name'
terraform-module-versions_3.3.13_checksums.txt
terraform-module-versions_Darwin_arm64.tar.gz
terraform-module-versions_Darwin_x86_64.tar.gz
terraform-module-versions_Linux_arm64.tar.gz
terraform-module-versions_Linux_i386.tar.gz
terraform-module-versions_Linux_x86_64.tar.gz
terraform-module-versions_Windows_arm64.zip
terraform-module-versions_Windows_i386.zip
terraform-module-versions_Windows_x86_64.zip
```

The version left the asset name, the OS is capitalised, a checksums file appeared, and macOS arm64 and Windows arm64 are now built natively. The tags also gained a `v` prefix at `v3.2.1`.

The release history splits cleanly:

| versions | assets | naming |
| --- | --- | --- |
| … 3.1.13 | 6 | `_<version>_<os>_<arch>`, lowercase, `osx` |
| 3.1.14 | 0 | already `no_asset` |
| 3.2.0, 3.2.1 | 6 | same as 3.1.13 |
| v3.2.1 | 0 | empty duplicate of 3.2.1 |
| v3.3.0 … v3.3.13 | 9 | `_<Os>_<arch>` + checksums |

All fourteen `v3.3.x` releases carry an identical asset set, so one branch covers them.

## Change

- A `semver(">= 3.3.0")` branch with the new asset template, a `checksum` entry, and darwin/linux/windows on both architectures.
- The `semver("< 3.1.14")` branch widens to `semver("< 3.3.0")` so 3.2.0 and 3.2.1 are covered; `rosetta2` moves from the top level into it, because the new releases ship a native `Darwin_arm64` build and no longer need Rosetta.
- `v3.2.1` joins the `no_asset` list.
- `pkg.yaml` pins `v3.3.13` for the new branch and adds `3.2.1` for the widened one. The `no_asset` branch cannot be pinned — `argd t` rejects such versions with `no asset is released for this version`.

The pinned version moving from `3.1.13` to `v3.3.13` matters beyond the test: aqua-registry-updater only compares versions that share a prefix, so a bare `3.1.13` pin can never be advanced by a `v`-prefixed release. That is why this package has sat at a 2022 version with no failing pull request to show for it — #12439 targets `3.1.14`, which has no assets at all.

## Verification

```console
$ argd t keilerkonzept/terraform-module-versions
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
$ echo $?
0
```

Every environment resolves to its own native asset, including the two the old configuration could not reach:

```console
linux/amd64    .../v3.3.13/terraform-module-versions_Linux_x86_64.tar.gz/terraform-module-versions
linux/arm64    .../v3.3.13/terraform-module-versions_Linux_arm64.tar.gz/terraform-module-versions
darwin/amd64   .../v3.3.13/terraform-module-versions_Darwin_x86_64.tar.gz/terraform-module-versions
darwin/arm64   .../v3.3.13/terraform-module-versions_Darwin_arm64.tar.gz/terraform-module-versions
windows/amd64  .../v3.3.13/terraform-module-versions_Windows_x86_64.zip/terraform-module-versions.exe
windows/arm64  .../v3.3.13/terraform-module-versions_Windows_arm64.zip/terraform-module-versions.exe
```

The checksum entry resolves, and the hash aqua recorded matches the published file:

```console
$ cat aqua-checksums.json     # after installing v3.3.12
"id": "github_release/github.com/keilerkonzept/terraform-module-versions/v3.3.12/terraform-module-versions_Linux_x86_64.tar.gz",
"checksum": "2A2C42E0515825A0679C849575962B26523BA21D2A3A13B5483D132F00018073",

$ grep Linux_x86_64 terraform-module-versions_3.3.12_checksums.txt
2a2c42e0515825a0679c849575962b26523ba21d2a3a13b5483d132f00018073  terraform-module-versions_Linux_x86_64.tar.gz
```

```console
$ conftest test -p policy/pkg --combine pkgs/keilerkonzept/terraform-module-versions/pkg.yaml
2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions

$ conftest test -p policy/registry --combine pkgs/keilerkonzept/terraform-module-versions/registry.yaml
12 tests, 12 passed, 0 warnings, 0 failures, 0 exceptions

$ npx prettier@3 --check pkgs/keilerkonzept/terraform-module-versions/
All matched files use Prettier code style!
```

`registry.yaml` is regenerated by `argd gr`.

<sub>Written with Claude Code (co-author on the commit). Every command and its output above is from a run I actually made, and I have reviewed the change.</sub>
