### PR TITLE
feat: add yadm-dev/yadm

### DIFF
--- a/pkgs/yadm-dev/yadm/pkg.yaml
+++ b/pkgs/yadm-dev/yadm/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: yadm-dev/yadm@3.5.0

--- a/pkgs/yadm-dev/yadm/registry.yaml
+++ b/pkgs/yadm-dev/yadm/registry.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_content
+    repo_owner: yadm-dev
+    repo_name: yadm
+    description: Yet Another Dotfiles Manager
+    path: yadm
+    aliases:
+      - name: TheLocehiliosan/yadm
+    supported_envs:
+      - darwin
+      - linux

--- a/registry.yaml
+++ b/registry.yaml
@@ -103205,6 +103205,16 @@ packages:
       - darwin
       - linux
       - amd64
+  - type: github_content
+    repo_owner: yadm-dev
+    repo_name: yadm
+    description: Yet Another Dotfiles Manager
+    path: yadm
+    aliases:
+      - name: TheLocehiliosan/yadm
+    supported_envs:
+      - darwin
+      - linux
   - type: github_release
     repo_owner: yamafaktory
     repo_name: jql


### PR DESCRIPTION
## Description

Add `yadm-dev/yadm` (Yet Another Dotfiles Manager) as a `github_content` package.

- Aliases: `TheLocehiliosan/yadm`
- Supported envs: `darwin`, `linux`

## Verification

### 1. Conftest
```sh
$ conftest test --combine pkgs/yadm-dev/yadm/registry.yaml pkgs/yadm-dev/yadm/pkg.yaml
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

### 2. Repo check
```sh
$ argd check-repo yadm-dev/yadm
```

### 3. Direct execution via aqua
```sh
$ aqua -c pkgs/yadm-dev/yadm/pkg.yaml cp -o /tmp/yadm-bin yadm
$ /tmp/yadm-bin/yadm --version
bash version 5.2.21(1)-release
 git version 2.43.0
yadm version 3.5.0
```