### PR TITLE
Fix editorconfig-checker/editorconfig-checker for >=4.0.0

### DIFF
--- a/pkgs/editorconfig-checker/editorconfig-checker/pkg.yaml
+++ b/pkgs/editorconfig-checker/editorconfig-checker/pkg.yaml
@@ -1,5 +1,7 @@
 packages:
-  - name: editorconfig-checker/editorconfig-checker@v3.11.2
+  - name: editorconfig-checker/editorconfig-checker@v4.0.1
+  - name: editorconfig-checker/editorconfig-checker
+    version: v3.11.3
   - name: editorconfig-checker/editorconfig-checker
     version: v3.0.3
   - name: editorconfig-checker/editorconfig-checker

--- a/pkgs/editorconfig-checker/editorconfig-checker/registry.yaml
+++ b/pkgs/editorconfig-checker/editorconfig-checker/registry.yaml
@@ -52,7 +52,7 @@ packages:
         overrides:
           - goos: windows
             asset: ec-{{.OS}}-{{.Arch}}.exe.{{.Format}}
-      - version_constraint: "true"
+      - version_constraint: semver("< 4.0.0")
         asset: ec-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -63,5 +63,19 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: editorconfig-checker-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: editorconfig-checker
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: editorconfig-checker-{{.OS}}-all.{{.Format}}
           - goos: windows
             format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -36461,7 +36461,7 @@ packages:
         overrides:
           - goos: windows
             asset: ec-{{.OS}}-{{.Arch}}.exe.{{.Format}}
-      - version_constraint: "true"
+      - version_constraint: semver("< 4.0.0")
         asset: ec-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
         files:
@@ -36472,6 +36472,20 @@ packages:
           asset: checksums.txt
           algorithm: sha256
         overrides:
+          - goos: windows
+            format: zip
+      - version_constraint: "true"
+        asset: editorconfig-checker-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        files:
+          - name: editorconfig-checker
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: darwin
+            asset: editorconfig-checker-{{.OS}}-all.{{.Format}}
           - goos: windows
             format: zip
   - type: github_release


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

The binary and asset names are now 'editorconfig-checker', and Darwin builds are now universal instead of per-arch.

Fixes the errors seen in https://github.com/aquaproj/aqua-registry/pull/60041, https://github.com/aquaproj/aqua-registry/pull/60175
