### PR TITLE
fix(sharkdp/fd): support intel mac again.

### DIFF
--- a/pkgs/sharkdp/fd/pkg.yaml
+++ b/pkgs/sharkdp/fd/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: sharkdp/fd@v10.5.0
   - name: sharkdp/fd
+    version: v10.4.2
+  - name: sharkdp/fd
     version: v10.3.0
   - name: sharkdp/fd
     version: v10.2.0

--- a/pkgs/sharkdp/fd/registry.yaml
+++ b/pkgs/sharkdp/fd/registry.yaml
@@ -115,7 +115,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 10.4.2")
         asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -134,3 +134,15 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: "true"
+        asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -84707,7 +84707,7 @@ packages:
         overrides:
           - goos: windows
             format: zip
-      - version_constraint: "true"
+      - version_constraint: semver("<= 10.4.2")
         asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -84726,6 +84726,18 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: "true"
+        asset: fd-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_release
     repo_owner: sharkdp
     repo_name: hexyl


### PR DESCRIPTION
https://github.com/aquaproj/aqua-registry/issues/52696#issuecomment-5515866840

> fd added back Intel Mac build in sharkdp/fd@1b66ab5, so starting from v10.5.0 there is again the fd-v10.5.0-x86_64-apple-darwin.tar.gz asset.
> Unfortunately this change is not mentioned in v10.5.0 release note.
