### PR TITLE
fix(pnpm/pnpm): support macOS Intel from v12.0.0

### DIFF
--- a/pkgs/pnpm/pnpm/pkg.yaml
+++ b/pkgs/pnpm/pnpm/pkg.yaml
@@ -1,6 +1,8 @@
 packages:
   - name: pnpm/pnpm@v12.3.0
   - name: pnpm/pnpm
+    version: v11.24.0
+  - name: pnpm/pnpm
     version: v11.0.6
   - name: pnpm/pnpm
     version: v11.0.4

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -134,44 +134,7 @@ packages:
           - linux
           - windows
           - darwin/arm64
-      - version_constraint: semver(">= 12.0.0")
-        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: pnpm
-          - name: pn
-            src: pnpm
-            link: pn
-          - name: pnpx
-            src: pnpm
-            link: pnpx
-            hard: true
-          - name: pnx
-            src: pnpm
-            link: pnx
-            hard: true
-        replacements:
-          amd64: x64
-          windows: win32
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
-            variants:
-              - key: libc
-                value: musl
-          - goos: windows
-            format: zip
-        github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
-        supported_envs:
-          - linux
-          - windows
-          - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("< 12.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -208,3 +171,40 @@ packages:
           - linux
           - windows
           - darwin/arm64
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
+        supported_envs:
+          - linux
+          - windows
+          - darwin

--- a/pkgs/pnpm/pnpm/registry.yaml
+++ b/pkgs/pnpm/pnpm/registry.yaml
@@ -134,6 +134,43 @@ packages:
           - linux
           - windows
           - darwin/arm64
+      - version_constraint: semver(">= 12.0.0")
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
+        supported_envs:
+          - linux
+          - windows
+          - darwin
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -77135,6 +77135,43 @@ packages:
           - linux
           - windows
           - darwin/arm64
+      - version_constraint: semver(">= 12.0.0")
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
+        supported_envs:
+          - linux
+          - windows
+          - darwin
       - version_constraint: "true"
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz

--- a/registry.yaml
+++ b/registry.yaml
@@ -77135,44 +77135,7 @@ packages:
           - linux
           - windows
           - darwin/arm64
-      - version_constraint: semver(">= 12.0.0")
-        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
-        format: tar.gz
-        files:
-          - name: pnpm
-          - name: pn
-            src: pnpm
-            link: pn
-          - name: pnpx
-            src: pnpm
-            link: pnpx
-            hard: true
-          - name: pnx
-            src: pnpm
-            link: pnx
-            hard: true
-        replacements:
-          amd64: x64
-          windows: win32
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
-            variants:
-              - key: libc
-                value: musl
-          - goos: windows
-            format: zip
-        github_artifact_attestations:
-          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
-        supported_envs:
-          - linux
-          - windows
-          - darwin
-      - version_constraint: "true"
+      - version_constraint: semver("< 12.0.0")
         asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -77209,6 +77172,43 @@ packages:
           - linux
           - windows
           - darwin/arm64
+      - version_constraint: "true"
+        asset: pnpm-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: pnpm
+          - name: pn
+            src: pnpm
+            link: pn
+          - name: pnpx
+            src: pnpm
+            link: pnpx
+            hard: true
+          - name: pnx
+            src: pnpm
+            link: pnx
+            hard: true
+        replacements:
+          amd64: x64
+          windows: win32
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            asset: pnpm-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+            variants:
+              - key: libc
+                value: musl
+          - goos: windows
+            format: zip
+        github_artifact_attestations:
+          signer_workflow: pnpm/pnpm/.github/workflows/release.yml
+        supported_envs:
+          - linux
+          - windows
+          - darwin
   - type: github_release
     repo_owner: po3rin
     repo_name: github_link_creator


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

## Problem

The pnpm registry configuration supports only `darwin/arm64` now, although [pnpm publishes Intel macOS archives from v12.0.0](https://github.com/pnpm/pnpm/releases/tag/v12.0.0) with a `pnpm-darwin-x64.tar.gz`.

As a result, aqua does not install pnpm v12 on `darwin/amd64`.

## Change

- Make Intel and Apple Silicon macOS support the default behavior for v12.0.0 and future versions.
- Preserve the existing platform configuration for pnpm versions earlier than v12.0.0.
- Earlier version overrides continue to take precedence.
