### PR TITLE
fix: add yadm-dev/yadm version_source github_tag

### DIFF
--- a/pkgs/yadm-dev/yadm/registry.yaml
+++ b/pkgs/yadm-dev/yadm/registry.yaml
@@ -4,6 +4,7 @@ packages:
     repo_owner: yadm-dev
     repo_name: yadm
     description: Yet Another Dotfiles Manager
+    version_source: github_tag
     path: yadm
     aliases:
       - name: TheLocehiliosan/yadm

--- a/registry.yaml
+++ b/registry.yaml
@@ -103485,6 +103485,7 @@ packages:
     repo_owner: yadm-dev
     repo_name: yadm
     description: Yet Another Dotfiles Manager
+    version_source: github_tag
     path: yadm
     aliases:
       - name: TheLocehiliosan/yadm


### PR DESCRIPTION
## Summary

Follow-up fix to #60259. `yadm-dev/yadm` publishes releases as git tags only and has no GitHub Releases, so with the default `github_release` version source no versions could be resolved.

## Changes

- Add `version_source: github_tag` to `pkgs/yadm-dev/yadm/registry.yaml`
- Regenerate root `registry.yaml` with `argd gr` (matches the same setup as `awslabs/git-secrets`)

## Result

With `version_source: github_tag`, aqua resolves versions from the repo's git tags (e.g. `3.5.0`, `3.4.0`) instead of GitHub Releases.