### PR TITLE
feat: add openai/tunnel-client

### DIFF
--- a/pkgs/openai/tunnel-client/pkg.yaml
+++ b/pkgs/openai/tunnel-client/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: openai/tunnel-client@v0.0.14

--- a/pkgs/openai/tunnel-client/registry.yaml
+++ b/pkgs/openai/tunnel-client/registry.yaml
@@ -3,7 +3,9 @@ packages:
   - type: github_release
     repo_owner: openai
     repo_name: tunnel-client
-    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    description: Client for connecting private MCP servers to ChatGPT, Codex, and the Responses API
+    files:
+      - name: tunnel-client
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.0.6--context-conduit-saphire"

--- a/pkgs/openai/tunnel-client/registry.yaml
+++ b/pkgs/openai/tunnel-client/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: openai
+    repo_name: tunnel-client
+    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.6--context-conduit-saphire"
+        no_asset: true
+      - version_constraint: "true"
+        asset: tunnel-client-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -27844,6 +27844,27 @@ packages:
         github_artifact_attestations:
           signer_workflow: coder/coder/.github/workflows/release.yaml
   - type: github_release
+    repo_owner: coder3101
+    repo_name: protols
+    description: Language Server for protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: codesenberg
     repo_name: bombardier
     description: Fast cross-platform HTTP benchmarking tool written in Go

--- a/registry.yaml
+++ b/registry.yaml
@@ -27753,27 +27753,6 @@ packages:
       - name: cc-test-reporter
         src: test-reporter
   - type: github_release
-    repo_owner: coder3101
-    repo_name: protols
-    description: Language Server for protocol buffers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.2.1")
-        no_asset: true
-      - version_constraint: "true"
-        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
-  - type: github_release
     repo_owner: coder
     repo_name: boo
     description: A GNU screen style terminal multiplexer built on libghostty
@@ -72789,7 +72768,9 @@ packages:
   - type: github_release
     repo_owner: openai
     repo_name: tunnel-client
-    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    description: Client for connecting private MCP servers to ChatGPT, Codex, and the Responses API
+    files:
+      - name: tunnel-client
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.0.6--context-conduit-saphire"

--- a/registry.yaml
+++ b/registry.yaml
@@ -27753,6 +27753,27 @@ packages:
       - name: cc-test-reporter
         src: test-reporter
   - type: github_release
+    repo_owner: coder3101
+    repo_name: protols
+    description: Language Server for protocol buffers
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.2.1")
+        no_asset: true
+      - version_constraint: "true"
+        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
+        format: tar.gz
+        windows_arm_emulation: true
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: apple-darwin
+          linux: unknown-linux-gnu
+          windows: pc-windows-msvc
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: coder
     repo_name: boo
     description: A GNU screen style terminal multiplexer built on libghostty
@@ -27843,27 +27864,6 @@ packages:
             format: tar.gz
         github_artifact_attestations:
           signer_workflow: coder/coder/.github/workflows/release.yaml
-  - type: github_release
-    repo_owner: coder3101
-    repo_name: protols
-    description: Language Server for protocol buffers
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: semver("<= 0.2.1")
-        no_asset: true
-      - version_constraint: "true"
-        asset: protols-{{.Arch}}-{{.OS}}.{{.Format}}
-        format: tar.gz
-        windows_arm_emulation: true
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
-          darwin: apple-darwin
-          linux: unknown-linux-gnu
-          windows: pc-windows-msvc
-        overrides:
-          - goos: windows
-            format: zip
   - type: github_release
     repo_owner: codesenberg
     repo_name: bombardier
@@ -72786,6 +72786,21 @@ packages:
       algorithm: sha256
     supported_envs:
       - darwin
+  - type: github_release
+    repo_owner: openai
+    repo_name: tunnel-client
+    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.6--context-conduit-saphire"
+        no_asset: true
+      - version_constraint: "true"
+        asset: tunnel-client-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
   - name: openbao/openbao/bao
     type: github_release
     repo_owner: openbao


### PR DESCRIPTION
## Summary

- Add openai/tunnel-client as a GitHub Release package
- Support the six published OS/architecture archives
- Select the tunnel-client executable and verify SHA256SUMS.txt
- Exclude the assetless v0.0.6--context-conduit-saphire release

## Verification

- argd t openai/tunnel-client passed on Linux, Darwin, and Windows for amd64/arm64
- conftest test --combine passed for the package and root registry
- prettier --check passed
- Published SHA-256 matched the downloaded archive
- Both commits are SSH-signed

## AI usage

OpenAI Codex assisted with release-asset analysis, registry configuration, validation, and PR preparation. I reviewed and verified the resulting changes.