### PR TITLE
fix(minio/mc): download assets from GitHub Releases

### DIFF
--- a/pkgs/minio/mc/registry.yaml
+++ b/pkgs/minio/mc/registry.yaml
@@ -1,23 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
 packages:
-  - type: http
+  - type: github_release
     repo_owner: minio
     repo_name: mc
     description: Unix like utilities for object store
-    url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}
-    complete_windows_ext: false
+    asset: mc.{{.OS}}-{{.Arch}}.{{.Version}}
     windows_arm_emulation: true
     format: raw
-    overrides:
-      - goos: windows
-        files:
-          - name: mc
-            link: mc.exe
     checksum:
-      type: http
+      type: github_release
       algorithm: sha256
-      url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.sha256sum
+      asset: "{{.Asset}}.sha256sum"
     minisign:
-      type: http
-      url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.minisig
+      type: github_release
+      asset: "{{.Asset}}.minisig"
       public_key: RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav

--- a/registry.yaml
+++ b/registry.yaml
@@ -67100,26 +67100,20 @@ packages:
         overrides:
           - goos: windows
             asset: minc
-  - type: http
+  - type: github_release
     repo_owner: minio
     repo_name: mc
     description: Unix like utilities for object store
-    url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}
-    complete_windows_ext: false
+    asset: mc.{{.OS}}-{{.Arch}}.{{.Version}}
     windows_arm_emulation: true
     format: raw
-    overrides:
-      - goos: windows
-        files:
-          - name: mc
-            link: mc.exe
     checksum:
-      type: http
+      type: github_release
       algorithm: sha256
-      url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.sha256sum
+      asset: "{{.Asset}}.sha256sum"
     minisign:
-      type: http
-      url: https://dl.min.io/client/mc/release/{{.OS}}-{{.Arch}}/archive/mc.{{.Version}}.minisig
+      type: github_release
+      asset: "{{.Asset}}.minisig"
       public_key: RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav
   - type: github_release
     repo_owner: miniscruff


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
  - :warning: [Avoid force push](https://github.com/aquaproj/aqua-registry/blob/main/docs/manner.md#dont-do-force-pushes-after-opening-pull-requests)
  - :warning: [Use `argd s` command when adding new packages](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
- [x] [Install and execute the package and confirm if the package works well](https://github.com/aquaproj/aqua-registry/blob/main/docs/run_tool.md)

MinIO's archive download endpoint now returns HTTP 410, so Aqua can no longer install `minio/mc`. This switches the package, checksum, and minisign downloads to the equivalent assets published on the existing GitHub release.

Related: https://github.com/jdx/mise/pull/13113

## Reproduction

Environment: Linux amd64, Aqua 2.62.3

```yaml
registries:
  - type: standard
    ref: v4.432.0
packages:
  - name: minio/mc@RELEASE.2025-08-13T08-35-41Z
```

```console
$ aqua install
ERR install the package package_name=minio/mc package_version=RELEASE.2025-08-13T08-35-41Z http_status_code=410 download_url=https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-08-13T08-35-41Z
```

Expected: Aqua installs `mc` from the assets attached to MinIO's GitHub release.

## Verification

```console
$ argd t minio/mc
# passed for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64,
# windows/amd64, and windows/arm64
```

```console
$ conftest test --combine pkgs/minio/mc/*
14 tests, 14 passed, 0 warnings, 0 failures, 0 exceptions
```

```console
$ aqua exec -- mc --version
mc version RELEASE.2025-08-13T08-35-41Z (commit-id=7394ce0dd2a80935aded936b09fa12cbb3cb8096)
Runtime: go1.24.6 linux/amd64
```

The focused Aqua install also verified MinIO's published minisign signature.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*
