### PR TITLE
feat: add unikraft-cloud/cli

### DIFF
--- a/pkgs/unikraft-cloud/cli/pkg.yaml
+++ b/pkgs/unikraft-cloud/cli/pkg.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/pkgs/unikraft-cloud/cli/pkg.yaml
+++ b/pkgs/unikraft-cloud/cli/pkg.yaml
@@ -1,1 +1,2 @@
-packages: []
+packages:
+  - name: unikraft-cloud/cli@v0.5.0

--- a/pkgs/unikraft-cloud/cli/registry.yaml
+++ b/pkgs/unikraft-cloud/cli/registry.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: unikraft-cloud
+    repo_name: cli

--- a/pkgs/unikraft-cloud/cli/registry.yaml
+++ b/pkgs/unikraft-cloud/cli/registry.yaml
@@ -3,3 +3,16 @@ packages:
   - type: github_release
     repo_owner: unikraft-cloud
     repo_name: cli
+    description: Command-line interface for Unikraft Cloud
+    version_filter: not (Version contains "-staging.")
+    asset: unikraft-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: unikraft
+    checksum:
+      type: github_release
+      asset: cli_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    supported_envs:
+      - linux
+      - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -98695,6 +98695,9 @@ packages:
             format: raw
             asset: dug
   - type: github_release
+    repo_owner: unikraft-cloud
+    repo_name: cli
+  - type: github_release
     repo_owner: updatecli
     repo_name: updatecli
     description: A Declarative Dependency Management tool

--- a/registry.yaml
+++ b/registry.yaml
@@ -98697,6 +98697,19 @@ packages:
   - type: github_release
     repo_owner: unikraft-cloud
     repo_name: cli
+    description: Command-line interface for Unikraft Cloud
+    version_filter: not (Version contains "-staging.")
+    asset: unikraft-cli_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    files:
+      - name: unikraft
+    checksum:
+      type: github_release
+      asset: cli_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    supported_envs:
+      - linux
+      - darwin
   - type: github_release
     repo_owner: updatecli
     repo_name: updatecli


### PR DESCRIPTION
## Check List

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Adds the standalone `unikraft` command from [unikraft-cloud/cli](https://github.com/unikraft-cloud/cli), using the canonical GitHub owner/repository package name.

The package was scaffolded with `argd s unikraft-cloud/cli`. The shared anonymous GitHub API quota had been exhausted while scanning KraftKit's large release history, so this initial scaffold correctly remains as a separate commit but could only emit a stub. The follow-up configuration was checked against the repository's complete authenticated release metadata: all 11 stable releases from v0.1.0 through v0.5.0 use the same Linux/macOS amd64/arm64 archive layout and SHA-256 checksum file.

The other 375 releases are explicitly marked `-staging.N` prereleases upstream. The version filter excludes that development channel so stable v0.5.0 remains the package selected as latest. Upstream does not publish Windows archives.

No existing registry package or open/closed pull request was found for this repository or tool before submission.

### Verification

```console
$ argd t unikraft-cloud/cli
INF testing os=linux arch=amd64
INF testing os=linux arch=arm64
INF testing os=darwin arch=amd64
INF testing os=darwin arch=arm64
INF Updating registry.yaml
$ echo $?
0

$ docker exec -w /workspace -e AQUA_GOOS=linux -e AQUA_GOARCH=amd64 aqua-registry aqua exec -- unikraft version
unikraft-cli
  version:    0.5.0
  platform:   linux/amd64

$ conftest test --combine pkgs/unikraft-cloud/cli/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ prettier -c pkgs/unikraft-cloud/cli/*.yaml
All matched files use Prettier code style!
```

### AI usage

OpenAI Codex assisted with release-asset analysis, registry configuration, validation, and PR preparation. I reviewed and verified the resulting changes.
