### PR TITLE
feat(getgaal/gaal): add getgaal/gaal

### DIFF
--- a/pkgs/getgaal/gaal/pkg.yaml
+++ b/pkgs/getgaal/gaal/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: getgaal/gaal@v0.3.0
+  - name: getgaal/gaal
+    version: v0.1.0

--- a/pkgs/getgaal/gaal/registry.yaml
+++ b/pkgs/getgaal/gaal/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: getgaal
+    repo_name: gaal
+    description: A single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: gaal-{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: "true"
+        asset: gaal-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -41531,6 +41531,22 @@ packages:
       - goos: windows
         format: zip
   - type: github_release
+    repo_owner: getgaal
+    repo_name: gaal
+    description: A single CLI to keep your local repositories, AI agent skills, and MCP server configurations in sync
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        asset: gaal-{{.OS}}-{{.Arch}}
+        format: raw
+      - version_constraint: "true"
+        asset: gaal-{{.OS}}-{{.Arch}}
+        format: raw
+        checksum:
+          type: github_release
+          asset: SHA256SUMS
+          algorithm: sha256
+  - type: github_release
     repo_owner: getgauge
     repo_name: gauge
     asset: gauge-{{trimV .Version}}-{{.OS}}.{{.Arch}}.zip


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

Add [getgaal/gaal](https://github.com/getgaal/gaal) — a single CLI to keep local repositories, AI agent skills, and MCP server configurations in sync.

Scaffolded with `argd s getgaal/gaal` (no manual edits to the generated config).

`v0.1.0` is the only release without a `SHA256SUMS` asset, hence the dedicated `version_overrides` entry without a `checksum` block; `v0.1.2`, `v0.2.0` and `v0.3.0` all ship it.

## Verification

`argd t getgaal/gaal` — passes on all 6 platforms:

```console
$ argd t getgaal/gaal
INF testing os=linux arch=amd64
INF download and unarchive the package env=linux/amd64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=linux/amd64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF testing os=linux arch=arm64
INF download and unarchive the package env=linux/arm64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=linux/arm64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF testing os=darwin arch=amd64
INF download and unarchive the package env=darwin/amd64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=darwin/amd64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF testing os=darwin arch=arm64
INF download and unarchive the package env=darwin/arm64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=darwin/arm64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF testing os=windows arch=amd64
INF download and unarchive the package env=windows/amd64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=windows/amd64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF testing os=windows arch=arm64
INF download and unarchive the package env=windows/arm64 package_name=getgaal/gaal package_version=v0.1.0 registry=standard
INF download and unarchive the package env=windows/arm64 package_name=getgaal/gaal package_version=v0.3.0 registry=standard
INF Updating registry.yaml
```

`conftest`:

```console
$ conftest test --combine pkgs/getgaal/gaal/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

Executing the installed binaries in the test container (both `version_overrides` branches):

```console
$ gaal version   # v0.3.0
gaal v0.3.0
built 2026-05-25T18:40:22Z

$ gaal version   # v0.1.0
gaal v0.1.0 (built: 2026-04-11T01:02:35Z)
```

---

AI disclosure per [docs/ai.md](https://github.com/aquaproj/aqua-registry/blob/main/docs/ai.md): this PR was prepared with the help of Claude Code (Opus 5). The configuration itself is the unmodified output of `argd s`; I reviewed the result, verified the release assets per version, and take responsibility for the content.
