### PR TITLE
feat(nklmilojevic/sofka): scaffold nklmilojevic/sofka

### DIFF
--- a/pkgs/nklmilojevic/sofka/pkg.yaml
+++ b/pkgs/nklmilojevic/sofka/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: nklmilojevic/sofka@v0.24.4
+  - name: nklmilojevic/sofka
+    version: v0.23.0
+  - name: nklmilojevic/sofka
+    version: v0.13.4

--- a/pkgs/nklmilojevic/sofka/registry.yaml
+++ b/pkgs/nklmilojevic/sofka/registry.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: nklmilojevic
+    repo_name: sofka
+    description: "A Kubernetes TUI, reimagined in Rust - built on kube-rs and ratatui, async-first from the ground up"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.13.4"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.23.0")
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -71083,6 +71083,49 @@ packages:
           asset: SHA256SUMS.txt
           algorithm: sha256
   - type: github_release
+    repo_owner: nklmilojevic
+    repo_name: sofka
+    description: "A Kubernetes TUI, reimagined in Rust - built on kube-rs and ratatui, async-first from the ground up"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.13.4"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.23.0")
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: sofka-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: nmstate
     repo_name: nmstate
     description: Nmstate is a library with an accompanying command line tool that manages host networking settings in a declarative manner


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md) (Installed via `- import: pkgs/nklmilojevic/sofka/pkg.yaml` and ran `sofka --check` against a real cluster)

<!-- Please write the description here -->
## Description

[sofka](https://github.com/nklmilojevic/sofka) is a rust-based Kubernetes tui

Three things that stand out are:
- checksums are only available from `v0.24.0` onward, see https://github.com/nklmilojevic/sofka/pull/233
- `v0.13.4` is the only version that ships musl instead of gnu due to a change in the build process quickly reverted, see https://github.com/nklmilojevic/sofka/pull/97 and https://github.com/nklmilojevic/sofka/pull/98
- there's no windows support yet, see https://github.com/nklmilojevic/sofka/blob/main/docs/roadmap.md#milestone-7-distribution-polish