### PR TITLE
feat: add openai/tunnel-client

### DIFF
--- a/pkgs/openai/tunnel-client/pkg.yaml
+++ b/pkgs/openai/tunnel-client/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: openai/tunnel-client@v0.0.14

--- a/pkgs/openai/tunnel-client/registry.yaml
+++ b/pkgs/openai/tunnel-client/registry.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: openai
+    repo_name: tunnel-client
+    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.6--context-conduit-saphire"
+        no_asset: true
+      - version_constraint: "true"
+        asset: tunnel-client-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -72935,6 +72935,21 @@ packages:
       algorithm: sha256
     supported_envs:
       - darwin
+  - type: github_release
+    repo_owner: openai
+    repo_name: tunnel-client
+    description: "Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.0.6--context-conduit-saphire"
+        no_asset: true
+      - version_constraint: "true"
+        asset: tunnel-client-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: zip
+        checksum:
+          type: github_release
+          asset: SHA256SUMS.txt
+          algorithm: sha256
   - name: openbao/openbao/bao
     type: github_release
     repo_owner: openbao


### PR DESCRIPTION
[openai/tunnel-client](https://github.com/openai/tunnel-client): Customer-run client for Secure MCP Tunnel: connect private or localhost MCP servers to ChatGPT, Codex, the Responses API, and AgentKit without exposing them to the public internet

```sh
aqua g -i openai/tunnel-client
```

Close #60340