### PR TITLE
fix(jdx/aube): transfer repository and update signer workflow

### DIFF
--- a/pkgs/aubepkg/aube/pkg.yaml
+++ b/pkgs/aubepkg/aube/pkg.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: aubepkg/aube@v2.2.4
+  - name: aubepkg/aube
+    version: v1.1.0
+  - name: aubepkg/aube
+    version: v1.0.0-beta.11
+  - name: aubepkg/aube
+    version: v1.0.0-beta.1

--- a/pkgs/aubepkg/aube/pkg.yaml
+++ b/pkgs/aubepkg/aube/pkg.yaml
@@ -1,19 +1,7 @@
 packages:
   - name: aubepkg/aube@v2.2.13
   - name: aubepkg/aube
-    version: v2.2.12
-  - name: aubepkg/aube
-    version: v2.2.11
-  - name: aubepkg/aube
-    version: v2.2.10
-  - name: aubepkg/aube
-    version: v2.2.9
-  - name: aubepkg/aube
     version: v2.2.8
-  - name: aubepkg/aube
-    version: v2.2.7
-  - name: aubepkg/aube
-    version: v2.2.6
   - name: aubepkg/aube
     version: v2.2.4
   - name: aubepkg/aube

--- a/pkgs/aubepkg/aube/pkg.yaml
+++ b/pkgs/aubepkg/aube/pkg.yaml
@@ -1,6 +1,16 @@
 packages:
   - name: aubepkg/aube@v2.2.13
   - name: aubepkg/aube
+    version: v2.2.12
+  - name: aubepkg/aube
+    version: v2.2.11
+  - name: aubepkg/aube
+    version: v2.2.10
+  - name: aubepkg/aube
+    version: v2.2.9
+  - name: aubepkg/aube
+    version: v2.2.8
+  - name: aubepkg/aube
     version: v2.2.7
   - name: aubepkg/aube
     version: v2.2.6

--- a/pkgs/aubepkg/aube/pkg.yaml
+++ b/pkgs/aubepkg/aube/pkg.yaml
@@ -1,5 +1,11 @@
 packages:
-  - name: aubepkg/aube@v2.2.4
+  - name: aubepkg/aube@v2.2.13
+  - name: aubepkg/aube
+    version: v2.2.7
+  - name: aubepkg/aube
+    version: v2.2.6
+  - name: aubepkg/aube
+    version: v2.2.4
   - name: aubepkg/aube
     version: v1.1.0
   - name: aubepkg/aube

--- a/pkgs/aubepkg/aube/registry.yaml
+++ b/pkgs/aubepkg/aube/registry.yaml
@@ -63,7 +63,7 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: semver("<= 1.18.1")
+      - version_constraint: semver("<= 2.2.4")
         asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -92,6 +92,34 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: semver("<= 2.2.8")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            variants:
+              - key: libc
+                value: glibc
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+        github_artifact_attestations:
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml
       - version_constraint: "true"
         asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -107,11 +135,11 @@ packages:
               - key: libc
                 value: glibc
           - goos: linux
-            replacements:
-              linux: unknown-linux-musl
             variants:
               - key: libc
                 value: musl
+            replacements:
+              linux: unknown-linux-musl
           - goos: darwin
             replacements:
               amd64: amd64

--- a/pkgs/aubepkg/aube/registry.yaml
+++ b/pkgs/aubepkg/aube/registry.yaml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
   - type: github_release
-    repo_owner: jdx
+    repo_owner: aubepkg
     repo_name: aube
     aliases:
       - name: endevco/aube
+      - name: jdx/aube
     description: A fast Node.js package manager
     version_constraint: "false"
     version_overrides:
@@ -121,4 +122,4 @@ packages:
           - darwin/arm64
           - windows
         github_artifact_attestations:
-          signer_workflow: jdx/aube/.github/workflows/release.yml
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml

--- a/pkgs/jdx/aube/pkg.yaml
+++ b/pkgs/jdx/aube/pkg.yaml
@@ -1,8 +1,0 @@
-packages:
-  - name: jdx/aube@v2.2.4
-  - name: jdx/aube
-    version: v1.1.0
-  - name: jdx/aube
-    version: v1.0.0-beta.11
-  - name: jdx/aube
-    version: v1.0.0-beta.1

--- a/registry.yaml
+++ b/registry.yaml
@@ -17247,7 +17247,7 @@ packages:
           - linux
           - darwin/arm64
           - windows
-      - version_constraint: semver("<= 1.18.1")
+      - version_constraint: semver("<= 2.2.4")
         asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
         replacements:
@@ -17276,6 +17276,34 @@ packages:
           - linux
           - darwin/arm64
           - windows
+      - version_constraint: semver("<= 2.2.8")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            goarch: amd64
+            variants:
+              - key: libc
+                value: glibc
+            replacements:
+              linux: unknown-linux-gnu
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+        github_artifact_attestations:
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml
       - version_constraint: "true"
         asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
         format: tar.gz
