### PR TITLE
feat(redhat-et/ripwire): scaffold redhat-et/ripwire

### DIFF
--- a/pkgs/redhat-et/ripwire/pkg.yaml
+++ b/pkgs/redhat-et/ripwire/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: redhat-et/ripwire@v0.6.0
+  - name: redhat-et/ripwire
+    version: v0.3.5
+  - name: redhat-et/ripwire
+    version: v0.2.2

--- a/pkgs/redhat-et/ripwire/registry.yaml
+++ b/pkgs/redhat-et/ripwire/registry.yaml
@@ -3,7 +3,7 @@ packages:
   - type: github_release
     repo_owner: redhat-et
     repo_name: ripwire
-    description: "The ripgrep of AI context: a zero-dependency C++23 CLI + MCP server for coding agents. Find what you want without reading the repo, then check you built what you meant — blast radius, tests-to-run, quality deltas. Signatures at 74.7% fewer bytes than bodies; every guess labelled, every loss published. Paddle out with a map"
+    description: A zero-dependency CLI and MCP server for finding context in codebases
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -11,6 +11,9 @@ packages:
       - version_constraint: semver("<= 0.2.2")
         asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos
@@ -24,6 +27,9 @@ packages:
       - version_constraint: semver("<= 0.3.5")
         asset: ripwire-0.2.2-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-0.2.2-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos
@@ -37,6 +43,9 @@ packages:
       - version_constraint: "true"
         asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos

--- a/pkgs/redhat-et/ripwire/registry.yaml
+++ b/pkgs/redhat-et/ripwire/registry.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: redhat-et
+    repo_name: ripwire
+    description: "The ripgrep of AI context: a zero-dependency C++23 CLI + MCP server for coding agents. Find what you want without reading the repo, then check you built what you meant — blast radius, tests-to-run, quality deltas. Signatures at 74.7% fewer bytes than bodies; every guess labelled, every loss published. Paddle out with a map"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.2.2")
+        asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.5")
+        asset: ripwire-0.2.2-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -80205,7 +80205,7 @@ packages:
   - type: github_release
     repo_owner: redhat-et
     repo_name: ripwire
-    description: "The ripgrep of AI context: a zero-dependency C++23 CLI + MCP server for coding agents. Find what you want without reading the repo, then check you built what you meant — blast radius, tests-to-run, quality deltas. Signatures at 74.7% fewer bytes than bodies; every guess labelled, every loss published. Paddle out with a map"
+    description: A zero-dependency CLI and MCP server for finding context in codebases
     version_constraint: "false"
     version_overrides:
       - version_constraint: Version == "v0.1.0"
@@ -80213,6 +80213,9 @@ packages:
       - version_constraint: semver("<= 0.2.2")
         asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos
@@ -80226,6 +80229,9 @@ packages:
       - version_constraint: semver("<= 0.3.5")
         asset: ripwire-0.2.2-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-0.2.2-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos
@@ -80239,6 +80245,9 @@ packages:
       - version_constraint: "true"
         asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
         format: tar.gz
+        files:
+          - name: ripwire
+            src: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}/ripwire
         replacements:
           amd64: x64
           darwin: macos

--- a/registry.yaml
+++ b/registry.yaml
@@ -80202,6 +80202,53 @@ packages:
           type: http
           url: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/{{.Version}}/odo-{{.OS}}-{{.Arch}}.exe.sha256
           algorithm: sha256
+  - type: github_release
+    repo_owner: redhat-et
+    repo_name: ripwire
+    description: "The ripgrep of AI context: a zero-dependency C++23 CLI + MCP server for coding agents. Find what you want without reading the repo, then check you built what you meant — blast radius, tests-to-run, quality deltas. Signatures at 74.7% fewer bytes than bodies; every guess labelled, every loss published. Paddle out with a map"
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: Version == "v0.1.0"
+        no_asset: true
+      - version_constraint: semver("<= 0.2.2")
+        asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: semver("<= 0.3.5")
+        asset: ripwire-0.2.2-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: ripwire-{{trimV .Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x64
+          darwin: macos
+        checksum:
+          type: github_release
+          asset: "{{.Asset}}.sha256"
+          algorithm: sha256
+        supported_envs:
+          - linux
+          - darwin
   - name: redhat.com/openshift-install
     type: http
     url: https://mirror.openshift.com/pub/openshift-v4/{{.Arch}}/clients/ocp/{{trimV .Version}}/openshift-install-{{.OS}}.tar.gz


### PR DESCRIPTION
## Summary
- Add `redhat-et/ripwire` as a `github_release` package (single `ripwire` binary, linux/darwin only — no Windows releases)
- Fixed a scaffolding gap: each release tarball unpacks into a `ripwire-<version>-<os>-<arch>/` subdirectory rather than placing the binary at the archive root, so added `files[].src` per version_override
- Trimmed the auto-generated description to one sentence per the style guide

## Test plan
`argd t redhat-et/ripwire` passed for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, and windows (no-op, unsupported).

`conftest test pkgs/redhat-et/ripwire/*.yaml`: 28 tests, 28 passed.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)