### PR TITLE
feat: add kjanat/actionlint

### DIFF
--- a/pkgs/kjanat/actionlint/pkg.yaml
+++ b/pkgs/kjanat/actionlint/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kjanat/actionlint@v1.16.1

--- a/pkgs/kjanat/actionlint/registry.yaml
+++ b/pkgs/kjanat/actionlint/registry.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: kjanat
+    repo_name: actionlint
+    description: Static checker for GitHub Actions workflow files. Actively released fork of rhysd/actionlint with attested binaries and multi-platform images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: actionlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/pkgs/kjanat/actionlint/registry.yaml
+++ b/pkgs/kjanat/actionlint/registry.yaml
@@ -3,16 +3,24 @@ packages:
   - type: github_release
     repo_owner: kjanat
     repo_name: actionlint
-    description: Static checker for GitHub Actions workflow files. Actively released fork of rhysd/actionlint with attested binaries and multi-platform images
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: actionlint_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
+    description: Find problems in your GitHub Actions workflows
+    search_words:
+      - lint
+      - linter
+      - workflow
+      - ci
+      - github-actions
+    asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: actionlint_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip
+    github_artifact_attestations:
+      enabled: true
+    build:
+      type: go_install
+      path: actionlint.kjanat.dev/cmd/actionlint

--- a/registry.yaml
+++ b/registry.yaml
@@ -57849,19 +57849,27 @@ packages:
   - type: github_release
     repo_owner: kjanat
     repo_name: actionlint
-    description: Static checker for GitHub Actions workflow files. Actively released fork of rhysd/actionlint with attested binaries and multi-platform images
-    version_constraint: "false"
-    version_overrides:
-      - version_constraint: "true"
-        asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
-        format: tar.gz
-        checksum:
-          type: github_release
-          asset: actionlint_{{trimV .Version}}_checksums.txt
-          algorithm: sha256
-        overrides:
-          - goos: windows
-            format: zip
+    description: Find problems in your GitHub Actions workflows
+    search_words:
+      - lint
+      - linter
+      - workflow
+      - ci
+      - github-actions
+    asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: actionlint_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip
+    github_artifact_attestations:
+      enabled: true
+    build:
+      type: go_install
+      path: actionlint.kjanat.dev/cmd/actionlint
   - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc

--- a/registry.yaml
+++ b/registry.yaml
@@ -57846,6 +57846,22 @@ packages:
     supported_envs:
       - linux
       - darwin
+  - type: github_release
+    repo_owner: kjanat
+    repo_name: actionlint
+    description: Static checker for GitHub Actions workflow files. Actively released fork of rhysd/actionlint with attested binaries and multi-platform images
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: "true"
+        asset: actionlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: actionlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
   - type: github_content
     repo_owner: kjokjo
     repo_name: ipcalc


### PR DESCRIPTION
Add `kjanat/actionlint`, a maintained fork of rhysd/actionlint.

Scaffolded with `argd s kjanat/actionlint`. The second commit adds manual refinements:

- `github_artifact_attestations` (repo-only) — releases carry GitHub artifact attestations across the whole version range
- `go_install` build fallback via the module's vanity path `actionlint.kjanat.dev/cmd/actionlint`
- `search_words` for discoverability

Tested with `argd t` across all six standard OS/arch targets. Attestation verification passes on both sides of a release-workflow rename (v1.8.0 signed by `release.yaml`, v1.16.1 by `release.yml`), which the repo-only attestation config handles without a version split.

Fork-side tracking (context, not part of this PR): kjanat/actionlint#167, kjanat/actionlint#168