@@ -17291,11 +17319,11 @@ packages:
               - key: libc
                 value: glibc
           - goos: linux
-            replacements:
-              linux: unknown-linux-musl
             variants:
               - key: libc
                 value: musl
+            replacements:
+              linux: unknown-linux-musl
           - goos: darwin
             replacements:
               amd64: amd64

--- a/registry.yaml
+++ b/registry.yaml
@@ -17185,6 +17185,129 @@ packages:
           - darwin/arm64
           - windows/amd64
   - type: github_release
+    repo_owner: aubepkg
+    repo_name: aube
+    aliases:
+      - name: endevco/aube
+      - name: jdx/aube
+    description: A fast Node.js package manager
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v1.0.0-beta.1"
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux/amd64
+          - darwin
+          - windows
+      - version_constraint: semver("<= 1.0.0-beta.11")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 1.1.0")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-musl
+          windows: pc-windows-msvc
+        overrides:
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: semver("<= 1.18.1")
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+      - version_constraint: "true"
+        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: glibc
+          - goos: linux
+            replacements:
+              linux: unknown-linux-musl
+            variants:
+              - key: libc
+                value: musl
+          - goos: darwin
+            replacements:
+              amd64: amd64
+          - goos: windows
+            format: zip
+        supported_envs:
+          - linux
+          - darwin/arm64
+          - windows
+        github_artifact_attestations:
+          signer_workflow: aubepkg/aube/.github/workflows/release.yml
+  - type: github_release
     repo_owner: aurc
     repo_name: loggo
     description: A powerful terminal app for structured log streaming
@@ -52619,128 +52742,6 @@ packages:
       type: github_release
       asset: terradozer_{{trimV .Version}}_checksums.txt
       algorithm: sha256
-  - type: github_release
-    repo_owner: jdx
-    repo_name: aube
-    aliases:
-      - name: endevco/aube
-    description: A fast Node.js package manager
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: Version == "v1.0.0-beta.1"
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux/amd64
-          - darwin
-          - windows
-      - version_constraint: semver("<= 1.0.0-beta.11")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: semver("<= 1.1.0")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-musl
-          windows: pc-windows-msvc
-        overrides:
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: semver("<= 1.18.1")
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            replacements:
-              linux: unknown-linux-musl
-            variants:
-              - key: libc
-                value: musl
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-      - version_constraint: "true"
-        asset: aube-{{.Version}}-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: linux
-            variants:
-              - key: libc
-                value: glibc
-          - goos: linux
-            replacements:
-              linux: unknown-linux-musl
-            variants:
-              - key: libc
-                value: musl
-          - goos: darwin
-            replacements:
-              amd64: amd64
-          - goos: windows
-            format: zip
-        supported_envs:
-          - linux
-          - darwin/arm64
-          - windows
-        github_artifact_attestations:
-          signer_workflow: jdx/aube/.github/workflows/release.yml
   - type: github_release
     repo_owner: jdx
     repo_name: fnox


### PR DESCRIPTION
## Summary

- transfer the canonical Aube package from `jdx/aube` to `aubepkg/aube`
- preserve `jdx/aube` and `endevco/aube` as aliases
- update `github_artifact_attestations.signer_workflow` to the new repository identity
- regenerate `registry.yaml` with `argd gr`

This supersedes #60040. That PR updates `repo_owner`, but leaves the signer workflow as `jdx/aube/.github/workflows/release.yml`, so attestation verification still fails for releases produced after the transfer.

## Reproduction

Environment:

- macOS 26.6.2, arm64
- aqua 2.61.0
- Aube 2.2.12

Minimal configuration against the local registry:

```yaml
registries:
  - name: standard
    type: local
    path: ../registry.yaml
packages:
  - name: jdx/aube@v2.2.12
```

Before this change, `aqua install` invokes:

```text
gh attestation verify <asset> -R jdx/aube \
  --signer-workflow jdx/aube/.github/workflows/release.yml
```

and fails with `verify GitHub Artifact Attestations`. The release artifacts are produced by `aubepkg/aube/.github/workflows/release.yml`.

Expected: Aube installs and its release attestation verifies against the current repository identity.

Actual: attestation verification uses the old repository and signer workflow.

## Verification

```text
$ argd fix pkgs/aubepkg/aube/pkg.yaml pkgs/aubepkg/aube/registry.yaml
$ argd gr
$ conftest test --combine pkgs/aubepkg/aube/pkg.yaml pkgs/aubepkg/aube/registry.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions

$ aqua install --config .ai/repro-aube.yaml
$ aqua exec --config .ai/repro-aube.yaml -- aube --version
2.2.12 macos-arm64 (2026-09-06)
```

The direct aqua install succeeded with GitHub Artifact Attestations enabled for both `aubepkg/aube` and the legacy `jdx/aube` alias.

I also attempted `argd test aubepkg/aube`, but the local Docker Desktop daemon exited before the container matrix could start; CI should exercise the remaining platforms.

AI assistance disclosure: Codex was used to reproduce the failure, prepare the change, and run the checks above.
