### PR TITLE
feat: add unikraft/kraftkit

### DIFF
--- a/pkgs/unikraft/kraftkit/pkg.yaml
+++ b/pkgs/unikraft/kraftkit/pkg.yaml
@@ -1,2 +1,6 @@
 packages:
-  - name: unikraft/kraftkit@v0.8.7-209-g67d1db51
+  - name: unikraft/kraftkit@v0.12.15
+  - name: unikraft/kraftkit
+    version: v0.7.0
+  - name: unikraft/kraftkit
+    version: v0.6.4

--- a/pkgs/unikraft/kraftkit/pkg.yaml
+++ b/pkgs/unikraft/kraftkit/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: unikraft/kraftkit@v0.8.7-209-g67d1db51

--- a/pkgs/unikraft/kraftkit/registry.yaml
+++ b/pkgs/unikraft/kraftkit/registry.yaml
@@ -4,19 +4,42 @@ packages:
     repo_owner: unikraft
     repo_name: kraftkit
     description: Build and use highly customized and ultra-lightweight unikernel VMs
+    version_filter: not (Version matches "-\\d+-g[0-9a-f]+$")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 0.6.4")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kraft
         checksum:
           type: github_release
           asset: kraftkit_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: runu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.7.0")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+          - name: kraftld
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - darwin

--- a/pkgs/unikraft/kraftkit/registry.yaml
+++ b/pkgs/unikraft/kraftkit/registry.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: unikraft
+    repo_name: kraftkit
+    description: Build and use highly customized and ultra-lightweight unikernel VMs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: runu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -98695,6 +98695,26 @@ packages:
             format: raw
             asset: dug
   - type: github_release
+    repo_owner: unikraft
+    repo_name: kraftkit
+    description: Build and use highly customized and ultra-lightweight unikernel VMs
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: linux
+            goarch: amd64
+            asset: runu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: updatecli
     repo_name: updatecli
     description: A Declarative Dependency Management tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -98698,19 +98698,42 @@ packages:
     repo_owner: unikraft
     repo_name: kraftkit
     description: Build and use highly customized and ultra-lightweight unikernel VMs
+    version_filter: not (Version matches "-\\d+-g[0-9a-f]+$")
     version_constraint: "false"
     version_overrides:
-      - version_constraint: "true"
-        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+      - version_constraint: semver("<= 0.6.4")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: kraft
         checksum:
           type: github_release
           asset: kraftkit_{{trimV .Version}}_checksums.txt
           algorithm: sha256
-        overrides:
-          - goos: linux
-            goarch: amd64
-            asset: runu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver("<= 0.7.0")
+        asset: kraftkit_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: kraft_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: kraft
+          - name: kraftld
+        checksum:
+          type: github_release
+          asset: kraftkit_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
         supported_envs:
           - linux
           - darwin


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds the standalone `kraft` and `kraftld` commands from [unikraft/kraftkit](https://github.com/unikraft/kraftkit), using the canonical GitHub owner/repository package name.

The package was scaffolded with `argd s unikraft/kraftkit`. The repository has 2,059 git-describe build releases alongside 71 normal stable releases, so the follow-up configuration excludes only those build tags and corrects the scaffolder's selection of the unrelated `runu` artifact.

The release history has three tested layouts: Linux amd64 archives named `kraftkit_...` through v0.6.4; Linux and macOS amd64/arm64 archives with that name through v0.7.0; and `kraft_...` archives containing both commands from v0.7.1 onward. All branches verify the published SHA-256 checksum file. Upstream does not publish Windows archives.

No existing registry package or open/closed pull request was found for this repository or tool before submission.

### Verification

```console
$ argd t unikraft/kraftkit
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF testing os=windows arch=amd64
INF testing os=windows arch=arm64
INF Updating registry.yaml
$ echo $?
0

$ docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=amd64 aqua-registry aqua exec -- kraft version
kraft 0.12.15 (3e55f74c57579b4169b3f2271a695b0b8b9966a3) go1.26.2 2026-08-05T07:43:23Z

$ conftest test --combine pkgs/unikraft/kraftkit/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier -c pkgs/unikraft/kraftkit/*.yaml
All matched files use Prettier code style!
```

### AI usage

OpenAI Codex assisted with release-asset analysis, registry configuration, validation, and PR preparation. I reviewed and verified the resulting changes.
